### PR TITLE
update exceptions to be a class instead of an struct

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Other changes and Improvements
 
 - Add high-level and simplified core.hpp file for simpler include experience for customers.
+- Update Exceptions as classes. 
 
 ### Bug Fixes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Other changes and Improvements
 
 - Add high-level and simplified core.hpp file for simpler include experience for customers.
-- Update Exceptions as classes. 
+- Update SDK-defined exception types to be classes instead of structs.
 
 ### Bug Fixes
 

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -26,8 +26,17 @@ namespace Azure { namespace Core {
     virtual ~ValueBase() {}
   };
 
-  struct OperationCanceledException : public std::runtime_error
-  {
+  /**
+   * @brief An exception that gets thrown when some operation is canceled.
+   *
+   */
+  class OperationCanceledException : public std::runtime_error {
+  public:
+    /**
+     * @brief Construct with message string as description.
+     *
+     * @param message The description for the exception.
+     */
     explicit OperationCanceledException(std::string const& message) : std::runtime_error(message) {}
   };
 

--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -15,8 +15,8 @@ namespace Azure { namespace Core {
    * @brief An error while trying to send a request to Azure service.
    *
    */
-  struct RequestFailedException : public std::runtime_error
-  {
+  class RequestFailedException : public std::runtime_error {
+  public:
     /**
      * @brief Construct a new Request Failed Exception object.
      *

--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -52,8 +52,8 @@ namespace Azure { namespace Core { namespace Http {
   /**
    * @brief HTTP transport layer error.
    */
-  struct TransportException : public Azure::Core::RequestFailedException
-  {
+  class TransportException : public Azure::Core::RequestFailedException {
+  public:
     /**
      * @brief An error while sending the HTTP request with the transport adapter.
      *
@@ -72,8 +72,8 @@ namespace Azure { namespace Core { namespace Http {
    * @brief An invalid header key name in @Request or @RawResponse.
    *
    */
-  struct InvalidHeaderException : public Azure::Core::RequestFailedException
-  {
+  class InvalidHeaderException : public Azure::Core::RequestFailedException {
+  public:
     /**
      * @brief An invalid header key name detected in the HTTP request or response.
      *


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/828