### PR TITLE
Allow skip publish DocMS or Github IO for each artifact

### DIFF
--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -42,7 +42,7 @@ stages:
                         ReleaseSha: $(Build.SourceVersion)
                         RepoId: Azure/azure-sdk-for-cpp
 
-          - ${{if ne(artifact.options.skipPublishDocs, 'true')}}:
+          - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
             - deployment: PublishDocs
               displayName: Publish Docs to GitHub pages
               condition: ne(variables['Skip.PublishDocs'], 'true')
@@ -69,7 +69,7 @@ stages:
                           # we override the regular script path because we have cloned the build tools repo as a separate artifact.
                           ScriptPath: '$(Build.SourcesDirectory)/eng/common/scripts/copy-docs-to-blobstorage.ps1'
 
-          - ${{if ne(artifact.options.skipUpdatePackageVersion, 'true')}}:
+          - ${{if ne(artifact.skipUpdatePackageVersion, 'true')}}:
             - deployment: UpdatePackageVersion
               displayName: "Update Package Version"
               condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))


### PR DESCRIPTION
Added feature of enable/disable DocMs step per artifact level.
Issue:https://github.com/Azure/azure-sdk-tools/issues/922