### PR TITLE
Add core.hpp general header

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Other changes and Improvements
 
-- Add high-level and simplified core.hpp files for simpler include experience for customers.
+- Add high-level and simplified core.hpp file for simpler include experience for customers.
 
 ## 1.0.0-beta.2 (2020-10-09)
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `Azure::Core::Http::Url::AppendPath` now does not encode the input by default.
 
+### Other changes and Improvements
+
+- Add high-level and simplified core.hpp files for simpler include experience for customers.
+
 ## 1.0.0-beta.2 (2020-10-09)
 
 ### Breaking Changes

--- a/sdk/core/azure-core/inc/azure/core.hpp
+++ b/sdk/core/azure-core/inc/azure/core.hpp
@@ -4,8 +4,7 @@
 #pragma once
 
 /**
- * @file core.hpp
- * @brief Adds all headers from Azure Core.
+ * @brief Add all headers from Azure Core.
  *
  */
 

--- a/sdk/core/azure-core/inc/azure/core.hpp
+++ b/sdk/core/azure-core/inc/azure/core.hpp
@@ -6,6 +6,8 @@
 /**
  * @brief Add all headers from Azure Core.
  *
+ * @remark transport adapter headers are not included and are expected to be manually included.
+ *
  */
 
 // azure/core
@@ -24,12 +26,6 @@
 #include "azure/core/http/pipeline.hpp"
 #include "azure/core/http/policy.hpp"
 #include "azure/core/http/transport.hpp"
-
-// azure/core/http/curl
-#include "azure/core/http/curl/curl.hpp"
-
-// azure/core/http/winhttp
-#include "azure/core/http/winhttp/win_http_client.hpp"
 
 // azure/core/logging
 #include "azure/core/logging/logging.hpp"

--- a/sdk/core/azure-core/inc/azure/core.hpp
+++ b/sdk/core/azure-core/inc/azure/core.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 /**
- * @brief Add all headers from Azure Core.
+ * @brief Add all non-optional headers from Azure Core.
  *
- * @remark transport adapter headers are not included and are expected to be manually included.
+ * @remark The transport adapter headers are not included and are expected to be manually included.
  *
  */
 

--- a/sdk/core/azure-core/inc/azure/core/core.hpp
+++ b/sdk/core/azure-core/inc/azure/core/core.hpp
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/**
+ * @file core.hpp
+ * @brief Adds all headers from Azure Core.
+ *
+ */
+
+// azure/core
+#include "azure/core/azure.hpp"
+#include "azure/core/context.hpp"
+#include "azure/core/credentials.hpp"
+#include "azure/core/datetime.hpp"
+#include "azure/core/nullable.hpp"
+#include "azure/core/response.hpp"
+#include "azure/core/uuid.hpp"
+#include "azure/core/version.hpp"
+
+// azure/core/http
+#include "azure/core/http/body_stream.hpp"
+#include "azure/core/http/http.hpp"
+#include "azure/core/http/pipeline.hpp"
+#include "azure/core/http/policy.hpp"
+#include "azure/core/http/transport.hpp"
+
+// azure/core/http/curl
+#include "azure/core/http/curl/curl.hpp"
+
+// azure/core/http/winhttp
+#include "azure/core/http/winhttp/win_http_client.hpp"
+
+// azure/core/logging
+#include "azure/core/logging/logging.hpp"


### PR DESCRIPTION
General header for all public Core headers.
This header will be used for API review tool.

https://github.com/Azure/azure-sdk-for-cpp/issues/812