### PR TITLE
Add -NoNewLine to portfile output

### DIFF
--- a/eng/scripts/Initialize-VcpkgRelease.ps1
+++ b/eng/scripts/Initialize-VcpkgRelease.ps1
@@ -56,4 +56,4 @@ $portfileLocation = "$SourceDirectory/port/portfile.cmake"
 $newContent = Get-Content -Raw -Path $portfileLocation `
     | ForEach-Object { $_ -replace '(SHA512\s+)1', "`${1}$sha512" }
 
-$newContent | Set-Content $portfileLocation
+$newContent | Set-Content $portfileLocation -NoNewLine


### PR DESCRIPTION
Example portfile.cmake from build.. note line 20: 

![image](https://user-images.githubusercontent.com/2158838/108915746-2e9c8380-75e2-11eb-8610-527bbf2789ff.png)


Example portfile WITHOUT `-NoNewLine`.. note the extra line 21 (the bad behavior today): 
![image](https://user-images.githubusercontent.com/2158838/108915796-41af5380-75e2-11eb-9692-0881e94963e0.png)

Example portfile with `-NoNewLine`.. note the last line of the file is line 20 (same as the initial version of the file): 
![image](https://user-images.githubusercontent.com/2158838/108915869-5ab80480-75e2-11eb-8e75-6d1e80a04749.png)
