### PR TITLE
Move clang-format check to include tests

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -139,6 +139,7 @@ jobs:
       brew install clang-format
       clang-format --version
       find . -regex '.*\.\(cpp\|hpp\)' -exec clang-format -style=file -i {} \;
+      git status
 
       if [[ `git status | grep modified | awk '{print $2}'` ]]; then
         echo Some files were not formatted correctly according to the .clang-format file.

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -138,6 +138,7 @@ jobs:
       echo "Check clang-formatting"
       brew install clang-format
       clang-format --version
+      pwd
       find sdk/ -regex '.*\.\(cpp\|hpp\)' -exec clang-format -style=file -i {} \;
 
       if [[ `git status | grep modified | awk '{print $2}'` ]]; then

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -138,8 +138,7 @@ jobs:
       echo "Check clang-formatting"
       brew install clang-format
       clang-format --version
-      find . -regex '.*\.\(cpp\|hpp\)' -exec clang-format -style=file -i {} \;
-      git status
+      find . -regex '.*\.\(cpp\|hpp\)' -exec clang-format --verbose -style=file -i {} \;
 
       if [[ `git status | grep modified | awk '{print $2}'` ]]; then
         echo Some files were not formatted correctly according to the .clang-format file.

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -73,7 +73,6 @@ jobs:
         OSVmImage: 'macOS-10.14'
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        CHECK_CLANG_FORMAT: 1
 
       # Unit testing ON
       Linux_x64_with_unit_test:
@@ -111,6 +110,7 @@ jobs:
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
+        CHECK_CLANG_FORMAT: 1
   pool:
     name: $[coalesce(variables['Pool'], '')]
     vmImage: $[coalesce(variables['OSVmImage'], '')]

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -138,9 +138,7 @@ jobs:
       echo "Check clang-formatting"
       brew install clang-format
       clang-format --version
-      pwd
-      ls
-      find sdk/ -regex '.*\.\(cpp\|hpp\)' -exec clang-format -style=file -i {} \;
+      find . -regex '.*\.\(cpp\|hpp\)' -exec clang-format -style=file -i {} \;
 
       if [[ `git status | grep modified | awk '{print $2}'` ]]; then
         echo Some files were not formatted correctly according to the .clang-format file.

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -138,7 +138,7 @@ jobs:
       echo "Check clang-formatting"
       brew install clang-format
       clang-format --version
-      find . -regex '.*\.\(cpp\|hpp\)' -exec clang-format --verbose -style=file -i {} \;
+      find . \( -iname '*.hpp' -o -iname '*.cpp' \) -exec clang-format --verbose -i {} \;
 
       if [[ `git status | grep modified | awk '{print $2}'` ]]; then
         echo Some files were not formatted correctly according to the .clang-format file.

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -138,7 +138,7 @@ jobs:
       echo "Check clang-formatting"
       brew install clang-format
       clang-format --version
-      find . \( -iname '*.hpp' -o -iname '*.cpp' \) -exec clang-format --verbose -i {} \;
+      find ./sdk \( -iname '*.hpp' -o -iname '*.cpp' \) ! -iname 'json.hpp' -exec clang-format -i {} \;
 
       if [[ `git status | grep modified | awk '{print $2}'` ]]; then
         echo Some files were not formatted correctly according to the .clang-format file.

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -73,6 +73,7 @@ jobs:
         OSVmImage: 'macOS-10.14'
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+        CHECK_CLANG_FORMAT: 1
 
       # Unit testing ON
       Linux_x64_with_unit_test:
@@ -110,7 +111,6 @@ jobs:
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
-        CHECK_CLANG_FORMAT: 1
   pool:
     name: $[coalesce(variables['Pool'], '')]
     vmImage: $[coalesce(variables['OSVmImage'], '')]

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -139,6 +139,7 @@ jobs:
       brew install clang-format
       clang-format --version
       pwd
+      ls
       find sdk/ -regex '.*\.\(cpp\|hpp\)' -exec clang-format -style=file -i {} \;
 
       if [[ `git status | grep modified | awk '{print $2}'` ]]; then

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_path_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_path_client_test.cpp
@@ -282,7 +282,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(pathClient.SetPermissions(pathPermissions, options1));
     }
   }
-  #if 0
+#if 0
   TEST_F(DataLakePathClientTest, LeaseRelated)
   {
     std::string leaseId1 = CreateUniqueLeaseId();
@@ -343,7 +343,7 @@ namespace Azure { namespace Storage { namespace Test {
     options.BreakPeriod = 0;
     m_pathClient->BreakLease(options);
   }
-  #endif
+#endif
   TEST_F(DataLakePathClientTest, ConstructorsWorks)
   {
     {


### PR DESCRIPTION
After moving clang-format-check to macOS, it was not working as expected with the regex command used for Linux

Updated the command to work on Mac