### PR TITLE
Special curl transport setup callback

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl/curl.hpp
@@ -647,7 +647,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Construct a new Curl Transport object.
      *
      */
-    explicit CurlTransport() : CurlTransport(nullptr) {}
+    CurlTransport() : CurlTransport(nullptr) {}
 
     /**
      * @brief Construct a new Curl Transport object.
@@ -655,7 +655,7 @@ namespace Azure { namespace Core { namespace Http {
      * @param advancedCurlSettingsFn The user defined function to manually set the curl handle
      * options.
      */
-    explicit CurlTransport(std::function<CURLcode(CURL* curlHandle)> advancedCurlSettingsFn)
+    CurlTransport(std::function<CURLcode(CURL* curlHandle)> advancedCurlSettingsFn)
         : m_advancedCurlSettingsFn(advancedCurlSettingsFn)
     {
     }

--- a/sdk/core/azure-core/test/ut/transport_adapter.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter.cpp
@@ -102,6 +102,40 @@ namespace Azure { namespace Core { namespace Test {
       }
 #endif
     }
+
+#ifdef RUN_LONG_UNIT_TESTS
+    // Proxy test might take up to 10 seconds
+    TEST_F(TransportAdapter, advancedCurlOptionsProxy)
+    {
+      // Creates used-defined callback to set a proxy
+      auto manualCurlSetUp = [](CURL* handle) {
+        // http://www.freeproxylists.net/136.228.165.138.html
+        return curl_easy_setopt(handle, CURLOPT_PROXY, "136.228.165.138:8080");
+      };
+
+      // Retry and transport policies
+      std::vector<std::unique_ptr<Azure::Core::Http::HttpPolicy>> policies;
+      Azure::Core::Http::RetryOptions rOpt;
+      rOpt.RetryDelay = std::chrono::milliseconds(10);
+      policies.push_back(std::make_unique<Azure::Core::Http::RetryPolicy>(rOpt));
+      policies.push_back(std::make_unique<Azure::Core::Http::TransportPolicy>(
+          std::make_unique<Azure::Core::Http::CurlTransport>(
+              manualCurlSetUp))); // Use callback for curl transport adapter
+      Azure::Core::Http::HttpPipeline pipelineWithManualSettings(policies);
+
+      Azure::Core::Http::Url host("http://httpbin.org/get");
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      auto response = pipelineWithManualSettings.Send(context, request);
+
+      checkResponseCode(response->GetStatusCode());
+      for (auto h : response->GetHeaders())
+      {
+        std::cout << h.first << ":" << h.second << std::endl;
+      }
+      auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
+      CheckBodyFromBuffer(*response, expectedResponseBodySize);
+    }
+#endif
 #endif
 
     TEST_F(TransportAdapter, get)
@@ -480,35 +514,4 @@ namespace Azure { namespace Core { namespace Test {
       cancelThis.Cancel();
       t1.join();
     }
-
-    TEST_F(TransportAdapter, advancedCurlOptionsProxy)
-    {
-      // Creates used-defined callback to set a proxy
-      auto manualCurlSetUp = [](CURL* handle) {
-        return curl_easy_setopt(handle, CURLOPT_PROXY, "136.228.165.138:8080");
-      };
-
-      // Retry and transport policies
-      std::vector<std::unique_ptr<Azure::Core::Http::HttpPolicy>> policies;
-      Azure::Core::Http::RetryOptions rOpt;
-      rOpt.RetryDelay = std::chrono::milliseconds(10);
-      policies.push_back(std::make_unique<Azure::Core::Http::RetryPolicy>(rOpt));
-      policies.push_back(std::make_unique<Azure::Core::Http::TransportPolicy>(
-          std::make_unique<Azure::Core::Http::CurlTransport>(
-              manualCurlSetUp))); // Use callback for curl transport adapter
-      Azure::Core::Http::HttpPipeline pipelineWithManualSettings(policies);
-
-      Azure::Core::Http::Url host("http://httpbin.org/get");
-      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
-      auto response = pipelineWithManualSettings.Send(context, request);
-
-      checkResponseCode(response->GetStatusCode());
-      for (auto h : response->GetHeaders())
-      {
-        std::cout << h.first << ":" << h.second << std::endl;
-      }
-      auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
-      CheckBodyFromBuffer(*response, expectedResponseBodySize);
-    }
-
 }}} // namespace Azure::Core::Test

--- a/sdk/core/azure-core/test/ut/transport_adapter.hpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter.hpp
@@ -6,6 +6,7 @@
 #include <azure/core/http/curl/curl.hpp>
 #include <azure/core/http/http.hpp>
 #include <azure/core/http/pipeline.hpp>
+#include <curl/curl.h>
 
 #include <memory>
 #include <vector>

--- a/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_file_upload.cpp
@@ -27,11 +27,9 @@ namespace Azure { namespace Core { namespace Test {
       Azure::Core::Http::HttpStatusCode expectedCode)
   {
     EXPECT_PRED2(
-        [](Azure::Core::Http::HttpStatusCode a, Azure::Core::Http::HttpStatusCode b) {
-          return a == b;
-        },
-        code,
-        expectedCode);
+        [](int a, int b) { return a == b; },
+        static_cast<typename std::underlying_type<Http::HttpStatusCode>::type>(code),
+        static_cast<typename std::underlying_type<Http::HttpStatusCode>::type>(expectedCode));
   }
 
   void TransportAdapter::CheckBodyFromBuffer(


### PR DESCRIPTION
Expose curl handle for CurlTransportAdapter. Final users can use this feature to manually set options for curl.

Fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/90