### PR TITLE
remove throw from NextPolicy

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/pipeline.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/pipeline.hpp
@@ -99,7 +99,7 @@ namespace Azure { namespace Core { namespace Http {
     {
       // Accessing position zero is fine because pipeline must be constructed with at least one
       // policy.
-      return m_policies[0]->Send(ctx, request, NextHttpPolicy(0, &m_policies));
+      return m_policies[0]->Send(ctx, request, NextHttpPolicy(0, m_policies));
     }
   };
 }}} // namespace Azure::Core::Http

--- a/sdk/core/azure-core/inc/azure/core/http/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policy.hpp
@@ -65,7 +65,7 @@ namespace Azure { namespace Core { namespace Http {
   // Represents the next HTTP policy in the stack sequence of policies.
   class NextHttpPolicy {
     const std::size_t m_index;
-    const std::vector<std::unique_ptr<HttpPolicy>>* m_policies;
+    const std::vector<std::unique_ptr<HttpPolicy>>& m_policies;
 
   public:
     /**
@@ -78,7 +78,7 @@ namespace Azure { namespace Core { namespace Http {
      */
     explicit NextHttpPolicy(
         std::size_t index,
-        const std::vector<std::unique_ptr<HttpPolicy>>* policies)
+        const std::vector<std::unique_ptr<HttpPolicy>>& policies)
         : m_index(index), m_policies(policies)
     {
     }

--- a/sdk/core/azure-core/src/http/policy.cpp
+++ b/sdk/core/azure-core/src/http/policy.cpp
@@ -16,16 +16,15 @@ Azure::Core::Logging::LogClassification const
     Azure::Core::Http::LogClassification::HttpTransportAdapter;
 #endif
 
+// The NextHttpPolicy can't be created from a nullptr because it is a reference. So we don't need to
+// check if m_policies is nullptr.
 std::unique_ptr<RawResponse> NextHttpPolicy::Send(Context const& ctx, Request& req)
 {
-  if (m_policies == nullptr)
-    throw;
-
-  if (m_index == m_policies->size() - 1)
+  if (m_index == m_policies.size() - 1)
   {
     // All the policies have run without running a transport policy
-    throw;
+    throw std::invalid_argument("Invalid pipeline. No transport policy found. Endless policy.");
   }
 
-  return (*m_policies)[m_index + 1]->Send(ctx, req, NextHttpPolicy{m_index + 1, m_policies});
+  return m_policies[m_index + 1]->Send(ctx, req, NextHttpPolicy{m_index + 1, m_policies});
 }

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable (
      main.cpp
      nullable.cpp
      pipeline.cpp
+     policy.cpp
      simplified_header.cpp
      string.cpp
      telemetry_policy.cpp

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "gtest/gtest.h"
+#include <azure/core/http/pipeline.hpp>
+#include <azure/core/http/policy.hpp>
+
+#include <vector>
+
+TEST(Policy, throwWhenNoTransportPolicy)
+{
+  // Construct pipeline without exception
+  std::vector<std::unique_ptr<Azure::Core::Http::HttpPolicy>> policies;
+  policies.push_back(std::make_unique<Azure::Core::Http::TelemetryPolicy>("test", "test"));
+  policies.push_back(std::make_unique<Azure::Core::Http::TelemetryPolicy>("test", "test"));
+  policies.push_back(std::make_unique<Azure::Core::Http::TelemetryPolicy>("test", "test"));
+  policies.push_back(std::make_unique<Azure::Core::Http::TelemetryPolicy>("test", "test"));
+
+  Azure::Core::Http::HttpPipeline pipeline(policies);
+  Azure::Core::Http::Url url("");
+  Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
+  EXPECT_THROW(pipeline.Send(Azure::Core::GetApplicationContext(), request), std::invalid_argument);
+}
+
+TEST(Policy, throwWhenNoTransportPolicyMessage)
+{
+  // Construct pipeline without exception
+  std::vector<std::unique_ptr<Azure::Core::Http::HttpPolicy>> policies;
+  policies.push_back(std::make_unique<Azure::Core::Http::TelemetryPolicy>("test", "test"));
+  policies.push_back(std::make_unique<Azure::Core::Http::TelemetryPolicy>("test", "test"));
+  policies.push_back(std::make_unique<Azure::Core::Http::TelemetryPolicy>("test", "test"));
+  policies.push_back(std::make_unique<Azure::Core::Http::TelemetryPolicy>("test", "test"));
+
+  Azure::Core::Http::HttpPipeline pipeline(policies);
+  Azure::Core::Http::Url url("");
+  Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
+
+  try
+  {
+    pipeline.Send(Azure::Core::GetApplicationContext(), request);
+  }
+  catch (std::invalid_argument& err)
+  {
+    EXPECT_STREQ("Invalid pipeline. No transport policy found. Endless policy.", err.what());
+  }
+}


### PR DESCRIPTION
Update NextPolicy to that a reference instead of a pointer to the policies vector.
This way we don't need to check if the pointer is null.

Then, handle the case were no transport adapter was found

fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/874