### PR TITLE
update CMake min version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 
 # Compile Options

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 set(TARGET_NAME "azure-core")
 project(${TARGET_NAME} LANGUAGES CXX)
 

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.15)
 set(TARGET_NAME "azure-core")
 project(${TARGET_NAME} LANGUAGES CXX)
 

--- a/sdk/core/azure-core/test/e2e/CMakeLists.txt
+++ b/sdk/core/azure-core/test/e2e/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 if (BUILD_CURL_TRANSPORT)
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 set(TARGET_NAME "azure_core_with_curl")
 set(TARGET_NAME_STREAM "azure_core_with_curl_stream")
 set(TARGET_NAME_STORAGE_ISSUE_249 "azure_core_storage_issue_249")

--- a/sdk/core/azure-core/test/e2e/CMakeLists.txt
+++ b/sdk/core/azure-core/test/e2e/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 if (BUILD_CURL_TRANSPORT)
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.15)
 set(TARGET_NAME "azure_core_with_curl")
 set(TARGET_NAME_STREAM "azure_core_with_curl_stream")
 set(TARGET_NAME_STORAGE_ISSUE_249 "azure_core_storage_issue_249")

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 
 set(TARGET_NAME "azure-core-test")
 

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.15)
 
 set(TARGET_NAME "azure-core-test")
 

--- a/sdk/core/performance-stress/CMakeLists.txt
+++ b/sdk/core/performance-stress/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.15)
 set(TARGET_NAME "azure-perf-stress")
 project(${TARGET_NAME} LANGUAGES CXX)
 

--- a/sdk/core/performance-stress/CMakeLists.txt
+++ b/sdk/core/performance-stress/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 set(TARGET_NAME "azure-perf-stress")
 project(${TARGET_NAME} LANGUAGES CXX)
 

--- a/sdk/core/performance-stress/test/CMakeLists.txt
+++ b/sdk/core/performance-stress/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 
 set(TARGET_NAME "azure-perf-stress-test")
 

--- a/sdk/core/performance-stress/test/CMakeLists.txt
+++ b/sdk/core/performance-stress/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.15)
 
 set(TARGET_NAME "azure-perf-stress-test")
 

--- a/sdk/storage/CMakeLists.txt
+++ b/sdk/storage/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 
 project (azure-storage LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)

--- a/sdk/storage/azure-storage-blobs/CMakeLists.txt
+++ b/sdk/storage/azure-storage-blobs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 
 set (AZURE_STORAGE_BLOB_HEADER
     inc/azure/storage/blobs/append_blob_client.hpp

--- a/sdk/storage/azure-storage-common/CMakeLists.txt
+++ b/sdk/storage/azure-storage-common/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 
 set(AZURE_STORAGE_COMMON_HEADER
     inc/azure/storage/common/access_conditions.hpp

--- a/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 
 set (AZURE_STORAGE_DATALAKE_HEADER
     inc/azure/storage/files/datalake/datalake.hpp

--- a/sdk/storage/azure-storage-files-shares/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-shares/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 
 set (AZURE_STORAGE_SHARES_HEADER
     inc/azure/storage/files/shares/protocol/share_rest_client.hpp

--- a/sdk/template/azure-template/CMakeLists.txt
+++ b/sdk/template/azure-template/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.15)
 set(TARGET_NAME "azure-template")
 project(azure-template LANGUAGES CXX)
 

--- a/sdk/template/azure-template/CMakeLists.txt
+++ b/sdk/template/azure-template/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 set(TARGET_NAME "azure-template")
 project(azure-template LANGUAGES CXX)
 

--- a/sdk/template/azure-template/test/CMakeLists.txt
+++ b/sdk/template/azure-template/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.13)
 
 project (azure-template-test LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)

--- a/sdk/template/azure-template/test/CMakeLists.txt
+++ b/sdk/template/azure-template/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.15)
 
 project (azure-template-test LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
Storage is using CMake version 3.15 and it is currently required for generating without errors