### PR TITLE
Renamed `Crc64` to `Crc64Hash` and change it to derive from the `Azure::Core::Cryptography::Hash` class.

### DIFF
--- a/sdk/storage/azure-storage-blobs/test/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/block_blob_client_test.cpp
@@ -131,9 +131,12 @@ namespace Azure { namespace Storage { namespace Test {
     res = m_blockBlobClient->Download(options);
     ASSERT_TRUE(res->TransactionalContentHash.HasValue());
     EXPECT_EQ(res->TransactionalContentHash.GetValue().Algorithm, HashAlgorithm::Crc64);
-    EXPECT_EQ(
-        res->TransactionalContentHash.GetValue().Value,
-        Crc64::Hash(m_blobContent.data(), downloadLength));
+    {
+      Crc64Hash instance;
+      EXPECT_EQ(
+          res->TransactionalContentHash.GetValue().Value,
+          instance.Final(m_blobContent.data(), downloadLength));
+    }
   }
 
   TEST_F(BlockBlobClientTest, DISABLED_LastAccessTime)

--- a/sdk/storage/azure-storage-blobs/test/page_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/page_blob_client_test.cpp
@@ -280,7 +280,11 @@ namespace Azure { namespace Storage { namespace Test {
     Blobs::UploadPageBlobPagesOptions options;
     ContentHash hash;
     hash.Algorithm = HashAlgorithm::Crc64;
-    hash.Value = Crc64::Hash(blobContent.data(), blobContent.size());
+
+    {
+      Crc64Hash instance;
+      hash.Value = instance.Final(blobContent.data(), blobContent.size());
+    }
     options.TransactionalContentHash = hash;
     EXPECT_NO_THROW(pageBlobClient.UploadPages(0, &pageContent, options));
 

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking Changes
 
-- Remove the `Azure::Storage::Md5` class from `crypt.hpp`. Use the type from `Azure::Core::Cryptography` namespace instead, from `azure/core/cryptography/hash.hpp`.
+- Removed the `Azure::Storage::Md5` class from `crypt.hpp`. Use the type from `Azure::Core::Cryptography` namespace instead, from `azure/core/cryptography/hash.hpp`.
+- Renamed `Crc64` to `Crc64Hash` and change it to derive from the `Azure::Core::Cryptography::Hash` class.
 
 ## 12.0.0-beta.7 (2021-02-03)
 

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/crypt.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/crypt.hpp
@@ -16,6 +16,8 @@ namespace Azure { namespace Storage {
   public:
     void Concatenate(const Crc64Hash& other);
 
+    ~Crc64Hash() override = default;
+
   private:
     uint64_t m_context = 0ULL;
     uint64_t m_length = 0ULL;

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/crypt.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/crypt.hpp
@@ -7,32 +7,21 @@
 #include <string>
 #include <vector>
 
+#include "azure/core/cryptography/hash.hpp"
 #include <azure/core/base64.hpp>
 
 namespace Azure { namespace Storage {
 
-  class Crc64 {
+  class Crc64Hash : public Azure::Core::Cryptography::Hash {
   public:
-    void Update(const uint8_t* data, std::size_t length);
-    void Concatenate(const Crc64& other);
-
-    std::vector<uint8_t> Digest() const;
-
-    static std::vector<uint8_t> Hash(const uint8_t* data, std::size_t length)
-    {
-      Crc64 instance;
-      instance.Update(data, length);
-      return instance.Digest();
-    }
-
-    static std::vector<uint8_t> Hash(const std::string& data)
-    {
-      return Hash(reinterpret_cast<const uint8_t*>(data.data()), data.length());
-    }
+    void Concatenate(const Crc64Hash& other);
 
   private:
     uint64_t m_context = 0ULL;
     uint64_t m_length = 0ULL;
+
+    void OnAppend(const uint8_t* data, std::size_t length) override;
+    std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length) override;
   };
 
   namespace Details {

--- a/sdk/storage/azure-storage-common/src/crypt.cpp
+++ b/sdk/storage/azure-storage-common/src/crypt.cpp
@@ -910,7 +910,7 @@ namespace Azure { namespace Storage {
     return vr[0] ^ vr[1];
   }
 
-  void Crc64::Update(const uint8_t* data, std::size_t length)
+  void Crc64Hash::OnAppend(const uint8_t* data, std::size_t length)
   {
     m_length += length;
 
@@ -1058,7 +1058,7 @@ namespace Azure { namespace Storage {
     m_context = uCrc ^ ~0ULL;
   }
 
-  void Crc64::Concatenate(const Crc64& other)
+  void Crc64Hash::Concatenate(const Crc64Hash& other)
   {
     m_length += other.m_length;
 
@@ -1087,8 +1087,9 @@ namespace Azure { namespace Storage {
     m_context ^= other.m_context;
   }
 
-  std::vector<uint8_t> Crc64::Digest() const
+  std::vector<uint8_t> Crc64Hash::OnFinal(const uint8_t* data, std::size_t length)
   {
+    OnAppend(data, length);
     std::vector<uint8_t> binary;
     binary.resize(sizeof(m_context));
     for (std::size_t i = 0; i < sizeof(m_context); ++i)


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk-for-cpp/pull/1632

Also partially addresses https://github.com/Azure/azure-sdk-for-cpp/issues/1619 for Crc64 as well, similar to Md5 (topic 1 and 2).

I will leave it up to @Jinming-Hu and storage folks to help decide whether they want this change in this release, or wait for the next one.