### PR TITLE
Adding toLower for header names

### DIFF
--- a/sdk/core/azure-core/src/http/request.cpp
+++ b/sdk/core/azure-core/src/http/request.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
+#include <azure.hpp>
 #include <http/http.hpp>
 #include <map>
 #include <string>
@@ -25,14 +26,15 @@ void Request::AddQueryParameter(std::string const& name, std::string const& valu
 
 void Request::AddHeader(std::string const& name, std::string const& value)
 {
+  auto headerNameLowerCase = Azure::Core::Details::ToLower(name);
   if (this->m_retryModeEnabled)
   {
     // When retry mode is ON, any new value must override previous
-    this->m_retryHeaders[name] = value;
+    this->m_retryHeaders[headerNameLowerCase] = value;
   }
   else
   {
-    this->m_headers.insert(std::pair<std::string, std::string>(name, value));
+    this->m_headers.insert(std::pair<std::string, std::string>(headerNameLowerCase, value));
   }
 }
 

--- a/sdk/core/azure-core/src/http/response.cpp
+++ b/sdk/core/azure-core/src/http/response.cpp
@@ -30,8 +30,7 @@ void Response::AddHeader(uint8_t const* const begin, uint8_t const* const last)
   }
 
   // Always toLower() headers
-  // auto headerName = Azure::Core::Details::ToLower(std::string(start, end));
-  auto headerName = std::string(start, end);
+  auto headerName = Azure::Core::Details::ToLower(std::string(start, end));
   start = end + 1; // start value
   while (start < last && (*start == ' ' || *start == '\t'))
   {

--- a/sdk/core/azure-core/test/ut/http.cpp
+++ b/sdk/core/azure-core/test/ut/http.cpp
@@ -19,11 +19,12 @@ TEST(Http_Request, getters)
       [](Http::HttpMethod a, Http::HttpMethod b) { return a == b; }, req.GetMethod(), httpMethod);
   EXPECT_PRED2([](std::string a, std::string b) { return a == b; }, req.GetEncodedUrl(), url);
 
-  EXPECT_NO_THROW(req.AddHeader("name", "value"));
-  EXPECT_NO_THROW(req.AddHeader("name2", "value2"));
+  EXPECT_NO_THROW(req.AddHeader("Name", "value"));
+  EXPECT_NO_THROW(req.AddHeader("naME2", "value2"));
 
   auto headers = req.GetHeaders();
 
+  // Headers should be lower-cased
   EXPECT_TRUE(headers.count("name"));
   EXPECT_TRUE(headers.count("name2"));
   EXPECT_FALSE(headers.count("newHeader"));
@@ -36,21 +37,21 @@ TEST(Http_Request, getters)
   // now add to retry headers
   req.StartRetry();
   // same headers first, then one new
-  EXPECT_NO_THROW(req.AddHeader("name", "retryValue"));
-  EXPECT_NO_THROW(req.AddHeader("name2", "retryValue2"));
+  EXPECT_NO_THROW(req.AddHeader("namE", "retryValue"));
+  EXPECT_NO_THROW(req.AddHeader("HEADER-to-Lower-123", "retryValue2"));
   EXPECT_NO_THROW(req.AddHeader("newHeader", "new"));
 
   headers = req.GetHeaders();
 
   EXPECT_TRUE(headers.count("name"));
-  EXPECT_TRUE(headers.count("name2"));
-  EXPECT_TRUE(headers.count("newHeader"));
+  EXPECT_TRUE(headers.count("header-to-lower-123"));
+  EXPECT_TRUE(headers.count("newheader"));
 
   value = headers.find("name");
   EXPECT_PRED2([](std::string a, std::string b) { return a == b; }, value->second, "retryValue");
-  value2 = headers.find("name2");
+  value2 = headers.find("header-to-lower-123");
   EXPECT_PRED2([](std::string a, std::string b) { return a == b; }, value2->second, "retryValue2");
-  auto value3 = headers.find("newHeader");
+  auto value3 = headers.find("newheader");
   EXPECT_PRED2([](std::string a, std::string b) { return a == b; }, value3->second, "new");
 }
 

--- a/sdk/core/azure-core/test/ut/string.cpp
+++ b/sdk/core/azure-core/test/ut/string.cpp
@@ -19,3 +19,19 @@ TEST(String, invariantCompare)
   EXPECT_FALSE(LocaleInvariantCaseInsensitiveEqual("a", "aA"));
   EXPECT_FALSE(LocaleInvariantCaseInsensitiveEqual("abc", "abcd"));
 }
+
+TEST(String, toLower)
+{
+  using Azure::Core::Details::ToLower;
+  EXPECT_TRUE(ToLower("") == "");
+  EXPECT_TRUE(ToLower("a") == "a");
+  EXPECT_TRUE(ToLower("A") == "a");
+  EXPECT_TRUE(ToLower("AA") == "aa");
+  EXPECT_TRUE(ToLower("aA") == "aa");
+  EXPECT_TRUE(ToLower("ABC") == "abc");
+  EXPECT_TRUE(ToLower("ABC-1-,!@#$%^&*()_+=ABC") == "abc-1-,!@#$%^&*()_+=abc");
+  EXPECT_FALSE(ToLower("") == "a");
+  EXPECT_FALSE(ToLower("a") == "");
+  EXPECT_FALSE(ToLower("a") == "aA");
+  EXPECT_FALSE(ToLower("abc") == "abcd");
+}


### PR DESCRIPTION
This is a breaking change for Storage at run time,

@katmsft @JinmingHu-MSFT please fix storage code to expect header names to always be lowerCase