### PR TITLE
Add VcPkg OpenSSL dependency for Azure::Core

### DIFF
--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -116,10 +116,9 @@ create_code_coverage(core azure-core azure-core-test)
 
 target_link_libraries(azure-core INTERFACE Threads::Threads)
 
-if(MSVC)
+if(WIN32)
     target_link_libraries(azure-core PRIVATE crypt32)
 else()
-    message("Find the OpenSSL package on MacOS, used for Base64 encoding.")
     find_package(OpenSSL REQUIRED)
     target_link_libraries(azure-core PRIVATE OpenSSL::SSL)
 endif()

--- a/sdk/core/azure-core/vcpkg/CONTROL
+++ b/sdk/core/azure-core/vcpkg/CONTROL
@@ -3,6 +3,7 @@
 #
 Source: azure-core-cpp
 Version: @AZ_LIBRARY_VERSION@
+Build-Depends: openssl (!windows)
 Description: Microsoft Azure Core SDK for C++
   This library provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C++.
 Homepage: https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/core/azure-core

--- a/sdk/core/azure-core/vcpkg/CONTROL
+++ b/sdk/core/azure-core/vcpkg/CONTROL
@@ -3,7 +3,7 @@
 #
 Source: azure-core-cpp
 Version: @AZ_LIBRARY_VERSION@
-Build-Depends: openssl (!windows)
+Build-Depends: openssl (!windows&!uwp)
 Description: Microsoft Azure Core SDK for C++
   This library provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C++.
 Homepage: https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/core/azure-core

--- a/sdk/core/azure-core/vcpkg/Config.cmake.in
+++ b/sdk/core/azure-core/vcpkg/Config.cmake.in
@@ -5,8 +5,13 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
+
 if(@BUILD_TRANSPORT_CURL@)
   find_dependency(CURL @CURL_MIN_REQUIRED_VERSION@)
+endif()
+
+if(NOT WIN32)
+  find_dependency(OpenSSL)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-core-cppTargets.cmake")

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/CONTROL
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/CONTROL
@@ -1,6 +1,6 @@
 Source: azure-security-keyvault-common-cpp
 Version: @AZ_LIBRARY_VERSION@
-Build-Depends: azure-core-cpp, openssl (!windows)
+Build-Depends: azure-core-cpp
 Description: Microsoft Azure Common Key Vault SDK for C++
   This library provides common Azure KeyVault-related abstractions for Azure SDK.
 Homepage: https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/keyvault/azure-security-keyvault-common

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/Config.cmake.in
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/Config.cmake.in
@@ -6,10 +6,6 @@
 include(CMakeFindDependencyMacro)
 find_dependency(azure-core-cpp)
 
-if(NOT MSVC)
-  find_dependency(OpenSSL)
-endif()
-
 include("${CMAKE_CURRENT_LIST_DIR}/azure-security-keyvault-common-cppTargets.cmake")
 
 check_required_components("azure-security-keyvault-common-cpp")

--- a/sdk/storage/azure-storage-common/CMakeLists.txt
+++ b/sdk/storage/azure-storage-common/CMakeLists.txt
@@ -80,7 +80,7 @@ target_link_libraries(azure-storage-common PUBLIC Azure::azure-core)
 target_include_directories(azure-storage-common PRIVATE ${LIBXML2_INCLUDE_DIRS})
 target_link_libraries(azure-storage-common PRIVATE ${LIBXML2_LIBRARIES})
 
-if(MSVC)
+if(WIN32)
     target_link_libraries(azure-storage-common PRIVATE bcrypt)
     # C28020 and C28204 are introduced by nlohmann/json
     target_compile_options(azure-storage-common PUBLIC /wd28204 /wd28020)

--- a/sdk/storage/azure-storage-common/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-common/vcpkg/Config.cmake.in
@@ -8,7 +8,7 @@ find_dependency(LibXml2)
 find_dependency(Threads)
 find_dependency(azure-core-cpp)
 
-if(NOT MSVC)
+if(NOT WIN32)
   find_dependency(OpenSSL)
 endif()
 


### PR DESCRIPTION
Closes #1609.
I can confirm - I can build from VcPkg on Windows - before and after, on Mac it fails before, succeeds after.