### PR TITLE
no crash on missing x-ms-default-encryption-scope or x-ms-deny-encryption-scope-override

### DIFF
--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
@@ -751,7 +751,7 @@ namespace Azure { namespace Storage { namespace Blobs {
       Azure::Core::Nullable<BlobLeaseDurationType> LeaseDuration;
       BlobLeaseState LeaseState = BlobLeaseState::Available;
       BlobLeaseStatus LeaseStatus = BlobLeaseStatus::Unlocked;
-      std::string DefaultEncryptionScope;
+      std::string DefaultEncryptionScope = "$account-encryption-key";
       bool PreventEncryptionScopeOverride = false;
       Azure::Core::Nullable<int32_t> RemainingRetentionDays;
       Azure::Core::Nullable<Azure::Core::DateTime> DeletedOn;
@@ -808,7 +808,7 @@ namespace Azure { namespace Storage { namespace Blobs {
       Azure::Core::Nullable<BlobLeaseDurationType> LeaseDuration;
       BlobLeaseState LeaseState = BlobLeaseState::Available;
       BlobLeaseStatus LeaseStatus = BlobLeaseStatus::Unlocked;
-      std::string DefaultEncryptionScope;
+      std::string DefaultEncryptionScope = "$account-encryption-key";
       bool PreventEncryptionScopeOverride = false;
     }; // struct GetBlobContainerPropertiesResult
 
@@ -3306,10 +3306,19 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             response.LeaseDuration = BlobLeaseDurationType(x_ms_lease_duration__iterator->second);
           }
-          response.DefaultEncryptionScope
-              = httpResponse.GetHeaders().at("x-ms-default-encryption-scope");
-          response.PreventEncryptionScopeOverride
-              = httpResponse.GetHeaders().at("x-ms-deny-encryption-scope-override") == "true";
+          auto x_ms_default_encryption_scope__iterator
+              = httpResponse.GetHeaders().find("x-ms-default-encryption-scope");
+          if (x_ms_default_encryption_scope__iterator != httpResponse.GetHeaders().end())
+          {
+            response.DefaultEncryptionScope = x_ms_default_encryption_scope__iterator->second;
+          }
+          auto x_ms_deny_encryption_scope_override__iterator
+              = httpResponse.GetHeaders().find("x-ms-deny-encryption-scope-override");
+          if (x_ms_deny_encryption_scope_override__iterator != httpResponse.GetHeaders().end())
+          {
+            response.PreventEncryptionScopeOverride
+                = x_ms_deny_encryption_scope_override__iterator->second == "true";
+          }
           return Azure::Core::Response<GetBlobContainerPropertiesResult>(
               std::move(response), std::move(pHttpResponse));
         }


### PR DESCRIPTION
This PR is to fix an issue where mandatory headers aren't always present for some non standards-compliant storage servers, like Azurite. The change in this PR doesn't, on any level, establish the rule that we should not crash on missing headers. It's just an accommodation to those storage servers that have missing features or lagging service versions, and we only compromise on those less important headers. Storage team is going to hold the yardstick of which headers should be considered _important_ and make decisions on a case-by-case basis, under the guidance of C++ working group.


# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/master/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?

