### PR TITLE
Fix context for unique

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -38,6 +38,7 @@
 ### Bug Fixes
 
 - Make sure to rewind the body stream at the start of each request retry attempt, including the first.
+- Fix `Azure::Context` to support unique_ptr.
 
 ## 1.0.0-beta.6 (2021-02-09)
 

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -126,7 +126,12 @@ namespace Azure { namespace Core {
      *
      * @param p Smart pointer to #Azure::Core::ValueBase.
      */
-    ContextValue(std::unique_ptr<ValueBase>&& p) noexcept
+    template <
+        class DerivedFromValueBase,
+        typename std::
+            enable_if<std::is_convertible<DerivedFromValueBase*, ValueBase*>::value, int>::type
+        = 0>
+    ContextValue(std::unique_ptr<DerivedFromValueBase>&& p)
         : m_contextValueType(ContextValueType::UniquePtr), m_p(std::move(p))
     {
     }

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -253,3 +253,19 @@ TEST(Context, MatchingKeys)
   value = valueT3.Get<int>();
   EXPECT_TRUE(value == 456);
 }
+
+struct SomeStructForContext : ValueBase
+{
+  bool someField = false;
+};
+
+TEST(Context, UniquePtr)
+{
+  auto contextP
+      = GetApplicationContext().WithValue("bool", std::make_unique<SomeStructForContext>());
+  auto& contextValueRef = contextP["bool"].Get<std::unique_ptr<ValueBase>>();
+  SomeStructForContext* pointerToStruct{static_cast<SomeStructForContext*>(contextValueRef.get())};
+  EXPECT_FALSE(pointerToStruct->someField);
+  pointerToStruct->someField = true;
+  EXPECT_TRUE(pointerToStruct->someField);
+}

--- a/sdk/core/perf/test/inc/azure/perf/test/http_client_get_test.hpp
+++ b/sdk/core/perf/test/inc/azure/perf/test/http_client_get_test.hpp
@@ -57,10 +57,10 @@ namespace Azure { namespace Perf { namespace Test {
     void Run(Azure::Core::Context const& ctx) override
     {
       Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, m_url);
-      auto response = Details::HttpClient->Send(ctx, request);
+      auto response = Details::HttpClient->Send(request, ctx);
       // Read the body from network
       auto bodyStream = response->GetBodyStream();
-      response->SetBody(Azure::IO::BodyStream::ReadToEnd(ctx, *bodyStream));
+      response->SetBody(Azure::IO::BodyStream::ReadToEnd(*bodyStream, ctx));
     }
 
     /**

--- a/sdk/keyvault/azure-security-keyvault-keys/sample/get-key/main.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/sample/get-key/main.cpp
@@ -38,9 +38,6 @@ using namespace Azure::Security::KeyVault::Keys;
 
 int main()
 {
-  Azure::Core::Logging::SetLogListener(
-      [](auto, std::string const& message) { std::cout << message << std::endl; });
-
   auto tenantId = std::getenv("AZURE_KEYVAULT_TENANT_ID");
   auto clientId = std::getenv("AZURE_KEYVAULT_CLIENT_ID");
   auto clientSecret = std::getenv("AZURE_KEYVAULT_CLIENT_SECRET");


### PR DESCRIPTION
Context was updated in the past and the template for ValueBase was removed, breaking its functionality.

Adding the template back and a test about how to use it.

fixes: #1796 