### PR TITLE
Add build instruction for running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ cmake --build .
 ```
 If you want to run tests also, generate build files using below command and then build.
 ```sh
-cmake -Duse_default_uuid=ON -DBUILD_TESTING=ON -DBUILD_CURL_TRANSPORT=ON ..
+cmake -DBUILD_TESTING=ON -DBUILD_CURL_TRANSPORT=ON ..
 cmake --build .
 ```
 #### Testing the project

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,6 @@ cmake --build .
 #### Testing the project
 Tests are executed via the `ctest` command included with CMake. From the repo root, run:
 
-
 ```sh
 cd build
 ctest -C Debug

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,11 @@ cd build
 cmake -Duse_default_uuid=ON ..
 cmake --build .
 ```
-
+If you want to run tests also, generate build files using below command and then build.
+```sh
+cmake -Duse_default_uuid=ON -DBUILD_TESTING=ON -DBUILD_CURL_TRANSPORT=ON ..
+cmake --build .
+```
 #### Testing the project
 Tests are executed via the `ctest` command included with CMake. From the repo root, run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,7 @@ cmake --build .
 #### Testing the project
 Tests are executed via the `ctest` command included with CMake. From the repo root, run:
 
+
 ```sh
 cd build
 ctest -C Debug


### PR DESCRIPTION
Added build arguments to pass to cmake  for running tests. If these
options are not passed during cmake build and someone tries to run test,
it will throw error "No tests were found!!!"