### PR TITLE
Fix main ut tests when not using libcurl

### DIFF
--- a/sdk/core/azure-core/test/ut/main.cpp
+++ b/sdk/core/azure-core/test/ut/main.cpp
@@ -4,18 +4,18 @@
 #include <gtest/gtest.h>
 
 #if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
-  #include <curl/curl.h>
+#include <curl/curl.h>
 #endif
 
 int main(int argc, char** argv)
 {
-  #if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
+#if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
   curl_global_init(CURL_GLOBAL_ALL);
-  #endif
+#endif
 
   testing::InitGoogleTest(&argc, argv);
   auto r = RUN_ALL_TESTS();
-  
+
 #if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
   curl_global_cleanup();
 #endif

--- a/sdk/core/azure-core/test/ut/main.cpp
+++ b/sdk/core/azure-core/test/ut/main.cpp
@@ -1,14 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <curl/curl.h>
 #include <gtest/gtest.h>
+
+#if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
+  #include <curl/curl.h>
+#endif
 
 int main(int argc, char** argv)
 {
+  #if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
   curl_global_init(CURL_GLOBAL_ALL);
+  #endif
+
   testing::InitGoogleTest(&argc, argv);
   auto r = RUN_ALL_TESTS();
+  
+#if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
   curl_global_cleanup();
+#endif
   return r;
 }


### PR DESCRIPTION
When not building the curl transport adapter, the tests should still work to be built.

After the latest change to out project. We are not requiring libcurl all the time if we are not building the libcurl transport adapter.

This uncover a bug in the unit test that were always expecting libcurl to be linked