### PR TITLE
Operations should provide a RawResposne

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -89,11 +89,6 @@
           "name": "BUILD_PERFORMANCE_TESTS",
           "value": "true",
           "type": "BOOL"
-        },
-        {
-          "name": "CMAKE_BUILD_TYPE",
-          "value": "MinSizeRel",
-          "type": "STRING"
         }
       ]
     },
@@ -137,11 +132,6 @@
           "name": "BUILD_PERFORMANCE_TESTS",
           "value": "True",
           "type": "BOOL"
-        },
-        {
-          "name": "CMAKE_BUILD_TYPE",
-          "value": "MinSizeRel",
-          "type": "STRING"
         }
       ]
     },
@@ -180,11 +170,6 @@
           "name": "BUILD_PERFORMANCE_TESTS",
           "value": "True",
           "type": "BOOL"
-        },
-        {
-          "name": "CMAKE_BUILD_TYPE",
-          "value": "MinSizeRel",
-          "type": "STRING"
         }
       ]
     },
@@ -218,11 +203,6 @@
           "name": "BUILD_PERFORMANCE_TESTS",
           "value": "True",
           "type": "BOOL"
-        },
-        {
-          "name": "CMAKE_BUILD_TYPE",
-          "value": "MinSizeRel",
-          "type": "STRING"
         }
       ]
     }

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed `Azure::Core::Http::HttpPipeline` by making it internal, used only within the SDK.
 - Split `Azure::Core::RequestConditions` into `Azure::Core::MatchConditions` and `Azure::Core::ModifiedConditions`.
 - Removed `TransportKind` enum from `Azure::Core::Http`.
+- Added `Azure::Core::Operation<T>::GetRawResponse`
 - Renamed `NoRevoke` to `EnableCertificateRevocationListCheck` for `Azure::Core::Http::CurlTransportSSLOptions`.
 - Renamed `GetString()` to `ToString()` in `Azure::Core::DateTime`.
 - Renamed `GetUuidString()` to `ToString()` in `Azure::Core::Uuid`.

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Removed `Azure::Core::Http::HttpPipeline` by making it internal, used only within the SDK.
 - Split `Azure::Core::RequestConditions` into `Azure::Core::MatchConditions` and `Azure::Core::ModifiedConditions`.
 - Removed `TransportKind` enum from `Azure::Core::Http`.
-- Added `Azure::Core::Operation<T>::GetRawResponse`
+- Added `Azure::Core::Operation<T>::GetRawResponse().`
 - Renamed `NoRevoke` to `EnableCertificateRevocationListCheck` for `Azure::Core::Http::CurlTransportSSLOptions`.
 - Renamed `GetString()` to `ToString()` in `Azure::Core::DateTime`.
 - Renamed `GetUuidString()` to `ToString()` in `Azure::Core::Uuid`.

--- a/sdk/core/azure-core/inc/azure/core/operation.hpp
+++ b/sdk/core/azure-core/inc/azure/core/operation.hpp
@@ -53,8 +53,7 @@ namespace Azure { namespace Core {
 
     /**
      * @brief Get the raw HTTP response.
-     * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
-     * exist.
+     * @return A pointer to #Azure::Core::Http::RawResponse.
      * @note Does not give up ownership of the RawResponse.
      */
     virtual Azure::Core::Http::RawResponse* GetRawResponse() const = 0;

--- a/sdk/core/azure-core/inc/azure/core/operation.hpp
+++ b/sdk/core/azure-core/inc/azure/core/operation.hpp
@@ -55,7 +55,7 @@ namespace Azure { namespace Core {
      * @brief Get the raw HTTP response.
      * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
      * exist.
-     * @note Does not give up ownership of the RawResponse
+     * @note Does not give up ownership of the RawResponse.
      */
     virtual Azure::Core::Http::RawResponse* GetRawResponse() const = 0;
 

--- a/sdk/core/azure-core/inc/azure/core/operation.hpp
+++ b/sdk/core/azure-core/inc/azure/core/operation.hpp
@@ -51,6 +51,12 @@ namespace Azure { namespace Core {
      */
     virtual std::string GetResumeToken() const = 0;
 
+    /**
+     * @brief Get the raw HTTP response.
+     * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
+     * exist.
+     * @note Does not give up ownership of the RawResponse
+     */
     virtual Azure::Core::Http::RawResponse* GetRawResponse() const = 0;
 
     /**

--- a/sdk/core/azure-core/inc/azure/core/operation.hpp
+++ b/sdk/core/azure-core/inc/azure/core/operation.hpp
@@ -51,6 +51,8 @@ namespace Azure { namespace Core {
      */
     virtual std::string GetResumeToken() const = 0;
 
+    virtual Azure::Core::Http::RawResponse* GetRawResponse() const = 0;
+
     /**
      * @brief Returns the current #Azure::Core::OperationStatus of the long-running operation.
      */

--- a/sdk/core/azure-core/test/ut/operation_test.hpp
+++ b/sdk/core/azure-core/test/ut/operation_test.hpp
@@ -19,9 +19,9 @@ namespace Azure { namespace Core { namespace Test {
   class StringOperation : public Operation<std::string> {
 
   private:
-    StringClient* m_client;
     std::string m_operationToken;
     std::string m_value;
+    std::unique_ptr<Azure::Core::Http::RawResponse> m_rawResponse;
 
   private:
     int m_count = 0;
@@ -58,7 +58,7 @@ namespace Azure { namespace Core { namespace Test {
     }
 
   public:
-    StringOperation(StringClient* client) : m_client(client) { (void)m_client; }
+    Azure::Core::Http::RawResponse* GetRawResponse() const override { return m_rawResponse.get(); }
 
     std::string GetResumeToken() const override { return m_operationToken; }
 
@@ -82,7 +82,7 @@ namespace Azure { namespace Core { namespace Test {
     StringOperation StartStringUpdate()
     {
       // Make initial String call
-      StringOperation operation = StringOperation(this);
+      StringOperation operation = StringOperation();
       return operation;
     }
   };

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
@@ -78,6 +78,13 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
 
   public:
     /**
+     * @brief Get the #Azure::Core::Http::RawResponse of the operation request.
+     * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
+     * exist.
+     */
+    Azure::Core::Http::RawResponse* GetRawResponse() const override { return m_rawResponse.get(); }
+
+    /**
      * @brief Get the #Azure::Security::KeyVault::Keys::DeletedKey object.
      *
      * @remark The deleted key contains the recovery id if the key can be recovered.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
@@ -79,8 +79,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
   public:
     /**
      * @brief Get the #Azure::Core::Http::RawResponse of the operation request.
-     * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
-     * exist.
+     * @return A pointer to #Azure::Core::Http::RawResponse or null.
      */
     Azure::Core::Http::RawResponse* GetRawResponse() const override { return m_rawResponse.get(); }
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
@@ -81,6 +81,16 @@ namespace Azure { namespace Storage { namespace Blobs {
 
   public:
     Models::GetBlobPropertiesResult Value() const override { return m_pollResult; }
+    /**
+     * @brief Get the #Azure::Core::Http::RawResponse of the operation request.
+     * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
+     * exist.
+     */
+    Azure::Core::Http::RawResponse* GetRawResponse() const override
+    {
+      // TODO: Fix to return the rawResponse
+      return nullptr;
+    }
 
     ~StartCopyBlobOperation() override {}
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
@@ -81,10 +81,12 @@ namespace Azure { namespace Storage { namespace Blobs {
 
   public:
     Models::GetBlobPropertiesResult Value() const override { return m_pollResult; }
+
     /**
-     * @brief Get the #Azure::Core::Http::RawResponse of the operation request.
+     * @brief Get the raw HTTP response.
      * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
      * exist.
+     * @note Does not give up ownership of the RawResponse
      */
     Azure::Core::Http::RawResponse* GetRawResponse() const override
     {

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
@@ -84,8 +84,7 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     /**
      * @brief Get the raw HTTP response.
-     * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
-     * exist.
+     * @return A pointer to #Azure::Core::Http::RawResponse.
      * @note Does not give up ownership of the RawResponse.
      */
     Azure::Core::Http::RawResponse* GetRawResponse() const override

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
@@ -86,7 +86,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Get the raw HTTP response.
      * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
      * exist.
-     * @note Does not give up ownership of the RawResponse
+     * @note Does not give up ownership of the RawResponse.
      */
     Azure::Core::Http::RawResponse* GetRawResponse() const override
     {

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -200,8 +200,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     /**
      * @brief Get the raw HTTP response.
-     * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
-     * exist.
+     * @return A pointer to #Azure::Core::Http::RawResponse.
      * @note Does not give up ownership of the RawResponse.
      */
     Azure::Core::Http::RawResponse* GetRawResponse() const override

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -199,9 +199,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     Models::GetShareFilePropertiesResult Value() const override { return m_pollResult; }
 
     /**
-     * @brief Get the #Azure::Core::Http::RawResponse of the operation request.
+     * @brief Get the raw HTTP response.
      * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
      * exist.
+     * @note Does not give up ownership of the RawResponse
      */
     Azure::Core::Http::RawResponse* GetRawResponse() const override
     {

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -198,6 +198,17 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   public:
     Models::GetShareFilePropertiesResult Value() const override { return m_pollResult; }
 
+    /**
+     * @brief Get the #Azure::Core::Http::RawResponse of the operation request.
+     * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
+     * exist.
+     */
+    Azure::Core::Http::RawResponse* GetRawResponse() const override
+    {
+      // TODO: Fix to return the rawResponse
+      return nullptr;
+    }
+
     ~StartCopyShareFileOperation() override {}
 
   private:

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -202,7 +202,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Get the raw HTTP response.
      * @return A pointer to #Azure::Core::Http::RawResponse or null if the RawResponse does not
      * exist.
-     * @note Does not give up ownership of the RawResponse
+     * @note Does not give up ownership of the RawResponse.
      */
     Azure::Core::Http::RawResponse* GetRawResponse() const override
     {


### PR DESCRIPTION
Fixes #1739 
Added the pure virtual method
On storage operation types they currently return null.  Storage will need to update their implementation to return the actual rawResponse.


# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/master/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
