### PR TITLE
Use Ninja for Win64 and no libcurl when no testing

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -37,14 +37,13 @@ jobs:
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
         CmakeArgs: ' -DBUILD_TRANSPORT_CURL=ON' #Leaving curl on here to explicitly test what the default behavior is on windows.
-        BuildArgs: '-v --parallel 8'
+        BuildArgs: '--parallel 8'
       Win_x64:
         OSVmImage: 'windows-2019'
-        VcpkgInstall: 'curl[winssl] libxml2 nlohmann-json'
+        VcpkgInstall: 'libxml2 nlohmann-json'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR: 'Ninja'
         CMAKE_GENERATOR_PLATFORM: x64
-        BuildArgs: '-v --parallel 8'
       MacOS_x64:
        OSVmImage: 'macOS-10.14'
        VcpkgInstall: 'curl[ssl] libxml2 openssl nlohmann-json'
@@ -68,7 +67,7 @@ jobs:
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
         CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
-        BuildArgs: '-v --parallel 8'
+        BuildArgs: '--parallel 8'
       Win_x64_with_unit_test:
         OSVmImage: 'windows-2019'
         VcpkgInstall: 'curl[winssl] libxml2 nlohmann-json'
@@ -76,7 +75,7 @@ jobs:
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
         CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
-        BuildArgs: '-v --parallel 8'
+        BuildArgs: '--parallel 8'
       MacOS_x64_with_unit_test:
         OSVmImage: 'macOS-10.14'
         VcpkgInstall: 'curl[ssl] libxml2 openssl nlohmann-json'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -43,7 +43,6 @@ jobs:
         VcpkgInstall: 'libxml2 nlohmann-json'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Ninja'
-        CMAKE_GENERATOR_PLATFORM: x64
       MacOS_x64:
        OSVmImage: 'macOS-10.14'
        VcpkgInstall: 'curl[ssl] libxml2 openssl nlohmann-json'

--- a/eng/pipelines/templates/steps/cmake-build.yml
+++ b/eng/pipelines/templates/steps/cmake-build.yml
@@ -17,6 +17,6 @@ steps:
     displayName: cmake generate
 
   - ${{ if eq(parameters.Build, true) }}:
-    - script: cmake --build . ${{ parameters.BuildArgs }}
+    - script: cmake -v --build . ${{ parameters.BuildArgs }}
       workingDirectory: build
       displayName: cmake build


### PR DESCRIPTION
Updating CI coverage for:
-  Ninja project on Windows
-  No libcurl dependency installation on Windows