### PR TITLE
Do not reuse a connection that fail while uploading

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Bug Fixes
 
 - Prevent pipeline of length zero to be created.
+- Avoid re-using a connection when an uploading request fail when using CurlTransport.
 
 ### New Features
 


### PR DESCRIPTION
The issue is that if that if a connection throw while reading from the server, when we check if it is EOF (contentLenght == session.totalRead) is true because we don't know the content length yet.  
We need to introduce an internal state to check this case and do not move the connection back to the connection pool.

Right now, the connection is moved back to the pool and will fail every time we try to reuse that connection.

fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/815