### PR TITLE
Discard the space after colon in HTTP respone headers

### DIFF
--- a/sdk/platform/http_client/curl/src/curl_client.cpp
+++ b/sdk/platform/http_client/curl/src/curl_client.cpp
@@ -99,7 +99,7 @@ static void ParseHeader(std::string const& header, std::unique_ptr<Response>& re
 
   auto headerName = std::string(start, end);
   start = end + 1; // start value
-  if (start < header.end() && *start == ' ')
+  while (start < header.end() && (*start == ' ' || *start == '\t'))
   {
     ++start;
   }

--- a/sdk/platform/http_client/curl/src/curl_client.cpp
+++ b/sdk/platform/http_client/curl/src/curl_client.cpp
@@ -99,6 +99,10 @@ static void ParseHeader(std::string const& header, std::unique_ptr<Response>& re
 
   auto headerName = std::string(start, end);
   start = end + 1; // start value
+  if (start < header.end() && *start == ' ')
+  {
+    ++start;
+  }
 
   auto headerValue = std::string(start, header.end() - 2); // remove \r and \n from the end
 


### PR DESCRIPTION
For example, for a response header `Content-Encoding: gzip`, intuitively people would expect the value without the leading space when trying to get the value of content encoding.