### PR TITLE
Remove BUILD_ENV_LOGGER cmake option and always honor AZURE_LOG_LEVEL environment variable, if it is set.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ option(RUN_LONG_UNIT_TESTS "Tests that takes more than 5 minutes to complete. No
 option(BUILD_STORAGE_SAMPLES "Build sample application for Azure Storage clients" OFF)
 option(BUILD_PERFORMANCE_TESTS "Build the performance test library" OFF)
 option(MSVC_USE_STATIC_CRT "(MSVC only) Set to ON to link SDK with static CRT (/MT or /MTd switch)." OFF)
-option(BUILD_ENV_LOGGER "Build support for enabling logging to console when AZURE_LOG_LEVEL environment variable is set." ON)
 
 include(AzureTransportAdapters)
 include(AzureVcpkg)

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -21,10 +21,6 @@ az_vcpkg_integrate()
 
 find_package(Threads REQUIRED)
 
-if (NOT BUILD_ENV_LOGGER)
-  add_compile_definitions(AZ_NO_ENV_LOGGER)
-endif()
-
 if(BUILD_TRANSPORT_CURL)
   # min version for `CURLSSLOPT_NO_REVOKE`
   # https://curl.haxx.se/libcurl/c/CURLOPT_SSL_OPTIONS.html

--- a/sdk/core/azure-core/src/environment_log_level_listener.cpp
+++ b/sdk/core/azure-core/src/environment_log_level_listener.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#if defined(AZ_NO_ENV_LOGGER)
 #include "azure/core/platform.hpp"
 
 #if defined(AZ_PLATFORM_WINDOWS)
@@ -14,11 +13,9 @@
 
 #include <windows.h>
 #endif
-#endif
 
-#if !defined(AZ_NO_ENV_LOGGER) \
-    && (!defined(WINAPI_PARTITION_DESKTOP) \
-        || WINAPI_PARTITION_DESKTOP) // See azure/core/platform.hpp for explanation.
+#if (!defined(WINAPI_PARTITION_DESKTOP) || WINAPI_PARTITION_DESKTOP) // See azure/core/platform.hpp
+                                                                     // for explanation.
 
 #include "environment_log_level_listener_private.hpp"
 

--- a/sdk/core/azure-core/src/environment_log_level_listener_private.hpp
+++ b/sdk/core/azure-core/src/environment_log_level_listener_private.hpp
@@ -27,9 +27,8 @@ namespace Azure { namespace Core { namespace Details {
     static Logger::Listener GetLogListener();
   };
 
-#if defined(AZ_NO_ENV_LOGGER) \
-    || (defined(WINAPI_PARTITION_DESKTOP) \
-        && !WINAPI_PARTITION_DESKTOP) // See azure/core/platform.hpp for explanation.
+#if (defined(WINAPI_PARTITION_DESKTOP) && !WINAPI_PARTITION_DESKTOP) // See azure/core/platform.hpp
+                                                                     // for explanation.
   inline Logger::Level EnvironmentLogLevelListener::GetLogLevel(Logger::Level defaultValue)
   {
     return defaultValue;


### PR DESCRIPTION
I don't currently see a customer scenario to turn building the environment logger off. To reduce breaking changes, I propose we remove this capability for now and add it back once it is explicitly requested.

If we were to add this in the future, we'll need a CI leg which tests building with this option turned off.