### PR TITLE
Mention VCPKG_DEFAULT_TRIPLET in Build instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ can install them with Homebrew.
 ### Building and Testing
 
 #### Building the project
-First, ensure that the `VCPKG_ROOT` environment variable is set, as described [above](#vcpkg). This needs to be defined
+First, ensure that the `VCPKG_ROOT` and `VCPKG_DEFAULT_TRIPLET` environment variables are set, as described [above](#vcpkg). This need to be defined
 any time you want to build. Then generate the build files and build as you would any standard CMake project. From the
 repo root, run:
 


### PR DESCRIPTION
Cmake fails to find packages(curl, etc) if VCPKG_DEFAULT_TRIPLET is not set to x64-windows-static. If not set, cmake sets VCPKG_TARGET_TRIPLET to x64-windows instead of x64-windows-static. Since curl was installed using x64-windows-static in vcpkg, cmake fails to find the package. Adding set VCPKG_DEFAULT_TRIPLET to x64-windows-static explicitly in build instructions so that it is helpful to avoid cmake error(could not find CURL)