### PR TITLE
Throw a logic error when calling Rewind on unsupported BodyStreams and update the exception message to be actionable.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/body_stream.hpp
@@ -68,10 +68,10 @@ namespace Azure { namespace Core { namespace Http {
      */
     virtual void Rewind()
     {
-      // Exception is not meant to be caught. This is rather an indication of a bad program that
-      // needs to be updated. This is the reason of using `throw` alone.
-      throw "The upload BodyStream doesn't support Rewind which is required to guarantee fault "
-            "tolerance when retrying the operation.";
+      throw std::runtime_error(
+          "The specified BodyStream doesn't support Rewind which is required to guarantee fault "
+          "tolerance when retrying any operation. Consider creating a MemoryBodyStream or "
+          "FileBodyStream, which are rewindable.");
     };
 
     /**

--- a/sdk/core/azure-core/inc/azure/core/http/body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/body_stream.hpp
@@ -68,7 +68,7 @@ namespace Azure { namespace Core { namespace Http {
      */
     virtual void Rewind()
     {
-      throw std::runtime_error(
+      throw std::logic_error(
           "The specified BodyStream doesn't support Rewind which is required to guarantee fault "
           "tolerance when retrying any operation. Consider creating a MemoryBodyStream or "
           "FileBodyStream, which are rewindable.");

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -30,6 +30,7 @@ include(GoogleTest)
 add_executable (
   azure-core-test
     base64.cpp
+    bodystream.cpp
     context.cpp
     ${CURL_CONNECTION_POOL_TESTS}
     ${CURL_OPTIONS_TESTS}

--- a/sdk/core/azure-core/test/ut/bodystream.cpp
+++ b/sdk/core/azure-core/test/ut/bodystream.cpp
@@ -1,6 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
+#include <azure/core/platform.hpp>
+
+#include <iostream>
+
+#if defined(AZ_PLATFORM_POSIX)
+#include <fcntl.h>
+#elif defined(AZ_PLATFORM_WINDOWS)
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
 #include <gtest/gtest.h>
 
 #include <azure/core/http/body_stream.hpp>

--- a/sdk/core/azure-core/test/ut/bodystream.cpp
+++ b/sdk/core/azure-core/test/ut/bodystream.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+
+#include <azure/core/http/body_stream.hpp>
+
+using namespace Azure::Core;
+
+// Used to test virtual, default behavior of BodyStream.
+class TestBodyStream : public Http::BodyStream {
+  int64_t OnRead(Context const& context, uint8_t* buffer, int64_t count) override { return 0; }
+  int64_t Length() const override { return 0; }
+};
+
+TEST(BodyStream, Rewind)
+{
+  TestBodyStream tb;
+  EXPECT_THROW(tb.Rewind(), std::runtime_error);
+
+  std::string testDataPath(AZURE_TEST_DATA_PATH);
+
+#if defined(AZ_PLATFORM_POSIX)
+  testDataPath.append("/fileData");
+  int f = open(testDataPath.data(), O_RDONLY);
+  EXPECT_GE(f, 0);
+#elif defined(AZ_PLATFORM_WINDOWS)
+  testDataPath.append("\\fileData");
+  HANDLE f = CreateFile(
+      testDataPath.data(),
+      GENERIC_READ,
+      FILE_SHARE_READ,
+      NULL,
+      OPEN_EXISTING,
+      FILE_FLAG_SEQUENTIAL_SCAN,
+      NULL);
+  EXPECT_NE(f, INVALID_HANDLE_VALUE);
+#else
+#error "Unknown platform"
+#endif
+  auto fileBodyStream = Azure::Core::Http::FileBodyStream(f, 0, 0);
+  EXPECT_NO_THROW(fileBodyStream.Rewind());
+
+  std::vector<uint8_t> data = {1, 2, 3, 4};
+  Azure::Core::Http::MemoryBodyStream ms(data);
+  EXPECT_NO_THROW(ms.Rewind());
+}

--- a/sdk/core/azure-core/test/ut/bodystream.cpp
+++ b/sdk/core/azure-core/test/ut/bodystream.cpp
@@ -16,7 +16,7 @@ class TestBodyStream : public Http::BodyStream {
 TEST(BodyStream, Rewind)
 {
   TestBodyStream tb;
-  EXPECT_THROW(tb.Rewind(), std::runtime_error);
+  EXPECT_THROW(tb.Rewind(), std::logic_error);
 
   std::string testDataPath(AZURE_TEST_DATA_PATH);
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/1704
Throwing `invalid_argument`, as the issue described, didn't fit well, especially since the API doesn't accept any arguments directly.

Other alternatives are just throw an `std::exception` (base type of `runtime_error`).