### PR TITLE
Use the default coverage report path

### DIFF
--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -39,7 +39,6 @@ stages:
       CtestRegex: no-run
       Coverage: disabled
       LiveTestCtestRegex: azure-storage
-      CoverageReportPath: sdk/*/*cov_xml.xml
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
       Artifacts:
         - Name: azure-storage-common


### PR DESCRIPTION
Now that the Storage structure is defined to have a CMakeList file per each package (blobs, file, shares), we need to remove the special path option from the CI config