### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,24 +6,30 @@
 ###########
 
 # Catch all for non-code project files and unowned files | folders
-*      @ahsonkhan @rickwinter @joshfree
-/sdk/  @ahsonkhan @rickwinter @joshfree
+*                        @rickwinter @ahsonkhan @antkmsft @vhvb1989
+/sdk/                    @rickwinter @ahsonkhan @antkmsft @vhvb1989
 
 # Samples
-/samples/      @ahsonkhan @rickwinter
-/sdk/samples/  @ahsonkhan @rickwinter
+/samples/                @rickwinter @ahsonkhan @antkmsft @vhvb1989
 
-# Azure::Core
-/sdk/core/     @ahsonkhan @antkmsft @rickwinter @vhvb1989
+# PRLabel: %Azure.Core
+/sdk/core/               @rickwinter @ahsonkhan @antkmsft @vhvb1989
 
-# Azure::Identity
-/sdk/identity/     @antkmsft
+# PRLabel: %Azure.Identity
+/sdk/identity/           @antkmsft @schaabs @ahsonkhan @rickwinter @vhvb1989
 
-# Service teams
-/sdk/storage/  @vinjiang @katmsft @JinmingHu-MSFT @antkmsft @rickwinter @vhvb1989
+# PRLabel: %KeyVault
+/sdk/keyvault/           @vhvb1989 @ahsonkhan @antkmsft @rickwinter
+
+# PRLabel: %Storage
+/sdk/storage/            @vinjiang @katmsft @JinmingHu-MSFT @ahsonkhan @antkmsft @rickwinter @vhvb1989
+
+# PRLabel: %EngSys
+/sdk/template/           @danieljurek @Azure/azure-sdk-eng
 
 ###########
 # Eng Sys
 ###########
-/eng/       @danieljurek @azure/azure-sdk-eng
-/**/ci.yml  @danieljurek @azure/azure-sdk-eng
+/eng/                    @danieljurek @azure/azure-sdk-eng
+/**/ci.yml               @danieljurek @azure/azure-sdk-eng
+/**/tests.yml            @danieljurek @azure/azure-sdk-eng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 /sdk/keyvault/           @vhvb1989 @ahsonkhan @antkmsft @rickwinter
 
 # PRLabel: %Storage
-/sdk/storage/            @vinjiang @katmsft @JinmingHu-MSFT @ahsonkhan @antkmsft @rickwinter @vhvb1989
+/sdk/storage/            @vinjiang @katmsft @JinmingHu-MSFT @antkmsft @rickwinter @vhvb1989
 
 # PRLabel: %EngSys
 /sdk/template/           @danieljurek @Azure/azure-sdk-eng


### PR DESCRIPTION
Updating to reflect primary contacts for each area.  For now everyone is connected to storage as that is our first service and the changes are relevant to everyone.  Once Storage GA's the codeowner will update to include our teams primary service contact