### PR TITLE
Adding retry policy to unit tests

### DIFF
--- a/sdk/core/azure-core/test/ut/transport_adapter.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter.cpp
@@ -15,7 +15,11 @@ namespace Azure { namespace Core { namespace Test {
     std::vector<std::unique_ptr<Azure::Core::Http::HttpPolicy>> p;
     std::shared_ptr<Azure::Core::Http::HttpTransport> transport
         = std::make_shared<Azure::Core::Http::CurlTransport>();
+    Azure::Core::Http::RetryOptions opt;
+    opt.RetryDelay = std::chrono::milliseconds(10);
 
+    // Retry policy will help to prevent server-occasionally-errors
+    p.push_back(std::make_unique<Azure::Core::Http::RetryPolicy>(opt));
     p.push_back(std::make_unique<Azure::Core::Http::TransportPolicy>(std::move(transport)));
     return p;
   }
@@ -143,7 +147,7 @@ namespace Azure { namespace Core { namespace Test {
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
 
     // loop sending request
-    for (auto i = 0; i < 500; i++)
+    for (auto i = 0; i < 50; i++)
     {
       auto response = pipeline.Send(context, request);
       auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));

--- a/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
@@ -26,7 +26,12 @@ namespace Azure { namespace Core { namespace Test {
       Azure::Core::Http::HttpStatusCode code,
       Azure::Core::Http::HttpStatusCode expectedCode)
   {
-    EXPECT_TRUE(code == expectedCode);
+    EXPECT_PRED2(
+        [](Azure::Core::Http::HttpStatusCode a, Azure::Core::Http::HttpStatusCode b) {
+          return a == b;
+        },
+        code,
+        expectedCode);
   }
 
   void TransportAdapter::CheckBodyFromBuffer(


### PR DESCRIPTION
Adding retry policy to unit tests. This will help to avoid the sporadic issues we had been having on CI when the 3rd party server return error codes.
Also updating the way we validate the return codes so we can see the values in the log
Fixes #634 
Fixes #635 