### PR TITLE
Use the port defined in the URL when setting up the transport adapter usage.

### DIFF
--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -1148,6 +1148,14 @@ std::unique_ptr<CurlNetworkConnection> CurlConnectionPool::GetCurlConnection(
         + std::string(curl_easy_strerror(result)));
   }
 
+  uint16_t port = request.GetUrl().GetPort();
+  if (port != 0 && !SetLibcurlOption(newHandle, CURLOPT_PORT, port, &result))
+  {
+    throw Azure::Core::Http::TransportException(
+        Details::DefaultFailedToGetNewConnectionTemplate + host + ". "
+        + std::string(curl_easy_strerror(result)));
+  }
+
   if (!SetLibcurlOption(newHandle, CURLOPT_CONNECT_ONLY, 1L, &result))
   {
     throw Azure::Core::Http::TransportException(

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -208,13 +208,15 @@ void WinHttpTransport::CreateSessionHandle(std::unique_ptr<Details::HandleManage
 void WinHttpTransport::CreateConnectionHandle(
     std::unique_ptr<Details::HandleManager>& handleManager)
 {
+  // If port is 0, i.e. INTERNET_DEFAULT_PORT, it uses port 80 for HTTP and port 443 for HTTPS.
+  uint16_t port = m_request.GetUrl().GetPort();
+
   // Specify an HTTP server.
-  // Uses port 80 for HTTP and port 443 for HTTPS.
   // This function always operates synchronously.
   handleManager->m_connectionHandle = WinHttpConnect(
       handleManager->m_sessionHandle,
       StringToWideString(handleManager->m_request.GetUrl().GetHost()).c_str(),
-      INTERNET_DEFAULT_PORT,
+      port == 0 ? INTERNET_DEFAULT_PORT : port,
       0);
 
   if (!handleManager->m_connectionHandle)

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -209,7 +209,7 @@ void WinHttpTransport::CreateConnectionHandle(
     std::unique_ptr<Details::HandleManager>& handleManager)
 {
   // If port is 0, i.e. INTERNET_DEFAULT_PORT, it uses port 80 for HTTP and port 443 for HTTPS.
-  uint16_t port = m_request.GetUrl().GetPort();
+  uint16_t port = handleManager->m_request.GetUrl().GetPort();
 
   // Specify an HTTP server.
   // This function always operates synchronously.

--- a/sdk/core/azure-core/test/ut/url.cpp
+++ b/sdk/core/azure-core/test/ut/url.cpp
@@ -205,8 +205,16 @@ namespace Azure { namespace Core { namespace Test {
   TEST(URL, getPortAfterSet)
   {
     Http::Url url("http://test.com");
+
+    uint16_t expected = 0;
+
+    EXPECT_PRED2(
+        [](uint16_t expectedValue, uint16_t code) { return expectedValue == code; },
+        url.GetPort(),
+        expected);
+
     url.SetPort(40);
-    uint16_t expected = 40;
+    expected = 40;
 
     EXPECT_PRED2(
         [](uint16_t expectedValue, uint16_t code) { return expectedValue == code; },


### PR DESCRIPTION
The goal was to fix this for the winhttp transport adater, but turns out curl transport adapter doesn't honor it either. I am wondering if this is actually something we need to do. @JeffreyRichter, what do you think?

Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/1122

I am trying to figure out how to test this, at least locally, by configuring the specific port that needs to be used and am open to suggestions.