### PR TITLE
Test that a connection won't be moved to the connection pool if uploading fails

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Bug Fixes
 
 - Prevent pipeline of length zero to be created.
-- Avoid re-using a connection when an uploading request fail when using CurlTransport.
+- Avoid re-using a connection when a request to upload data fails while using the `CurlTransport`.
 
 ### New Features
 

--- a/sdk/core/azure-core/test/ut/curl_session_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_session_test.cpp
@@ -6,6 +6,8 @@
 #include <azure/core/http/curl/curl.hpp>
 #include <azure/core/http/http.hpp>
 
+#include <curl/curl.h>
+
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::Return;
@@ -77,5 +79,34 @@ namespace Azure { namespace Core { namespace Test {
     }
     // Clear the connections from the pool to invoke clean routine
     Azure::Core::Http::CurlConnectionPool::ConnectionPoolIndex.clear();
+  }
+
+  TEST_F(CurlSession, DoNotReuseConnectionIfDownloadFail)
+  {
+
+    // Can't mock the curMock directly from a unique ptr, heap allocate it first and then make a
+    // unique ptr for it
+    MockCurlNetworkConnection* curlMock = new MockCurlNetworkConnection();
+    // mock an upload error
+    EXPECT_CALL(*curlMock, SendBuffer(_, _, _)).WillOnce(Return(CURLE_SEND_ERROR));
+    EXPECT_CALL(*curlMock, DestructObj());
+
+    // Create the unique ptr to take care about memory free at the end
+    std::unique_ptr<MockCurlNetworkConnection> uniqueCurlMock(curlMock);
+
+    // Simulate a request to be sent
+    Azure::Core::Http::Url url("http://microsoft.com");
+    Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
+
+    {
+      // Create the session inside scope so it is released and the connection is moved to the pool
+      auto session = std::make_unique<Azure::Core::Http::CurlSession>(
+          request, std::move(uniqueCurlMock), true);
+
+      auto returnCode = session->Perform(Azure::Core::GetApplicationContext());
+      EXPECT_EQ(CURLE_SEND_ERROR, returnCode);
+    }
+    // Check connection pool is empty (connection was not moved to the pool)
+    EXPECT_EQ(Azure::Core::Http::CurlConnectionPool::ConnectionPoolIndex.size(), 0);
   }
 }}} // namespace Azure::Core::Test

--- a/sdk/core/azure-core/test/ut/curl_session_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_session_test.cpp
@@ -84,7 +84,7 @@ namespace Azure { namespace Core { namespace Test {
   TEST_F(CurlSession, DoNotReuseConnectionIfDownloadFail)
   {
 
-    // Can't mock the curMock directly from a unique ptr, heap allocate it first and then make a
+    // Can't mock the curlMock directly from a unique ptr, heap allocate it first and then make a
     // unique ptr for it
     MockCurlNetworkConnection* curlMock = new MockCurlNetworkConnection();
     // mock an upload error


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/905