### PR TITLE
Use case-insensitive maps for Request and RawResponse headers

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -11,6 +11,7 @@
 #include "azure/core/exception.hpp"
 #include "azure/core/http/body_stream.hpp"
 #include "azure/core/internal/contract.hpp"
+#include "azure/core/internal/strings.hpp"
 #include "azure/core/nullable.hpp"
 
 #include <algorithm>
@@ -45,7 +46,10 @@ namespace Azure { namespace Core { namespace Http {
      * @throw if \p headerName is invalid.
      */
     void InsertHeaderWithValidation(
-        std::map<std::string, std::string>& headers,
+        std::map<
+            std::string,
+            std::string,
+            Azure::Core::Internal::Strings::CaseInsensitiveComparator>& headers,
         std::string const& headerName,
         std::string const& headerValue);
   } // namespace Details
@@ -454,12 +458,16 @@ namespace Azure { namespace Core { namespace Http {
     friend class Azure::Core::Test::TestHttp_getters_Test;
     friend class Azure::Core::Test::TestHttp_query_parameter_Test;
 #endif
+  public:
+    typedef std::
+        map<std::string, std::string, Azure::Core::Internal::Strings::CaseInsensitiveComparator>
+            HeaderMap;
 
   private:
     HttpMethod m_method;
     Url m_url;
-    std::map<std::string, std::string> m_headers;
-    std::map<std::string, std::string> m_retryHeaders;
+    HeaderMap m_headers;
+    HeaderMap m_retryHeaders;
 
     BodyStream* m_bodyStream;
 
@@ -559,7 +567,7 @@ namespace Azure { namespace Core { namespace Http {
     /**
      * @brief Get HTTP headers.
      */
-    std::map<std::string, std::string> GetHeaders() const;
+    HeaderMap GetHeaders() const;
 
     /**
      * @brief Get HTTP body as #BodyStream.
@@ -604,13 +612,17 @@ namespace Azure { namespace Core { namespace Http {
    * @brief Raw HTTP response.
    */
   class RawResponse {
+  public:
+    typedef std::
+        map<std::string, std::string, Azure::Core::Internal::Strings::CaseInsensitiveComparator>
+            HeaderMap;
 
   private:
     int32_t m_majorVersion;
     int32_t m_minorVersion;
     HttpStatusCode m_statusCode;
     std::string m_reasonPhrase;
-    std::map<std::string, std::string> m_headers;
+    HeaderMap m_headers;
 
     std::unique_ptr<BodyStream> m_bodyStream;
     std::vector<uint8_t> m_body;
@@ -726,7 +738,7 @@ namespace Azure { namespace Core { namespace Http {
     /**
      * @brief Get HTTP response headers.
      */
-    std::map<std::string, std::string> const& GetHeaders() const;
+    HeaderMap const& GetHeaders() const;
 
     /**
      * @brief Get HTTP response body as #BodyStream.

--- a/sdk/core/azure-core/inc/azure/core/http/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policy.hpp
@@ -427,7 +427,7 @@ namespace Azure { namespace Core { namespace Http {
      */
     struct ValuePolicyOptions
     {
-      std::map<std::string, std::string> HeaderValues;
+      Request::HeaderMap HeaderValues;
       std::map<std::string, std::string> QueryValues;
     };
 

--- a/sdk/core/azure-core/inc/azure/core/internal/strings.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/strings.hpp
@@ -15,4 +15,15 @@ namespace Azure { namespace Core { namespace Internal { namespace Strings {
   std::string const ToLower(const std::string& src) noexcept;
   unsigned char ToLower(const unsigned char src) noexcept;
 
+  struct CaseInsensitiveComparator
+  {
+    bool operator()(const std::string& lhs, const std::string& rhs) const
+    {
+      return std::lexicographical_compare(
+          lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), [](char c1, char c2) {
+            return ToLower(c1) < ToLower(c2);
+          });
+    }
+  };
+
 }}}} // namespace Azure::Core::Internal::Strings

--- a/sdk/core/azure-core/src/http/http.cpp
+++ b/sdk/core/azure-core/src/http/http.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 
 void Azure::Core::Http::Details::InsertHeaderWithValidation(
-    std::map<std::string, std::string>& headers,
+    Azure::Core::Http::Request::HeaderMap& headers,
     std::string const& headerName,
     std::string const& headerValue)
 {

--- a/sdk/core/azure-core/src/http/raw_response.cpp
+++ b/sdk/core/azure-core/src/http/raw_response.cpp
@@ -15,10 +15,7 @@ HttpStatusCode RawResponse::GetStatusCode() const { return m_statusCode; }
 
 std::string const& RawResponse::GetReasonPhrase() const { return m_reasonPhrase; }
 
-std::map<std::string, std::string> const& RawResponse::GetHeaders() const
-{
-  return this->m_headers;
-}
+RawResponse::HeaderMap const& RawResponse::GetHeaders() const { return this->m_headers; }
 
 void RawResponse::AddHeader(uint8_t const* const first, uint8_t const* const last)
 {

--- a/sdk/core/azure-core/src/http/request.cpp
+++ b/sdk/core/azure-core/src/http/request.cpp
@@ -13,9 +13,7 @@ using namespace Azure::Core::Http;
 namespace {
 // returns left map plus all items in right
 // when duplicates, left items are preferred
-static std::map<std::string, std::string> MergeMaps(
-    std::map<std::string, std::string> left,
-    std::map<std::string, std::string> const& right)
+static Request::HeaderMap MergeMaps(Request::HeaderMap left, Request::HeaderMap const& right)
 {
   left.insert(right.begin(), right.end());
   return left;
@@ -44,7 +42,7 @@ void Request::StartTry()
 
 HttpMethod Request::GetMethod() const { return this->m_method; }
 
-std::map<std::string, std::string> Request::GetHeaders() const
+Request::HeaderMap Request::GetHeaders() const
 {
   // create map with retry headers which are the most important and we don't want
   // to override them with any duplicate header

--- a/sdk/core/azure-core/test/ut/http.cpp
+++ b/sdk/core/azure-core/test/ut/http.cpp
@@ -24,7 +24,7 @@ namespace Azure { namespace Core { namespace Test {
 
     EXPECT_NO_THROW(req.AddHeader(expected.first, expected.second));
     EXPECT_PRED2(
-        [](std::map<std::string, std::string> headers,
+        [](Azure::Core::Http::Request::HeaderMap headers,
            std::pair<std::string, std::string> expected) {
           auto firstHeader = headers.begin();
           return firstHeader->first == expected.first && firstHeader->second == expected.second
@@ -39,7 +39,7 @@ namespace Azure { namespace Core { namespace Test {
     std::pair<std::string, std::string> expectedOverride("valid", "override");
     EXPECT_NO_THROW(req.AddHeader(expectedOverride.first, expectedOverride.second));
     EXPECT_PRED2(
-        [](std::map<std::string, std::string> headers,
+        [](Azure::Core::Http::Request::HeaderMap headers,
            std::pair<std::string, std::string> expected) {
           auto firstHeader = headers.begin();
           return firstHeader->first == expected.first && firstHeader->second == expected.second
@@ -52,7 +52,7 @@ namespace Azure { namespace Core { namespace Test {
     std::pair<std::string, std::string> expected2("valid2", "header2");
     EXPECT_NO_THROW(req.AddHeader(expected2.first, expected2.second));
     EXPECT_PRED2(
-        [](std::map<std::string, std::string> headers,
+        [](Azure::Core::Http::Request::HeaderMap headers,
            std::pair<std::string, std::string> expected) {
           auto secondHeader = headers.begin();
           secondHeader++;
@@ -72,7 +72,7 @@ namespace Azure { namespace Core { namespace Test {
 
     EXPECT_NO_THROW(response.AddHeader(expected.first, expected.second));
     EXPECT_PRED2(
-        [](std::map<std::string, std::string> headers,
+        [](Azure::Core::Http::RawResponse::HeaderMap headers,
            std::pair<std::string, std::string> expected) {
           auto firstHeader = headers.begin();
           return firstHeader->first == expected.first && firstHeader->second == expected.second
@@ -88,7 +88,7 @@ namespace Azure { namespace Core { namespace Test {
     std::pair<std::string, std::string> expectedOverride("valid", "override");
     EXPECT_NO_THROW(response.AddHeader(expectedOverride.first, expectedOverride.second));
     EXPECT_PRED2(
-        [](std::map<std::string, std::string> headers,
+        [](Azure::Core::Http::RawResponse::HeaderMap headers,
            std::pair<std::string, std::string> expected) {
           auto firstHeader = headers.begin();
           return firstHeader->first == expected.first && firstHeader->second == expected.second
@@ -101,7 +101,7 @@ namespace Azure { namespace Core { namespace Test {
     std::pair<std::string, std::string> expected2("valid2", "header2");
     EXPECT_NO_THROW(response.AddHeader(expected2.first, expected2.second));
     EXPECT_PRED2(
-        [](std::map<std::string, std::string> headers,
+        [](Azure::Core::Http::RawResponse::HeaderMap headers,
            std::pair<std::string, std::string> expected) {
           auto secondtHeader = headers.begin();
           secondtHeader++;
@@ -119,7 +119,7 @@ namespace Azure { namespace Core { namespace Test {
     // adding header after previous error just happened on add from string
     EXPECT_NO_THROW(response.AddHeader("valid3: header3"));
     EXPECT_PRED2(
-        [](std::map<std::string, std::string> headers,
+        [](Azure::Core::Http::RawResponse::HeaderMap headers,
            std::pair<std::string, std::string> expected) {
           auto secondtHeader = headers.begin();
           secondtHeader++;

--- a/sdk/keyvault/azure-security-keyvault-common/src/keyvault_exception.cpp
+++ b/sdk/keyvault/azure-security-keyvault-common/src/keyvault_exception.cpp
@@ -14,7 +14,7 @@ using namespace Azure::Security::KeyVault::Common;
 namespace {
 
 inline std::string GetHeaderOrEmptyString(
-    std::map<std::string, std::string> const& headers,
+    Azure::Core::Http::RawResponse::HeaderMap const& headers,
     std::string const& headerName)
 {
   auto header = headers.find(headerName);

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_common.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_common.hpp
@@ -52,20 +52,11 @@ namespace Azure { namespace Storage {
   };
 
   namespace Details {
-    struct CaseInsensitiveComparator
-    {
-      bool operator()(const std::string& lhs, const std::string& rhs) const
-      {
-        return std::lexicographical_compare(
-            lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), [](char c1, char c2) {
-              return Core::Internal::Strings::ToLower(c1) < Core::Internal::Strings::ToLower(c2);
-            });
-      }
-    };
-
     ContentHash FromBase64String(const std::string& base64String, HashAlgorithm algorithm);
     std::string ToBase64String(const ContentHash& hash);
   } // namespace Details
-  using Metadata = std::map<std::string, std::string, Details::CaseInsensitiveComparator>;
+
+  using Metadata = std::
+      map<std::string, std::string, Azure::Core::Internal::Strings::CaseInsensitiveComparator>;
 
 }} // namespace Azure::Storage


### PR DESCRIPTION
There was idea about this in our recent discussion.
Do we want this? If so, when?
Is there a work item for this?