### PR TITLE
Add unit test for simplified core.hpp header

### DIFF
--- a/sdk/core/azure-core/inc/azure/core.hpp
+++ b/sdk/core/azure-core/inc/azure/core.hpp
@@ -14,7 +14,6 @@
 #include "azure/core/context.hpp"
 #include "azure/core/credentials.hpp"
 #include "azure/core/datetime.hpp"
-#include "azure/core/extra_header.hpp"
 #include "azure/core/nullable.hpp"
 #include "azure/core/response.hpp"
 #include "azure/core/strings.hpp"
@@ -24,7 +23,6 @@
 // azure/core/http
 #include "azure/core/http/body_stream.hpp"
 #include "azure/core/http/http.hpp"
-#include "azure/core/http/pipeline.hpp"
 #include "azure/core/http/policy.hpp"
 #include "azure/core/http/transport.hpp"
 

--- a/sdk/core/azure-core/inc/azure/core.hpp
+++ b/sdk/core/azure-core/inc/azure/core.hpp
@@ -14,6 +14,7 @@
 #include "azure/core/context.hpp"
 #include "azure/core/credentials.hpp"
 #include "azure/core/datetime.hpp"
+#include "azure/core/extra_header.hpp"
 #include "azure/core/nullable.hpp"
 #include "azure/core/response.hpp"
 #include "azure/core/strings.hpp"

--- a/sdk/core/azure-core/inc/azure/core.hpp
+++ b/sdk/core/azure-core/inc/azure/core.hpp
@@ -23,6 +23,7 @@
 // azure/core/http
 #include "azure/core/http/body_stream.hpp"
 #include "azure/core/http/http.hpp"
+#include "azure/core/http/pipeline.hpp"
 #include "azure/core/http/policy.hpp"
 #include "azure/core/http/transport.hpp"
 

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable (
      main.cpp
      nullable.cpp
      pipeline.cpp
+     simplified_header.cpp
      string.cpp
      telemetry_policy.cpp
      transport_adapter.cpp

--- a/sdk/core/azure-core/test/ut/simplified_header.cpp
+++ b/sdk/core/azure-core/test/ut/simplified_header.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief makes sure azure/core.hpp can be included.
+ *
+ * @remark This file will catch any issue while trying to use/include the core.hpp header
+ *
+ */
+
+#include "gtest/gtest.h"
+#include <azure/core.hpp>
+
+#include <vector>
+
+TEST(Logging, simplifiedHeader)
+{
+  EXPECT_NO_THROW(Azure::Core::Context c);
+  EXPECT_NO_THROW(Azure::Core::DateTime::DateTime::FromSeconds(10));
+  EXPECT_NO_THROW(Azure::Core::Nullable<int> n);
+  EXPECT_NO_THROW(Azure::Core::Http::RawResponse r(
+      1, 1, Azure::Core::Http::HttpStatusCode::Accepted, "phrase"));
+  EXPECT_NO_THROW(Azure::Core::Strings::ToLower("A"));
+  EXPECT_NO_THROW(Azure::Core::Uuid::CreateUuid());
+  EXPECT_NO_THROW(Azure::Core::Version::VersionString());
+
+  {
+    std::vector<uint8_t> buffer(10);
+    EXPECT_NO_THROW(Azure::Core::Http::MemoryBodyStream mb(buffer));
+  }
+  EXPECT_NO_THROW(Azure::Core::Http::TelemetryPolicy tp("", ""));
+  EXPECT_NO_THROW(Azure::Core::Http::HttpPipeline pipeline(
+      std::vector<std::unique_ptr<Azure::Core::Http::HttpPolicy>>(1)));
+}


### PR DESCRIPTION
This tests will ensure that if any header included by core.hpp gets broken (missing/removed/renamed/etc) then CI will catch it.
`Compilation will fail`