### PR TITLE
Make sure DateTime.ToString() works without requiring additional parameters by choosing RFC 3339 as the default.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/datetime.hpp
+++ b/sdk/core/azure-core/inc/azure/core/datetime.hpp
@@ -74,7 +74,8 @@ namespace Azure { namespace Core {
         int8_t localDiffMinutes,
         bool roundFracSecUp = false);
 
-    void ValidateYear() const;
+    void ThrowIfUnsupportedYear() const;
+
     void GetDateTimeParts(
         int16_t* year,
         int8_t* month,
@@ -84,8 +85,8 @@ namespace Azure { namespace Core {
         int8_t* second,
         int32_t* fracSec,
         int8_t* dayOfWeek) const;
+
     std::string ToStringRfc1123() const;
-    std::string ToStringRfc3339() const;
 
   public:
     /**

--- a/sdk/core/azure-core/inc/azure/core/datetime.hpp
+++ b/sdk/core/azure-core/inc/azure/core/datetime.hpp
@@ -74,6 +74,19 @@ namespace Azure { namespace Core {
         int8_t localDiffMinutes,
         bool roundFracSecUp = false);
 
+    void ValidateYear() const;
+    void GetDateTimeParts(
+        int16_t* year,
+        int8_t* month,
+        int8_t* day,
+        int8_t* hour,
+        int8_t* minute,
+        int8_t* second,
+        int32_t* fracSec,
+        int8_t* dayOfWeek) const;
+    std::string ToStringRfc1123() const;
+    std::string ToStringRfc3339() const;
+
   public:
     /**
      * @brief Construct an instance of #Azure::Core::DateTime.
@@ -166,15 +179,22 @@ namespace Azure { namespace Core {
     /**
      * @brief Get a string representation of the #Azure::Core::DateTime.
      *
+     * @param format The representation format to use, defaulted to use RFC 3339.
+     *
+     * @throw std::invalid_argument If year exceeds 9999, or if \p format is not recognized.
+     */
+    std::string ToString(DateFormat format = DateFormat::Rfc3339) const;
+
+    /**
+     * @brief Get a string representation of the #Azure::Core::DateTime.
+     *
      * @param format The representation format to use.
      * @param fractionFormat The format for the fraction part of the DateTime. Only
      * supported by RFC3339.
      *
      * @throw std::invalid_argument If year exceeds 9999, or if \p format is not recognized.
      */
-    std::string ToString(
-        DateFormat format,
-        TimeFractionFormat fractionFormat = TimeFractionFormat::DropTrailingZeros) const;
+    std::string ToString(DateFormat format, TimeFractionFormat fractionFormat) const;
   };
 
   inline Details::Clock::time_point Details::Clock::now() noexcept

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -729,7 +729,7 @@ DateTime DateTime::Parse(std::string const& dateTime, DateFormat format)
   }
 }
 
-void DateTime::ValidateYear() const
+void DateTime::ThrowIfUnsupportedYear() const
 {
   static DateTime const Year0001 = DateTime();
   static DateTime const Eoy9999 = DateTime(9999, 12, 31, 23, 59, 59, 9999999, -1, 0, 0);
@@ -803,7 +803,7 @@ void DateTime::GetDateTimeParts(
 
 std::string DateTime::ToStringRfc1123() const
 {
-  ValidateYear();
+  ThrowIfUnsupportedYear();
 
   int16_t year = 1;
 
@@ -848,7 +848,7 @@ std::string DateTime::ToString(DateFormat format, TimeFractionFormat fractionFor
         "Unrecognized date format (" + std::to_string(static_cast<int64_t>(format)) + ").");
   }
 
-  ValidateYear();
+  ThrowIfUnsupportedYear();
 
   int16_t year = 1;
 

--- a/sdk/core/azure-core/test/ut/datetime.cpp
+++ b/sdk/core/azure-core/test/ut/datetime.cpp
@@ -448,6 +448,39 @@ TEST(DateTime, ParseTimeRoundtripAcceptsInvalidNoTrailingTimezone)
   }
 }
 
+TEST(DateTime, ToStringNoArg)
+{
+  auto dt = DateTime::Parse("2013-05-17T01:02:03.1230000Z", DateTime::DateFormat::Rfc3339);
+  EXPECT_EQ(dt.ToString(), "2013-05-17T01:02:03.123Z");
+}
+
+TEST(DateTime, ToStringOneArg)
+{
+  auto dt = DateTime::Parse("2013-05-17T01:02:03.1230000Z", DateTime::DateFormat::Rfc3339);
+  EXPECT_EQ(dt.ToString(DateTime::DateFormat::Rfc3339), "2013-05-17T01:02:03.123Z");
+  EXPECT_EQ(dt.ToString(DateTime::DateFormat::Rfc1123), "Fri, 17 May 2013 01:02:03 GMT");
+}
+
+TEST(DateTime, ToStringInvalid)
+{
+  auto dt = DateTime::Parse("2013-05-17T01:02:03.1230000Z", DateTime::DateFormat::Rfc3339);
+
+  EXPECT_THROW(dt.ToString((DateTime::DateFormat)2), std::invalid_argument);
+
+  EXPECT_THROW(
+      dt.ToString(DateTime::DateFormat::Rfc1123, DateTime::TimeFractionFormat::AllDigits),
+      std::invalid_argument);
+  EXPECT_THROW(
+      dt.ToString(DateTime::DateFormat::Rfc1123, DateTime::TimeFractionFormat::DropTrailingZeros),
+      std::invalid_argument);
+  EXPECT_THROW(
+      dt.ToString(DateTime::DateFormat::Rfc1123, DateTime::TimeFractionFormat::Truncate),
+      std::invalid_argument);
+  EXPECT_THROW(
+      dt.ToString(DateTime::DateFormat::Rfc1123, (DateTime::TimeFractionFormat)3),
+      std::invalid_argument);
+}
+
 TEST(DateTime, ParseTimeInvalid2)
 {
   // Various unsupported cases. In all cases, we have produce an empty date time

--- a/sdk/core/azure-core/test/ut/datetime.cpp
+++ b/sdk/core/azure-core/test/ut/datetime.cpp
@@ -34,6 +34,7 @@ TEST(DateTime, ParseDateBasic)
   {
     auto dt = DateTime::Parse("20130517", DateTime::DateFormat::Rfc3339);
     EXPECT_NE(0, dt.time_since_epoch().count());
+    EXPECT_EQ(dt.ToString(), "2013-05-17T00:00:00Z");
   }
 }
 
@@ -135,6 +136,7 @@ TEST(DateTime, sameResultFromDefaultRfc3339)
         DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::DropTrailingZeros);
     auto const str2 = dt2.ToString(DateTime::DateFormat::Rfc3339);
     EXPECT_EQ(str1, str2);
+    EXPECT_EQ(str1, dt2.ToString());
   }
 }
 

--- a/sdk/core/azure-core/test/ut/datetime.cpp
+++ b/sdk/core/azure-core/test/ut/datetime.cpp
@@ -465,7 +465,7 @@ TEST(DateTime, ToStringInvalid)
 {
   auto dt = DateTime::Parse("2013-05-17T01:02:03.1230000Z", DateTime::DateFormat::Rfc3339);
 
-  EXPECT_THROW(dt.ToString((DateTime::DateFormat)2), std::invalid_argument);
+  EXPECT_THROW(dt.ToString(static_cast<DateTime::DateFormat>(2)), std::invalid_argument);
 
   EXPECT_THROW(
       dt.ToString(DateTime::DateFormat::Rfc1123, DateTime::TimeFractionFormat::AllDigits),
@@ -477,7 +477,7 @@ TEST(DateTime, ToStringInvalid)
       dt.ToString(DateTime::DateFormat::Rfc1123, DateTime::TimeFractionFormat::Truncate),
       std::invalid_argument);
   EXPECT_THROW(
-      dt.ToString(DateTime::DateFormat::Rfc1123, (DateTime::TimeFractionFormat)3),
+      dt.ToString(DateTime::DateFormat::Rfc1123, static_cast<DateTime::TimeFractionFormat>(3)),
       std::invalid_argument);
 }
 


### PR DESCRIPTION
Enabling `dateTime.ToString()`. Due to method overloading, there are no breaking changes here, and no functionality changes.


Validate and throw that you can't pass fractional format enum when dateformat is rfc1123.