### PR TITLE
Add support for HTTP methods to unblock storage team

### DIFF
--- a/sdk/core/azure-core/inc/http/http.hpp
+++ b/sdk/core/azure-core/inc/http/http.hpp
@@ -129,6 +129,27 @@ namespace Azure { namespace Core { namespace Http {
     Patch,
   };
 
+  inline std::string HttpMethodToString(const HttpMethod& method)
+  {
+    switch (method)
+    {
+      case HttpMethod::Get:
+        return "GET";
+      case HttpMethod::Head:
+        return "HEAD";
+      case HttpMethod::Post:
+        return "POST";
+      case HttpMethod::Put:
+        return "PUT";
+      case HttpMethod::Delete:
+        return "DELETE";
+      case HttpMethod::Patch:
+        return "PATCH";
+      default:
+        return "";
+    }
+  }
+
   class Request {
 
   private:

--- a/sdk/core/azure-core/inc/http/http.hpp
+++ b/sdk/core/azure-core/inc/http/http.hpp
@@ -249,9 +249,9 @@ namespace Azure { namespace Core { namespace Http {
     void StartRetry(); // only called by retry policy
 
     // Methods used by transport layer (and logger) to send request
-    HttpMethod GetMethod();
-    std::string GetEncodedUrl(); // should return encoded url
-    std::map<std::string, std::string> GetHeaders();
+    HttpMethod GetMethod() const;
+    std::string GetEncodedUrl() const; // should return encoded url
+    std::map<std::string, std::string> GetHeaders() const;
     BodyStream* GetBodyStream();
     std::vector<uint8_t> const& GetBodyBuffer();
   };

--- a/sdk/core/azure-core/src/http/curl/curl_transport.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl_transport.cpp
@@ -47,7 +47,7 @@ CURLcode CurlTransport::Perform(Context& context, Request& request)
 
   if (request.GetMethod() == HttpMethod::Get)
   {
-    settingUp = curl_easy_setopt(m_pCurl, CURLOPT_HTTPGET);
+    settingUp = curl_easy_setopt(m_pCurl, CURLOPT_HTTPGET, 1L);
   }
   else if (request.GetMethod() == HttpMethod::Put)
   {

--- a/sdk/core/azure-core/src/http/curl/curl_transport.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl_transport.cpp
@@ -45,6 +45,33 @@ CURLcode CurlTransport::Perform(Context& context, Request& request)
     return settingUp;
   }
 
+  if (request.GetMethod() == HttpMethod::Get)
+  {
+    settingUp = curl_easy_setopt(m_pCurl, CURLOPT_HTTPGET);
+  }
+  else if (request.GetMethod() == HttpMethod::Put)
+  {
+    settingUp = curl_easy_setopt(m_pCurl, CURLOPT_PUT, 1L);
+  }
+  else
+  {
+    settingUp
+        = curl_easy_setopt(m_pCurl, CURLOPT_CUSTOMREQUEST, HttpMethodToString(request.GetMethod()).data());
+  }
+  if (settingUp != CURLE_OK)
+  {
+    return settingUp;
+  }
+
+  if (request.GetMethod() == HttpMethod::Head)
+  {
+    settingUp = curl_easy_setopt(m_pCurl, CURLOPT_NOBODY, 1L);
+    if (settingUp != CURLE_OK)
+    {
+      return settingUp;
+    }
+  }
+
   settingUp = SetHeaders(request);
   if (settingUp != CURLE_OK)
   {

--- a/sdk/core/azure-core/src/http/request.cpp
+++ b/sdk/core/azure-core/src/http/request.cpp
@@ -42,9 +42,9 @@ void Request::StartRetry()
   this->m_retryHeaders.clear();
 }
 
-HttpMethod Request::GetMethod() { return this->_method; }
+HttpMethod Request::GetMethod() const { return this->_method; }
 
-std::string Request::GetEncodedUrl()
+std::string Request::GetEncodedUrl() const
 {
   if (this->m_queryParameters.size() == 0 && this->m_retryQueryParameters.size() == 0)
   {
@@ -63,7 +63,7 @@ std::string Request::GetEncodedUrl()
   return _url + queryString;
 }
 
-std::map<std::string, std::string> Request::GetHeaders()
+std::map<std::string, std::string> Request::GetHeaders() const
 {
   // create map with retry headers witch are the most important and we don't want
   // to override them with any duplicate header


### PR DESCRIPTION
1. HTTP methods besides GET
2. const qualifiers

Note that POST/PUT data  is still not supported.