### PR TITLE
Add alternate code path for Get-cpp-PackageInfoFromRepo

### DIFF
--- a/eng/scripts/Get-PkgVersion.ps1
+++ b/eng/scripts/Get-PkgVersion.ps1
@@ -8,15 +8,15 @@ param (
 )
 
 $repoRoot = Resolve-Path "$PSScriptRoot/../..";
-. ${repoRoot}\eng\common\scripts\logging.ps1
-. ${repoRoot}\eng\scripts\SdkVersion-Common.ps1
+. (Join-Path ${repoRoot} "eng" "common" "scripts" "logging.ps1")
+. (Join-Path ${repoRoot} "eng" "scripts" "SdkVersion-Common.ps1")
 
 $versionFileLocation = Get-VersionHppLocaiton `
     -ServiceDirectory $ServiceDirectory `
     -PackageName $PackageName
 
 if (!$versionFileLocation) {
-    $fallbackpath = "$RepoRoot\sdk\$ServiceDirectory\$PackageName\version.txt"
+    $fallbackpath = Join-Path $RepoRoot "sdk" $ServiceDirectory $PackageName "version.txt"
     if (!(Test-Path $fallbackpath))
     {
         LogWarning "Failed to retrieve package version. No version file found."

--- a/eng/scripts/Get-PkgVersion.ps1
+++ b/eng/scripts/Get-PkgVersion.ps1
@@ -8,15 +8,15 @@ param (
 )
 
 $repoRoot = Resolve-Path "$PSScriptRoot/../..";
-. (Join-Path ${repoRoot} "eng" "common" "scripts" "logging.ps1")
-. (Join-Path ${repoRoot} "eng" "scripts" "SdkVersion-Common.ps1")
+. (Join-Path ${repoRoot} eng common scripts logging.ps1)
+. (Join-Path ${repoRoot} eng scripts SdkVersion-Common.ps1)
 
 $versionFileLocation = Get-VersionHppLocaiton `
     -ServiceDirectory $ServiceDirectory `
     -PackageName $PackageName
 
 if (!$versionFileLocation) {
-    $fallbackpath = Join-Path $RepoRoot "sdk" $ServiceDirectory $PackageName "version.txt"
+    $fallbackpath = Join-Path $RepoRoot sdk $ServiceDirectory $PackageName version.txt
     if (!(Test-Path $fallbackpath))
     {
         LogWarning "Failed to retrieve package version. No version file found."

--- a/eng/scripts/Get-PkgVersion.ps1
+++ b/eng/scripts/Get-PkgVersion.ps1
@@ -7,26 +7,36 @@ param (
     [string] $PackageName
 )
 
-. ${PSScriptRoot}/SdkVersion-Common.ps1
+$repoRoot = Resolve-Path "$PSScriptRoot/../..";
+. ${repoRoot}\eng\common\scripts\logging.ps1
+. ${repoRoot}\eng\scripts\SdkVersion-Common.ps1
 
 $versionFileLocation = Get-VersionHppLocaiton `
     -ServiceDirectory $ServiceDirectory `
     -PackageName $PackageName
 
 if (!$versionFileLocation) {
-    $fallback = Get-Content $RepoRoot/sdk/$ServiceDirectory/$PackageName/version.txt
+    $fallbackpath = "$RepoRoot\sdk\$ServiceDirectory\$PackageName\version.txt"
+    if (!(Test-Path $fallbackpath))
+    {
+        LogWarning "Failed to retrieve package version. No version file found."
+        return $null
+    }
+
+    $fallback = Get-Content $fallbackpath
     if ($fallback) {
         return $fallback
     } else {
-        Write-Error "Cannot locate package version"
-        exit 1
+        LogWarning "Cannot locate package version"
+        return $null
     }
 }
 
 $versionFileContents = Get-Content $versionFileLocation -Raw
 
 if (!($versionFileContents -match $VersionRegex)) {
-    Write-Error "does not match version information schema"
+    LogWarning "does not match version information schema"
+    return $null
 }
 
 $VersionString = if ($Matches.prerelease) {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -12,12 +12,23 @@ function Get-cpp-PackageInfoFromRepo($pkgPath, $serviceDirectory, $pkgName)
   # Test if the package path ends with the package name (e.g. sdk/storage/azure-storage-common)
   # This function runs in a loop where $pkgPath might be the path to the package and must return 
   # $null in cases where $pkgPath is not the path to the package specified by $pkgName
-  if ($pkgName -ne (Split-Path -Leaf $pkgPath)) { 
+  if ($pkgName -and ($pkgName -ne (Split-Path -Leaf $pkgPath))) { 
     return $null
   }
 
+  if (!$pkgName)
+  {
+    $pkgName = Split-Path -Leaf $pkgPath
+  }
+
   $packageVersion = & $PSScriptRoot/Get-PkgVersion.ps1 -ServiceDirectory $serviceDirectory -PackageName $pkgName
-  return [PackageProps]::new($pkgName, $packageVersion, $pkgPath, $serviceDirectory)
+  if ($null -ne $packageVersion)
+  {
+    $packageProps = [PackageProps]::new($pkgName, $packageVersion, $pkgPath, $serviceDirectory)
+    $packageProps.ArtifactName = $pkgName
+    return $packageProps
+  }
+  return $null
 }
 
 # Parse out package publishing information from a package-info.json file.


### PR DESCRIPTION
Add alternative code paths depending on parameters which allows for coming changes to common tools.
This change is solely intended to prevent breaking the build while making changes to common across various repos.