### PR TITLE
Fix Language-Settings.ps1 to use correct logic

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -8,6 +8,13 @@ $BlobStorageUrl = "https://azuresdkdocs.blob.core.windows.net/%24web?restype=con
 
 function Get-cpp-PackageInfoFromRepo($pkgPath, $serviceDirectory, $pkgName) 
 {
+  # Test if the package path ends with the package name (e.g. sdk/storage/azure-storage-common)
+  # This function runs in a loop where $pkgPath might be the path to the package and must return 
+  # $null in cases where $pkgPath is not the path to the package specified by $pkgName
+  if ($pkgName -ne (Split-Path -Leaf $pkgPath)) { 
+    return $null
+  }
+
   $packageVersion = & $PSScriptRoot/Get-PkgVersion.ps1 -ServiceDirectory $serviceDirectory -PackageName $pkgName
   return [PackageProps]::new($pkgName, $packageVersion, $pkgPath, $serviceDirectory)
 }


### PR DESCRIPTION
@chidozieononiwu and I worked on a fix to `Language-Settings.ps1` 

The `Get-cpp-PackageInfoFromRepo` function is called in a loop through potential package directories and needs to return `$null` in cases where the directory does not match the package. This checks the leaf of the path (e.g. "bar" in "c:\foo\bar\") of the path and returns `$null` in cases where the package name does not match the path