### PR TITLE
Do not pass a placeholder user-agent string as a fallback when using WinHttp

### DIFF
--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -186,7 +186,8 @@ void WinHttpTransport::CreateSessionHandle(std::unique_ptr<Details::HandleManage
   // Use WinHttpOpen to obtain a session handle.
   // The dwFlags is set to 0 - all WinHTTP functions are performed synchronously.
   handleManager->m_sessionHandle = WinHttpOpen(
-      L"WinHTTP Azure SDK",
+      NULL, // Do not use a fallback user-agent string, and only rely on the header within the
+            // request itself.
       WINHTTP_ACCESS_TYPE_NO_PROXY,
       WINHTTP_NO_PROXY_NAME,
       WINHTTP_NO_PROXY_BYPASS,


### PR DESCRIPTION
Verified the behavior is now as expected when telemetry policy is turned off.

**Before:**
![image](https://user-images.githubusercontent.com/6527137/106042018-65d64e00-6091-11eb-8741-c6c42cb028d3.png)

**After:**
![image](https://user-images.githubusercontent.com/6527137/106042157-86060d00-6091-11eb-9699-929128eb6ea1.png)
