### PR TITLE
[Perf fw] add test metadata to the tests for the perf fw

### DIFF
--- a/sdk/core/performance-stress/CMakeLists.txt
+++ b/sdk/core/performance-stress/CMakeLists.txt
@@ -14,6 +14,7 @@ set(
   inc/azure/performance-stress/dynamic_test_options.hpp
   inc/azure/performance-stress/options.hpp
   inc/azure/performance-stress/program.hpp
+  inc/azure/performance-stress/test_metadata.hpp
   inc/azure/performance-stress/test.hpp
   inc/azure/performance-stress/test_options.hpp
 )

--- a/sdk/core/performance-stress/inc/azure/performance-stress/program.hpp
+++ b/sdk/core/performance-stress/inc/azure/performance-stress/program.hpp
@@ -10,13 +10,9 @@
 #pragma once
 
 #include "azure/performance-stress/argagg.hpp"
-#include "azure/performance-stress/test.hpp"
+#include "azure/performance-stress/test_metadata.hpp"
 
-#include <functional>
-#include <iostream>
-#include <map>
-#include <memory>
-#include <string>
+#include <vector>
 
 namespace Azure { namespace PerformanceStress {
   /**
@@ -47,10 +43,7 @@ namespace Azure { namespace PerformanceStress {
      */
     static void Run(
         Azure::Core::Context const& context,
-        std::map<
-            std::string,
-            std::function<std::unique_ptr<Azure::PerformanceStress::PerformanceTest>(
-                Azure::PerformanceStress::TestOptions)>> const& tests,
+        std::vector<Azure::PerformanceStress::TestMetadata> const& tests,
         int argc,
         char** argv);
   };

--- a/sdk/core/performance-stress/inc/azure/performance-stress/test_metadata.hpp
+++ b/sdk/core/performance-stress/inc/azure/performance-stress/test_metadata.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ * @brief Define the metadata of a performance test.
+ *
+ */
+
+#pragma once
+
+#include "azure/performance-stress/test.hpp"
+#include "azure/performance-stress/test_options.hpp"
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace Azure { namespace PerformanceStress {
+  /**
+   * @brief Define the metadata of a test that can be run by the performance framework.
+   *
+   */
+  struct TestMetadata
+  {
+    /**
+     * @brief The name of the test.
+     *
+     */
+    std::string Name;
+    /**
+     * @brief Describe the goal or intention of the test.
+     *
+     */
+    std::string Description;
+
+    /**
+     * @brief The callback function which produces the performance test.
+     *
+     */
+    std::function<std::unique_ptr<Azure::PerformanceStress::PerformanceTest>(
+        Azure::PerformanceStress::TestOptions)>
+        Factory;
+  };
+}} // namespace Azure::PerformanceStress

--- a/sdk/core/performance-stress/inc/azure/performance_framework.hpp
+++ b/sdk/core/performance-stress/inc/azure/performance_framework.hpp
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ * @brief Convenience top level header to include all the performance framework functionality.
+ *
+ */
+
+#pragma once
+
+#include "azure/performance-stress/argagg.hpp"
+#include "azure/performance-stress/base_test.hpp"
+#include "azure/performance-stress/dynamic_test_options.hpp"
+#include "azure/performance-stress/options.hpp"
+#include "azure/performance-stress/program.hpp"
+#include "azure/performance-stress/test.hpp"
+#include "azure/performance-stress/test_metadata.hpp"
+#include "azure/performance-stress/test_options.hpp"

--- a/sdk/core/performance-stress/test/inc/azure/performance-stress/test/curl_http_client_get_test.hpp
+++ b/sdk/core/performance-stress/test/inc/azure/performance-stress/test/curl_http_client_get_test.hpp
@@ -46,6 +46,21 @@ namespace Azure { namespace PerformanceStress { namespace Test {
     }
 
     void GlobalCleanup() override { curl_global_cleanup(); }
+
+    /**
+     * @brief Get the static Test Metadata for the test.
+     *
+     * @return Azure::PerformanceStress::TestMetadata describing the test.
+     */
+    static Azure::PerformanceStress::TestMetadata GetTestMetadata()
+    {
+      return {
+          "curlHttpClientGet",
+          "Send an Http Get request to a configurable url using libcurl.",
+          [](Azure::PerformanceStress::TestOptions options) {
+            return std::make_unique<Azure::PerformanceStress::Test::CurlHttpClientGetTest>(options);
+          }};
+    }
   };
 
 }}} // namespace Azure::PerformanceStress::Test

--- a/sdk/core/performance-stress/test/inc/azure/performance-stress/test/delay_test.hpp
+++ b/sdk/core/performance-stress/test/inc/azure/performance-stress/test/delay_test.hpp
@@ -13,9 +13,9 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <thread>
 #include <vector>
-#include <memory>
 
 namespace Azure { namespace PerformanceStress { namespace Test {
 

--- a/sdk/core/performance-stress/test/inc/azure/performance-stress/test/delay_test.hpp
+++ b/sdk/core/performance-stress/test/inc/azure/performance-stress/test/delay_test.hpp
@@ -9,14 +9,13 @@
 
 #pragma once
 
-#include <azure/performance-stress/options.hpp>
-#include <azure/performance-stress/test.hpp>
-#include <azure/performance-stress/test_options.hpp>
+#include <azure/performance_framework.hpp>
 
 #include <atomic>
 #include <chrono>
 #include <thread>
 #include <vector>
+#include <memory>
 
 namespace Azure { namespace PerformanceStress { namespace Test {
 
@@ -93,6 +92,21 @@ namespace Azure { namespace PerformanceStress { namespace Test {
            "Initial delay (in milliseconds). The delay of iteration N will be (InitialDelayMS * "
            "(IterationGrowthFactor ^ IterationCount)). Default to 1",
            1}};
+    }
+
+    /**
+     * @brief Get the static Test Metadata for the test.
+     *
+     * @return Azure::PerformanceStress::TestMetadata describing the test.
+     */
+    static Azure::PerformanceStress::TestMetadata GetTestMetadata()
+    {
+      return {
+          "delay",
+          "The no op test with a configurable time delay for the main test loop.",
+          [](Azure::PerformanceStress::TestOptions options) {
+            return std::make_unique<Azure::PerformanceStress::Test::DelayTest>(options);
+          }};
     }
   };
 

--- a/sdk/core/performance-stress/test/inc/azure/performance-stress/test/exception_test.hpp
+++ b/sdk/core/performance-stress/test/inc/azure/performance-stress/test/exception_test.hpp
@@ -10,8 +10,9 @@
 
 #pragma once
 
-#include <azure/performance-stress/options.hpp>
-#include <azure/performance-stress/test.hpp>
+#include <azure/performance_framework.hpp>
+
+#include <memory>
 
 namespace Azure { namespace PerformanceStress { namespace Test {
 
@@ -43,6 +44,21 @@ namespace Azure { namespace PerformanceStress { namespace Test {
       {
         // just ignore
       }
+    }
+
+    /**
+     * @brief Get the static Test Metadata for the test.
+     *
+     * @return Azure::PerformanceStress::TestMetadata describing the test.
+     */
+    static Azure::PerformanceStress::TestMetadata GetTestMetadata()
+    {
+      return {
+          "exception",
+          "Measure how the impact of catching a runtime exception.",
+          [](Azure::PerformanceStress::TestOptions options) {
+            return std::make_unique<Azure::PerformanceStress::Test::ExceptionTest>(options);
+          }};
     }
   };
 

--- a/sdk/core/performance-stress/test/inc/azure/performance-stress/test/extended_options_test.hpp
+++ b/sdk/core/performance-stress/test/inc/azure/performance-stress/test/extended_options_test.hpp
@@ -9,10 +9,9 @@
 
 #pragma once
 
-#include <azure/performance-stress/options.hpp>
-#include <azure/performance-stress/test.hpp>
-#include <azure/performance-stress/test_options.hpp>
+#include <azure/performance_framework.hpp>
 
+#include <memory>
 #include <vector>
 
 namespace Azure { namespace PerformanceStress { namespace Test {
@@ -50,6 +49,22 @@ namespace Azure { namespace PerformanceStress { namespace Test {
     std::vector<Azure::PerformanceStress::TestOption> GetTestOptions() override
     {
       return {{"extraOption", {"-e"}, "Example for extended option for test.", 1}};
+    }
+
+    /**
+     * @brief Get the static Test Metadata for the test.
+     *
+     * @return Azure::PerformanceStress::TestMetadata describing the test.
+     */
+    static Azure::PerformanceStress::TestMetadata GetTestMetadata()
+    {
+      return {
+          "extendedOptions",
+          "Demostrate how to include a test option to a test and measures how expensive is to do "
+          "it.",
+          [](Azure::PerformanceStress::TestOptions options) {
+            return std::make_unique<Azure::PerformanceStress::Test::ExtendedOptionsTest>(options);
+          }};
     }
   };
 

--- a/sdk/core/performance-stress/test/inc/azure/performance-stress/test/http_client_get_test.hpp
+++ b/sdk/core/performance-stress/test/inc/azure/performance-stress/test/http_client_get_test.hpp
@@ -9,9 +9,7 @@
 
 #pragma once
 
-#include <azure/performance-stress/options.hpp>
-#include <azure/performance-stress/test.hpp>
-#include <azure/performance-stress/test_options.hpp>
+#include <azure/performance_framework.hpp>
 
 #include <azure/core/http/body_stream.hpp>
 #include <azure/core/http/http.hpp>

--- a/sdk/core/performance-stress/test/inc/azure/performance-stress/test/no_op_test.hpp
+++ b/sdk/core/performance-stress/test/inc/azure/performance-stress/test/no_op_test.hpp
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <azure/performance-stress/options.hpp>
-#include <azure/performance-stress/test.hpp>
+#include <azure/performance_framework.hpp>
+
+#include <memory>
 
 namespace Azure { namespace PerformanceStress { namespace Test {
 
@@ -33,6 +34,21 @@ namespace Azure { namespace PerformanceStress { namespace Test {
      * @param ctx The cancellation token.
      */
     void Run(Azure::Core::Context const&) override {}
+
+    /**
+     * @brief Get the static Test Metadata for the test.
+     *
+     * @return Azure::PerformanceStress::TestMetadata describing the test.
+     */
+    static Azure::PerformanceStress::TestMetadata GetTestMetadata()
+    {
+      return {
+          "NoOp",
+          "Simplest test to measure the performance framework speed.",
+          [](Azure::PerformanceStress::TestOptions options) {
+            return std::make_unique<Azure::PerformanceStress::Test::NoOp>(options);
+          }};
+    }
   };
 
 }}} // namespace Azure::PerformanceStress::Test

--- a/sdk/core/performance-stress/test/inc/azure/performance-stress/test/win_http_client_get_test.hpp
+++ b/sdk/core/performance-stress/test/inc/azure/performance-stress/test/win_http_client_get_test.hpp
@@ -38,6 +38,21 @@ namespace Azure { namespace PerformanceStress { namespace Test {
     {
       Details::HttpClient = std::make_unique<Azure::Core::Http::WinHttpTransport>();
     }
+
+    /**
+     * @brief Get the static Test Metadata for the test.
+     *
+     * @return Azure::PerformanceStress::TestMetadata describing the test.
+     */
+    static Azure::PerformanceStress::TestMetadata GetTestMetadata()
+    {
+      return {
+          "winHttpClientGet",
+          "Send an Http Get request to a configurable url using winHttp.",
+          [](Azure::PerformanceStress::TestOptions options) {
+            return std::make_unique<Azure::PerformanceStress::Test::WinHttpClientGetTest>(options);
+          }};
+    }
   };
 
 }}} // namespace Azure::PerformanceStress::Test

--- a/sdk/core/performance-stress/test/src/main.cpp
+++ b/sdk/core/performance-stress/test/src/main.cpp
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/performance-stress/options.hpp>
-#include <azure/performance-stress/program.hpp>
+#include <azure/performance_framework.hpp>
 
 #include "azure/performance-stress/test/delay_test.hpp"
 #include "azure/performance-stress/test/extended_options_test.hpp"
@@ -15,47 +14,22 @@
 #include "azure/performance-stress/test/exception_test.hpp"
 #include "azure/performance-stress/test/no_op_test.hpp"
 
-#include <functional>
-#include <iostream>
-#include <map>
-
 int main(int argc, char** argv)
 {
 
   // Create the test list
-  std::map<
-      std::string,
-      std::function<std::unique_ptr<Azure::PerformanceStress::PerformanceTest>(
-          Azure::PerformanceStress::TestOptions)>>
-      tests{
-          {"noOp",
-           [](Azure::PerformanceStress::TestOptions options) {
-             return std::make_unique<Azure::PerformanceStress::Test::NoOp>(options);
-           }},
-          {"extendedOptions",
-           [](Azure::PerformanceStress::TestOptions options) {
-             return std::make_unique<Azure::PerformanceStress::Test::ExtendedOptionsTest>(options);
-           }},
-          {"delay",
-           [](Azure::PerformanceStress::TestOptions options) {
-             return std::make_unique<Azure::PerformanceStress::Test::DelayTest>(options);
-           }},
-          {"exception", [](Azure::PerformanceStress::TestOptions options) {
-             return std::make_unique<Azure::PerformanceStress::Test::ExceptionTest>(options);
-           }}};
+  std::vector<Azure::PerformanceStress::TestMetadata> tests{
+      Azure::PerformanceStress::Test::NoOp::GetTestMetadata(),
+      Azure::PerformanceStress::Test::ExtendedOptionsTest::GetTestMetadata(),
+      Azure::PerformanceStress::Test::DelayTest::GetTestMetadata(),
+      Azure::PerformanceStress::Test::ExceptionTest::GetTestMetadata()};
 
 #if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
-  tests.emplace("curlHttpClientGet", [](Azure::PerformanceStress::TestOptions options) {
-    // Another test
-    return std::make_unique<Azure::PerformanceStress::Test::CurlHttpClientGetTest>(options);
-  });
+  tests.emplace_back(Azure::PerformanceStress::Test::CurlHttpClientGetTest::GetTestMetadata());
 #endif
 
 #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
-  tests.emplace("winHttpClientGet", [](Azure::PerformanceStress::TestOptions options) {
-    // Another test
-    return std::make_unique<Azure::PerformanceStress::Test::WinHttpClientGetTest>(options);
-  });
+  tests.emplace_back(Azure::PerformanceStress::Test::WinHttpClientGetTest::GetTestMetadata());
 #endif
 
   Azure::PerformanceStress::Program::Run(Azure::Core::GetApplicationContext(), tests, argc, argv);


### PR DESCRIPTION
fixes: #1636 

Adding test metadata class and letting each test to define it.
This data is used to print the test info when running the test