### PR TITLE
Remove vcpkg integration snippet duplication for the root cmakefile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,18 +20,6 @@ option(BUILD_STORAGE_SAMPLES "Build sample application for Azure Storage clients
 
 include(AzureTransportAdapters)
 
-# VCPKG Integration
-if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-  set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-      CACHE STRING "")
-elseif(DEFINED ENV{VCPKG_INSTALLATION_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-  set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake"
-      CACHE STRING "")
-endif()
-if(DEFINED ENV{VCPKG_DEFAULT_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET)
-  set(VCPKG_TARGET_TRIPLET "$ENV{VCPKG_DEFAULT_TRIPLET}" CACHE STRING "")
-endif()
-
 # Project definition
 project(azure-sdk LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ option(RUN_LONG_UNIT_TESTS "Tests that takes more than 5 minutes to complete. No
 option(BUILD_STORAGE_SAMPLES "Build sample application for Azure Storage clients" OFF)
 
 include(AzureTransportAdapters)
+include(AzureVcpkg)
+
+az_vcpkg_integrate()
 
 # Project definition
 project(azure-sdk LANGUAGES CXX)


### PR DESCRIPTION
Removes an unnecessary code snippet (but not the integration - we have it in a macro file and invoke from each cmakefile).

Closes #754:
AK> Hey Charlie, Victor told me that you don't recommend this kind of vcpkg integration; if so - why? It looks harmless to me, we only set CMAKE_TOOLCHAIN_FILE if it is not defined, and vcpkg is present - https://github.com/Azure/azure-sdk-for-cpp/blob/master/cmake-modules/AzureVcpkg.cmake#L9-L18

CB> part of it is personal preference, I prefer not to have my project's build system know/care about vcpkg.
CB> it's not _that_ bad
CB> I also don't love my build system trying to divine things about the building system based on environment variables and such
CB> that said, we do a similar thing in the STL and it works allright

AK> I understand, thank you! I'd say it has predictable and defined behavior, and it makes it easier for the new users to build, without the need to provide CMAKE_TOOLCHAIN_FILE in common configuration, so, it sounds like it has the right to exist?..

CB> I'd also just write that code before your toplevel "project" call instead of the macro
CB> it's not like you're going to be calling that macro multiple times
CB> yeah, it's not super bad

AK> thank you! The reason that it is in macro is that there are multiple entry points - you can either load the entire Azure SDK "solution", or the individual "project" ("projects" are primarily used when being built as vcpackages).

CB> yeah, I'd just put it on the toplevel one, I'm not sure how setting CMAKE_TOOLCHAIN_FILE works when you're set it between two calls to project()

AK> all works fine, and it is not going to be set multiple times, because once we set it, the next time the check of ifndef(CMAKE_TOOLCHAIN_FILE) is not going to let us through to set it again. This is what I like about this technique - it is "smart", but not too invasive.
AK> thank you Charlie!