### PR TITLE
add CMakeLists.txt and eng to CI and PR triggers

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -7,8 +7,9 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - sdk/core
       - eng/
+      - CMakeLists.txt
+      - sdk/core
 
 pr:
   branches:
@@ -19,8 +20,9 @@ pr:
       - hotfix/*
   paths:
     include:
-      - sdk/core/
       - eng/
+      - CMakeLists.txt
+      - sdk/core
 
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -7,6 +7,8 @@ trigger:
       - hotfix/*
   paths:
     include:
+      - eng/
+      - CMakeLists.txt
       - sdk/core
       - sdk/storage
 
@@ -19,6 +21,8 @@ pr:
       - hotfix/*
   paths:
     include:
+      - eng/
+      - CMakeLists.txt
       - sdk/core/
       - sdk/storage
 


### PR DESCRIPTION
Adds trigger criteria for CMakeLists.txt to all current pipelines. This should be a template going forward. Also add `eng` to storage (it's already included in core) 