### PR TITLE
`startsOn` parameter for `GetUserDelegationKey` was changed to optional.

### DIFF
--- a/sdk/storage/azure-storage-blobs/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blobs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `ListType` in `GetBlockListOptions` was changed to non-nullable.
 - Added `BlobLeaseClient`, all lease related APIs are moved to `BlobLeaseClient`.
 - Type for lease duration in requests was changed to `std::chrono::seconds`, in response was changed to enum.
+- `startsOn` parameter for `GetUserDelegationKey` was changed to optional.
 
 ## 12.0.0-beta.6 (2020-01-14)
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
@@ -203,6 +203,12 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Context for cancelling long running operations.
      */
     Azure::Core::Context Context;
+
+     /**
+     * @brief Start time for the key's validity. The time should be specified in UTC, and
+     * will be truncated to second.
+     */
+    Azure::Core::DateTime startsOn = std::chrono::system_clock::now();
   };
 
   /**

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
@@ -204,7 +204,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      */
     Azure::Core::Context Context;
 
-     /**
+    /**
      * @brief Start time for the key's validity. The time should be specified in UTC, and
      * will be truncated to second.
      */

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_service_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_service_client.hpp
@@ -104,15 +104,12 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Retrieves a key that can be used to delegate Active Directory authorization to
      * shared access signatures.
      *
-     * @param startsOn Start time for the key's validity. The time should be specified in UTC, and
-     * will be truncated to second.
      * @param expiresOn Expiration of the key's validity. The time should be specified in UTC, and
      * will be truncated to second.
      * @param options Optional parameters to execute this function.
      * @return A deserialized GetUserDelegationKeyResult instance.
      */
     Azure::Core::Response<Models::GetUserDelegationKeyResult> GetUserDelegationKey(
-        const Azure::Core::DateTime& startsOn,
         const Azure::Core::DateTime& expiresOn,
         const GetUserDelegationKeyOptions& options = GetUserDelegationKeyOptions()) const;
 

--- a/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
@@ -134,12 +134,11 @@ namespace Azure { namespace Storage { namespace Blobs {
   }
 
   Azure::Core::Response<Models::GetUserDelegationKeyResult> BlobServiceClient::GetUserDelegationKey(
-      const Azure::Core::DateTime& startsOn,
       const Azure::Core::DateTime& expiresOn,
       const GetUserDelegationKeyOptions& options) const
   {
     Details::BlobRestClient::Service::GetUserDelegationKeyOptions protocolLayerOptions;
-    protocolLayerOptions.StartsOn = startsOn;
+    protocolLayerOptions.StartsOn = options.startsOn;
     protocolLayerOptions.ExpiresOn = expiresOn;
     return Details::BlobRestClient::Service::GetUserDelegationKey(
         options.Context, *m_pipeline, m_serviceUrl, protocolLayerOptions);

--- a/sdk/storage/azure-storage-blobs/test/blob_sas_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/blob_sas_test.cpp
@@ -52,8 +52,7 @@ namespace Azure { namespace Storage { namespace Test {
         serviceUrl,
         std::make_shared<Azure::Identity::ClientSecretCredential>(
             AadTenantId(), AadClientId(), AadClientSecret()));
-    auto userDelegationKey
-        = blobServiceClient1.GetUserDelegationKey(sasStartsOn, sasExpiresOn)->Key;
+    auto userDelegationKey = blobServiceClient1.GetUserDelegationKey(sasExpiresOn)->Key;
 
     auto verify_blob_read = [&](const std::string& sas) {
       EXPECT_NO_THROW(blobClient0.Create());

--- a/sdk/storage/azure-storage-blobs/test/blob_service_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/blob_service_client_test.cpp
@@ -425,7 +425,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobServiceClientTest, UserDelegationKey)
   {
-    auto sasStartsOn = std::chrono::system_clock::now() - std::chrono::minutes(5);
     auto sasExpiresOn = std::chrono::system_clock::now() + std::chrono::minutes(60);
 
     auto blobServiceClient1 = Blobs::BlobServiceClient(
@@ -433,8 +432,7 @@ namespace Azure { namespace Storage { namespace Test {
         std::make_shared<Azure::Identity::ClientSecretCredential>(
             AadTenantId(), AadClientId(), AadClientSecret()));
 
-    auto getUserDelegationKeyResult
-        = blobServiceClient1.GetUserDelegationKey(sasStartsOn, sasExpiresOn);
+    auto getUserDelegationKeyResult = blobServiceClient1.GetUserDelegationKey(sasExpiresOn);
 
     EXPECT_FALSE(getUserDelegationKeyResult->RequestId.empty());
 

--- a/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Removed `Directory` in `ListPathsSinglePageOptions`.
 - Removed unused type `AccountResourceType` and `PathLeaseAction`.
 - Changed all previous `LeaseDuration` members to a new type named `LeaseDurationType`.
+- `startsOn` parameter for `GetUserDelegationKey` was changed to optional.
 
 ## 12.0.0-beta.6 (2020-01-14)
 

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_service_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_service_client.hpp
@@ -92,8 +92,6 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Retrieves a key that can be used to delegate Active Directory authorization to
      * shared access signatures.
      *
-     * @param startsOn Start time for the key's validity. The time should be specified in UTC, and
-     * will be truncated to second.
      * @param expiresOn Expiration of the key's validity. The time should be specified in UTC, and
      * will be truncated to second.
      * @param options Optional parameters to execute
@@ -103,11 +101,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @remark This request is sent to blob endpoint.
      */
     Azure::Core::Response<Models::GetUserDelegationKeyResult> GetUserDelegationKey(
-        const Azure::Core::DateTime& startsOn,
         const Azure::Core::DateTime& expiresOn,
         const GetUserDelegationKeyOptions& options = GetUserDelegationKeyOptions()) const
     {
-      return m_blobServiceClient.GetUserDelegationKey(startsOn, expiresOn, options);
+      return m_blobServiceClient.GetUserDelegationKey(expiresOn, options);
     }
 
   private:

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_sas_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_sas_test.cpp
@@ -62,7 +62,7 @@ namespace Azure { namespace Storage { namespace Test {
         serviceUrl,
         std::make_shared<Azure::Identity::ClientSecretCredential>(
             AadTenantId(), AadClientId(), AadClientSecret()));
-    auto userDelegationKey = serviceClient1.GetUserDelegationKey(sasStartsOn, sasExpiresOn)->Key;
+    auto userDelegationKey = serviceClient1.GetUserDelegationKey(sasExpiresOn)->Key;
 
     auto verify_file_read = [&](const std::string& sas) {
       EXPECT_NO_THROW(fileClient0.Create());


### PR DESCRIPTION
closes https://github.com/Azure/azure-sdk-for-cpp/issues/1434

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/master/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
