### PR TITLE
Fix default EndpointSuffix when parsing connection string

### DIFF
--- a/sdk/storage/azure-storage-common/CMakeLists.txt
+++ b/sdk/storage/azure-storage-common/CMakeLists.txt
@@ -69,6 +69,7 @@ target_sources(
     PRIVATE
     test/bearer_token_test.cpp
     test/crypt_functions_test.cpp
+    test/storage_credential_test.cpp
     test/test_base.cpp
     test/test_base.hpp
 )
@@ -85,7 +86,7 @@ target_sources(
     sample/main.cpp
     sample/samples_common.hpp
 )
-    
+
 target_include_directories(azure-storage-sample PUBLIC sample)
 
 generate_documentation(azure-storage-common ${AZ_LIBRARY_VERSION})

--- a/sdk/storage/azure-storage-common/src/storage_credential.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_credential.cpp
@@ -51,7 +51,7 @@ namespace Azure { namespace Storage { namespace Details {
     std::string defaultEndpointsProtocol
         = getWithDefault(connectionStringMap, "DefaultEndpointsProtocol", "https");
     std::string EndpointSuffix
-        = getWithDefault(connectionStringMap, "EndpointSuffix", ".core.windows.net");
+        = getWithDefault(connectionStringMap, "EndpointSuffix", "core.windows.net");
     std::string accountName = getWithDefault(connectionStringMap, "AccountName");
 
     std::string endpoint = getWithDefault(connectionStringMap, "BlobEndpoint");

--- a/sdk/storage/azure-storage-common/test/storage_credential_test.cpp
+++ b/sdk/storage/azure-storage-common/test/storage_credential_test.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "azure/storage/common/storage_credential.hpp"
+#include "test_base.hpp"
+
+namespace Azure { namespace Storage { namespace Test {
+
+  TEST(StorageCredentialTest, DefaultHostCorrect)
+  {
+    EXPECT_EQ(Azure::Storage::Details::ParseConnectionString(
+            "DefaultEndpointsProtocol=https;AccountName=testaccount;AccountKey=testkey").BlobServiceUri.GetHost(), "testaccount.blob.core.windows.net");
+  }
+
+}}} // namespace Azure::Storage::Test


### PR DESCRIPTION
Creating a storage client with a connection string where no EndpointSuffix is defined results in faulty service URI containing two '.' characters between the uri and the suffix. This goal of this change is to correct this issue. Addresses issue #964 