### PR TITLE
Fix for connection re-use on response error

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
@@ -109,6 +109,8 @@ namespace Azure { namespace Core { namespace Http {
 
     static int32_t s_connectionCounter;
     static bool s_isCleanConnectionsRunning;
+    // Removes all connections and indexes
+    static void ClearIndex() { CurlConnectionPool::s_connectionPoolIndex.clear(); }
 
     // Makes possible to know the number of current connections in the connection pool for an
     // index
@@ -483,7 +485,8 @@ namespace Azure { namespace Core { namespace Http {
       // destructor to clean libcurl handle and close the connection.
       if (this->IsEOF())
       {
-        CurlConnectionPool::MoveConnectionBackToPool(std::move(this->m_connection), this->m_lastStatusCode);
+        CurlConnectionPool::MoveConnectionBackToPool(
+            std::move(this->m_connection), this->m_lastStatusCode);
       }
     }
 

--- a/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
@@ -431,7 +431,7 @@ namespace Azure { namespace Core { namespace Http {
      *
      * @return CURL_OK when an HTTP response is created.
      */
-    void ReadStatusLineAndHeadersFromRawResponse();
+    void ReadStatusLineAndHeadersFromRawResponse(bool reUseInternalBUffer = false);
 
     /**
      * @brief Reads from inner buffer or from Wire until chunkSize is parsed and converted to

--- a/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
@@ -454,6 +454,14 @@ namespace Azure { namespace Core { namespace Http {
                                            : this->m_contentLength == this->m_sessionTotalRead;
     }
 
+    /**
+     * @brief The status code from the last request performed in the session. A connection is closed
+     * when server response code is equal or greater to 300 (error response.). For that cases, the
+     * connection from the session should not be re-used.
+     *
+     */
+    Http::HttpStatusCode m_lastResponseCode;
+
   public:
     /**
      * @brief Construct a new Curl Session object. Init internal libcurl handler.
@@ -477,7 +485,9 @@ namespace Azure { namespace Core { namespace Http {
       // in the wire.
       // By not moving the connection back to the pool, it gets destroyed calling the connection
       // destructor to clean libcurl handle and close the connection.
-      if (IsEOF())
+      auto lastStatusCode = static_cast<typename std::underlying_type<Http::HttpStatusCode>::type>(
+          this->m_lastResponseCode);
+      if (this->IsEOF() && lastStatusCode >= 200 && lastStatusCode < 300)
       {
         CurlConnectionPool::MoveConnectionBackToPool(std::move(this->m_connection));
       }

--- a/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
@@ -454,14 +454,6 @@ namespace Azure { namespace Core { namespace Http {
                                            : this->m_contentLength == this->m_sessionTotalRead;
     }
 
-    /**
-     * @brief The status code from the last request performed in the session. A connection is closed
-     * when server response code is equal or greater to 300 (error response.). For that cases, the
-     * connection from the session should not be re-used.
-     *
-     */
-    Http::HttpStatusCode m_lastResponseCode;
-
   public:
     /**
      * @brief Construct a new Curl Session object. Init internal libcurl handler.
@@ -485,8 +477,8 @@ namespace Azure { namespace Core { namespace Http {
       // in the wire.
       // By not moving the connection back to the pool, it gets destroyed calling the connection
       // destructor to clean libcurl handle and close the connection.
-      auto lastStatusCode = static_cast<typename std::underlying_type<Http::HttpStatusCode>::type>(
-          this->m_lastResponseCode);
+      int lastStatusCode = 0;
+      curl_easy_getinfo(this->m_connection->GetHandle(), CURLINFO_RESPONSE_CODE, &lastStatusCode);
       if (this->IsEOF() && lastStatusCode >= 200 && lastStatusCode < 300)
       {
         CurlConnectionPool::MoveConnectionBackToPool(std::move(this->m_connection));

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -811,7 +811,7 @@ std::unique_ptr<CurlConnection> CurlConnectionPool::GetCurlConnection(Request& r
       CurlConnectionPool::s_connectionCounter -= 1;
 
       // Remove index if there are no more connections
-      if (CurlConnectionPool::s_connectionPoolIndex.size() == 0)
+      if (hostPoolIndex->second.size() == 0)
       {
         CurlConnectionPool::s_connectionPoolIndex.erase(hostPoolIndex);
       }

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -109,7 +109,7 @@ CURLcode CurlSession::Perform(Context const& context)
 
   // Check server response from Expect:100-continue for PUT;
   // This help to prevent us from start uploading data when Server can't handle it
-  if (this->m_response->GetStatusCode() != HttpStatusCode::Continue)
+  if (this->m_lastResponseCode != HttpStatusCode::Continue)
   {
     return result; // Won't upload.
   }
@@ -356,6 +356,7 @@ void CurlSession::ReadStatusLineAndHeadersFromRawResponse()
   }
 
   this->m_response = parser.GetResponse();
+  this->m_lastResponseCode = this->m_response->GetStatusCode();
   this->m_innerBufferSize = static_cast<size_t>(bufferSize);
 
   // For Head request, set the length of body response to 0.
@@ -364,7 +365,7 @@ void CurlSession::ReadStatusLineAndHeadersFromRawResponse()
   // For NoContent status code, also need to set conentLength to 0.
   // https://github.com/Azure/azure-sdk-for-cpp/issues/406
   if (this->m_request.GetMethod() == HttpMethod::Head
-      || this->m_response->GetStatusCode() == Azure::Core::Http::HttpStatusCode::NoContent)
+      || this->m_lastResponseCode == Azure::Core::Http::HttpStatusCode::NoContent)
   {
     this->m_contentLength = 0;
     this->m_bodyStartInBuffer = -1;
@@ -830,15 +831,16 @@ std::unique_ptr<CurlConnection> CurlConnectionPool::GetCurlConnection(Request& r
   if (result != CURLE_OK)
   {
     throw std::runtime_error(
-        Details::c_DefaultFailedToGetNewConnectionTemplate + host + ". Could not set URL.");
+        Details::c_DefaultFailedToGetNewConnectionTemplate + host + ". "
+        + std::string(curl_easy_strerror(result)));
   }
 
   result = curl_easy_setopt(newConnection->GetHandle(), CURLOPT_CONNECT_ONLY, 1L);
   if (result != CURLE_OK)
   {
     throw std::runtime_error(
-        Details::c_DefaultFailedToGetNewConnectionTemplate + host
-        + ". Could not set connect only ON.");
+        Details::c_DefaultFailedToGetNewConnectionTemplate + host + ". "
+        + std::string(curl_easy_strerror(result)));
   }
 
   // curl_easy_setopt(newConnection->GetHandle(), CURLOPT_VERBOSE, 1L);
@@ -849,14 +851,16 @@ std::unique_ptr<CurlConnection> CurlConnectionPool::GetCurlConnection(Request& r
   if (result != CURLE_OK)
   {
     throw std::runtime_error(
-        Details::c_DefaultFailedToGetNewConnectionTemplate + host + ". Could not set timeout.");
+        Details::c_DefaultFailedToGetNewConnectionTemplate + host + ". "
+        + std::string(curl_easy_strerror(result)));
   }
 
   result = curl_easy_perform(newConnection->GetHandle());
   if (result != CURLE_OK)
   {
     throw std::runtime_error(
-        Details::c_DefaultFailedToGetNewConnectionTemplate + host + ". Could not open connection.");
+        Details::c_DefaultFailedToGetNewConnectionTemplate + host + ". "
+        + std::string(curl_easy_strerror(result)));
   }
   return newConnection;
 }

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -355,9 +355,9 @@ void CurlSession::ReadStatusLineAndHeadersFromRawResponse(bool reUseInternalBUff
     {
       // parse from internal buffer. This means previous read from server got more than one response.
       // This happens when Server returns a 100-continue plus an error code
+      bufferSize = this->m_innerBufferSize - this->m_bodyStartInBuffer;
       bytesParsed = parser.Parse(
-          this->m_readBuffer + this->m_bodyStartInBuffer,
-          static_cast<size_t>(this->m_innerBufferSize - this->m_bodyStartInBuffer));
+          this->m_readBuffer + this->m_bodyStartInBuffer, static_cast<size_t>(bufferSize));
       // if parsing from internal buffer is not enough, do next read from wire
       reUseInternalBUffer = false;
       // reset body start

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -109,7 +109,7 @@ CURLcode CurlSession::Perform(Context const& context)
 
   // Check server response from Expect:100-continue for PUT;
   // This help to prevent us from start uploading data when Server can't handle it
-  if (this->m_lastResponseCode != HttpStatusCode::Continue)
+  if (this->m_response->GetStatusCode() != HttpStatusCode::Continue)
   {
     return result; // Won't upload.
   }
@@ -356,7 +356,6 @@ void CurlSession::ReadStatusLineAndHeadersFromRawResponse()
   }
 
   this->m_response = parser.GetResponse();
-  this->m_lastResponseCode = this->m_response->GetStatusCode();
   this->m_innerBufferSize = static_cast<size_t>(bufferSize);
 
   // For Head request, set the length of body response to 0.
@@ -365,7 +364,7 @@ void CurlSession::ReadStatusLineAndHeadersFromRawResponse()
   // For NoContent status code, also need to set conentLength to 0.
   // https://github.com/Azure/azure-sdk-for-cpp/issues/406
   if (this->m_request.GetMethod() == HttpMethod::Head
-      || this->m_lastResponseCode == Azure::Core::Http::HttpStatusCode::NoContent)
+      || this->m_response->GetStatusCode() == Azure::Core::Http::HttpStatusCode::NoContent)
   {
     this->m_contentLength = 0;
     this->m_bodyStartInBuffer = -1;

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -21,7 +21,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_executable (
      ${TARGET_NAME}
-     file_upload.cpp
      http.cpp
      logging.cpp
      main.cpp
@@ -30,6 +29,7 @@ add_executable (
      telemetry_policy.cpp
      transport_adapter.cpp
      transport_adapter.hpp
+     transport_adapter_file_upload.cpp
      uuid.cpp
      context.cpp)
 

--- a/sdk/core/azure-core/test/ut/transport_adapter.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter.cpp
@@ -425,7 +425,7 @@ namespace Azure { namespace Core { namespace Test {
     }
   }
 
-  TEST_F(TransportAdapter, DISABLE_putWithStreamOnFail)
+  TEST_F(TransportAdapter, putWithStreamOnFail)
   {
     // point to bad address pah to generate server MethodNotAllowed error
     std::string host("http://httpbin.org/get");

--- a/sdk/core/azure-core/test/ut/transport_adapter.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter.cpp
@@ -425,7 +425,7 @@ namespace Azure { namespace Core { namespace Test {
     }
   }
 
-  TEST_F(TransportAdapter, putWithStreamOnFail)
+  TEST_F(TransportAdapter, DISABLE_putWithStreamOnFail)
   {
     // point to bad address pah to generate server MethodNotAllowed error
     std::string host("http://httpbin.org/get");

--- a/sdk/core/azure-core/test/ut/transport_adapter.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter.cpp
@@ -174,6 +174,7 @@ namespace Azure { namespace Core { namespace Test {
   TEST_F(TransportAdapter, getMultiThread)
   {
     std::string host("http://httpbin.org/get");
+    Azure::Core::Http::CurlConnectionPool::ClearIndex();
 
     auto threadRoutine = [host]() {
       auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);

--- a/sdk/core/azure-core/test/ut/transport_adapter.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter.cpp
@@ -242,6 +242,23 @@ namespace Azure { namespace Core { namespace Test {
     CheckBodyFromBuffer(*response, expectedResponseBodySize, expectedChunkResponse);
   }
 
+  TEST_F(TransportAdapter, putErrorResponse)
+  {
+    std::string host("http://httpbin.org/get");
+
+    // Try to make a PUT to a GET url. This will return an error code from server.
+    // This test makes sure that the connection is not re-used (because it gets closed by server)
+    // and next request is not hang
+    for (auto i = 0; i < 10; i++)
+    {
+      auto requestBodyVector = std::vector<uint8_t>(10, 'x');
+      auto bodyRequest = Azure::Core::Http::MemoryBodyStream(requestBodyVector);
+      auto request
+          = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest);
+      auto response = pipeline.Send(context, request);
+    }
+  }
+
   // **********************
   // ***Same tests but getting stream to pull from socket, simulating the Download Op
   // **********************

--- a/sdk/core/azure-core/test/ut/transport_adapter.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter.cpp
@@ -44,96 +44,6 @@ namespace Azure { namespace Core { namespace Test {
     CheckBodyFromBuffer(*response, expectedResponseBodySize + 6 + 13);
   }
 
-  // multiThread test requires `ConnectionsOnPool` hook which is only available when building
-  // TESTING_BUILD. This test cases are only built when that case is true.`
-  TEST_F(TransportAdapter, getMultiThread)
-  {
-    std::string host("http://httpbin.org/get");
-
-    auto threadRoutine = [host]() {
-      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
-      auto response = pipeline.Send(context, request);
-      checkResponseCode(response->GetStatusCode());
-      auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
-      CheckBodyFromBuffer(*response, expectedResponseBodySize);
-    };
-
-    std::thread t1(threadRoutine);
-    std::thread t2(threadRoutine);
-    t1.join();
-    t2.join();
-    auto connectionsNow = Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org");
-
-    // 2 connections must be available at this point
-    EXPECT_EQ(connectionsNow, 2);
-
-    std::thread t3(threadRoutine);
-    std::thread t4(threadRoutine);
-    std::thread t5(threadRoutine);
-    t3.join();
-    t4.join();
-    t5.join();
-    connectionsNow = Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org");
-    // Two connections re-used plus one connection created
-    EXPECT_EQ(connectionsNow, 3);
-  }
-
-#ifdef RUN_LONG_UNIT_TESTS
-  TEST_F(TransportAdapter, ConnectionPoolCleaner)
-  {
-    std::string host("http://httpbin.org/get");
-
-    auto threadRoutine = [host]() {
-      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
-      auto response = pipeline.Send(context, request);
-      checkResponseCode(response->GetStatusCode());
-      auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
-      CheckBodyFromBuffer(*response, expectedResponseBodySize);
-    };
-
-    // one index expected from previous tests
-    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsIndexOnPool(), 1);
-
-    std::cout
-        << "Running Connection Pool Cleaner Test. This test takes more than 3 minutes to complete."
-        << std::endl
-        << "Add compiler option -DRUN_LONG_UNIT_TESTS=OFF when building if you want to skip this "
-           "test."
-        << std::endl;
-
-    // Wait for 100 secs to make sure any previous connection is removed by the cleaner
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000 * 100));
-
-    std::cout << "First wait time done. Validating state." << std::endl;
-
-    // index is not affected by cleaner. It does not remove index
-    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsIndexOnPool(), 1);
-    // cleaner should have remove connections
-    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org"), 0);
-
-    // Let cleaner finish
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
-    std::thread t1(threadRoutine);
-    std::thread t2(threadRoutine);
-    t1.join();
-    t2.join();
-
-    // 2 connections must be available at this point and one index
-    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsIndexOnPool(), 1);
-    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org"), 2);
-
-    // At this point, cleaner should be ON and will clean connections after on second.
-    // After 5 seconds connection pool should have been cleaned
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000 * 100));
-
-    std::cout << "Second wait time done. Validating state." << std::endl;
-
-    // EXPECT_EQ(Http::CurlSession::ConnectionsIndexOnPool(), 0);
-    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org"), 0);
-  }
-#endif
-
   TEST_F(TransportAdapter, get204)
   {
     std::string host("http://mt3.google.com/generate_204");
@@ -258,6 +168,97 @@ namespace Azure { namespace Core { namespace Test {
       auto response = pipeline.Send(context, request);
     }
   }
+
+  // multiThread test requires `ConnectionsOnPool` hook which is only available when building
+  // TESTING_BUILD. This test cases are only built when that case is true.`
+  TEST_F(TransportAdapter, getMultiThread)
+  {
+    std::string host("http://httpbin.org/get");
+
+    auto threadRoutine = [host]() {
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      auto response = pipeline.Send(context, request);
+      checkResponseCode(response->GetStatusCode());
+      auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
+      CheckBodyFromBuffer(*response, expectedResponseBodySize);
+    };
+
+    std::thread t1(threadRoutine);
+    std::thread t2(threadRoutine);
+    t1.join();
+    t2.join();
+    // wait a few ms for connections to go back to pool.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // 2 connections must be available at this point
+    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org"), 2);
+
+    std::thread t3(threadRoutine);
+    std::thread t4(threadRoutine);
+    std::thread t5(threadRoutine);
+    t3.join();
+    t4.join();
+    t5.join();
+    // wait a few ms for connections to go back to pool.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // Two connections re-used plus one connection created
+    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org"), 3);
+  }
+
+#ifdef RUN_LONG_UNIT_TESTS
+  TEST_F(TransportAdapter, ConnectionPoolCleaner)
+  {
+    std::string host("http://httpbin.org/get");
+
+    auto threadRoutine = [host]() {
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      auto response = pipeline.Send(context, request);
+      checkResponseCode(response->GetStatusCode());
+      auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
+      CheckBodyFromBuffer(*response, expectedResponseBodySize);
+    };
+
+    // one index expected from previous tests
+    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsIndexOnPool(), 1);
+
+    std::cout
+        << "Running Connection Pool Cleaner Test. This test takes more than 3 minutes to complete."
+        << std::endl
+        << "Add compiler option -DRUN_LONG_UNIT_TESTS=OFF when building if you want to skip this "
+           "test."
+        << std::endl;
+
+    // Wait for 100 secs to make sure any previous connection is removed by the cleaner
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000 * 100));
+
+    std::cout << "First wait time done. Validating state." << std::endl;
+
+    // index is not affected by cleaner. It does not remove index
+    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsIndexOnPool(), 1);
+    // cleaner should have remove connections
+    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org"), 0);
+
+    // Let cleaner finish
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+    std::thread t1(threadRoutine);
+    std::thread t2(threadRoutine);
+    t1.join();
+    t2.join();
+
+    // 2 connections must be available at this point and one index
+    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsIndexOnPool(), 1);
+    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org"), 2);
+
+    // At this point, cleaner should be ON and will clean connections after on second.
+    // After 5 seconds connection pool should have been cleaned
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000 * 100));
+
+    std::cout << "Second wait time done. Validating state." << std::endl;
+
+    // EXPECT_EQ(Http::CurlSession::ConnectionsIndexOnPool(), 0);
+    EXPECT_EQ(Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org"), 0);
+  }
+#endif
 
   // **********************
   // ***Same tests but getting stream to pull from socket, simulating the Download Op

--- a/sdk/core/azure-core/test/ut/transport_adapter.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter.cpp
@@ -200,7 +200,7 @@ namespace Azure { namespace Core { namespace Test {
     t4.join();
     t5.join();
     // wait a few ms for connections to go back to pool.
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     // Two connections re-used plus one connection created
     EXPECT_EQ(Http::CurlConnectionPool::ConnectionsOnPool("httpbin.org"), 3);
   }

--- a/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
@@ -46,7 +46,7 @@ namespace Azure { namespace Core { namespace Test {
 
     if (size > 0)
     { // only for known body size
-      EXPECT_EQ(bodyVector.size(), size);
+      EXPECT_EQ(bodySize, size);
     }
 
     if (expectedBody.size() > 0)

--- a/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
@@ -81,7 +81,7 @@ namespace Azure { namespace Core { namespace Test {
     }
   }
 
-  TEST_F(TransportAdapter, customSizePutFromFile)
+  TEST_F(TransportAdapter, SizePutFromFile)
   {
     std::string host("http://httpbin.org/put");
     std::string testDataPath(AZURE_TEST_DATA_PATH);
@@ -116,7 +116,7 @@ namespace Azure { namespace Core { namespace Test {
     }
   }
 
-  TEST_F(TransportAdapter, customSizePutFromFileDefault)
+  TEST_F(TransportAdapter, SizePutFromFileDefault)
   {
     std::string host("http://httpbin.org/put");
     std::string testDataPath(AZURE_TEST_DATA_PATH);
@@ -150,7 +150,7 @@ namespace Azure { namespace Core { namespace Test {
     }
   }
 
-  TEST_F(TransportAdapter, customSizePutFromFileBiggerPage)
+  TEST_F(TransportAdapter, SizePutFromFileBiggerPage)
   {
     std::string host("http://httpbin.org/put");
     std::string testDataPath(AZURE_TEST_DATA_PATH);


### PR DESCRIPTION
Fix: Connection should not be re-used if the previous request had an Error response code
Fix: When sending a PUT request with expect-100; if response is an ERROR, Server will return the 100-continue first.  On this cases, sometimes client would read both responses from wire.  Fixing client to handle the case of reading more than the first response content.

fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/455
fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/550