### PR TITLE
Fix coverage report for template and core pipelines

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -4,6 +4,7 @@ parameters:
   Coverage: ''
   CtestRegex: .*
   BuildReleaseArtifacts: true
+  CoverageReportPath: 'sdk/*/*/*cov_xml.xml'
 
 jobs:
 - job: Validate
@@ -119,7 +120,7 @@ jobs:
   # coverage report
   - bash: |
       make `cat ${{ parameters.ServiceDirectory }}-targets-coverage.txt`
-      ../tools/reportgenerator "-reports:sdk/*/*/*cov_xml.xml" "-targetdir:." "-reporttypes:Cobertura"
+      ../tools/reportgenerator "-reports:${{ parameters.CoverageReportPath }}" "-targetdir:." "-reporttypes:Cobertura"
     workingDirectory: build
     displayName: Generate Code Coverage Data
     condition: and(succeededOrFailed(), ne(variables['CODE_COVERAGE'], 'disabled'), ne(variables['CODE_COVERAGE'], ''))

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -14,6 +14,9 @@ parameters:
 - name: Coverage
   type: string
   default: 'enabled'
+- name: CoverageReportPath
+  type: string
+  default: sdk/*/*/*cov_xml.xml
 
 jobs:
 - job: Validate
@@ -93,7 +96,7 @@ jobs:
   # coverage report
   - bash: |
       make `cat ${{ parameters.ServiceDirectory }}-targets-coverage.txt`
-      ../tools/reportgenerator "-reports:sdk/*/*cov_xml.xml" "-targetdir:." "-reporttypes:Cobertura"
+      ../tools/reportgenerator "-reports:${{ parameters.CoverageReportPath }}" "-targetdir:." "-reporttypes:Cobertura"
     workingDirectory: build
     displayName: Generate Code Coverage Data
     condition: and(succeededOrFailed(), ne(variables['CODE_COVERAGE'], 'disabled'), ne(variables['CODE_COVERAGE'], ''))

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -20,6 +20,9 @@ parameters:
 - name: SubscriptionConfiguration
   type: string
   default: $(sub-config-azure-cloud-test-resources)
+- name: CoverageReportPath
+  type: string
+  default: 'sdk/*/*/*cov_xml.xml'
 
 stages:
   - stage: Build
@@ -30,6 +33,7 @@ stages:
           Artifacts: ${{ parameters.Artifacts }}
           CtestRegex: ${{ parameters.CtestRegex }}
           Coverage: ${{ parameters.Coverage }}
+          CoverageReportPath: ${{ parameters.CoverageReportPath }}
 
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
     - stage: LiveTest
@@ -42,6 +46,7 @@ stages:
             CtestRegex: ${{ parameters.LiveTestCtestRegex }}
             Location: ${{ parameters.Location }}
             SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
+            CoverageReportPath: ${{ parameters.CoverageReportPath }}
 
   - ${{ if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'), not(endsWith(variables['Build.DefinitionName'], ' - tests'))) }}:
     - template: archetype-cpp-release.yml

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -32,8 +32,6 @@ stages:
     parameters:
       ServiceDirectory: core
       CtestRegex: azure-core.
-      # no live tests, all tests are currently for CI only
-      #LiveTestCtestRegex: azure-core.
       Artifacts:
         - Name: azure-core
           Path: azure-core

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -32,7 +32,8 @@ stages:
     parameters:
       ServiceDirectory: core
       CtestRegex: azure-core.
-      LiveTestCtestRegex: azure-core.
+      # no live tests, all tests are currently for CI only
+      #LiveTestCtestRegex: azure-core.
       Artifacts:
         - Name: azure-core
           Path: azure-core

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -39,6 +39,7 @@ stages:
       CtestRegex: no-run
       Coverage: disabled
       LiveTestCtestRegex: azure-storage
+      CoverageReportPath: sdk/*/*cov_xml.xml
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
       Artifacts:
         - Name: azure-storage-common

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -34,8 +34,6 @@ stages:
     parameters:
       ServiceDirectory: template
       CtestRegex: azure-template
-      # Enable for running LiveTests on test pipeline
-      #LiveTestCtestRegex: azure-template
       Artifacts:
         - Name: azure-template
           Path: azure-template

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -34,7 +34,8 @@ stages:
     parameters:
       ServiceDirectory: template
       CtestRegex: azure-template
-      LiveTestCtestRegex: azure-template
+      # Enable for running LiveTests on test pipeline
+      #LiveTestCtestRegex: azure-template
       Artifacts:
         - Name: azure-template
           Path: azure-template


### PR DESCRIPTION
Root Cause:
Storage project generates coverage files in a different location (sdk/*/*cov_xml.xml) from where Core and Template (sdk/*/*/*cov_xml.xml). Basically one level up.

When I added the coverage for Storage, I didn’t know we were also running live tests for Core and Template pipelines. It failed on them because the xml files were not found.

In the PR, I add a new parameter to pipelines to change the default path, and also I am disabling LiveTests from Core and Template, since it only runs the same thing that we run on CI pipelines (We can enable it if we ever have some live tests)


fix: #1001 