### PR TITLE
Adding a PR checklist to add guidance/reminders for authors to check for recurring PR review feedback.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,15 +2,19 @@
 
 Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:
 
-- [ ] Does the API design and implementation within your PR follow the [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)?
-  - [ ] Do you have an issue or spec doc that describes the design, usage, and motivating scenario?
-- [ ] If you are modifying header files, are the changes documented using doxygen style comments?
-- [ ] Have you added relevant unit tests to ensure CI will catch future regressions?
-- [ ] Have you reviewed your own PR to make sure there aren't any unintended changes or commits?
-- [ ] Does your PR have a descriptive title and description (with issue number), which explains why the change is being made?
-  - [ ] Does your PR have a single purpose or does it have other unrelated changes that can be separated out into its own PR?
-- [ ] Do you have any complex components that could use comments in source to explain (focusing on the "why")?
-- [ ] Are there any typos or spelling errors, especially in user-facing documentation?
-- [ ] Is the PR actually ready for review or is it work-in-progress (WIP) or an experiment? If so, can it start off as a draft PR?
-- [ ] Do your changes have impact elsewhere? For instance, do you need to update other docs or exiting markdown files that might be impacted?
-- [ ] Does the PR contain any breaking changes?
+See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/master/CONTRIBUTING.md#pull-requests).
+
+- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
+- [ ] Doxygen docs
+- [ ] Unit tests
+- [ ] No unwanted commits/changes
+- [ ] Descriptive title/description
+  - [ ] PR is single purpose
+  - [ ] Related issue listed
+- [ ] Comments in source
+- [ ] No typos
+- [ ] Update changelog
+- [ ] Not work-in-progress
+- [ ] External references or docs updated
+- [ ] Self review done
+- [ ] Any breaking changes?

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -13,3 +13,4 @@ Please leverage this checklist as a reminder to address commonly occurring feedb
 - [ ] Are there any typos or spelling errors, especially in user-facing documentation?
 - [ ] Is the PR actually ready for review or is it work-in-progress (WIP) or an experiment? If so, can it start off as a draft PR?
 - [ ] Do your changes have impact elsewhere? For instance, do you need to update other docs or exiting markdown files that might be impacted?
+- [ ] Does the PR contain any breaking changes?

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -16,5 +16,5 @@ See the detailed list in the [contributing guide](https://github.com/Azure/azure
 - [ ] Update changelog
 - [ ] Not work-in-progress
 - [ ] External references or docs updated
-- [ ] Self review done
+- [ ] Self review of PR done
 - [ ] Any breaking changes?

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,15 @@
+# Pull Request Checklist
+
+Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:
+
+- [ ] Does the API design and implementation within your PR follow the [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)?
+  - [ ] Do you have an issue or spec doc that describes the design, usage, and motivating scenario?
+- [ ] If you are modifying header files, are the changes documented using doxygen style comments?
+- [ ] Have you added relevant unit tests to ensure CI will catch future regressions?
+- [ ] Have you reviewed your own PR to make sure there aren't any unintended changes or commits?
+- [ ] Does your PR have a descriptive title and description (with issue number), which explains why the change is being made?
+  - [ ] Does your PR have a single purpose or does it have other unrelated changes that can be separated out into its own PR?
+- [ ] Do you have any complex components that could use comments in source to explain (focusing on the "why")?
+- [ ] Are there any typos or spelling errors, especially in user-facing documentation?
+- [ ] Is the PR actually ready for review or is it work-in-progress (WIP) or an experiment? If so, can it start off as a draft PR?
+- [ ] Do your changes have impact elsewhere? For instance, do you need to update other docs or exiting markdown files that might be impacted?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Please leverage this checklist as a reminder to address commonly occurring feedb
 - [ ] Does your PR have a descriptive title and description (with issue number), which explains why the change is being made?
 - [ ] Do you have any complex components that could use comments in source to explain (focusing on the "why")?
 - [ ] Are there any typos or spelling errors, especially in user-facing documentation?
+- [ ] Is the PR actually ready for review or is it work-in-progress (WIP) or an experiment? If so, can it start off as a draft PR?
 
 Merging Pull Requests (for project contributors with write access)
 ----------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Please leverage this checklist as a reminder to address commonly occurring feedb
 - [ ] Have you added relevant unit tests to ensure CI will catch future regressions?
 - [ ] Have you reviewed your own PR to make sure there aren't any unintended changes or commits?
 - [ ] Does your PR have a descriptive title and description (with issue number), which explains why the change is being made?
+  - [ ] Does your PR have a single purpose or does it have other unrelated changes that can be separated out into its own PR?
 - [ ] Do you have any complex components that could use comments in source to explain (focusing on the "why")?
 - [ ] Are there any typos or spelling errors, especially in user-facing documentation?
 - [ ] Is the PR actually ready for review or is it work-in-progress (WIP) or an experiment? If so, can it start off as a draft PR?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Pull Requests
 - **DO** assume that ["Squash and Merge"](https://github.com/blog/2141-squash-your-commits) will be used to merge your commit unless you request otherwise in the PR.
 - **DO NOT** mix independent, unrelated changes in one PR. Separate real product/test code changes from larger code formatting/dead code removal changes. Separate unrelated fixes into separate PRs, especially if they are in different modules or files that otherwise wouldn't be changed.
 - **DO** comment your code focusing on "why", where necessary. Otherwise, aim to keep it self-documenting with appropriate names and style.
-- **DO** add doxygen style API comments when adding new APIs or modifying header files.
+- **DO** add [doxygen style API comments](https://azure.github.io/azure-sdk/cpp_documentation.html#docstrings) when adding new APIs or modifying header files.
 - **DO** make sure there are no typos or spelling errors, especially in user-facing documentation.
 - **DO** verify if your changes have impact elsewhere. For instance, do you need to update other docs or exiting markdown files that might be impacted?
 - **DO** add relevant unit tests to ensure CI will catch future regressions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,23 +25,6 @@ Pull Requests
 * **DO NOT** fix merge conflicts using a merge commit. Prefer `git rebase`.
 * **DO NOT** mix independent, unrelated changes in one PR. Separate real product/test code changes from larger code formatting/dead code removal changes. Separate unrelated fixes into separate PRs, especially if they are in different assemblies.
 
-Pull Request Checklist
-----------------------
-
-Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:
-
-- [ ] Does the API design and implementation within your PR follow the [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)?
-  - [ ] Do you have an issue or spec doc that describes the design, usage, and motivating scenario?
-- [ ] If you are modifying header files, are the changes documented using doxygen style comments?
-- [ ] Have you added relevant unit tests to ensure CI will catch future regressions?
-- [ ] Have you reviewed your own PR to make sure there aren't any unintended changes or commits?
-- [ ] Does your PR have a descriptive title and description (with issue number), which explains why the change is being made?
-  - [ ] Does your PR have a single purpose or does it have other unrelated changes that can be separated out into its own PR?
-- [ ] Do you have any complex components that could use comments in source to explain (focusing on the "why")?
-- [ ] Are there any typos or spelling errors, especially in user-facing documentation?
-- [ ] Is the PR actually ready for review or is it work-in-progress (WIP) or an experiment? If so, can it start off as a draft PR?
-- [ ] Do your changes have impact elsewhere? For instance, do you need to update other docs or exiting markdown files that might be impacted?
-
 Merging Pull Requests (for project contributors with write access)
 ----------------------------------------------------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Please leverage this checklist as a reminder to address commonly occurring feedb
 - [ ] Do you have any complex components that could use comments in source to explain (focusing on the "why")?
 - [ ] Are there any typos or spelling errors, especially in user-facing documentation?
 - [ ] Is the PR actually ready for review or is it work-in-progress (WIP) or an experiment? If so, can it start off as a draft PR?
-- [ ] Does your changes have impact elsewhere? For instance, do you need to update other docs or exiting markdown files that might be impacted?
+- [ ] Do your changes have impact elsewhere? For instance, do you need to update other docs or exiting markdown files that might be impacted?
 
 Merging Pull Requests (for project contributors with write access)
 ----------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,19 @@ Pull Requests
 * **DO NOT** fix merge conflicts using a merge commit. Prefer `git rebase`.
 * **DO NOT** mix independent, unrelated changes in one PR. Separate real product/test code changes from larger code formatting/dead code removal changes. Separate unrelated fixes into separate PRs, especially if they are in different assemblies.
 
+Pull Request Checklist
+----------------------
+
+Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:
+
+- [ ] Does the API design and implementation within your PR follow the [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)?
+- [ ] If you are modifying header files, are the changes documented using doxygen style comments?
+- [ ] Have you added relevant unit tests to ensure CI will catch future regressions?
+- [ ] Have you reviewed your own PR to make sure there aren't any unintended changes or commits?
+- [ ] Does your PR have a descriptive title and description (with issue number), which explains why the change is being made?
+- [ ] Do you have any complex components that could use comments in source to explain (focusing on the "why")?
+- [ ] Are there any typos or spelling errors, especially in user-facing documentation?
+
 Merging Pull Requests (for project contributors with write access)
 ----------------------------------------------------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ Pull Request Checklist
 Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:
 
 - [ ] Does the API design and implementation within your PR follow the [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)?
+  - [ ] Do you have an issue or spec doc that describes the design, usage, and motivating scenario?
 - [ ] If you are modifying header files, are the changes documented using doxygen style comments?
 - [ ] Have you added relevant unit tests to ensure CI will catch future regressions?
 - [ ] Have you reviewed your own PR to make sure there aren't any unintended changes or commits?
@@ -38,6 +39,7 @@ Please leverage this checklist as a reminder to address commonly occurring feedb
 - [ ] Do you have any complex components that could use comments in source to explain (focusing on the "why")?
 - [ ] Are there any typos or spelling errors, especially in user-facing documentation?
 - [ ] Is the PR actually ready for review or is it work-in-progress (WIP) or an experiment? If so, can it start off as a draft PR?
+- [ ] Does your changes have impact elsewhere? For instance, do you need to update other docs or exiting markdown files that might be impacted?
 
 Merging Pull Requests (for project contributors with write access)
 ----------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,16 +14,24 @@ Thank you for your interest in contributing to Azure SDK for C++.
 Pull Requests
 -------------
 
-* **DO** submit all code changes via pull requests (PRs) rather than through a direct commit. PRs will be reviewed and potentially merged by the repo maintainers after a peer review that includes at least one maintainer.
-* **DO NOT** submit "work in progress" PRs.  A PR should only be submitted when it is considered ready for review and subsequent merging by the contributor.
-* **DO** give PRs short-but-descriptive names (e.g. "Improve code coverage for Azure.Core by 10%", not "Fix #1234")
-* **DO** refer to any relevant issues, and include [keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) that automatically close issues when the PR is merged.
-* **DO** tag any users that should know about and/or review the change.
-* **DO** ensure each commit successfully builds.  The entire PR must pass all tests in the Continuous Integration (CI) system before it'll be merged.
-* **DO** address PR feedback in an additional commit(s) rather than amending the existing commits, and only rebase/squash them when necessary.  This makes it easier for reviewers to track changes.
-* **DO** assume that ["Squash and Merge"](https://github.com/blog/2141-squash-your-commits) will be used to merge your commit unless you request otherwise in the PR.
-* **DO NOT** fix merge conflicts using a merge commit. Prefer `git rebase`.
-* **DO NOT** mix independent, unrelated changes in one PR. Separate real product/test code changes from larger code formatting/dead code removal changes. Separate unrelated fixes into separate PRs, especially if they are in different assemblies.
+- **DO** follow the API design and implementation [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html).
+  - When submitting large changes or features, **DO** have an issue or spec doc that describes the design, usage, and motivating scenario.
+- **DO** submit all code changes via pull requests (PRs) rather than through a direct commit. PRs will be reviewed and potentially merged by the repo maintainers after a peer review that includes at least one maintainer.
+- **DO** review your own PR to make sure there aren't any unintended changes or commits before submitting it.
+- **DO NOT** submit "work in progress" PRs. A PR should only be submitted when it is considered ready for review and subsequent merging by the contributor.
+  - If the change is work-in-progress or an experiment, **DO** start if off as a temporary draft PR.
+- **DO** give PRs short-but-descriptive names (e.g. "Improve code coverage for Azure.Core by 10%", not "Fix #1234") and add a description which explains why the change is being made.
+- **DO** refer to any relevant issues, and include [keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) that automatically close issues when the PR is merged.
+- **DO** tag any users that should know about and/or review the change.
+- **DO** ensure each commit successfully builds.  The entire PR must pass all tests in the Continuous Integration (CI) system before it'll be merged.
+- **DO** address PR feedback in an additional commit(s) rather than amending the existing commits, and only rebase/squash them when necessary.  This makes it easier for reviewers to track changes.
+- **DO** assume that ["Squash and Merge"](https://github.com/blog/2141-squash-your-commits) will be used to merge your commit unless you request otherwise in the PR.
+- **DO NOT** mix independent, unrelated changes in one PR. Separate real product/test code changes from larger code formatting/dead code removal changes. Separate unrelated fixes into separate PRs, especially if they are in different modules or files that otherwise wouldn't be changed.
+- **DO** comment your code focusing on "why", where necessary. Otherwise, aim to keep it self-documenting with appropriate names and style.
+- **DO** add doxygen style API comments when adding new APIs or modifying header files.
+- **DO** make sure there are no typos or spelling errors, especially in user-facing documentation.
+- **DO** verify if your changes have impact elsewhere. For instance, do you need to update other docs or exiting markdown files that might be impacted?
+- **DO** add relevant unit tests to ensure CI will catch future regressions.
 
 Merging Pull Requests (for project contributors with write access)
 ----------------------------------------------------------


### PR DESCRIPTION
It is generally useful for PR authors to go through their own PR first to make sure that commonly occurring feedback and issues have already been addressed. This checklist should help remind contributors what to look out for and is a living doc that we can modify and add to.

I ask these questions to myself before submitting a PR, when looking through my changes in the "pre-PR-submit-view".

Where possible leverage linter tools and CI gates to help address some of these. For example, for spell-check, here are some solutions to make things easier within the developer inner-loop:
- VS Code extension: [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
- VS Code extension: [Markdown linter](https://github.com/DavidAnson/vscode-markdownlint)
- Browser extension: [Site Spell](https://www.site-spell.com/)