### PR TITLE
Reserve Claims in TokenRequestOptions to be used when CAE support is implemented

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policy.hpp
@@ -318,6 +318,11 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Authentication scopes.
      */
     std::vector<std::string> Scopes;
+
+    /**
+     * @brief Authentication claims.
+     */
+    std::string Claims;
   };
 
   /**

--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -32,7 +32,7 @@ KeyClient::KeyClient(
 
   {
     Azure::Core::Http::TokenRequestOptions const tokenOptions
-        = {{"https://vault.azure.net/.default"}};
+        = {{"https://vault.azure.net/.default"}, std::string()};
 
     policies.emplace_back(
         std::make_unique<BearerTokenAuthenticationPolicy>(credential, tokenOptions));


### PR DESCRIPTION
Both Java and .NET have Claims as string:
* Java - https://github.com/Azure/azure-sdk-for-java/blob/a4f73634f6044e479fd19c0fa18514f2bd7f0128/sdk/core/azure-core/src/main/java/com/azure/core/credential/TokenRequestContext.java#L16
* .NET - https://github.com/Azure/azure-sdk-for-net/blob/e3d0298d92883afd722d400de65f1cfe7134ea11/sdk/core/Azure.Core/src/TokenRequestContext.cs#L49

We currently don't have Continuous Access support, this field will be used when it gets implemented.