### PR TITLE
Added API to extract raw response.

### DIFF
--- a/sdk/core/azure-core/inc/response.hpp
+++ b/sdk/core/azure-core/inc/response.hpp
@@ -29,5 +29,10 @@ namespace Azure { namespace Core {
     const T& operator*() const { return this->m_value; };
 
     T ExtractValue() { return std::move(this->m_value); }
+
+    std::unique_ptr<Http::RawResponse> ExtractRawResponse()
+    {
+      return std::move(this->m_rawResponse);
+    }
   };
 }} // namespace Azure::Core

--- a/sdk/core/azure-core/inc/response.hpp
+++ b/sdk/core/azure-core/inc/response.hpp
@@ -21,16 +21,14 @@ namespace Azure { namespace Core {
     // Do not give up raw response ownership.
     Http::RawResponse& GetRawResponse() { return *this->m_rawResponse; }
 
-    T& operator=(const Response& other) = delete;
-
     const T* operator->() const { return &this->m_value; };
     T* operator->() { return &this->m_value; };
     T& operator*() { return this->m_value; };
     const T& operator*() const { return this->m_value; };
 
-    T ExtractValue() { return std::move(this->m_value); }
+    T&& ExtractValue() { return std::move(this->m_value); }
 
-    std::unique_ptr<Http::RawResponse> ExtractRawResponse()
+    std::unique_ptr<Http::RawResponse>&& ExtractRawResponse()
     {
       return std::move(this->m_rawResponse);
     }


### PR DESCRIPTION
This is needed because in the convenience layer, some APIs will reconstruct the returned Response<T> object. Without the API the convenience layer have to make a copy of the existing RawResponse, which introduces unneeded memory copy.
E.g: https://github.com/Azure/azure-sdk-for-cpp/blob/master/sdk/storage/src/datalake/path_client.cpp#L290