### PR TITLE
Remove MD5 and CRC64 function interface

### DIFF
--- a/sdk/storage/inc/common/crypt.hpp
+++ b/sdk/storage/inc/common/crypt.hpp
@@ -10,7 +10,5 @@ namespace Azure { namespace Storage {
   std::string HMAC_SHA256(const std::string& text, const std::string& key);
   std::string Base64Encode(const std::string& text);
   std::string Base64Decode(const std::string& text);
-  std::string MD5(const std::string& text);
-  std::string CRC64(const std::string& text);
 
 }} // namespace Azure::Storage


### PR DESCRIPTION
Since we haven't implemented them yet, we'll just remove them for now to avoid misunderstanding. We'll add them back when we have implementation.