### PR TITLE
Update clang format validate script instructions when it fails to be accurate

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -143,7 +143,7 @@ jobs:
       if [[ `git status | grep modified | awk '{print $2}'` ]]; then
         echo Some files were not formatted correctly according to the .clang-format file.
         echo Please run clang-format version 10 or greater to fix the issue by using this bash command at the root of the repo:
-        echo "find sdk/ -regex '.*\.\(cpp\|hpp\)' -exec clang-format -style=file -i {} \;"
+        echo "find ./sdk \( -iname '*.hpp' -o -iname '*.cpp' \) ! -iname 'json.hpp' -exec clang-format -i {} \;"
         echo ""
         echo "List of files not formatted correctly:"
         git status | grep modified | awk '{print $2}'


### PR DESCRIPTION

Syncing the instructions based on changes from https://github.com/Azure/azure-sdk-for-cpp/pull/1438

Currently, the instructions suggest running a command which may not work on all OSes:
https://dev.azure.com/azure-sdk/public/_build/results?buildId=701256&view=logs&j=0585f5d6-0937-5c15-894c-06e189e06847&t=a45688da-a69e-5817-f832-3aa6246959b7
```text
Some files were not formatted correctly according to the .clang-format file.
Please run clang-format version 10 or greater to fix the issue by using this bash command at the root of the repo:
find sdk/ -regex '.*\.\(cpp\|hpp\)' -exec clang-format -style=file -i {} \;
```