### PR TITLE
Updates to Context/ContextSharedState

### DIFF
--- a/sdk/core/azure-core/inc/context.hpp
+++ b/sdk/core/azure-core/inc/context.hpp
@@ -173,13 +173,13 @@ namespace Azure { namespace Core {
 
     Context& operator=(const Context&) = default;
 
-    Context WithDeadline(time_point cancelWhen)
+    Context WithDeadline(time_point cancelWhen) const
     {
       return Context{std::make_shared<ContextSharedState>(
           m_contextSharedState, cancelWhen, std::string(), ContextValue{})};
     }
 
-    Context WithValue(const std::string& key, ContextValue&& value)
+    Context WithValue(const std::string& key, ContextValue&& value) const
     {
       return Context{std::make_shared<ContextSharedState>(
           m_contextSharedState, time_point::max(), key, std::move(value))};
@@ -187,7 +187,7 @@ namespace Azure { namespace Core {
 
     time_point CancelWhen() const;
 
-    const ContextValue& operator[](const std::string& key)
+    const ContextValue& operator[](const std::string& key) const
     {
       if (!key.empty())
       {
@@ -204,7 +204,7 @@ namespace Azure { namespace Core {
       return empty;
     }
 
-    bool HasKey(const std::string& key)
+    bool HasKey(const std::string& key) const
     {
       if (!key.empty())
       {

--- a/sdk/core/azure-core/inc/context.hpp
+++ b/sdk/core/azure-core/inc/context.hpp
@@ -195,7 +195,7 @@ namespace Azure { namespace Core {
     {
       if (!key.empty())
       {
-        for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)
+        for (auto ptr = m_contextSharedState.get(); ptr; ptr = ptr->Parent.get())
         {
           if (ptr->Key == key)
           {
@@ -212,7 +212,7 @@ namespace Azure { namespace Core {
     {
       if (!key.empty())
       {
-        for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)
+        for (auto ptr = m_contextSharedState.get(); ptr; ptr = ptr->Parent.get())
         {
           if (ptr->Key == key)
           {

--- a/sdk/core/azure-core/inc/context.hpp
+++ b/sdk/core/azure-core/inc/context.hpp
@@ -146,10 +146,10 @@ namespace Azure { namespace Core {
     struct ContextSharedState
     {
       std::shared_ptr<ContextSharedState> Parent;
-      time_point CancelAt; // access guarded by Mtx
+      time_point CancelAt; // access guarded by Mutex
       std::string Key;
       ContextValue Value;
-      mutable std::mutex Mtx;
+      mutable std::mutex Mutex;
 
       explicit ContextSharedState() : CancelAt(time_point::max()) {}
 
@@ -225,7 +225,7 @@ namespace Azure { namespace Core {
 
     void Cancel()
     {
-      std::lock_guard<std::mutex> guard{m_contextSharedState->Mtx};
+      std::lock_guard<std::mutex> guard{m_contextSharedState->Mutex};
       m_contextSharedState->CancelAt = time_point::min();
     }
 

--- a/sdk/core/azure-core/inc/context.hpp
+++ b/sdk/core/azure-core/inc/context.hpp
@@ -154,11 +154,11 @@ namespace Azure { namespace Core {
       explicit ContextSharedState() : CancelAt(time_point::max()) {}
 
       explicit ContextSharedState(
-          const std::shared_ptr<ContextSharedState>& parent,
+          std::shared_ptr<ContextSharedState> parent,
           time_point cancelAt,
           const std::string& key,
           ContextValue&& value)
-          : Parent(parent), CancelAt(cancelAt), Key(key), Value(std::move(value))
+          : Parent(std::move(parent)), CancelAt(cancelAt), Key(key), Value(std::move(value))
       {
       }
 

--- a/sdk/core/azure-core/inc/context.hpp
+++ b/sdk/core/azure-core/inc/context.hpp
@@ -232,10 +232,7 @@ namespace Azure { namespace Core {
       return false;
     }
 
-    void Cancel()
-    {
-      m_contextSharedState->CancelNow();
-    }
+    void Cancel() { m_contextSharedState->CancelNow(); }
 
     void ThrowIfCanceled() const
     {

--- a/sdk/core/azure-core/src/context.cpp
+++ b/sdk/core/azure-core/src/context.cpp
@@ -21,7 +21,7 @@ inline time_point Context::ContextSharedState::GetCancelAt() const
 time_point Context::CancelWhen() const
 {
   auto result = time_point::max();
-  for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)
+  for (auto ptr = m_contextSharedState.get(); ptr; ptr = ptr->Parent.get())
   {
     const auto tmp = ptr->GetCancelAt();
     if (result > tmp)

--- a/sdk/core/azure-core/src/context.cpp
+++ b/sdk/core/azure-core/src/context.cpp
@@ -12,14 +12,21 @@ Context& Azure::Core::GetApplicationContext()
   return ctx;
 }
 
+inline time_point Context::ContextSharedState::GetCancelAt() const
+{
+  std::lock_guard<std::mutex> guard{Mtx};
+  return CancelAt;
+}
+
 time_point Context::CancelWhen() const
 {
   auto result = time_point::max();
   for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)
   {
-    if (result > ptr->CancelAt)
+    const auto tmp = ptr->GetCancelAt();
+    if (result > tmp)
     {
-      result = ptr->CancelAt;
+      result = tmp;
     }
   }
 

--- a/sdk/core/azure-core/src/context.cpp
+++ b/sdk/core/azure-core/src/context.cpp
@@ -14,7 +14,7 @@ Context& Azure::Core::GetApplicationContext()
 
 inline time_point Context::ContextSharedState::GetCancelAt() const
 {
-  std::lock_guard<std::mutex> guard{Mtx};
+  std::lock_guard<std::mutex> guard{Mutex};
   return CancelAt;
 }
 

--- a/sdk/storage/src/common/storage_uri_builder.cpp
+++ b/sdk/storage/src/common/storage_uri_builder.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <iterator>
 #include <vector>
 
 namespace Azure { namespace Storage {


### PR DESCRIPTION
Per discussion on 2020-07-28: Casey to `const`-qualify non-mutating member functions of `Context` and provide mutual exclusion for accesses to `Context::ContextSharedState::CancelAt`. 

There are also some drive-by changes. Two micro-optimizations:

  1. `ContextSharedState` accepts a `shared_ptr` argument by `const&` and makes a copy, increasing its reference count. This is suboptimal when the argument is an rvalue, which we could move into `ContextSharedState::parent` without touching reference counts. If the constructor is changed to instead take the `shared_ptr` by value and move it into `parent` then the caller will make a copy when the argument is an lvalue and no one makes a copy when the argument is an rvalue - optimally handling both cases.

  2. Several functions (`Context::operator[]`, `Context::HasKey`, and `Context::CancelWhen`) iterate over the chain of `parent` pointers rooted in the `Context`'s associated `ContextSharedState` member `m_contextSharedState`. They do so by using a `shared_ptr` iteration variable into which successive `shared_ptr` values from the chain of `parent`s are copied. Each of these `shared_ptr` copy assignments decreases the reference count of the old value and increases the reference count of the new value. However, the chain of parent pointers cannot be modified while we iterate over it so the reference count manipulation is unnecessary. If we instead use a raw pointer for the iteration variable and assign it successive values of `parent->get()` we can iterate the same sequence of parent objects more cheaply.

and one minor correctness fix:

  1. `storage_uri_builder.cpp` calls `std::back_inserter` without including the associated header `<iterator>`. This may compile - a standard library header may transitively include other headers - but is subject to breaking with different Standard Libraries or future versions. Including `<iterator>` is the obvious fix.
  
I've added no test coverage since these are modifications to existing behavior and not additions of behavior.