### PR TITLE
Standardize header includes

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/azure.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure.hpp
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#include <azure/core/internal/contract.hpp>
+#include "azure/core/internal/contract.hpp"
+
 #include <string>
 
 /**

--- a/sdk/core/azure-core/inc/azure/core/credentials/policy/policies.hpp
+++ b/sdk/core/azure-core/inc/azure/core/credentials/policy/policies.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <azure/core/credentials/credentials.hpp>
-#include <azure/core/http/policy.hpp>
+#include "azure/core/credentials/credentials.hpp"
+#include "azure/core/http/policy.hpp"
 #include <memory>
 #include <mutex>
 #include <string>

--- a/sdk/core/azure-core/inc/azure/core/http/body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/body_stream.hpp
@@ -20,7 +20,7 @@
 #include <Windows.h>
 #endif // Windows
 
-#include <azure/core/context.hpp>
+#include "azure/core/context.hpp"
 
 #include <algorithm>
 #include <cstdint>

--- a/sdk/core/azure-core/inc/azure/core/response.hpp
+++ b/sdk/core/azure-core/inc/azure/core/response.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <azure/core/http/http.hpp>
+#include "azure/core/http/http.hpp"
 
 namespace Azure { namespace Core {
   /**

--- a/sdk/core/azure-core/src/context.cpp
+++ b/sdk/core/azure-core/src/context.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/context.hpp>
+#include "azure/core/context.hpp"
 
 using namespace Azure::Core;
 using time_point = std::chrono::system_clock::time_point;

--- a/sdk/core/azure-core/src/credentials/credentials.cpp
+++ b/sdk/core/azure-core/src/credentials/credentials.cpp
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/credentials/credentials.hpp>
-#include <azure/core/http/body_stream.hpp>
-#include <azure/core/http/curl/curl.hpp>
-#include <azure/core/http/http.hpp>
-#include <azure/core/http/pipeline.hpp>
+#include "azure/core/credentials/credentials.hpp"
+#include "azure/core/http/body_stream.hpp"
+#include "azure/core/http/curl/curl.hpp"
+#include "azure/core/http/http.hpp"
+#include "azure/core/http/pipeline.hpp"
 
 #include <cstdlib>
 #include <iomanip>

--- a/sdk/core/azure-core/src/credentials/policy/policies.cpp
+++ b/sdk/core/azure-core/src/credentials/policy/policies.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/credentials/policy/policies.hpp>
+#include "azure/core/credentials/policy/policies.hpp"
 
 using namespace Azure::Core::Credentials::Policy;
 

--- a/sdk/core/azure-core/src/http/body_stream.cpp
+++ b/sdk/core/azure-core/src/http/body_stream.cpp
@@ -12,8 +12,8 @@
 #include <Windows.h>
 #endif // Windows
 
-#include <azure/core/context.hpp>
-#include <azure/core/http/body_stream.hpp>
+#include "azure/core/context.hpp"
+#include "azure/core/http/body_stream.hpp"
 
 #include <algorithm>
 #include <cstdint>

--- a/sdk/core/azure-core/src/http/logging_policy.cpp
+++ b/sdk/core/azure-core/src/http/logging_policy.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/http/policy.hpp>
-#include <azure/core/internal/log.hpp>
+#include "azure/core/http/policy.hpp"
+#include "azure/core/internal/log.hpp"
 
 #include <chrono>
 #include <sstream>

--- a/sdk/core/azure-core/src/http/policy.cpp
+++ b/sdk/core/azure-core/src/http/policy.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/http/http.hpp>
-#include <azure/core/http/policy.hpp>
+#include "azure/core/http/http.hpp"
+#include "azure/core/http/policy.hpp"
 
 using namespace Azure::Core::Http;
 

--- a/sdk/core/azure-core/src/http/raw_response.cpp
+++ b/sdk/core/azure-core/src/http/raw_response.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/azure.hpp>
-#include <azure/core/http/http.hpp>
+#include "azure/core/azure.hpp"
+#include "azure/core/http/http.hpp"
 
 #include <cctype>
 #include <map>

--- a/sdk/core/azure-core/src/http/request.cpp
+++ b/sdk/core/azure-core/src/http/request.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/azure.hpp>
-#include <azure/core/http/http.hpp>
+#include "azure/core/azure.hpp"
+#include "azure/core/http/http.hpp"
+
 #include <map>
 #include <string>
 #include <vector>

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/http/policy.hpp>
-
-#include <azure/core/internal/log.hpp>
+#include "azure/core/http/policy.hpp"
+#include "azure/core/internal/log.hpp"
 
 #include <algorithm>
 #include <cstdlib>

--- a/sdk/core/azure-core/src/http/telemetry_policy.cpp
+++ b/sdk/core/azure-core/src/http/telemetry_policy.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/http/policy.hpp>
+#include "azure/core/http/policy.hpp"
 
 #include <sstream>
 

--- a/sdk/core/azure-core/src/http/transport_policy.cpp
+++ b/sdk/core/azure-core/src/http/transport_policy.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/http/policy.hpp>
+#include "azure/core/http/policy.hpp"
 
 using namespace Azure::Core::Http;
 

--- a/sdk/core/azure-core/src/strings.cpp
+++ b/sdk/core/azure-core/src/strings.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
+#include "azure/core/azure.hpp"
+
 #include <algorithm>
-#include <azure/core/azure.hpp>
 
 namespace {
 // The locale invariant case table is generated with the following program

--- a/sdk/core/azure-core/test/e2e/azure_core_storage_list_containers_sample.cpp
+++ b/sdk/core/azure-core/test/e2e/azure_core_storage_list_containers_sample.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "azure/core/http/curl/curl.hpp"
-#include "azure/core/http/http.hpp"
-#include "azure/core/http/pipeline.hpp"
+#include <azure/core/http/curl/curl.hpp>
+#include <azure/core/http/http.hpp>
+#include <azure/core/http/pipeline.hpp>
 
 #include <array>
 #include <iostream>

--- a/sdk/core/azure-core/test/e2e/azure_core_storage_test_sample.cpp
+++ b/sdk/core/azure-core/test/e2e/azure_core_storage_test_sample.cpp
@@ -5,9 +5,9 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include "azure/core/http/curl/curl.hpp"
-#include "azure/core/http/http.hpp"
-#include "azure/core/http/pipeline.hpp"
+#include <azure/core/http/curl/curl.hpp>
+#include <azure/core/http/http.hpp>
+#include <azure/core/http/pipeline.hpp>
 
 #include <array>
 #include <iostream>

--- a/sdk/core/azure-core/test/e2e/azure_core_with_curl_bodyBuffer.cpp
+++ b/sdk/core/azure-core/test/e2e/azure_core_with_curl_bodyBuffer.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include "azure/core/http/pipeline.hpp"
+#include <azure/core/http/pipeline.hpp>
 
 #ifdef POSIX
 #include <fcntl.h>

--- a/sdk/core/azure-core/test/e2e/azure_core_with_curl_bodyStream.cpp
+++ b/sdk/core/azure-core/test/e2e/azure_core_with_curl_bodyStream.cpp
@@ -7,7 +7,7 @@
  *
  */
 
-#include "azure/core/http/pipeline.hpp"
+#include <azure/core/http/pipeline.hpp>
 #include <azure/core/http/curl/curl.hpp>
 #include <azure/core/http/http.hpp>
 

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -3,7 +3,7 @@
 
 #include "gtest/gtest.h"
 
-#include "azure/core/context.hpp"
+#include <azure/core/context.hpp>
 
 #include <chrono>
 #include <memory>

--- a/sdk/core/azure-core/test/ut/http.cpp
+++ b/sdk/core/azure-core/test/ut/http.cpp
@@ -3,7 +3,7 @@
 
 #include "gtest/gtest.h"
 
-#include "azure/core/http/http.hpp"
+#include <azure/core/http/http.hpp>
 #include "http.hpp"
 
 #include <string>

--- a/sdk/core/azure-core/test/ut/http.hpp
+++ b/sdk/core/azure-core/test/ut/http.hpp
@@ -3,7 +3,7 @@
 
 #include "gtest/gtest.h"
 
-#include "azure/core/http/http.hpp"
+#include <azure/core/http/http.hpp>
 
 namespace Azure { namespace Core { namespace Test {
 

--- a/sdk/core/azure-core/test/ut/string.cpp
+++ b/sdk/core/azure-core/test/ut/string.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "gtest/gtest.h"
-#include <azure/core/strings.hpp>
+#include <azure/core/azure.hpp>
 #include <string>
 
 TEST(String, invariantCompare)

--- a/sdk/core/azure-core/test/ut/string.cpp
+++ b/sdk/core/azure-core/test/ut/string.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "gtest/gtest.h"
-#include <azure/core/azure.hpp>
+#include <azure/core/strings.hpp>
 #include <string>
 
 TEST(String, invariantCompare)

--- a/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
@@ -11,7 +11,7 @@
 #include <Windows.h>
 #endif // Windows
 
-#include "azure/core/http/http.hpp"
+#include <azure/core/http/http.hpp>
 
 #include "transport_adapter.hpp"
 

--- a/sdk/template/azure-template/src/template_client.cpp
+++ b/sdk/template/azure-template/src/template_client.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/template/template_client.hpp>
-#include <azure/template/version.hpp>
+#include "azure/template/template_client.hpp"
+#include "azure/template/version.hpp"
 
 #include <string>
 


### PR DESCRIPTION
Update sources to match guidelines

- `#include ""` when file is relative to the project
- `#include <>` when file is external to the project

Updated tests to mirror how a customer will include the header

- `#include <>`

Resolves #91 