### PR TITLE
Fix build on VS2017

### DIFF
--- a/sdk/core/azure-core/src/http/log_policy.cpp
+++ b/sdk/core/azure-core/src/http/log_policy.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <iterator>
 #include <sstream>
 
 using Azure::Core::Context;

--- a/sdk/core/azure-core/src/http/log_policy.cpp
+++ b/sdk/core/azure-core/src/http/log_policy.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <iterator>
 #include <sstream>
+#include <type_traits>
 
 using Azure::Core::Context;
 using namespace Azure::Core::Http;


### PR DESCRIPTION
* VS2017 is right, we should be including `<iterator>`, if we use `std::inserter`. It fails to compile on VS2017 without that include.
Why if fails on 2017 and not 2019? Some of the other stdlib headers we include must be including `<iterator>` indirectly in 2019. But we should not be relying on that. Standard says, you use `std::inserter` - include `<iterator>`, if it works without that, that's a coincidence which may break beween versions of stdlib/compilers.

* VS 2017 does not fail because we don't include `<type_taits>` here, but formally we should include it too, because we use 
`std::remove_reference` and `std::remove_const`. It just happens that `log.hpp` includes it, but we should not be relying on that.

This was found during local vcpkg verification - I happen to have it configured targeting VS2017. It does not mean it will fail in vcpkg CI, or would affect many customers, but some for sure. Verification on vcpkg CI looks good - https://github.com/microsoft/vcpkg/pull/16578 (it is based on our master as of Sat 3/6 + this fix).
I verified locally that it builds successfully on `x64-windows`, `x64-windows-static`, and `arm-uwp`.

We should run verification once again, once we have all the renames/moves in master.