### PR TITLE
Use move to initialize the body buffer

### DIFF
--- a/sdk/core/azure-core/inc/http/http.hpp
+++ b/sdk/core/azure-core/inc/http/http.hpp
@@ -204,8 +204,8 @@ namespace Azure { namespace Core { namespace Http {
     {
     }
 
-    Request(HttpMethod httpMethod, std::string const& url, std::vector<uint8_t> const& bodyBuffer)
-        : Request(httpMethod, url, BodyStream::null, bodyBuffer)
+    Request(HttpMethod httpMethod, std::string const& url, std::vector<uint8_t> bodyBuffer)
+        : Request(httpMethod, url, BodyStream::null, std::move(bodyBuffer))
     {
     }
 


### PR DESCRIPTION
This is a patch to https://github.com/Azure/azure-sdk-for-cpp/pull/148. Because in https://github.com/Azure/azure-sdk-for-cpp/pull/148, he only changed the private constructor and forgot about the public constructor.