### PR TITLE
Try to remove the dependency on a curl header in client secret credential implementation

### DIFF
--- a/sdk/identity/azure-identity/src/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_secret_credential.cpp
@@ -3,7 +3,6 @@
 
 #include "azure/identity/client_secret_credential.hpp"
 
-#include <azure/core/http/curl/curl.hpp>
 #include <azure/core/http/pipeline.hpp>
 
 #include <iomanip>


### PR DESCRIPTION
Ideally, there should be no direct dependency on a specific transport adapter, even in the implementation.