### PR TITLE
adding host header automatically if missing for libcurl transport

### DIFF
--- a/sdk/core/azure-core/inc/http/http.hpp
+++ b/sdk/core/azure-core/inc/http/http.hpp
@@ -193,6 +193,7 @@ namespace Azure { namespace Core { namespace Http {
       return this->m_scheme + "://" + this->m_host + port + this->m_path; // TODO: add query params
     }
     std::string GetPath() const { return this->m_path; }
+    std::string GetHost() const { return this->m_host; }
     std::map<std::string, std::string> GetQueryParameters() const
     {
       return this->m_queryParameters;
@@ -259,6 +260,7 @@ namespace Azure { namespace Core { namespace Http {
     // Methods used by transport layer (and logger) to send request
     HttpMethod GetMethod() const;
     std::string GetEncodedUrl() const; // should call URL encode
+    std::string GetHost() const;
     std::map<std::string, std::string> GetHeaders() const;
     BodyStream* GetBodyStream();
     std::string GetHTTPMessagePreBody() const;

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -45,6 +45,17 @@ CURLcode CurlSession::Perform(Context& context)
     return settingUp;
   }
 
+  // Make sure host is set
+  // TODO-> use isEqualNoCase here once it is merged
+  {
+    auto headers = this->m_request.GetHeaders();
+    auto hostHeader = headers.find("Host");
+    if (hostHeader == headers.end())
+    {
+      this->m_request.AddHeader("Host", this->m_request.GetHost());
+    }
+  }
+
   settingUp = SetConnectOnly();
   if (settingUp != CURLE_OK)
   {

--- a/sdk/core/azure-core/src/http/request.cpp
+++ b/sdk/core/azure-core/src/http/request.cpp
@@ -69,6 +69,8 @@ std::string Request::GetEncodedUrl() const
   return m_url.ToString() + GetQueryString();
 }
 
+std::string Request::GetHost() const { return m_url.GetHost(); }
+
 std::map<std::string, std::string> Request::GetHeaders() const
 {
   // create map with retry headers witch are the most important and we don't want

--- a/sdk/samples/http_client/curl/src/azure_core_with_curl_bodyStream.cpp
+++ b/sdk/samples/http_client/curl/src/azure_core_with_curl_bodyStream.cpp
@@ -9,12 +9,12 @@
 
 #include "http/pipeline.hpp"
 
+#include <array>
 #include <http/curl/curl.hpp>
 #include <http/http.hpp>
 #include <iostream>
 #include <memory>
 #include <vector>
-#include <array>
 
 using namespace Azure::Core;
 using namespace Azure::Core::Http;
@@ -121,7 +121,6 @@ Http::Request createPutRequest()
   request.AddHeader("other", "header2");
   request.AddHeader("header", "value");
 
-  request.AddHeader("Host", "httpbin.org");
   request.AddHeader("Content-Length", std::to_string(BufferSize));
 
   return request;
@@ -148,7 +147,6 @@ Http::Request createPutStreamRequest()
   request.AddHeader("other", "header2");
   request.AddHeader("header", "value");
 
-  request.AddHeader("Host", "httpbin.org");
   request.AddHeader("Content-Length", std::to_string(StreamSize));
 
   request.AddQueryParameter("dinamicArg", "1");


### PR DESCRIPTION
related to: https://github.com/Azure/azure-sdk-for-cpp/issues/198

This changes makes sure Host Header is automatically added (if it was not manually added) in libcurl transport