### PR TITLE
update tests from core to run together

### DIFF
--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -82,9 +82,21 @@ target_include_directories (azure-core-test PRIVATE $<BUILD_INTERFACE:${CMAKE_CU
 
 target_link_libraries(azure-core-test PRIVATE azure-core gtest gmock)
 
+## Global context test
+add_executable (
+  azure-core-global-context-test
+  global_context.cpp
+)
+target_link_libraries(azure-core-global-context-test PRIVATE azure-core gtest_main)
+
 # gtest_discover_tests will scan the test from azure-core-test and call add_test
 # for each test to ctest. This enables `ctest -r` to run specific tests directly.
 gtest_discover_tests(azure-core-test
      TEST_PREFIX azure-core.
+     NO_PRETTY_TYPES
+     NO_PRETTY_VALUES)
+
+gtest_discover_tests(azure-core-global-context-test
+     TEST_PREFIX azure-core-global-context.
      NO_PRETTY_TYPES
      NO_PRETTY_VALUES)

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -81,31 +81,6 @@ TEST(Context, BasicChar)
   EXPECT_TRUE(kind == ContextValue::ContextValueType::StdString);
 }
 
-TEST(Context, ApplicationContext)
-{
-  Context appContext;
-
-  EXPECT_FALSE(appContext.HasKey("Key"));
-  EXPECT_FALSE(appContext.HasKey("key"));
-  EXPECT_FALSE(appContext.HasKey("Value"));
-  EXPECT_FALSE(appContext.HasKey("value"));
-  EXPECT_FALSE(appContext.HasKey("1"));
-  EXPECT_FALSE(appContext.HasKey(""));
-
-  auto duration = std::chrono::milliseconds(250);
-  EXPECT_FALSE(appContext.IsCancelled());
-  std::this_thread::sleep_for(duration);
-  EXPECT_FALSE(appContext.IsCancelled());
-
-  appContext.Cancel();
-  EXPECT_TRUE(appContext.IsCancelled());
-
-  // AppContext2 is a node from the AppContext
-  //  The context should be cancelled
-  Context appContext2 = appContext.WithValue("aaa", 1);
-  EXPECT_TRUE(appContext2.IsCancelled());
-}
-
 TEST(Context, IsCancelled)
 {
   auto duration = std::chrono::milliseconds(250);

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -83,7 +83,7 @@ TEST(Context, BasicChar)
 
 TEST(Context, ApplicationContext)
 {
-  Context appContext = GetApplicationContext();
+  Context appContext;
 
   EXPECT_FALSE(appContext.HasKey("Key"));
   EXPECT_FALSE(appContext.HasKey("key"));
@@ -100,10 +100,10 @@ TEST(Context, ApplicationContext)
   appContext.Cancel();
   EXPECT_TRUE(appContext.IsCancelled());
 
-  // AppContext2 is the same context as AppContext
+  // AppContext2 is a node from the AppContext
   //  The context should be cancelled
-  Context appContext2 = GetApplicationContext();
-  EXPECT_TRUE(appContext.IsCancelled());
+  Context appContext2 = appContext.WithValue("aaa", 1);
+  EXPECT_TRUE(appContext2.IsCancelled());
 }
 
 TEST(Context, IsCancelled)

--- a/sdk/core/azure-core/test/ut/global_context.cpp
+++ b/sdk/core/azure-core/test/ut/global_context.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ * @brief This test is expected to be in one binary alone because it checks the cancellation of the
+ * global application context. Any other test using the global context after this test would fail.
+ *
+ * Do not add more tests to this file unless the tests will not use the global context.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <azure/core/context.hpp>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+using namespace Azure::Core;
+
+TEST(Context, ApplicationContext)
+{
+  Context appContext = GetApplicationContext();
+
+  EXPECT_FALSE(appContext.HasKey("Key"));
+  EXPECT_FALSE(appContext.HasKey("key"));
+  EXPECT_FALSE(appContext.HasKey("Value"));
+  EXPECT_FALSE(appContext.HasKey("value"));
+  EXPECT_FALSE(appContext.HasKey("1"));
+  EXPECT_FALSE(appContext.HasKey(""));
+
+  auto duration = std::chrono::milliseconds(250);
+  EXPECT_FALSE(appContext.IsCancelled());
+  std::this_thread::sleep_for(duration);
+  EXPECT_FALSE(appContext.IsCancelled());
+
+  appContext.Cancel();
+  EXPECT_TRUE(appContext.IsCancelled());
+
+  // AppContext2 is the same context as AppContext
+  //  The context should be cancelled
+  Context appContext2 = GetApplicationContext();
+  EXPECT_TRUE(appContext2.IsCancelled());
+}

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -145,7 +145,7 @@ TEST(Policy, RetryPolicyCounter)
 {
   using namespace Azure::Core;
   using namespace Azure::Core::Http;
-  using namespace Azure::Core::Http::Internal;;
+  using namespace Azure::Core::Http::Internal;
   // Clean the validation global state
   retryCounterState = 0;
 
@@ -171,7 +171,7 @@ TEST(Policy, RetryPolicyRetryCycle)
 {
   using namespace Azure::Core;
   using namespace Azure::Core::Http;
-  using namespace Azure::Core::Http::Internal;;
+  using namespace Azure::Core::Http::Internal;
   // Clean the validation global state
   retryCounterState = 0;
 

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -146,6 +146,8 @@ TEST(Policy, RetryPolicyCounter)
   using namespace Azure::Core;
   using namespace Azure::Core::Http;
   using namespace Azure::Core::Internal::Http;
+  // Clean the validation global state
+  retryCounterState = 0;
 
   // Check when there's no info about retry on the context
   auto initialContext = GetApplicationContext();
@@ -154,6 +156,8 @@ TEST(Policy, RetryPolicyCounter)
   // Pipeline with retry test
   std::vector<std::unique_ptr<HttpPolicy>> policies;
   RetryOptions opt;
+  // Make retry policy not to take too much time for this test
+  opt.RetryDelay = std::chrono::milliseconds(10);
   policies.push_back(std::make_unique<RetryPolicy>(opt));
   policies.push_back(std::make_unique<TestRetryPolicySharedState>());
   policies.push_back(std::make_unique<SuccessAfter>());
@@ -168,6 +172,8 @@ TEST(Policy, RetryPolicyRetryCycle)
   using namespace Azure::Core;
   using namespace Azure::Core::Http;
   using namespace Azure::Core::Internal::Http;
+  // Clean the validation global state
+  retryCounterState = 0;
 
   // Pipeline with retry test
   std::vector<std::unique_ptr<HttpPolicy>> policies;


### PR DESCRIPTION
Fixing test cases for Context and Retry
- Context was calling Cancel to the global context, making any next test trying to use the global context to fail
- Retry policy tests uses a global state for counting which needs to be reset for each test