### PR TITLE
Make sure CI pipelines legs get triggered when cmake modules are modified.

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -8,6 +8,7 @@ trigger:
       - hotfix/*
   paths:
     include:
+      - cmake-modules/
       - eng/
       - CMakeLists.txt
       - sdk/core

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -22,6 +22,7 @@ pr:
       - hotfix/*
   paths:
     include:
+      - cmake-modules/
       - eng/
       - CMakeLists.txt
       - sdk/core

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -8,6 +8,7 @@ trigger:
       - hotfix/*
   paths:
     include:
+      - cmake-modules/
       - eng/
       - CMakeLists.txt
       - sdk/core
@@ -22,6 +23,7 @@ pr:
       - hotfix/*
   paths:
     include:
+      - cmake-modules/
       - eng/
       - CMakeLists.txt
       - sdk/core/


### PR DESCRIPTION
Certain PRs, like this - https://github.com/Azure/azure-sdk-for-cpp/pull/753 weren't triggering any CI pipelines to run, when they should.

Following suggestion from Wes: https://github.com/Azure/azure-sdk-for-cpp/pull/728#issuecomment-707251860

@Jinming-Hu, @katmsft - I think we should make a similar change to the storage ci.yml file.