### PR TITLE
Check headers that could be missing when getting blob container properties

### DIFF
--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
@@ -3306,10 +3306,20 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             response.LeaseDuration = BlobLeaseDurationType(x_ms_lease_duration__iterator->second);
           }
-          response.DefaultEncryptionScope
-              = httpResponse.GetHeaders().at("x-ms-default-encryption-scope");
-          response.PreventEncryptionScopeOverride
-              = httpResponse.GetHeaders().at("x-ms-deny-encryption-scope-override") == "true";
+          auto x_ms_default_encryption_scope__iterator
+              = httpResponse.GetHeaders().find("x-ms-default-encryption-scope");
+          if (x_ms_default_encryption_scope__iterator != httpResponse.GetHeaders().end())
+          {
+            response.DefaultEncryptionScope
+                = httpResponse.GetHeaders().at("x-ms-default-encryption-scope");
+          }
+          auto x_ms_deny_encryption_scope_override__iterator
+              = httpResponse.GetHeaders().find("x-ms-deny-encryption-scope-override");
+          if (x_ms_deny_encryption_scope_override__iterator != httpResponse.GetHeaders().end())
+          {
+            response.PreventEncryptionScopeOverride
+                = httpResponse.GetHeaders().at("x-ms-deny-encryption-scope-override") == "true";
+          }
           return Azure::Core::Response<GetBlobContainerPropertiesResult>(
               std::move(response), std::move(pHttpResponse));
         }


### PR DESCRIPTION
When sending a get blob container properties request using [Azurite](url), azure-storage-blob library crashes. Upon debugging, I found the response does not contain "x-ms-default-encryption-scope" or "x-ms-deny-encryption-scope-override" headers. The code currently gets these header values directly from the map and crashes. This PR checks these headers before getting the value.


Below is the response:
```
(gdb) p httpResponse
$2 = (Azure::Core::Http::RawResponse &) @0x7f35645d1bf0: {m_majorVersion = 1, m_minorVersion = 1, m_statusCode = Azure::Core::Http::HttpStatusCode::Ok, m_reasonPhrase = "OK", m_headers = std::map with 12 elements = {["connection"] = "keep-alive",
    ["date"] = "Fri, 19 Feb 2021 01:13:17 GMT", ["etag"] = "\"0x2380243DA88F140\"", ["last-modified"] = "Fri, 19 Feb 2021 01:13:17 GMT", ["server"] = "Azurite-Blob/3.8.0", ["x-ms-client-request-id"] = "5088c48e-95d0-42a4-7084-ae7854ffedf8",
    ["x-ms-has-immutability-policy"] = "false", ["x-ms-has-legal-hold"] = "false", ["x-ms-lease-state"] = "available", ["x-ms-lease-status"] = "unlocked", ["x-ms-request-id"] = "9a23c5e5-0daf-4384-a1c1-0d1706781f75", ["x-ms-version"] = "2019-12-12"},
  m_bodyStream = std::unique_ptr<Azure::Core::Http::BodyStream> = {get() = 0x0}, m_body = std::vector of length 0, capacity 8192}
```
