### PR TITLE
Fix storage changelog entries for older releases for consistency (preview1, beta1) matching what shipped and add dates.

### DIFF
--- a/sdk/storage/azure-storage-blobs/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blobs/CHANGELOG.md
@@ -126,38 +126,26 @@
 - Support for Blob Index.
 - Release based on azure-core_1.0.0-beta.1.
 
-## 1.0.0-beta.1
-
-### New Features
-
-- New APIs:
-  - BlobServiceClient::SetProperties
-  - BlobServiceClient::GetProperties
-  - BlobServiceClient::GetAccountInfo
-  - BlobServiceClient::GetStatistics
-  - BlobContainerClient::Undelete
-  - BlobContainerClient::GetAccessPolicy
-  - BlobContainerClient::SetAccessPolicy
-  - AppendBlobClient::Seal
-- Support for blob versioning.
-- Support for blob lease and container lease.
-- Support for account SAS and blob SAS.
-- Support for transactional checksum.
-
-
-## 1.0.0-preview.1 (Unreleased)
+## 1.0.0-beta.1 (2020-08-28)
 
 ### New Features
 
 - Added support for Blob features:
   - BlobServiceClient::ListBlobContainersSegment
   - BlobServiceClient::GetUserDelegationKey
+  - BlobServiceClient::SetProperties
+  - BlobServiceClient::GetProperties
+  - BlobServiceClient::GetAccountInfo
+  - BlobServiceClient::GetStatistics
   - BlobContainerClient::Create
   - BlobContainerClient::Delete
   - BlobContainerClient::GetProperties
   - BlobContainerClient::SetMetadata
   - BlobContainerClient::ListBlobsFlat
   - BlobContainerClient::ListBlobsByHierarchy
+  - BlobContainerClient::Undelete
+  - BlobContainerClient::GetAccessPolicy
+  - BlobContainerClient::SetAccessPolicy
   - BlobClient::GetProperties
   - BlobClient::SetHttpHeaders
   - BlobClient::SetMetadata
@@ -180,6 +168,7 @@
   - AppendBlobClient::Create
   - AppendBlobClient::AppendBlock
   - AppendBlobClient::AppendBlockFromUri
+  - AppendBlobClient::Seal
   - PageBlobClient::Create
   - PageBlobClient::UploadPages
   - PageBlobClient::UploadPagesFromUri
@@ -187,3 +176,7 @@
   - PageBlobClient::Resize
   - PageBlobClient::GetPageRanges
   - PageBlobClient::StartCopyIncremental
+- Support for blob versioning.
+- Support for blob lease and container lease.
+- Support for account SAS and blob SAS.
+- Support for transactional checksum.

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -48,7 +48,7 @@
 
 - Release based on azure-core_1.0.0-beta.1.
 
-## 1.0.0-beta.1
+## 1.0.0-beta.1 (2020-08-28)
 
 ### New Features
 

--- a/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
@@ -64,13 +64,7 @@
 
 - Release based on azure-core_1.0.0-beta.1.
 
-## 1.0.0-beta.1
-
-### New Features
-
-- Support for Lease related operations.
-
-## 1.0.0-preview.1 (Unreleased)
+## 1.0.0-beta.1 (2020-08-28)
 
 ### New Features
 
@@ -103,3 +97,4 @@
   - DirectoryClient::Create
   - DirectoryClient::Rename
   - DirectoryClient::Delete
+- Support for Lease related operations.

--- a/sdk/storage/azure-storage-files-shares/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-shares/CHANGELOG.md
@@ -73,7 +73,7 @@
 - Added File SAS generation support.
 - Release based on azure-core_1.0.0-beta.1.
 
-## 1.0.0-preview.1 (Unreleased)
+## 1.0.0-beta.1 (2020-08-28)
 
 ### New Features
 


### PR DESCRIPTION
Hopefully, after this, we will get correct auto-version-increment PRs. See the following for more context:
https://github.com/Azure/azure-sdk-for-cpp/pull/1373#issuecomment-760018037

We also need to split up the storage release pipeline to be one per package and run them sequentially.