### PR TITLE
Add constructor for HttpPipeline which accepts rvalue

### DIFF
--- a/sdk/core/azure-core/inc/http/pipeline.hpp
+++ b/sdk/core/azure-core/inc/http/pipeline.hpp
@@ -17,13 +17,18 @@ namespace Azure { namespace Core { namespace Http {
     std::vector<std::unique_ptr<HttpPolicy>> m_policies;
 
   public:
-    HttpPipeline(std::vector<std::unique_ptr<HttpPolicy>>& policies)
+    explicit HttpPipeline(const std::vector<std::unique_ptr<HttpPolicy>>& policies)
     {
       m_policies.reserve(policies.size());
       for (auto&& policy : policies)
       {
         m_policies.emplace_back(policy->Clone());
       }
+    }
+
+    explicit HttpPipeline(std::vector<std::unique_ptr<HttpPolicy>>&& policies)
+        : m_policies(std::move(policies))
+    {
     }
 
     HttpPipeline(const HttpPipeline& other)


### PR DESCRIPTION
This reduced one copy when constructing HttpPipeline from a vector of policies. We've talked about this in the meeting on June 2.