### PR TITLE
Reuse connection when calling ReadToCount()

### DIFF
--- a/sdk/core/azure-core/inc/http/curl/curl.hpp
+++ b/sdk/core/azure-core/inc/http/curl/curl.hpp
@@ -409,7 +409,9 @@ namespace Azure { namespace Core { namespace Http {
     {
       // mark connection as reusable only if entire response was read
       // If not, connection can't be reused because next Read will start from what it is currently
-      // in the wire. We leave the connection blocked until Server closes the connection
+      // in the wire.
+      // By not moving the connection back to the pool, it gets destroyed calling the connection
+      // destructor to clean libcurl handle and close the connection.
       if (IsEOF())
       {
         MoveConnectionBackToPool(std::move(this->m_connection));

--- a/sdk/core/azure-core/inc/http/curl/curl.hpp
+++ b/sdk/core/azure-core/inc/http/curl/curl.hpp
@@ -374,6 +374,12 @@ namespace Azure { namespace Core { namespace Http {
      */
     int64_t ReadSocketToBuffer(uint8_t* buffer, int64_t bufferSize);
 
+    bool IsEOF()
+    {
+      return this->m_isChunkedResponseType ? this->m_chunkSize == 0
+                                           : this->m_contentLength == this->m_sessionTotalRead;
+    }
+
   public:
 #ifdef TESTING_BUILD
     // Makes possible to know the number of current connections in the connection pool
@@ -430,12 +436,6 @@ namespace Azure { namespace Core { namespace Http {
     int64_t Length() const override { return this->m_contentLength; }
 
     int64_t Read(Azure::Core::Context const& context, uint8_t* buffer, int64_t count) override;
-
-    bool IsEOF()
-    {
-      return this->m_isChunkedResponseType ? this->m_chunkSize == 0
-                                           : this->m_contentLength == this->m_sessionTotalRead;
-    }
   };
 
   /**

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -453,8 +453,9 @@ int64_t CurlSession::Read(Azure::Core::Context const& context, uint8_t* buffer, 
   }
 
   auto totalRead = int64_t();
-  auto readRequestLength
-      = this->m_isChunkedResponseType ? std::min(this->m_chunkSize, count) : count;
+  auto readRequestLength = this->m_isChunkedResponseType
+      ? std::min(this->m_chunkSize - this->m_sessionTotalRead, count)
+      : count;
 
   // For responses with content-length, avoid trying to read beyond Content-length or
   // libcurl could return a second response as BadRequest.


### PR DESCRIPTION
Fixing the case when customer knows the size of the downloaded blob stream and calls ReadToCount(..) asking for the specific size to be pulled.
In this case, the EOF flag was not updated at the end of reading all because it it updated until user try to read again.

Fixing this by removing EOF state and adding IsEOF function to check both chunked and non-chunked responses.

Fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/446