### PR TITLE
Add timeout parameter to live test job

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -17,10 +17,14 @@ parameters:
 - name: CoverageReportPath
   type: string
   default: sdk/*/*/*cov_xml.xml
+- name: TimeoutInMinutes
+  type: number
+  default: 60
 
 jobs:
 - job: Validate
   condition: and(succeededOrFailed(), ne(variables['Skip.LiveTest'], 'true'))
+  timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
   strategy:
     matrix:
       Linux_x64_with_unit_test:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -29,6 +29,9 @@ parameters:
 - name: LinuxPool
   type: string
   default: azsdk-pool-mms-ubuntu-1804-general
+- name: LiveTestTimeoutInMinutes
+  type: number
+  default: 60
 
 stages:
   - stage: Build
@@ -50,6 +53,7 @@ stages:
         - template: /eng/pipelines/templates/jobs/archetype-sdk-tests.yml
           # Code coverage is enabled by default for live tests
           parameters:
+            TimeoutInMinutes: ${{ parameters.LiveTestTimeoutInMinutes }}
             ServiceDirectory: ${{ parameters.ServiceDirectory }}
             CtestRegex: ${{ parameters.LiveTestCtestRegex }}
             Location: ${{ parameters.Location }}

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -34,6 +34,7 @@ stages:
       # CI has static code analisys disabled, while LiveTest will have it enabled
       CtestRegex: azure-core.
       LiveTestCtestRegex: azure-core.
+      LiveTestTimeoutInMinutes: 90
       Artifacts:
         - Name: azure-core
           Path: azure-core


### PR DESCRIPTION
Enable scenario for @vhvb1989 to fix core live tests that run for a long time.