### PR TITLE
Update the nlohmann json dependency version from 3.6.0 to 3.9.1

### DIFF
--- a/cmake-modules/add_nlohmann_json.cmake
+++ b/cmake-modules/add_nlohmann_json.cmake
@@ -8,7 +8,7 @@
 
 # Storage requires 3.6.0 version for using `contains` feature
 # Using QUIET to avoid warning message if lib is not found
-find_package(nlohmann_json 3.6.0 EXACT QUIET)
+find_package(nlohmann_json 3.9.1 EXACT QUIET)
 if (NOT nlohmann_json_FOUND)
 
     include(FetchContent)
@@ -16,7 +16,7 @@ if (NOT nlohmann_json_FOUND)
     # release code only. This save us from getting the entire nlohmann source code.
     FetchContent_Declare(json
         GIT_REPOSITORY https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent
-        GIT_TAG v3.8.0)
+        GIT_TAG v3.9.1)
 
     FetchContent_GetProperties(json)
     if (NOT json_POPULATED)

--- a/cmake-modules/add_nlohmann_json.cmake
+++ b/cmake-modules/add_nlohmann_json.cmake
@@ -8,7 +8,7 @@
 
 # Storage requires 3.6.0 version for using `contains` feature
 # Using QUIET to avoid warning message if lib is not found
-find_package(nlohmann_json 3.9.1 EXACT QUIET)
+find_package(nlohmann_json 3.9.0 EXACT QUIET)
 if (NOT nlohmann_json_FOUND)
 
     include(FetchContent)
@@ -16,7 +16,7 @@ if (NOT nlohmann_json_FOUND)
     # release code only. This save us from getting the entire nlohmann source code.
     FetchContent_Declare(json
         GIT_REPOSITORY https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent
-        GIT_TAG v3.9.1)
+        GIT_TAG v3.9.0)
 
     FetchContent_GetProperties(json)
     if (NOT json_POPULATED)


### PR DESCRIPTION
Testing to see if the issue from https://github.com/Azure/azure-sdk-for-cpp/pull/1053 becomes visible only if the JSON dependency is upgraded, without using vcpkg. Trying to isolate the differences from https://github.com/Azure/azure-sdk-for-cpp/pull/1054

cc @vhvb1989, @antkmsft 