### PR TITLE
Make RFC 3339 the default format for DateTime::ToString()

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/datetime.hpp
+++ b/sdk/core/azure-core/inc/azure/core/datetime.hpp
@@ -166,16 +166,26 @@ namespace Azure { namespace Core {
     /**
      * @brief Get a string representation of the #Azure::Core::DateTime.
      *
-     * @param format The representation format to use. Default is
-     * #Azure::Core::DateTime::DateFormat::Rfc3339.
+     * @param format The representation format to use.
      * @param fractionFormat The format for the fraction part of the DateTime. Only
      * supported by #Azure::Core::DateTime::DateFormat::Rfc3339.
      *
      * @throw std::invalid_argument If year exceeds 9999, or if \p format is not recognized.
      */
-    std::string ToString(
-        DateFormat format = DateFormat::Rfc3339,
-        TimeFractionFormat fractionFormat = TimeFractionFormat::DropTrailingZeros) const;
+    std::string ToString(DateFormat format, TimeFractionFormat fractionFormat) const;
+
+    /**
+     * @brief Get a string representation of the #Azure::Core::DateTime.
+     *
+     * @param format The representation format to use. Default is
+     * #Azure::Core::DateTime::DateFormat::Rfc3339.
+     *
+     * @throw std::invalid_argument If year exceeds 9999, or if \p format is not recognized.
+     */
+    std::string ToString(DateFormat format = DateFormat::Rfc3339) const
+    {
+      return this->ToString(format, TimeFractionFormat::DropTrailingZeros);
+    }
   };
 
   inline Details::Clock::time_point Details::Clock::now() noexcept

--- a/sdk/core/azure-core/inc/azure/core/datetime.hpp
+++ b/sdk/core/azure-core/inc/azure/core/datetime.hpp
@@ -166,14 +166,15 @@ namespace Azure { namespace Core {
     /**
      * @brief Get a string representation of the #Azure::Core::DateTime.
      *
-     * @param format The representation format to use.
+     * @param format The representation format to use. Default is
+     * #Azure::Core::DateTime::DateFormat::Rfc3339.
      * @param fractionFormat The format for the fraction part of the DateTime. Only
-     * supported by RFC3339.
+     * supported by #Azure::Core::DateTime::DateFormat::Rfc3339.
      *
      * @throw std::invalid_argument If year exceeds 9999, or if \p format is not recognized.
      */
     std::string ToString(
-        DateFormat format,
+        DateFormat format = DateFormat::Rfc3339,
         TimeFractionFormat fractionFormat = TimeFractionFormat::DropTrailingZeros) const;
   };
 

--- a/sdk/core/azure-core/test/ut/datetime.cpp
+++ b/sdk/core/azure-core/test/ut/datetime.cpp
@@ -765,3 +765,16 @@ TEST(DateTime, TimeRoundtrip)
   TestDateTimeRoundtrip<DateTime::TimeFractionFormat::AllDigits>("2021-02-05T10:00:00.0000000Z");
   TestDateTimeRoundtrip<DateTime::TimeFractionFormat::AllDigits>("2021-02-05T20:00:00.0000000Z");
 }
+
+TEST(DateTime, ToStringNoArg)
+{
+  auto dt = DateTime::Parse("2013-05-17T01:02:03.1230000Z", DateTime::DateFormat::Rfc3339);
+  EXPECT_EQ(dt.ToString(), "2013-05-17T01:02:03.123Z");
+}
+
+TEST(DateTime, ToStringOneArg)
+{
+  auto dt = DateTime::Parse("2013-05-17T01:02:03.1230000Z", DateTime::DateFormat::Rfc3339);
+  EXPECT_EQ(dt.ToString(DateTime::DateFormat::Rfc3339), "2013-05-17T01:02:03.123Z");
+  EXPECT_EQ(dt.ToString(DateTime::DateFormat::Rfc1123), "Fri, 17 May 2013 01:02:03 GMT");
+}


### PR DESCRIPTION
#1812