### PR TITLE
Use move to initialize the body buffer

### DIFF
--- a/sdk/core/azure-core/inc/http/http.hpp
+++ b/sdk/core/azure-core/inc/http/http.hpp
@@ -191,9 +191,9 @@ namespace Azure { namespace Core { namespace Http {
         HttpMethod httpMethod,
         std::string const& url,
         BodyStream* bodyStream,
-        std::vector<uint8_t> const& bodyBuffer)
+        std::vector<uint8_t> bodyBuffer)
         : _method(std::move(httpMethod)), _url(parseUrl(url)), m_bodyStream(bodyStream),
-          m_bodyBuffer(bodyBuffer), m_retryModeEnabled(false)
+          m_bodyBuffer(std::move(bodyBuffer)), m_retryModeEnabled(false)
     {
       // TODO: parse url
     }


### PR DESCRIPTION
Consider the following behavior from customer:
Before:
```
// Customer code generates a buffer std::vector<uint8_t> customerBuffer.
Request request = Request(HttpMethod::Put, url, null, customerBuffer); // Buffer gets copied once.
// Customer code generates a buffer by return value with function SerializeToXml().
Request request = Request(HttpMethod::Put, url, null, SerializeToXml()); // Buffer gets copied once.
```
After:
```
// Customer code generates a buffer std::vector<uint8_t> customerBuffer.
Request request = Request(HttpMethod::Put, url, null, std::move(customerBuffer)); // Buffer gets moved twice.
// Customer code generates a buffer by return value with function SerializeToXml().
Request request = Request(HttpMethod::Put, url, null, SerializeToXml()); // Buffer gets moved twice.
```