### PR TITLE
Remove alternative token usage

### DIFF
--- a/sdk/storage/azure-storage-files-shares/src/share_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_client.cpp
@@ -129,7 +129,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const DeleteShareOptions& options) const
   {
     auto protocolLayerOptions = Details::ShareRestClient::Share::DeleteOptions();
-    if (options.IncludeSnapshots.HasValue() and options.IncludeSnapshots.GetValue())
+    if (options.IncludeSnapshots.HasValue() && options.IncludeSnapshots.GetValue())
     {
       protocolLayerOptions.XMsDeleteSnapshots = Models::DeleteSnapshotsOptionType::Include;
     }


### PR DESCRIPTION
CI/CD sometimes fails, and MSVC build now fails on some of our personal machines with the latest updates.
https://github.com/Azure/azure-sdk-for-cpp/pull/1042 currently fails due to this.

I think it has to do with the compiler version update.

`and` shouldn't be used anyway - it is an alternative operator, that is intended to be used on the old systems with 7-bit char that don't have good representation for the `&` character.
https://en.cppreference.com/w/cpp/language/operator_alternative

I think the reason it worked is that it was available in older MSVC versions, but now you must use some sort of a compiler switch in order to make it available.

Other possible explanation, which I hope is not the case, is that someone (us or 3rd party library) has defined "and" as macro, and now it can be substituted by something random, but I don't think it is the case.

Anyways, this change goes in, we compile successfully everywhere.