### PR TITLE
fix clang warnings on e2e tests

### DIFF
--- a/sdk/core/azure-core/test/e2e/azure_core_with_curl_bodyBuffer.cpp
+++ b/sdk/core/azure-core/test/e2e/azure_core_with_curl_bodyBuffer.cpp
@@ -145,7 +145,7 @@ void doGetRequest(Context const& context, HttpPipeline& pipeline)
   request.AddHeader("Host", "httpbin.org");
 
   cout << endl << "GET:";
-  printRespose(std::move(pipeline.Send(context, request)));
+  printRespose(pipeline.Send(context, request));
 }
 
 void doPutRequest(Context const& context, HttpPipeline& pipeline)
@@ -171,7 +171,7 @@ void doPutRequest(Context const& context, HttpPipeline& pipeline)
   request.AddHeader("Host", "httpbin.org");
   request.AddHeader("Content-Length", std::to_string(BufferSize));
 
-  printRespose(std::move(pipeline.Send(context, request)));
+  printRespose(pipeline.Send(context, request));
 }
 
 void printRespose(std::unique_ptr<Http::RawResponse> response)
@@ -218,7 +218,7 @@ void doPatchRequest(Context const& context, HttpPipeline& pipeline)
   request.AddHeader("Host", "httpbin.org");
 
   cout << endl << "PATCH:";
-  printRespose(std::move(pipeline.Send(context, request)));
+  printRespose(pipeline.Send(context, request));
 }
 
 void doDeleteRequest(Context const& context, HttpPipeline& pipeline)
@@ -230,7 +230,7 @@ void doDeleteRequest(Context const& context, HttpPipeline& pipeline)
   request.AddHeader("Host", "httpbin.org");
 
   cout << endl << "DELETE:";
-  printRespose(std::move(pipeline.Send(context, request)));
+  printRespose(pipeline.Send(context, request));
 }
 
 void doHeadRequest(Context const& context, HttpPipeline& pipeline)
@@ -242,5 +242,5 @@ void doHeadRequest(Context const& context, HttpPipeline& pipeline)
   request.AddHeader("Host", "httpbin.org");
 
   cout << endl << "HEAD:";
-  printRespose(std::move(pipeline.Send(context, request)));
+  printRespose(pipeline.Send(context, request));
 }

--- a/sdk/core/azure-core/test/e2e/azure_core_with_curl_bodyStream.cpp
+++ b/sdk/core/azure-core/test/e2e/azure_core_with_curl_bodyStream.cpp
@@ -82,7 +82,7 @@ void doNoPathGetRequest(Context const& context, HttpPipeline& pipeline)
   auto request = Http::Request(Http::HttpMethod::Get, host);
   request.AddHeader("Host", "httpbin.org");
 
-  printStream(context, std::move(pipeline.Send(context, request)));
+  printStream(context, pipeline.Send(context, request));
 }
 
 // Request GET with no body that produces stream response
@@ -128,7 +128,7 @@ void doPutRequest(Context const& context, HttpPipeline& pipeline)
 
   request.AddHeader("Content-Length", std::to_string(BufferSize));
 
-  printStream(context, std::move(pipeline.Send(context, request)));
+  printStream(context, pipeline.Send(context, request));
 }
 
 // Put Request with stream body that produces stream
@@ -159,7 +159,7 @@ void doPutStreamRequest(Context const& context, HttpPipeline& pipeline)
   request.AddQueryParameter("dynamicArg2", "1");
   request.AddQueryParameter("dynamicArg3", "1");
 
-  printStream(context, std::move(pipeline.Send(context, request)));
+  printStream(context, pipeline.Send(context, request));
 }
 
 void printStream(Context const& context, std::unique_ptr<Http::RawResponse> response)
@@ -172,7 +172,7 @@ void printStream(Context const& context, std::unique_ptr<Http::RawResponse> resp
   }
 
   cout << static_cast<typename std::underlying_type<Http::HttpStatusCode>::type>(
-              response->GetStatusCode())
+      response->GetStatusCode())
        << endl;
   cout << response->GetReasonPhrase() << endl;
   cout << "headers:" << endl;


### PR DESCRIPTION
Had this fixes locally only. I wanted to merge at some point.

People using clang on Linux would find this issue at some point