### PR TITLE
cmake updates for building transport adapters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 
 # Compile Options
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
-option(BUILD_CURL_TRANSPORT "Build an http transport implementation with CURL" OFF)
-option(BUILD_WIN_HTTP_TRANSPORT "Build an http transport implementation with WIN HTTP" OFF)
+option(BUILD_TRANSPORT_CURL "Build an http transport implementation with CURL" OFF)
+option(BUILD_TRANSPORT_WINHTTP "Build an http transport implementation with WIN HTTP" OFF)
 option(BUILD_TESTING "Build test cases" OFF)
 option(BUILD_DOCUMENTATION "Create HTML based API documentation (requires Doxygen)" OFF)
 option(RUN_LONG_UNIT_TESTS "Tests that takes more than 5 minutes to complete. No effect if BUILD_TESTING is OFF" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,6 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules/az_version.cmake)
 # add_subdirectory(sdk/core/performance-stress)
 add_subdirectory(sdk/core/azure-core)
 
-# There is always a transport adapter added by default.
 if(BUILD_TESTING)
     add_subdirectory(sdk/core/azure-core/test/e2e)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 
 # Compile Options
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
-option(BUILD_TRANSPORT_CURL "Build an http transport implementation with CURL" OFF)
-option(BUILD_TRANSPORT_WINHTTP "Build an http transport implementation with WIN HTTP" OFF)
+option(BUILD_TRANSPORT_CURL "Build an HTTP transport implementation with CURL" OFF)
+option(BUILD_TRANSPORT_WINHTTP "Build an HTTP transport implementation with WIN HTTP" OFF)
 option(BUILD_TESTING "Build test cases" OFF)
 option(BUILD_DOCUMENTATION "Create HTML based API documentation (requires Doxygen)" OFF)
 option(RUN_LONG_UNIT_TESTS "Tests that takes more than 5 minutes to complete. No effect if BUILD_TESTING is OFF" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,10 @@
 cmake_minimum_required (VERSION 3.15)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 
-# referenced options from other cmake code/files, avoid break if name ever change
-SET(CURL_TRANSPORT_OPT_NAME "BUILD_CURL_TRANSPORT")
-SET(WIN_TRANSPORT_OPT_NAME "BUILD_WIN_HTTP_TRANSPORT")
 # Compile Options
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
-option(${CURL_TRANSPORT_OPT_NAME} "Build an http transport implementation with CURL" OFF)
-option(${WIN_TRANSPORT_OPT_NAME} "Build an http transport implementation with WIN HTTP" OFF)
+option(BUILD_CURL_TRANSPORT "Build an http transport implementation with CURL" OFF)
+option(BUILD_WIN_HTTP_TRANSPORT "Build an http transport implementation with WIN HTTP" OFF)
 option(BUILD_TESTING "Build test cases" OFF)
 option(BUILD_DOCUMENTATION "Create HTML based API documentation (requires Doxygen)" OFF)
 option(RUN_LONG_UNIT_TESTS "Tests that takes more than 5 minutes to complete. No effect if BUILD_TESTING is OFF" OFF)
@@ -64,8 +61,9 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules/az_version.cmake)
 # sub-projects
 # add_subdirectory(sdk/core/performance-stress)
 add_subdirectory(sdk/core/azure-core)
-if(${CURL_OPT_NAME})
-    add_subdirectory(sdk/core/azure-core/test/e2e) # will work only if BUILD_CURL_TRANSPORT=ON
-endif()
+
+# There is always a transport adapter added by default.
+add_subdirectory(sdk/core/azure-core/test/e2e)
+
 add_subdirectory(sdk/storage)
 add_subdirectory(sdk/template/azure-template)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,18 @@
 cmake_minimum_required (VERSION 3.15)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 
+# referenced options from other cmake code/files, avoid break if name ever change
+SET(CURL_TRANSPORT_OPT_NAME "BUILD_CURL_TRANSPORT")
+SET(WIN_TRANSPORT_OPT_NAME "BUILD_WIN_HTTP_TRANSPORT")
 # Compile Options
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
-option(BUILD_CURL_TRANSPORT "Build internal http transport implementation with CURL for HTTP Pipeline" OFF)
+option(${CURL_TRANSPORT_OPT_NAME} "Build an http transport implementation with CURL" OFF)
+option(${WIN_TRANSPORT_OPT_NAME} "Build an http transport implementation with WIN HTTP" OFF)
 option(BUILD_TESTING "Build test cases" OFF)
 option(BUILD_DOCUMENTATION "Create HTML based API documentation (requires Doxygen)" OFF)
 option(RUN_LONG_UNIT_TESTS "Tests that takes more than 5 minutes to complete. No effect if BUILD_TESTING is OFF" OFF)
+
+include(DefineTransportAdapter)
 
 if(BUILD_TESTING)
   # define a symbol that enables some test hooks in code
@@ -58,7 +64,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules/az_version.cmake)
 # sub-projects
 # add_subdirectory(sdk/core/performance-stress)
 add_subdirectory(sdk/core/azure-core)
-if(BUILD_CURL_TRANSPORT)
+if(${CURL_OPT_NAME})
     add_subdirectory(sdk/core/azure-core/test/e2e) # will work only if BUILD_CURL_TRANSPORT=ON
 endif()
 add_subdirectory(sdk/storage)

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -4,10 +4,12 @@
       "name": "x64-DebugWithTests",
       "generator": "Ninja",
       "configurationType": "Debug",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "inheritEnvironments": [
+        "msvc_x64_x64"
+      ],
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "-DINSTALL_GTEST=OFF -DBUILD_TESTING=ON -DBUILD_CURL_TRANSPORT=ON -DBUILD_STORAGE_SAMPLES=ON",
+      "cmakeCommandArgs": "-DINSTALL_GTEST=OFF -DBUILD_TESTING=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_STORAGE_SAMPLES=ON",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
       "variables": [
@@ -27,7 +29,9 @@
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x86" ],
+      "inheritEnvironments": [
+        "msvc_x86"
+      ],
       "variables": [
         {
           "name": "VCPKG_TARGET_TRIPLET",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,11 @@ cd build
 cmake -Duse_default_uuid=ON ..
 cmake --build .
 ```
-
+If you want to run tests also, generate build files using below command and then build.
+```sh
+cmake -DBUILD_TESTING=ON -DBUILD_CURL_TRANSPORT=ON ..
+cmake --build .
+```
 #### Testing the project
 Tests are executed via the `ctest` command included with CMake. From the repo root, run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ cmake --build .
 ```
 If you want to run tests also, generate build files using below command and then build.
 ```sh
-cmake -DBUILD_TESTING=ON -DBUILD_TRANSPORT_CURL=ON ..
+cmake -DBUILD_TESTING=ON ..
 cmake --build .
 ```
 #### Testing the project

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ cmake --build .
 ```
 If you want to run tests also, generate build files using below command and then build.
 ```sh
-cmake -DBUILD_TESTING=ON -DBUILD_CURL_TRANSPORT=ON ..
+cmake -DBUILD_TESTING=ON -DBUILD_TRANSPORT_CURL=ON ..
 cmake --build .
 ```
 #### Testing the project

--- a/cmake-modules/DefineTransportAdapter.cmake
+++ b/cmake-modules/DefineTransportAdapter.cmake
@@ -1,0 +1,29 @@
+## Copyright (c) Microsoft Corporation. All rights reserved.
+## SPDX-License-Identifier: MIT
+
+#############                      TRANSPORT ADAPTER BUILD                     #####################
+#  Default: If no option is explicitly added, curl will be used for POSIX and WIN HTTP for WIndows #
+#  Windows: Both CURL and WIN_HTTP can be build to be used.                                        #
+#  POSIX: Only CURL is acceptable. If WIN_HTTP is set, generate step will fail for user            #
+
+#  Defines `BUILD_WIN_HTTP_TRANSPORT_ADAPTER` and `BUILD_CURL_HTTP_TRANSPORT_ADAPTER` for source code
+
+if (WIN32 OR MINGW OR MSYS OR CYGWIN)
+  if(${CURL_TRANSPORT_OPT_NAME})
+    add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
+  endif()
+  # If explicitly adding WIN_HTTP or did not add CURL
+  if(${WIN_TRANSPORT_OPT_NAME} OR NOT ${CURL_TRANSPORT_OPT_NAME})
+    add_compile_definitions(BUILD_WIN_HTTP_TRANSPORT_ADAPTER)
+    SET(${WIN_TRANSPORT_OPT_NAME} ON)
+  endif()
+elseif(UNIX)
+    if(${WIN_TRANSPORT_OPT_NAME})
+        message(FATAL_ERROR "Win HTTP transport adapter is not supported for Unix platforms")
+    endif()
+    # regardless if CURL transport is set or not, it is always added for UNIX as default
+    add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
+    SET(${CURL_TRANSPORT_OPT_NAME} ON)
+else()
+    message(FATAL_ERROR "Unsupported platform")
+endif ()

--- a/cmake-modules/DefineTransportAdapter.cmake
+++ b/cmake-modules/DefineTransportAdapter.cmake
@@ -2,8 +2,8 @@
 ## SPDX-License-Identifier: MIT
 
 #############                      TRANSPORT ADAPTER BUILD                     #####################
-#  Default: If no option is explicitly added, curl will be used for POSIX and WIN HTTP for WIndows #
-#  Windows: Both CURL and WIN_HTTP can be build to be used.                                        #
+#  Default: If no option is explicitly added, curl will be used for POSIX and WIN HTTP for Windows #
+#  Windows: Both CURL and WIN_HTTP can be built to be used.                                        #
 #  POSIX: Only CURL is acceptable. If WIN_HTTP is set, generate step will fail for user            #
 
 #  Defines `BUILD_TRANSPORT_WINHTTP_ADAPTER` and `BUILD_CURL_HTTP_TRANSPORT_ADAPTER` for source code

--- a/cmake-modules/DefineTransportAdapter.cmake
+++ b/cmake-modules/DefineTransportAdapter.cmake
@@ -12,7 +12,7 @@ if (WIN32 OR MINGW OR MSYS OR CYGWIN)
   if(BUILD_TRANSPORT_CURL)
     add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
   endif()
-  # If explicitly adding WIN_HTTP or did not add CURL
+  # Make sure to build WinHTTP either if if was user-requested or no transport was selected at all
   if(BUILD_TRANSPORT_WINHTTP OR NOT BUILD_TRANSPORT_CURL)
     add_compile_definitions(BUILD_TRANSPORT_WINHTTP_ADAPTER)
     SET(BUILD_TRANSPORT_WINHTTP ON)

--- a/cmake-modules/DefineTransportAdapter.cmake
+++ b/cmake-modules/DefineTransportAdapter.cmake
@@ -9,21 +9,21 @@
 #  Defines `BUILD_WIN_HTTP_TRANSPORT_ADAPTER` and `BUILD_CURL_HTTP_TRANSPORT_ADAPTER` for source code
 
 if (WIN32 OR MINGW OR MSYS OR CYGWIN)
-  if(${CURL_TRANSPORT_OPT_NAME})
+  if(BUILD_CURL_TRANSPORT)
     add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
   endif()
   # If explicitly adding WIN_HTTP or did not add CURL
-  if(${WIN_TRANSPORT_OPT_NAME} OR NOT ${CURL_TRANSPORT_OPT_NAME})
+  if(BUILD_WIN_HTTP_TRANSPORT OR NOT BUILD_CURL_TRANSPORT)
     add_compile_definitions(BUILD_WIN_HTTP_TRANSPORT_ADAPTER)
-    SET(${WIN_TRANSPORT_OPT_NAME} ON)
+    SET(BUILD_WIN_HTTP_TRANSPORT ON)
   endif()
 elseif(UNIX)
-    if(${WIN_TRANSPORT_OPT_NAME})
+    if(BUILD_WIN_HTTP_TRANSPORT)
         message(FATAL_ERROR "Win HTTP transport adapter is not supported for Unix platforms")
     endif()
     # regardless if CURL transport is set or not, it is always added for UNIX as default
     add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
-    SET(${CURL_TRANSPORT_OPT_NAME} ON)
+    SET(BUILD_CURL_TRANSPORT ON)
 else()
     message(FATAL_ERROR "Unsupported platform")
 endif ()

--- a/cmake-modules/DefineTransportAdapter.cmake
+++ b/cmake-modules/DefineTransportAdapter.cmake
@@ -6,24 +6,24 @@
 #  Windows: Both CURL and WIN_HTTP can be build to be used.                                        #
 #  POSIX: Only CURL is acceptable. If WIN_HTTP is set, generate step will fail for user            #
 
-#  Defines `BUILD_WIN_HTTP_TRANSPORT_ADAPTER` and `BUILD_CURL_HTTP_TRANSPORT_ADAPTER` for source code
+#  Defines `BUILD_TRANSPORT_WINHTTP_ADAPTER` and `BUILD_CURL_HTTP_TRANSPORT_ADAPTER` for source code
 
 if (WIN32 OR MINGW OR MSYS OR CYGWIN)
-  if(BUILD_CURL_TRANSPORT)
+  if(BUILD_TRANSPORT_CURL)
     add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
   endif()
   # If explicitly adding WIN_HTTP or did not add CURL
-  if(BUILD_WIN_HTTP_TRANSPORT OR NOT BUILD_CURL_TRANSPORT)
-    add_compile_definitions(BUILD_WIN_HTTP_TRANSPORT_ADAPTER)
-    SET(BUILD_WIN_HTTP_TRANSPORT ON)
+  if(BUILD_TRANSPORT_WINHTTP OR NOT BUILD_TRANSPORT_CURL)
+    add_compile_definitions(BUILD_TRANSPORT_WINHTTP_ADAPTER)
+    SET(BUILD_TRANSPORT_WINHTTP ON)
   endif()
 elseif(UNIX)
-    if(BUILD_WIN_HTTP_TRANSPORT)
+    if(BUILD_TRANSPORT_WINHTTP)
         message(FATAL_ERROR "Win HTTP transport adapter is not supported for Unix platforms")
     endif()
     # regardless if CURL transport is set or not, it is always added for UNIX as default
     add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
-    SET(BUILD_CURL_TRANSPORT ON)
+    SET(BUILD_TRANSPORT_CURL ON)
 else()
     message(FATAL_ERROR "Unsupported platform")
 endif ()

--- a/cmake-modules/DefineTransportAdapter.cmake
+++ b/cmake-modules/DefineTransportAdapter.cmake
@@ -12,7 +12,7 @@ if (WIN32 OR MINGW OR MSYS OR CYGWIN)
   if(BUILD_TRANSPORT_CURL)
     add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
   endif()
-  # Make sure to build WinHTTP either if if was user-requested or no transport was selected at all
+  # Make sure to build WinHTTP either if was user-requested or no transport was selected at all
   if(BUILD_TRANSPORT_WINHTTP OR NOT BUILD_TRANSPORT_CURL)
     add_compile_definitions(BUILD_TRANSPORT_WINHTTP_ADAPTER)
     SET(BUILD_TRANSPORT_WINHTTP ON)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -31,12 +31,14 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
+        CmakeArgs: ' -DBUILD_CURL_TRANSPORT=ON' #ToBeRemoved once we WinTransport and Storage make HTTP stack user-config
       Win_x64:
         OSVmImage: 'windows-2019'
         VcpkgInstall: 'curl[winssl] libxml2'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
+        CmakeArgs: ' -DBUILD_CURL_TRANSPORT=ON' #ToBeRemoved once we WinTransport and Storage make HTTP stack user-config
       MacOS_x64:
        OSVmImage: 'macOS-10.14'
        VcpkgInstall: 'curl[ssl] libxml2 openssl'
@@ -61,12 +63,12 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON'
+        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_CURL_TRANSPORT=ON'
       MacOS_x64_with_unit_test:
         OSVmImage: 'macOS-10.14'
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON'
+        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_CURL_TRANSPORT=ON'
   pool:
     vmImage: $(OSVmImage)
   variables:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -31,14 +31,14 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        CmakeArgs: ' -DBUILD_CURL_TRANSPORT=ON' #ToBeRemoved once we WinTransport and Storage make HTTP stack user-config
+        CmakeArgs: ' -DBUILD_TRANSPORT_CURL=ON' #ToBeRemoved once we WinTransport and Storage make HTTP stack user-config
       Win_x64:
         OSVmImage: 'windows-2019'
         VcpkgInstall: 'curl[winssl] libxml2'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        CmakeArgs: ' -DBUILD_CURL_TRANSPORT=ON' #ToBeRemoved once we WinTransport and Storage make HTTP stack user-config
+        CmakeArgs: ' -DBUILD_TRANSPORT_CURL=ON' #ToBeRemoved once we WinTransport and Storage make HTTP stack user-config
       MacOS_x64:
        OSVmImage: 'macOS-10.14'
        VcpkgInstall: 'curl[ssl] libxml2 openssl'
@@ -56,19 +56,19 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_CURL_TRANSPORT=ON'
+        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
       Win_x64_with_unit_test:
         OSVmImage: 'windows-2019'
         VcpkgInstall: 'curl[winssl] libxml2'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_CURL_TRANSPORT=ON'
+        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
       MacOS_x64_with_unit_test:
         OSVmImage: 'macOS-10.14'
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_CURL_TRANSPORT=ON'
+        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
   pool:
     vmImage: $(OSVmImage)
   variables:
@@ -132,7 +132,7 @@ jobs:
           GenerateArgs: >-
             -DINSTALL_GTEST=OFF
             -DBUILD_TESTING=OFF
-            -DBUILD_CURL_TRANSPORT=OFF
+            -DBUILD_TRANSPORT_CURL=OFF
             -DBUILD_DOCUMENTATION=YES
 
       - pwsh: npm install -g moxygen

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -56,7 +56,7 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON'
+        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_CURL_TRANSPORT=ON'
       Win_x64_with_unit_test:
         OSVmImage: 'windows-2019'
         VcpkgInstall: 'curl[winssl] libxml2'

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -28,7 +28,6 @@ add_library (
   src/credentials/policy/policies.cpp
   src/http/body_stream.cpp
   ${CURL_TRANSPORT_ADAPTER_SRC}
-  src/http/curl/curl.cpp
   src/http/logging_policy.cpp
   src/http/policy.cpp
   src/http/request.cpp

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -28,7 +28,6 @@ add_library (
   src/credentials/policy/policies.cpp
   src/http/body_stream.cpp
   ${CURL_TRANSPORT_ADAPTER_SRC}
-  src/http/curl/curl.cpp
   src/http/http.cpp
   src/http/logging_policy.cpp
   src/http/policy.cpp

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -14,10 +14,10 @@ if(NOT CURL_FOUND)
   find_package(CURL ${CURL_MIN_REQUIRED_VERSION} REQUIRED)
 endif()
 
-if(BUILD_CURL_TRANSPORT)
+if(BUILD_TRANSPORT_CURL)
   SET(CURL_TRANSPORT_ADAPTER_SRC src/http/curl/curl.cpp)
 endif()
-if(BUILD_WIN_HTTP_TRANSPORT)
+if(BUILD_TRANSPORT_WINHTTP)
   SET(WIN_TRANSPORT_ADAPTER_SRC src/http/winhttp/win_http_transport.cpp)
 endif()
 

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -14,10 +14,10 @@ if(NOT CURL_FOUND)
   find_package(CURL ${CURL_MIN_REQUIRED_VERSION} REQUIRED)
 endif()
 
-if(${CURL_TRANSPORT_OPT_NAME})
+if(BUILD_CURL_TRANSPORT)
   SET(CURL_TRANSPORT_ADAPTER_SRC src/http/curl/curl.cpp)
 endif()
-if(${WIN_TRANSPORT_OPT_NAME})
+if(BUILD_WIN_HTTP_TRANSPORT)
   SET(WIN_TRANSPORT_ADAPTER_SRC src/http/winhttp/win_http_transport.cpp)
 endif()
 

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -14,12 +14,20 @@ if(NOT CURL_FOUND)
   find_package(CURL ${CURL_MIN_REQUIRED_VERSION} REQUIRED)
 endif()
 
+if(${CURL_TRANSPORT_OPT_NAME})
+  SET(CURL_TRANSPORT_ADAPTER_SRC src/http/curl/curl.cpp)
+endif()
+if(${WIN_TRANSPORT_OPT_NAME})
+  SET(WIN_TRANSPORT_ADAPTER_SRC src/http/winhttp/win_http_transport.cpp)
+endif()
+
 add_library (
   ${TARGET_NAME}
   src/context.cpp
   src/credentials/credentials.cpp
   src/credentials/policy/policies.cpp
   src/http/body_stream.cpp
+  ${CURL_TRANSPORT_ADAPTER_SRC}
   src/http/curl/curl.cpp
   src/http/logging_policy.cpp
   src/http/policy.cpp
@@ -29,7 +37,7 @@ add_library (
   src/http/transport_policy.cpp
   src/http/telemetry_policy.cpp
   src/http/url.cpp
-  src/http/winhttp/win_http_transport.cpp
+  ${BUILD_WIN_TRANSPORT}
   src/logging/logging.cpp
   src/strings.cpp
   src/version.cpp)

--- a/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#ifdef BUILD_CURL_HTTP_TRANSPORT_ADAPTER
 
 #include "azure/core/http/http.hpp"
 #include "azure/core/http/policy.hpp"
@@ -606,3 +607,5 @@ namespace Azure { namespace Core { namespace Http {
   };
 
 }}} // namespace Azure::Core::Http
+
+#endif

--- a/sdk/core/azure-core/inc/azure/core/http/winhttp/win_http_client.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/winhttp/win_http_client.hpp
@@ -6,7 +6,7 @@
  */
 
 #pragma once
-#ifdef BUILD_WIN_HTTP_TRANSPORT_ADAPTER
+#ifdef BUILD_TRANSPORT_WINHTTP_ADAPTER
 
 #include "azure/core/http/http.hpp"
 #include "azure/core/http/policy.hpp"

--- a/sdk/core/azure-core/inc/azure/core/http/winhttp/win_http_client.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/winhttp/win_http_client.hpp
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#ifdef BUILD_WIN_HTTP_TRANSPORT_ADAPTER
 
 #include "azure/core/http/http.hpp"
 #include "azure/core/http/policy.hpp"
@@ -29,3 +30,5 @@ namespace Azure { namespace Core { namespace Http {
   };
 
 }}} // namespace Azure::Core::Http
+
+#endif

--- a/sdk/core/azure-core/test/e2e/CMakeLists.txt
+++ b/sdk/core/azure-core/test/e2e/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-if (BUILD_CURL_TRANSPORT)
+if (BUILD_TRANSPORT_CURL)
 
 cmake_minimum_required (VERSION 3.12)
 set(TARGET_NAME "azure_core_with_curl")


### PR DESCRIPTION
Adding CMake module to enable/disable transport adapters

TRANSPORT ADAPTER BUILD  
Default: If no option is explicitly added, curl will be used for POSIX and WIN HTTP for WIndows 
 Windows: Both CURL and WIN_HTTP can be build to be used.                                        
POSIX: Only CURL is acceptable. If WIN_HTTP is set, generate step will fail for user            

Defines `BUILD_WIN_HTTP_TRANSPORT_ADAPTER` and `BUILD_CURL_HTTP_TRANSPORT_ADAPTER` for source code
 
Fixes #350 