### PR TITLE
Add ValuePolicy

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.5 (Unreleased)
 
+### New Features
+
+- Added `Azure::Core:Http::ValuePolicy`.
+
 ### Breaking Changes
 
 - Make `ToLower` and `LocaleInvariantCaseInsensitiveEqual` internal by moving them from `Azure::Core::Strings` to `Azure::Core::Internal::Strings`.

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 1.0.0-beta.5 (Unreleased)
 
-### New Features
-
-- Added `Azure::Core:Http::ValuePolicy`.
-
 ### Breaking Changes
 
 - Make `ToLower` and `LocaleInvariantCaseInsensitiveEqual` internal by moving them from `Azure::Core::Strings` to `Azure::Core::Internal::Strings`.

--- a/sdk/core/azure-core/inc/azure/core/http/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policy.hpp
@@ -12,7 +12,6 @@
 #include "azure/core/credentials.hpp"
 #include "azure/core/http/http.hpp"
 #include "azure/core/http/transport.hpp"
-#include "azure/core/internal/strings.hpp"
 #include "azure/core/logging/logging.hpp"
 #include "azure/core/uuid.hpp"
 

--- a/sdk/core/azure-core/inc/azure/core/http/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policy.hpp
@@ -12,6 +12,7 @@
 #include "azure/core/credentials.hpp"
 #include "azure/core/http/http.hpp"
 #include "azure/core/http/transport.hpp"
+#include "azure/core/internal/strings.hpp"
 #include "azure/core/logging/logging.hpp"
 #include "azure/core/uuid.hpp"
 
@@ -227,26 +228,20 @@ namespace Azure { namespace Core { namespace Http {
     std::map<std::string, std::string> m_headerValues;
     std::map<std::string, std::string> m_queryValues;
 
-    static void AppendToMapOverwritingExistingValues(
-        std::map<std::string, std::string>& destination,
-        std::map<std::string, std::string> const& source)
-    {
-      for (auto const& srcPair : source)
-      {
-        destination[srcPair.first] = srcPair.second;
-      }
-    }
-
   public:
     /**
      * @brief Add values (key-value pairs) that shall be applied to HTTP request headers.
      * @detail If a value with the a key from \p headerValues already exists in this @ValuePolicy,
      * the new value from \p headerValues will be taken.
+     * @note Header keys are case-insensitive.
      * @param headerValues Values that shall be applied.
      */
     void AddHeaderValues(std::map<std::string, std::string> const& headerValues)
     {
-      AppendToMapOverwritingExistingValues(m_headerValues, headerValues);
+      for (auto const& hdrPair : headerValues)
+      {
+        m_headerValues[Azure::Core::Internal::Strings::ToLower(hdrPair.first)] = hdrPair.second;
+      }
     }
 
     /**
@@ -259,7 +254,10 @@ namespace Azure { namespace Core { namespace Http {
      */
     void AddQueryValues(std::map<std::string, std::string> const& queryValues)
     {
-      AppendToMapOverwritingExistingValues(m_queryValues, queryValues);
+      for (auto const& qryPair : queryValues)
+      {
+        m_queryValues[qryPair.first] = qryPair.second;
+      }
     }
   };
 

--- a/sdk/core/azure-core/inc/azure/core/http/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policy.hpp
@@ -282,7 +282,7 @@ namespace Azure { namespace Core { namespace Http {
 
     std::unique_ptr<HttpPolicy> Clone() const override
     {
-      return std::make_unique<RequestIdPolicy>(*this);
+      return std::make_unique<ValuePolicy>(*this);
     }
 
     std::unique_ptr<RawResponse> Send(

--- a/sdk/core/azure-core/inc/azure/core/http/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policy.hpp
@@ -476,5 +476,4 @@ namespace Azure { namespace Core { namespace Http {
       }
     };
   } // namespace Details
-
 }}} // namespace Azure::Core::Http

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -74,7 +74,11 @@ TEST(Policy, ValuePolicy)
   options.AddHeaderValues({{"HdrKey2", "HdrVal2"}, {"HdrKey3", "HdrVal3"}});
   options.AddQueryValues({{"QryKey1", "QryVal1"}, {"QryKey3", "QryVal3"}});
 
-  HttpPipeline pipeline({std::make_unique<ValuePolicy>(options), std::make_unique<NoOpPolicy>()});
+  std::vector<std::unique_ptr<HttpPolicy>> policies;
+  policies.emplace_back(std::make_unique<ValuePolicy>(options));
+  policies.emplace_back(std::make_unique<NoOpPolicy>());
+  HttpPipeline pipeline(policies);
+
   Request request(HttpMethod::Get, Url("https:://www.example.com"));
 
   pipeline.Send(GetApplicationContext(), request);

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -7,6 +7,23 @@
 
 #include <vector>
 
+namespace {
+class NoOpPolicy : public Azure::Core::Http::HttpPolicy {
+public:
+  std::unique_ptr<Azure::Core::Http::HttpPolicy> Clone() const override
+  {
+    return std::make_unique<NoOpPolicy>(*this);
+  }
+
+  std::unique_ptr<Azure::Core::Http::RawResponse> Send(
+      Azure::Core::Context const&,
+      Azure::Core::Http::Request&,
+      Azure::Core::Http::NextHttpPolicy) const override
+  {
+  }
+};
+} // namespace
+
 TEST(Policy, throwWhenNoTransportPolicy)
 {
   // Construct pipeline without exception
@@ -43,4 +60,34 @@ TEST(Policy, throwWhenNoTransportPolicyMessage)
   {
     EXPECT_STREQ("Invalid pipeline. No transport policy found. Endless policy.", err.what());
   }
+}
+
+TEST(Policy, ValuePolicy)
+{
+  using namespace Azure::Core;
+  using namespace Azure::Core::Http;
+
+  ValuePolicyOptions options;
+  options.AddHeaderValues({{"HdrKey1", "HdrVal1"}, {"HdrKey2", "HdrVal0"}});
+  options.AddQueryValues({{"QryKey1", "QryVal0"}, {"QryKey2", "QryVal2"}});
+
+  options.AddHeaderValues({{"HdrKey2", "HdrVal2"}, {"HdrKey3", "HdrVal3"}});
+  options.AddQueryValues({{"QryKey1", "QryVal1"}, {"QryKey3", "QryVal3"}});
+
+  HttpPipeline pipeline({std::make_unique<ValuePolicy>(options), std::make_unique<NoOpPolicy>()});
+  Request request(HttpMethod::Get, Url("https:://www.example.com"));
+
+  pipeline.Send(GetApplicationContext(), request);
+
+  auto headers = request.GetHeaders();
+  auto queryParams = request.GetUrl().GetQueryParameters();
+
+  ASSERT_EQ(
+      headers,
+      decltype(headers)({{"HdrKey1", "HdrVal1"}, {"HdrKey2", "HdrVal2"}, {"HdrKey3", "HdrVal3"}}));
+
+  ASSERT_EQ(
+      queryParams,
+      decltype(queryParams)(
+          {{"QryKey1", "QryVal1"}, {"QryKey2", "QryVal2"}, {"QryKey3", "QryVal3"}}));
 }

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -68,15 +68,12 @@ TEST(Policy, ValuePolicy)
   using namespace Azure::Core;
   using namespace Azure::Core::Http;
 
-  ValuePolicyOptions options;
-  options.AddHeaderValues({{"HdrKey1", "HdrVal1"}, {"HdrKey2", "HdrVal0"}});
-  options.AddQueryValues({{"QryKey1", "QryVal0"}, {"QryKey2", "QryVal2"}});
-
-  options.AddHeaderValues({{"HdrKey2", "HdrVal2"}, {"HdrKey3", "HdrVal3"}});
-  options.AddQueryValues({{"QryKey1", "QryVal1"}, {"QryKey3", "QryVal3"}});
+  Azure::Core::Http::Details::ValuePolicyOptions options
+      = {{{"hdrkey1", "HdrVal1"}, {"hdrkey2", "HdrVal2"}},
+         {{"QryKey1", "QryVal1"}, {"QryKey2", "QryVal2"}}};
 
   std::vector<std::unique_ptr<HttpPolicy>> policies;
-  policies.emplace_back(std::make_unique<ValuePolicy>(options));
+  policies.emplace_back(std::make_unique<Azure::Core::Http::Details::ValuePolicy>(options));
   policies.emplace_back(std::make_unique<NoOpPolicy>());
   HttpPipeline pipeline(policies);
 
@@ -87,12 +84,6 @@ TEST(Policy, ValuePolicy)
   auto headers = request.GetHeaders();
   auto queryParams = request.GetUrl().GetQueryParameters();
 
-  ASSERT_EQ(
-      headers,
-      decltype(headers)({{"hdrkey1", "HdrVal1"}, {"hdrkey2", "HdrVal2"}, {"hdrkey3", "HdrVal3"}}));
-
-  ASSERT_EQ(
-      queryParams,
-      decltype(queryParams)(
-          {{"QryKey1", "QryVal1"}, {"QryKey2", "QryVal2"}, {"QryKey3", "QryVal3"}}));
+  ASSERT_EQ(headers, decltype(headers)({{"hdrkey1", "HdrVal1"}, {"hdrkey2", "HdrVal2"}}));
+  ASSERT_EQ(queryParams, decltype(queryParams)({{"QryKey1", "QryVal1"}, {"QryKey2", "QryVal2"}}));
 }

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -20,6 +20,7 @@ public:
       Azure::Core::Http::Request&,
       Azure::Core::Http::NextHttpPolicy) const override
   {
+    return nullptr;
   }
 };
 } // namespace

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -89,7 +89,7 @@ TEST(Policy, ValuePolicy)
 
   ASSERT_EQ(
       headers,
-      decltype(headers)({{"HdrKey1", "HdrVal1"}, {"HdrKey2", "HdrVal2"}, {"HdrKey3", "HdrVal3"}}));
+      decltype(headers)({{"hdrkey1", "HdrVal1"}, {"hdrkey2", "HdrVal2"}, {"hdrkey3", "HdrVal3"}}));
 
   ASSERT_EQ(
       queryParams,


### PR DESCRIPTION
Closes #1393.

Update: This policy is made internal, for responsible use by SDK client lib developers.

Previous:
This policy was added to bring the convenience to client library developers, however they should be careful that the values they add don't collide with the values that other policies are adding.  For that reason, it is probably safer to have this policy at the top of the policies stack.

There is a concern about having this policy all together (@vhvb1989):

> "I don't like about it is that it open a back door for bugs, IMO.
> It introduces an alternative to set headers/query parameters.
> 
> With this approach, as a service developer, I can wrongly use this policy to set any header (static or dynamic).  For example, nothing prevents me from setting the telemetry info with this policy. It would be a wrong implementation, but I feel like we should prevent it.
> 
> The alternative approaches are:
> * Let each service to create its own policy and expect it to be well defined about what headers it adds.
> * Or ask services to create a common function that updates or creates an initial request with the static headers  
> ​
> I agree people should be careful. 
> But, I really think we should not go to the path where we know there are more than one way to do the same thing with the SDK
> It breaks the single responsibility pattern, which I think is worth it.
>  how do I know if it must be before the retry policy or after?
> Also, what's the benefit against just directly calling `addHeader(...)` from the client SDK?"

I'd say the dev should be careful with what they are doing, and there is no good way for us to prevent accidental overwrite, and that overwrite is unlikely, plus it should come up during the dev developing their lib and getting errors, plus you always can modify request to add headers. We don't check there... I think that it is not worth it to burn CPU cycles each time on checking for things that is not likely to happen, not expected to be touched by users much, plus we need to maintain some kind of central place for reserved headers.

(also, for motivation, see the comments the original issue links to).