### PR TITLE
Add a test that forces core.hpp to be included

### DIFF
--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -41,7 +41,6 @@ add_library (
   src/logging/logging.cpp
   src/strings.cpp
   src/version.cpp
-  src/headers.cpp
   )
 
 target_include_directories (${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc> $<INSTALL_INTERFACE:include/az_core>)

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library (
   src/logging/logging.cpp
   src/strings.cpp
   src/version.cpp
+  src/headers.cpp
   )
 
 target_include_directories (${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc> $<INSTALL_INTERFACE:include/az_core>)

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable (
      transport_adapter.cpp
      transport_adapter_file_upload.cpp
      uuid.cpp
+     headers.cpp
      )
 
 target_link_libraries(${TARGET_NAME} PRIVATE azure-core gtest)

--- a/sdk/core/azure-core/test/ut/headers.cpp
+++ b/sdk/core/azure-core/test/ut/headers.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "gtest/gtest.h"
+
+#include <azure/core.hpp>
+
+#include <limits>
+
+using namespace Azure::Core;
+
+TEST(Headers, SimpleInclude)
+{
+  //This test exists to check compilation of core.hpp
+
+  auto dt1 = DateTime::FromString("20130517T00:00:00Z", DateTime::DateFormat::Iso8601);
+  EXPECT_NE(0u, dt1.ToInterval());
+
+  Nullable<std::string> testString{"hello world"};
+  EXPECT_TRUE(testString.HasValue());
+
+  Context context;  
+  auto& valueT = context["key"];
+  EXPECT_FALSE(context.HasKey(""));
+  EXPECT_FALSE(context.HasKey("key"));
+
+  auto uuid = Uuid::CreateUuid();
+  EXPECT_TRUE(uuid.GetUuidString().length() == 36);
+
+}


### PR DESCRIPTION
Adding a test that includes core.hpp for building.  It is not intended to be an exhaustive check of all the types in core.hpp.