### PR TITLE
Make SDK buildable in VS 2017

### DIFF
--- a/sdk/core/azure-core/src/http/body_stream.cpp
+++ b/sdk/core/azure-core/src/http/body_stream.cpp
@@ -23,6 +23,7 @@
 #include <stdexcept>
 #include <vector>
 
+using Azure::Core::Context;
 using namespace Azure::Core::Http;
 
 // Keep reading until buffer is all fill out of the end of stream content is reached
@@ -53,7 +54,7 @@ std::vector<uint8_t> BodyStream::ReadToEnd(Context const& context, BodyStream& b
 
   for (auto chunkNumber = 0;; chunkNumber++)
   {
-    buffer.resize((chunkNumber + 1) * chunkSize);
+    buffer.resize((static_cast<decltype(buffer)::size_type>(chunkNumber) + 1) * chunkSize);
     int64_t readBytes
         = ReadToCount(context, body, buffer.data() + (chunkNumber * chunkSize), chunkSize);
 

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -140,6 +140,7 @@ void WinSocketSetBuffSize(curl_socket_t socket)
 #endif // WINDOWS
 } // namespace
 
+using Azure::Core::Context;
 using Azure::Core::Http::CurlConnection;
 using Azure::Core::Http::CurlConnectionPool;
 using Azure::Core::Http::CurlNetworkConnection;
@@ -1149,7 +1150,7 @@ std::unique_ptr<CurlNetworkConnection> CurlConnectionPool::GetCurlConnection(
 // connection to be picked next time some one ask for a connection to the pool (LIFO)
 void CurlConnectionPool::MoveConnectionBackToPool(
     std::unique_ptr<CurlNetworkConnection> connection,
-    Http::HttpStatusCode lastStatusCode)
+    HttpStatusCode lastStatusCode)
 {
   auto code = static_cast<std::underlying_type<Http::HttpStatusCode>::type>(lastStatusCode);
   // laststatusCode = 0

--- a/sdk/core/azure-core/src/http/logging_policy.cpp
+++ b/sdk/core/azure-core/src/http/logging_policy.cpp
@@ -7,7 +7,7 @@
 #include <chrono>
 #include <sstream>
 
-using namespace Azure::Core;
+using Azure::Core::Context;
 using namespace Azure::Core::Http;
 
 namespace {

--- a/sdk/core/azure-core/src/http/policy.cpp
+++ b/sdk/core/azure-core/src/http/policy.cpp
@@ -4,6 +4,7 @@
 #include "azure/core/http/policy.hpp"
 #include "azure/core/http/http.hpp"
 
+using Azure::Core::Context;
 using namespace Azure::Core::Http;
 
 #ifndef _MSC_VER

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -10,7 +10,7 @@
 #include <sstream>
 #include <thread>
 
-using namespace Azure::Core;
+using Azure::Core::Context;
 using namespace Azure::Core::Http;
 
 namespace {

--- a/sdk/core/azure-core/src/http/telemetry_policy.cpp
+++ b/sdk/core/azure-core/src/http/telemetry_policy.cpp
@@ -3,6 +3,7 @@
 
 #include "azure/core/http/policy.hpp"
 
+#include <cctype>
 #include <sstream>
 
 #ifdef _WIN32
@@ -109,6 +110,7 @@ std::string TrimString(std::string s)
 }
 } // namespace
 
+using Azure::Core::Context;
 using namespace Azure::Core::Http;
 
 std::string TelemetryPolicy::BuildTelemetryId(

--- a/sdk/core/azure-core/src/http/transport_policy.cpp
+++ b/sdk/core/azure-core/src/http/transport_policy.cpp
@@ -3,6 +3,7 @@
 
 #include "azure/core/http/policy.hpp"
 
+using Azure::Core::Context;
 using namespace Azure::Core::Http;
 
 std::unique_ptr<RawResponse> TransportPolicy::Send(


### PR DESCRIPTION
This change was extracted from #1013, in order to isolate some of the changes.