### PR TITLE
Added additional information in `StorageException`, fixed a bug where `ClientRequestId` wasn't filled in `StorageException`.

### DIFF
--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## 12.0.0-beta.7 (Unreleased)
 
+### New Features
+
+- Added additional information in `StorageException`.
+
 ### Breaking Changes
 
 - `AccountSasResource::BlobContainer` was renamed to `AccountSasResource::Container`.
+
+### Bug Fixes
+
+- Fixed `ClientRequestId` wasn't filled in `StorageException`.
 
 ## 12.0.0-beta.6 (2020-01-14)
 

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -21,6 +22,7 @@ namespace Azure { namespace Storage {
     std::string RequestId;
     std::string ErrorCode;
     std::string Message;
+    std::map<std::string, std::string> AdditionalInformation;
     std::unique_ptr<Azure::Core::Http::RawResponse> RawResponse;
 
     static StorageException CreateFromResponse(

--- a/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
@@ -747,4 +747,47 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(1536, result.ClearRanges[1].Length.GetValue());
   }
 
+  TEST_F(FileShareFileClientTest, StorageExceptionAdditionalInfo)
+  {
+    Azure::Storage::Files::Shares::ShareClientOptions options;
+    class InvalidQueryParameterPolicy
+        : public Azure::Core::Http::HttpPolicy {
+    public:
+      ~InvalidQueryParameterPolicy() override {}
+
+      std::unique_ptr<HttpPolicy> Clone() const override
+      {
+        return std::make_unique<InvalidQueryParameterPolicy>(*this);
+      }
+
+      std::unique_ptr<Core::Http::RawResponse> Send(
+        Core::Context const& ctx,
+        Core::Http::Request& request,
+        Core::Http::NextHttpPolicy nextHttpPolicy) const override
+      {
+        request.GetUrl().AppendQueryParameter("comp", "lease1");
+        return nextHttpPolicy.Send(ctx, request);
+      }
+    };
+    options.PerOperationPolicies.emplace_back(std::make_unique<InvalidQueryParameterPolicy>());
+    auto fileClient = Azure::Storage::Files::Shares::ShareFileClient::CreateFromConnectionString(
+        StandardStorageConnectionString(), m_shareName, RandomString(), options);
+    try
+    {
+      fileClient.Create(1024);
+    }
+    catch(StorageException& e)
+    {
+      EXPECT_NE(e.StatusCode, Azure::Core::Http::HttpStatusCode::None);
+      EXPECT_FALSE(e.ReasonPhrase.empty());
+      EXPECT_FALSE(e.ClientRequestId.empty());
+      EXPECT_FALSE(e.RequestId.empty());
+      EXPECT_FALSE(e.ErrorCode.empty());
+      EXPECT_FALSE(e.Message.empty());
+      EXPECT_FALSE(e.AdditionalInformation.empty());
+      return;
+    }
+    FAIL();
+  }
+
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
@@ -750,8 +750,7 @@ namespace Azure { namespace Storage { namespace Test {
   TEST_F(FileShareFileClientTest, StorageExceptionAdditionalInfo)
   {
     Azure::Storage::Files::Shares::ShareClientOptions options;
-    class InvalidQueryParameterPolicy
-        : public Azure::Core::Http::HttpPolicy {
+    class InvalidQueryParameterPolicy : public Azure::Core::Http::HttpPolicy {
     public:
       ~InvalidQueryParameterPolicy() override {}
 
@@ -761,9 +760,9 @@ namespace Azure { namespace Storage { namespace Test {
       }
 
       std::unique_ptr<Core::Http::RawResponse> Send(
-        Core::Context const& ctx,
-        Core::Http::Request& request,
-        Core::Http::NextHttpPolicy nextHttpPolicy) const override
+          Core::Context const& ctx,
+          Core::Http::Request& request,
+          Core::Http::NextHttpPolicy nextHttpPolicy) const override
       {
         request.GetUrl().AppendQueryParameter("comp", "lease1");
         return nextHttpPolicy.Send(ctx, request);
@@ -776,7 +775,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       fileClient.Create(1024);
     }
-    catch(StorageException& e)
+    catch (StorageException& e)
     {
       EXPECT_NE(e.StatusCode, Azure::Core::Http::HttpStatusCode::None);
       EXPECT_FALSE(e.ReasonPhrase.empty());


### PR DESCRIPTION
closes  https://github.com/Azure/azure-sdk-for-cpp/issues/1140

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/master/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
