### PR TITLE
Update storage changelog to be consistent on section order, use past tense, and make it a bit more brief.

### DIFF
--- a/sdk/storage/azure-storage-blobs/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blobs/CHANGELOG.md
@@ -1,26 +1,27 @@
 # Release History
 
-## 12.0.0-beta.6 (Unreleased)
+## 12.0.0-beta.6 (2020-01-14)
 
 ### New Features
 
-- `CreateIfNotExists` and `DeleteIfExists` for blob containers and blobs.
-- Add `IsHierarchicalNamespaceEnabled` in `GetAccountInfoResult`.
-- New API: `PageBlobClient::GetPageRangesDiff` and `PageBlobClient::GetManagedDiskPageRangesDiff`.
-- Add `CreateBlobContainer`, `DeleteBlobContainer`, `UndeleteBlobContainer` into `BlobServiceClient`.
-- Add `DeleteBlob` into `BlobContainerClient`.
+- Added `CreateIfNotExists` and `DeleteIfExists` for blob containers and blobs.
+- Added `IsHierarchicalNamespaceEnabled` in `GetAccountInfoResult`.
+- Added `PageBlobClient::GetPageRangesDiff` and `PageBlobClient::GetManagedDiskPageRangesDiff`.
+- Added `CreateBlobContainer`, `DeleteBlobContainer`, `UndeleteBlobContainer` into `BlobServiceClient`.
+- Added `DeleteBlob` to `BlobContainerClient`.
+- Support setting blob SAS permission with a raw string.
 
 ### Breaking Changes
 
-- Rename AppendBlobAccessConditions::MaxSize to AppendBlobAccessConditions::IfMaxSizeLessThanOrEqual.
-- Rename AppendBlobAccessConditions::AppendPosition to AppendBlobAccessConditions::IfAppendPositionEqual.
-- BlobServiceProperties.DefaultServiceVersion is now nullable.
-- Rename `DeleteBlobSubRequest::containerName` to `DeleteBlobSubRequest::blobContainerName`.
-- Rename `SetBlobAccessTierSubRequest::containerName` to `SetBlobAccessTierSubRequest::blobContainerName`.
-- Rename `BlobSasBuilder::ContainerName` to `BlobSasBuilder::BlobContainerName`.
-- Rename `BlobSasResource::Container` to `BlobSasResource::BlobContainer`.
-- Rename `AccountSasResource::Container` to `AccountSasResource::BlobContainer`
-- Rename some structs:
+- Renamed `AppendBlobAccessConditions::MaxSize` to `IfMaxSizeLessThanOrEqual`.
+- Renamed `AppendBlobAccessConditions::AppendPosition` to `IfAppendPositionEqual`.
+- `BlobServiceProperties.DefaultServiceVersion` is now nullable.
+- Renamed `DeleteBlobSubRequest::containerName` to `blobContainerName`.
+- Renamed `SetBlobAccessTierSubRequest::containerName` to `blobContainerName`.
+- Renamed `BlobSasBuilder::ContainerName` to `BlobContainerName`.
+- Renamed `BlobSasResource::Container` to `BlobContainer`.
+- Renamed `AccountSasResource::Container` to `BlobContainer`
+- Renamed some structs:
   - `CreateContainerResult` to `CreateBlobContainerOptions`
   - `CreateContainerOptions` to `CreateBlobContainerOptions`
   - `DeleteContainerResult` to `DeleteBlobContainerResult`
@@ -28,7 +29,7 @@
   - `GetContainerPropertiesResult` to `GetBlobContainerPropertiesResult`
   - `GetContainerPropertiesOptions` to `GetBlobContainerPropertiesOptions`
   - `SetContainerMetadataResult` to `SetBlobContainerMetadataResult`
-  - `SetContainerMetadataOptions ` to `SetBlobContainerMetadataOptions`
+  - `SetContainerMetadataOptions` to `SetBlobContainerMetadataOptions`
   - `GetContainerAccessPolicyResult` to `GetBlobContainerAccessPolicyResult`
   - `GetContainerAccessPolicyOptions` to `GetBlobContainerAccessPolicyOptions`
   - `SetContainerAccessPolicyResult` to `SetBlobContainerAccessPolicyResult`
@@ -43,17 +44,17 @@
   - `ChangeContainerLeaseOptions` to `ChangeBlobContainerLeaseOptions`
   - `BreakContainerLeaseResult` to `BreakBlobContainerLeaseResult`
   - `BreakContainerLeaseOptions` to `BreakBlobContainerLeaseOptions`
-  - `ContainerAccessConditions ` to `BlobContainerAccessConditions`
+  - `ContainerAccessConditions` to `BlobContainerAccessConditions`
   - `ListContainersSegmentResult` to `ListBlobContainersSegmentResult`
   - `ListContainersSegmentOptions` to `ListBlobContainersSegmentOptions`
-- API signature for CommitBlockList has changed. `BlockType` doesn't need to be specified anymore.
+- API signature for `CommitBlockList` has changed. `BlockType` doesn't need to be specified anymore.
 - `PageBlobClient::GetPageRanges` doesn't support getting difference between current blob and a snapshot anymore. Use `PageBlobClient::GetPageRangesDiff` instead.
-- Move Blob SAS into `Azure::Storage::Sas` namespace.
-- Replace all transactional content MD5/CRC64 with `ContentHash` struct.
-- `EncrytionKeySha256` is changed to binary(`std::vector<uint8_t>`).
+- Moved Blob SAS into `Azure::Storage::Sas` namespace.
+- Replaced all transactional content MD5/CRC64 with the `ContentHash` struct.
+- `EncryptionKeySha256` is changed to binary (`std::vector<uint8_t>`).
 - `ContentMd5` HTTP header is renamed to `ContentHash`, the type is also changed to `ContentHash`.
 - `ServerEncrypted` fields are renamed to `IsServerEncrypted`, and changed to non-nullable type.
-- Add `Is` prefix to bool variable names. Like `IsAccessTierInferred`, `IsDeleted`.
+- Added `Is` prefix to bool variable names. Like `IsAccessTierInferred`, `IsDeleted`.
 - `IsServerEncrypted`, `EncryptionKeySha256` and `EncryptionScope` are removed from `ClearPageBlobPagesResult`, since they are never returned from storage server.
 - `ListBlobsFlatSegment` is renamed to `ListBlobsSinglePage`.
 - `ListBlobsByHierarchySegment` is renamed to `ListBlobsByHierarchySinglePage`.
@@ -61,16 +62,17 @@
 - `FindBlobsByTags` is renamed to `FindBlobsByTagsSinglePage`.
 - `MaxResults` in list APIs are renamed to `PageSizeHint`.
 - All date time related strings are now changed to `Azure::Core::DateTime` type.
-- Replace `std::pair<int64_t, int64_t>` with `Azure::Core::Http::Range` to denote blob ranges.
-- Move version strings into `Details` namespace.
-- Replace scoped enums that don't support bitwise operations with extensible enum.
+- Replaced `std::pair<int64_t, int64_t>` with `Azure::Core::Http::Range` to denote blob ranges.
+- Made version strings private by moving them into the `Details` namespace.
+- Replaced scoped enums that don't support bitwise operations with extensible enum.
 - Continuation token of result types are changed to nullable.
-- Rename `Models::DeleteSnapshotsOption::Only` to `Models::DeleteSnapshotsOption::OnlySnapshots`.
-- Rename `SourceConditions` in API options to `SourceAccessConditions`.
-- Remove Blob Batch.
-- `DownloadBlobResult::Content-Range` is changed to an `Azure::Core::Http::Range`, an extra field `BlobSize` is added.
-- Remove `Undelete` from `BlobContainerClient`.
-- `BlobRetentionPolicy::Enabled` is renamed to `BlobRetentionPolicy::IsEnabled`, `BlobStaticWebsite::Enabled` is renamed to `BlobStaticWebsite::IsEnabled`.
+- Renamed `Models::DeleteSnapshotsOption::Only` to `OnlySnapshots`.
+- Renamed `SourceConditions` in API options to `SourceAccessConditions`.
+- Removed Blob Batch.
+- Changed type for metadata to case-insensitive `std::map`.
+- Changed parameter type for token credential from `Azure::Identity::ClientSecretCredential` to `Azure::Core::TokenCredential`.
+- Renamed member function `GetUri` of client types to `GetUrl`.
+- `BlobClient::GetBlockBlobClient`, `BlobClient::GetAppendBlobClient` and `BlobClient::GetPageBlobClient` are renamed to `BlobClient::AsBlockBlobClient`, `BlobClient::AsAppendBlobClient` and `BlobClient::AsPageBlobClient` respectively.
 
 ## 12.0.0-beta.5 (2020-11-13)
 

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -19,6 +19,10 @@
 - Made version strings private by moving them into the `Details` namespace.
 - Moved `Base64Encode` and `Base64Decode` from the `Azure::Storage` namespace to `Azure::Core` and removed the string accepting overload of `Base64Encode`.
 
+### Bug Fixes
+
+- Fixed default EndpointSuffix when parsing a connection string.
+
 ## 12.0.0-beta.5 (2020-11-13)
 
 ### Breaking Changes

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -1,22 +1,23 @@
 # Release History
 
-## 12.0.0-beta.6 (Unreleased)
+## 12.0.0-beta.6 (2020-01-14)
 
 ### New Features
 
-- Add new type `ContentHash`.
+- Added new type `ContentHash`.
+- Added definition of `Metadata`.
+- Support setting account SAS permission with a raw string.
 
 ### Breaking Changes
 
-- Rename `SharedKeyCredential` to `StorageSharedKeyCredential`.
-- Rename `StorageSharedKeyCredential::UpdateAccountKey` to `StorageSharedKeyCredential::Update`.
-- Move `StorageRetryPolicy`, `StoragePerRetryPolicy` and `SharedKeyPolicy` to `Details` namespace.
-- Remove `StorageRetryOptions`, use `Azure::Core::Http::RetryOptions` instead.
-- Move Account SAS into `Azure::Storage::Sas` namespace.
+- Renamed `SharedKeyCredential` to `StorageSharedKeyCredential`.
+- Renamed `StorageSharedKeyCredential::UpdateAccountKey` to `Update`.
+- Made `StorageRetryPolicy`, `StoragePerRetryPolicy` and `SharedKeyPolicy` private by moving them to the `Details` namespace.
+- Removed `StorageRetryOptions`, use `Azure::Core::Http::RetryOptions` instead.
+- Moved Account SAS into `Azure::Storage::Sas` namespace.
 - All date time related strings are now changed to `Azure::Core::DateTime` type.
-- Move version strings into `Details` namespace.
-- Move `Base64Encode` and `Base64Decode` from the `Azure::Storage` namespace to `Azure::Core`.
-- Remove the string accepting overload of `Base64Encode`.
+- Made version strings private by moving them into the `Details` namespace.
+- Moved `Base64Encode` and `Base64Decode` from the `Azure::Storage` namespace to `Azure::Core` and removed the string accepting overload of `Base64Encode`.
 
 ## 12.0.0-beta.5 (2020-11-13)
 

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -18,6 +18,7 @@
 - All date time related strings are now changed to `Azure::Core::DateTime` type.
 - Made version strings private by moving them into the `Details` namespace.
 - Moved `Base64Encode` and `Base64Decode` from the `Azure::Storage` namespace to `Azure::Core` and removed the string accepting overload of `Base64Encode`.
+- Renamed public constants so they no longer start with the prefix `c_`. For example, `c_InfiniteLeaseDuration` became `InfiniteLeaseDuration`.
 
 ### Bug Fixes
 

--- a/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## 12.0.0-beta.6 (Unreleased)
 
+### New Features
+
+- Support setting DataLake SAS permission with a raw string.
+
 ### Breaking Changes
 
-- Move DataLake SAS into `Azure::Storage::Sas` namespace.
-- `EncrytionKeySha256` are changed to binary(`std::vector<uint8_t>`).
-- Replaced all transactional content MD5/CRC64 with `ContentHash` struct.
+- Moved DataLake SAS into `Azure::Storage::Sas` namespace.
+- `EncrytionKeySha256` are changed to binary (`std::vector<uint8_t>`).
+- Replaced all transactional content MD5/CRC64 with the `ContentHash` struct.
 - `DataLakeHttpHeaders` is renamed to `PathHttpHeaders`, and now contains `ContentHash` for the resource.
 - All date time related strings are now changed to `Azure::Core::DateTime` type.
 - `CreationTime` is renamed to `CreatedOn`.
@@ -14,12 +18,11 @@
 - `CopyCompletionTime` is renamed to `CopyCompletedOn`.
 - `ExpiryTime` is renamed to `ExpiresOn`.
 - `LastAccessTime` is renamed to `LastAccessedOn`.
-- Move version strings into `Details` namespace.
+- Made version strings private by moving them into the `Details` namespace.
 - Renamed all functions and structures that could retrieve partial query results from the server to have `SinglePage` suffix instead of `Segment` suffix.
 - `ReadFileResult` now have `ContentRange` as string.
-- `ReadFileOptions` now have `Azure::Core::Http::Range Range` instead of `Content-Length` and `Offset`.
-- Replace scoped enums that don't support bitwise operations with extensible enum.
-- `ListPaths` is renamed to `ListPathsSinglePage` and its related return type and options are also renamed accordingly.
+- `ReadFileOptions` now have `Azure::Core::Http::Range` instead of `Content-Length` and `Offset`.
+- Replaced scoped enums that don't support bitwise operations with extensible enum.
 
 ## 12.0.0-beta.5 (2020-11-13)
 

--- a/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
@@ -7,10 +7,6 @@
 - Support setting DataLake SAS permission with a raw string.
 - Added support for `CreateIfNotExists` and `DeleteIfExists` for FileSystem, Path, Directory and File clients.
 
-### New Features
-
-- Support setting DataLake SAS permission with a raw string.
-
 ### Breaking Changes
 
 - Moved DataLake SAS into `Azure::Storage::Sas` namespace.

--- a/sdk/storage/azure-storage-files-shares/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-shares/CHANGELOG.md
@@ -2,30 +2,25 @@
 
 ## 12.0.0-beta.6 (Unreleased)
 
-### Breaking Changes
-
-- Removed constructors in clients that takes a `Azure::Identity::ClientSecretCredential`.
-- Removed Share Lease related API due to it not supported in recent service versions.
-  - ShareClient::AcquireLease
-  - ShareClient::ReleaseLease
-  - ShareClient::ChangeLease
-  - ShareClient::BreakLease
-  - ShareClient::RenewLease
-- Move File SAS into `Azure::Storage::Sas` namespace.
-- Replaced all transactional content MD5/CRC64 with `ContentHash` struct.
-- `FileShareHttpHeaders` is renamed to `ShareFileHttpHeaders`, and member `std::string ContentMd5` is changed to `Storage::ContentHash ContentHash`.
-- All date time related strings are now changed to `Azure::Core::DateTime` type.
-- Move version strings into `Details` namespace.
-- Renamed all functions and structures that could retrieve partial query results from the server to have `SinglePage` suffix instead of `Segment` suffix.
-- Removed `FileRange` and `ClearRange`, they are now represented with `Azure::Core::Http::Range`.
-- Removed `Offset` and `Length` pair in options. They are now represented with `Azure::Core::Http::Range`.
-- Replace scoped enums that don't support bitwise operations with extensible enum.
-- `IsServerEncrypted` member in `DownloadFileToResult`, `UploadFileFromResult`, `FileDownloadResult` and `FileGetPropertiesResult` are no longer nullable.
-- Create APIs for Directory and File now returns `FileShareSmbProperties` that aggregates SMB related properties.
-
 ### New Features
 
 - Added support for `CreateIfNotExists` for Share and Directory clients, and `DeleteIfExists` for Share, Directory and File clients.
+- Support setting file SAS permission with a raw string.
+
+### Breaking Changes
+
+- Removed constructors in clients that takes a `Azure::Identity::ClientSecretCredential`.
+- Removed Share Lease related APIs such as `ShareClient::AcquireLease` and `ReleaseLease` since they are not supported in recent service versions.
+- Moved File SAS into `Azure::Storage::Sas` namespace.
+- Replaced all transactional content MD5/CRC64 with the `ContentHash` struct.
+- `FileShareHttpHeaders` is renamed to `ShareFileHttpHeaders`, and member `std::string ContentMd5` is changed to `Storage::ContentHash ContentHash`.
+- All date time related strings are now changed to `Azure::Core::DateTime` type.
+- Moved version strings into `Details` namespace.
+- Renamed all functions and structures that could retrieve partial query results from the server to have `SinglePage` suffix instead of `Segment` suffix.
+- Removed `FileRange`, `ClearRange`, and `Offset` and `Length` pair in options. They are now represented with `Azure::Core::Http::Range`.
+- Replace scoped enums that don't support bitwise operations with extensible enum.
+- `IsServerEncrypted` members in `DownloadFileToResult`, `UploadFileFromResult`, `FileDownloadResult` and `FileGetPropertiesResult` are no longer nullable.
+- Create APIs for Directory and File now returns `FileShareSmbProperties` that aggregates SMB related properties.
 
 ## 12.0.0-beta.5 (2020-11-13)
 

--- a/sdk/storage/azure-storage-files-shares/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-shares/CHANGELOG.md
@@ -7,11 +7,6 @@
 - Added support for `CreateIfNotExists` for Share and Directory clients, and `DeleteIfExists` for Share, Directory and File clients.
 - Support setting file SAS permission with a raw string.
 
-### New Features
-
-- Added support for `CreateIfNotExists` for Share and Directory clients, and `DeleteIfExists` for Share, Directory and File clients.
-- Support setting file SAS permission with a raw string.
-
 ### Breaking Changes
 
 - Removed constructors in clients that takes a `Azure::Identity::ClientSecretCredential`.


### PR DESCRIPTION
Also fixes a couple of typos and added back-ticks that were missing.