### PR TITLE
Fix MSVC warning D9025 ("overriding '/W3' with '/W4'")

### DIFF
--- a/cmake-modules/global_compile_options.cmake
+++ b/cmake-modules/global_compile_options.cmake
@@ -8,6 +8,9 @@ if(MSVC)
     set(WARNINGS_AS_ERRORS_FLAG "/WX")
   endif()
 
+  # https://stackoverflow.com/questions/58708772/cmake-project-in-visual-studio-gives-flag-override-warnings-command-line-warnin
+  string(REGEX REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
   #https://stackoverflow.com/questions/37527946/warning-unreferenced-inline-function-has-been-removed
   add_compile_options(/W4 ${WARNINGS_AS_ERRORS_FLAG} /wd5031 /wd4668 /wd4820 /wd4255 /wd4710 /analyze)
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
See https://stackoverflow.com/questions/58708772/cmake-project-in-visual-studio-gives-flag-override-warnings-command-line-warnin

--
This change was extracted from #1013, in order to isolate some of the changes.