### PR TITLE
support for no-path requests

### DIFF
--- a/sdk/core/azure-core/inc/http/http.hpp
+++ b/sdk/core/azure-core/inc/http/http.hpp
@@ -185,12 +185,14 @@ namespace Azure { namespace Core { namespace Http {
     URL(std::string const& url);
     void AppendPath(std::string const& path)
     {
-      this->m_path += "/" + path; // TODO: check if the path already finish with a /
+      // Constructor makes sure path never keeps slash at the end so we can feel OK on adding slash
+      // on every append path
+      this->m_path += "/" + path;
     }
     std::string ToString() const
     {
       auto port = this->m_port.size() > 0 ? ":" + this->m_port : "";
-      return this->m_scheme + "://" + this->m_host + port + this->m_path; // TODO: add query params
+      return this->m_scheme + "://" + this->m_host + port + this->m_path;
     }
     std::string GetPath() const { return this->m_path; }
     std::map<std::string, std::string> GetQueryParameters() const

--- a/sdk/core/azure-core/src/http/request.cpp
+++ b/sdk/core/azure-core/src/http/request.cpp
@@ -85,7 +85,9 @@ std::string Request::GetHTTPMessagePreBody() const
   std::string httpRequest(HttpMethodToString(this->m_method));
   // origin-form. TODO: parse URL to split host from path and use it here instead of empty
   // HTTP version harcoded to 1.0
-  httpRequest += " " + this->m_url.GetPath() + GetQueryString() + " HTTP/1.1\r\n";
+  auto path = this->m_url.GetPath();
+  path = path.size() > 0 ? path : "/";
+  httpRequest += " " + path + GetQueryString() + " HTTP/1.1\r\n";
   // headers
   for (auto header : this->GetHeaders())
   {

--- a/sdk/core/azure-core/src/http/url.cpp
+++ b/sdk/core/azure-core/src/http/url.cpp
@@ -50,8 +50,20 @@ URL::URL(std::string const& url)
 
   // Path
   this->m_path = std::string(start, endOfUrl);
-  if (this->m_path.size() > 0)
+  auto pathSize = this->m_path.size();
+  if (pathSize > 0)
   {
+    auto pathLast = pathSize - 1;
+    // remove any slashes from the end
+    for (unsigned long index = 0; index <= pathLast; index++)
+    {
+      if (this->m_path[pathLast - index] != '/')
+      {
+        this->m_path = this->m_path.substr(0, pathSize - index);
+        break;
+      }
+    }
+
     this->m_path = "/" + this->m_path;
   }
 }

--- a/sdk/samples/http_client/curl/src/azure_core_with_curl_bodyStream.cpp
+++ b/sdk/samples/http_client/curl/src/azure_core_with_curl_bodyStream.cpp
@@ -9,12 +9,12 @@
 
 #include "http/pipeline.hpp"
 
+#include <array>
 #include <http/curl/curl.hpp>
 #include <http/http.hpp>
 #include <iostream>
 #include <memory>
 #include <vector>
-#include <array>
 
 using namespace Azure::Core;
 using namespace Azure::Core::Http;
@@ -29,6 +29,7 @@ constexpr auto StreamSize = 200;
 std::array<uint8_t, StreamSize> bufferStream;
 
 Http::Request createGetRequest();
+Http::Request createNoPathGetRequest();
 Http::Request createPutRequest();
 Http::Request createPutStreamRequest();
 void printStream(std::unique_ptr<Http::Response> response);
@@ -39,6 +40,8 @@ int main()
   {
     // GetRequest. No body, produces stream
     auto getRequest = createGetRequest();
+    // no path request
+    auto noPathRequest = createNoPathGetRequest();
     // PutRequest. buffer body, produces stream
     auto putRequest = createPutRequest();
     // PutRequest. Stream body, produces stream
@@ -69,6 +72,9 @@ int main()
 
     response = httpPipeline.Send(context, putStreamRequest);
     printStream(std::move(response));
+
+    response = httpPipeline.Send(context, noPathRequest);
+    printStream(std::move(response));
   }
   catch (Http::CouldNotResolveHostException& e)
   {
@@ -82,10 +88,22 @@ int main()
   return 0;
 }
 
+// Request GET with no path
+Http::Request createNoPathGetRequest()
+{
+  string host("https://httpbin.org");
+  cout << "Creating a GET request to" << endl << "Host: " << host << endl;
+
+  auto request = Http::Request(Http::HttpMethod::Get, host);
+  request.AddHeader("Host", "httpbin.org");
+
+  return request;
+}
+
 // Request GET with no body that produces stream response
 Http::Request createGetRequest()
 {
-  string host("https://httpbin.org/get?arg=1&arg2=2");
+  string host("https://httpbin.org/get//////?arg=1&arg2=2");
   cout << "Creating a GET request to" << endl << "Host: " << host << endl;
 
   auto request = Http::Request(Http::HttpMethod::Get, host);
@@ -104,7 +122,7 @@ Http::Request createGetRequest()
 // Put Request with bodyBufferBody that produces stream
 Http::Request createPutRequest()
 {
-  string host("https://httpbin.org/put?a=1");
+  string host("https://httpbin.org/put/?a=1");
   cout << "Creating a PUT request to" << endl << "Host: " << host << endl;
 
   std::fill(buffer.begin(), buffer.end(), 'x');


### PR DESCRIPTION
for requests with no path, make libcurl transport to add slash in the raw request.

related to: https://github.com/Azure/azure-sdk-for-cpp/issues/198