### PR TITLE
Move Azure::IO types like BodyStream to Azure::Core::IO.

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Moved `Azure::Core::Logging` namespace entities to `Azure::Core::Logger` class.
 - Removed `Azure::Core::DateTime::GetRfc3339String()`: `Azure::Core::DateTime::ToString()` was extended to provide the same functionality.
 - Moved `Azure::Core::Response<T>` to `Azure::Response<T>`.
+- Moved types in the `Azure::IO` namespace like `BodyStream` to `Azure::Core::IO`.
 - Moved `Azure::Core::ETag` to `Azure::ETag`.
 
 ### Bug Fixes

--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -486,7 +486,7 @@ namespace Azure { namespace Core { namespace Http {
     CaseInsensitiveMap m_headers;
     CaseInsensitiveMap m_retryHeaders;
 
-    Azure::IO::BodyStream* m_bodyStream;
+    Azure::Core::IO::BodyStream* m_bodyStream;
 
     // flag to know where to insert header
     bool m_retryModeEnabled{false};
@@ -507,14 +507,14 @@ namespace Azure { namespace Core { namespace Http {
      *
      * @param httpMethod HTTP method.
      * @param url URL.
-     * @param bodyStream #Azure::IO::BodyStream.
+     * @param bodyStream #Azure::Core::IO::BodyStream.
      * @param downloadViaStream A boolean value indicating whether download should happen via
      * stream.
      */
     explicit Request(
         HttpMethod httpMethod,
         Url url,
-        Azure::IO::BodyStream* bodyStream,
+        Azure::Core::IO::BodyStream* bodyStream,
         bool downloadViaStream)
         : m_method(std::move(httpMethod)), m_url(std::move(url)), m_bodyStream(bodyStream),
           m_retryModeEnabled(false), m_isDownloadViaStream(downloadViaStream)
@@ -526,9 +526,9 @@ namespace Azure { namespace Core { namespace Http {
      *
      * @param httpMethod HTTP method.
      * @param url URL.
-     * @param bodyStream #Azure::IO::BodyStream.
+     * @param bodyStream #Azure::Core::IO::BodyStream.
      */
-    explicit Request(HttpMethod httpMethod, Url url, Azure::IO::BodyStream* bodyStream)
+    explicit Request(HttpMethod httpMethod, Url url, Azure::Core::IO::BodyStream* bodyStream)
         : Request(httpMethod, std::move(url), bodyStream, false)
     {
     }
@@ -590,9 +590,9 @@ namespace Azure { namespace Core { namespace Http {
     CaseInsensitiveMap GetHeaders() const;
 
     /**
-     * @brief Get HTTP body as #Azure::IO::BodyStream.
+     * @brief Get HTTP body as #Azure::Core::IO::BodyStream.
      */
-    Azure::IO::BodyStream* GetBodyStream() { return this->m_bodyStream; }
+    Azure::Core::IO::BodyStream* GetBodyStream() { return this->m_bodyStream; }
 
     /**
      * @brief Get the list of headers prior to HTTP body.
@@ -637,7 +637,7 @@ namespace Azure { namespace Core { namespace Http {
     std::string m_reasonPhrase;
     CaseInsensitiveMap m_headers;
 
-    std::unique_ptr<Azure::IO::BodyStream> m_bodyStream;
+    std::unique_ptr<Azure::Core::IO::BodyStream> m_bodyStream;
     std::vector<uint8_t> m_body;
 
     explicit RawResponse(
@@ -645,7 +645,7 @@ namespace Azure { namespace Core { namespace Http {
         int32_t minorVersion,
         HttpStatusCode statusCode,
         std::string const& reasonPhrase,
-        std::unique_ptr<Azure::IO::BodyStream> BodyStream)
+        std::unique_ptr<Azure::Core::IO::BodyStream> BodyStream)
         : m_majorVersion(majorVersion), m_minorVersion(minorVersion), m_statusCode(statusCode),
           m_reasonPhrase(reasonPhrase), m_bodyStream(std::move(BodyStream))
     {
@@ -730,11 +730,11 @@ namespace Azure { namespace Core { namespace Http {
     void SetHeader(uint8_t const* const first, uint8_t const* const last);
 
     /**
-     * @brief Set #Azure::IO::BodyStream for this HTTP response.
+     * @brief Set #Azure::Core::IO::BodyStream for this HTTP response.
      *
-     * @param stream #Azure::IO::BodyStream.
+     * @param stream #Azure::Core::IO::BodyStream.
      */
-    void SetBodyStream(std::unique_ptr<Azure::IO::BodyStream> stream);
+    void SetBodyStream(std::unique_ptr<Azure::Core::IO::BodyStream> stream);
 
     /**
      * @brief Set HTTP response body for this HTTP response.
@@ -772,9 +772,9 @@ namespace Azure { namespace Core { namespace Http {
     CaseInsensitiveMap const& GetHeaders() const;
 
     /**
-     * @brief Get HTTP response body as #Azure::IO::BodyStream.
+     * @brief Get HTTP response body as #Azure::Core::IO::BodyStream.
      */
-    std::unique_ptr<Azure::IO::BodyStream> GetBodyStream()
+    std::unique_ptr<Azure::Core::IO::BodyStream> GetBodyStream()
     {
       // If m_bodyStream was moved before. nullptr is returned
       return std::move(this->m_bodyStream);

--- a/sdk/core/azure-core/inc/azure/core/http/winhttp/win_http_client.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/winhttp/win_http_client.hpp
@@ -63,7 +63,7 @@ namespace Azure { namespace Core { namespace Http {
       }
     };
 
-    class WinHttpStream : public Azure::IO::BodyStream {
+    class WinHttpStream : public Azure::Core::IO::BodyStream {
     private:
       std::unique_ptr<HandleManager> m_handleManager;
       bool m_isEOF;
@@ -84,7 +84,7 @@ namespace Azure { namespace Core { namespace Http {
       int64_t m_streamTotalRead;
 
       /**
-       * @brief Implement #Azure::IO::BodyStream::OnRead(). Calling this function pulls data
+       * @brief Implement #Azure::Core::IO::BodyStream::OnRead(). Calling this function pulls data
        * from the wire.
        *
        * @param context #Azure::Core::Context so that operation can be cancelled.
@@ -102,7 +102,7 @@ namespace Azure { namespace Core { namespace Http {
       }
 
       /**
-       * @brief Implement #Azure::IO::BodyStream length.
+       * @brief Implement #Azure::Core::IO::BodyStream length.
        *
        * @return The size of the payload.
        */

--- a/sdk/core/azure-core/inc/azure/core/internal/null_body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/null_body_stream.hpp
@@ -10,10 +10,10 @@
 
 #include "azure/core/io/body_stream.hpp"
 
-namespace Azure { namespace IO { namespace _internal {
+namespace Azure { namespace Core { namespace IO { namespace _internal {
 
   /**
-   * @brief Empty #Azure::IO::BodyStream.
+   * @brief Empty #Azure::Core::IO::BodyStream.
    * @remark Used for requests with no body.
    */
   class NullBodyStream : public BodyStream {
@@ -35,7 +35,7 @@ namespace Azure { namespace IO { namespace _internal {
     void Rewind() override {}
 
     /**
-     * @brief Gets a singleton instance of a #Azure::IO::_internal::NullBodyStream.
+     * @brief Gets a singleton instance of a #Azure::Core::IO::_internal::NullBodyStream.
      */
     static NullBodyStream* GetNullBodyStream()
     {
@@ -44,4 +44,4 @@ namespace Azure { namespace IO { namespace _internal {
     }
   };
 
-}}} // namespace Azure::IO::_internal
+}}}} // namespace Azure::Core::IO::_internal

--- a/sdk/core/azure-core/inc/azure/core/io/body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/io/body_stream.hpp
@@ -31,7 +31,7 @@
 #include <memory>
 #include <vector>
 
-namespace Azure { namespace IO {
+namespace Azure { namespace Core { namespace IO {
 
   /**
    *@brief Used to read data to/from a service.
@@ -91,10 +91,10 @@ namespace Azure { namespace IO {
     };
 
     /**
-     * @brief Read #Azure::IO::BodyStream into a buffer until the buffer is filled, or until
+     * @brief Read #Azure::Core::IO::BodyStream into a buffer until the buffer is filled, or until
      * the stream is read to end.
      *
-     * @param body #Azure::IO::BodyStream to read.
+     * @param body #Azure::Core::IO::BodyStream to read.
      * @param buffer Pointer to a first byte of the byte buffer to read the data into.
      * @param count Size of the buffer to read the data into.
      * @param context #Azure::Core::Context so that operation can be cancelled.
@@ -108,11 +108,11 @@ namespace Azure { namespace IO {
         Azure::Core::Context const& context);
 
     /**
-     * @brief Read #Azure::IO::BodyStream until the stream is read to end, allocating memory
+     * @brief Read #Azure::Core::IO::BodyStream until the stream is read to end, allocating memory
      * for the entirety of contents.
      *
      * @param context #Azure::Core::Context so that operation can be cancelled.
-     * @param body #Azure::IO::BodyStream to read.
+     * @param body #Azure::Core::IO::BodyStream to read.
      *
      * @return A vector of bytes containing the entirety of data read from the \p body.
      */
@@ -120,7 +120,7 @@ namespace Azure { namespace IO {
   };
 
   /**
-   * @brief #Azure::IO::BodyStream providing data from an initialized memory buffer.
+   * @brief #Azure::Core::IO::BodyStream providing data from an initialized memory buffer.
    */
   class MemoryBodyStream : public BodyStream {
   private:
@@ -161,7 +161,7 @@ namespace Azure { namespace IO {
   };
 
   /**
-   * @brief #Azure::IO::BodyStream providing its data from a file.
+   * @brief #Azure::Core::IO::BodyStream providing its data from a file.
    */
   class FileBodyStream : public BodyStream {
   private:
@@ -211,4 +211,4 @@ namespace Azure { namespace IO {
     int64_t Length() const override { return this->m_length; };
   };
 
-}} // namespace Azure::IO
+}}} // namespace Azure::Core::IO

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -698,7 +698,7 @@ int64_t CurlSession::OnRead(uint8_t* buffer, int64_t count, Context const& conte
   if (this->m_bodyStartInBuffer >= 0)
   {
     // still have data to take from innerbuffer
-    Azure::IO::MemoryBodyStream innerBufferMemoryStream(
+    Azure::Core::IO::MemoryBodyStream innerBufferMemoryStream(
         this->m_readBuffer + this->m_bodyStartInBuffer,
         this->m_innerBufferSize - this->m_bodyStartInBuffer);
 

--- a/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
@@ -39,7 +39,7 @@ namespace Azure { namespace Core { namespace Http {
    * @remarks This component is expected to be used by an HTTP Transporter to ensure that
    * transporter to be reusable in multiple pipelines while every call to network is unique.
    */
-  class CurlSession : public Azure::IO::BodyStream {
+  class CurlSession : public Azure::Core::IO::BodyStream {
 #ifdef TESTING_BUILD
     // Give access to private to this tests class
     friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
@@ -354,7 +354,7 @@ namespace Azure { namespace Core { namespace Http {
     bool m_keepAlive = true;
 
     /**
-     * @brief Implement #Azure::IO::BodyStream::OnRead(). Calling this function pulls data
+     * @brief Implement #Azure::Core::IO::BodyStream::OnRead(). Calling this function pulls data
      * from the wire.
      *
      * @param context #Azure::Core::Context so that operation can be cancelled.
@@ -407,7 +407,7 @@ namespace Azure { namespace Core { namespace Http {
     std::unique_ptr<Azure::Core::Http::RawResponse> GetResponse();
 
     /**
-     * @brief Implement #Azure::IO::BodyStream length.
+     * @brief Implement #Azure::Core::IO::BodyStream length.
      *
      * @return The size of the payload.
      */

--- a/sdk/core/azure-core/src/http/http.cpp
+++ b/sdk/core/azure-core/src/http/http.cpp
@@ -7,7 +7,7 @@
 #include <utility>
 
 using namespace Azure::Core::Http;
-using namespace Azure::IO::_internal;
+using namespace Azure::Core::IO::_internal;
 
 void Azure::Core::Http::_detail::InsertHeaderWithValidation(
     Azure::Core::CaseInsensitiveMap& headers,

--- a/sdk/core/azure-core/src/http/raw_response.cpp
+++ b/sdk/core/azure-core/src/http/raw_response.cpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-using namespace Azure::IO;
+using namespace Azure::Core::IO;
 using namespace Azure::Core::Http;
 
 HttpStatusCode RawResponse::GetStatusCode() const { return m_statusCode; }

--- a/sdk/core/azure-core/src/http/transport_policy.cpp
+++ b/sdk/core/azure-core/src/http/transport_policy.cpp
@@ -12,7 +12,7 @@
 #endif
 
 using Azure::Core::Context;
-using namespace Azure::IO;
+using namespace Azure::Core::IO;
 using namespace Azure::Core::Http;
 
 std::shared_ptr<HttpTransport> Azure::Core::Http::_detail::GetTransportAdapter()

--- a/sdk/core/azure-core/src/io/body_stream.cpp
+++ b/sdk/core/azure-core/src/io/body_stream.cpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 using Azure::Core::Context;
-using namespace Azure::IO;
+using namespace Azure::Core::IO;
 
 // Keep reading until buffer is all fill out of the end of stream content is reached
 int64_t BodyStream::ReadToCount(

--- a/sdk/core/azure-core/test/ut/bodystream.cpp
+++ b/sdk/core/azure-core/test/ut/bodystream.cpp
@@ -21,7 +21,7 @@
 
 #include <azure/core/io/body_stream.hpp>
 
-using namespace Azure::IO;
+using namespace Azure::Core::IO;
 using namespace Azure::Core;
 
 // Used to test virtual, default behavior of BodyStream.
@@ -55,10 +55,10 @@ TEST(BodyStream, Rewind)
 #else
 #error "Unknown platform"
 #endif
-  auto fileBodyStream = Azure::IO::FileBodyStream(f, 0, 0);
+  auto fileBodyStream = Azure::Core::IO::FileBodyStream(f, 0, 0);
   EXPECT_NO_THROW(fileBodyStream.Rewind());
 
   std::vector<uint8_t> data = {1, 2, 3, 4};
-  Azure::IO::MemoryBodyStream ms(data);
+  Azure::Core::IO::MemoryBodyStream ms(data);
   EXPECT_NO_THROW(ms.Rewind());
 }

--- a/sdk/core/azure-core/test/ut/curl_session_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_session_test.cpp
@@ -123,7 +123,7 @@ namespace Azure { namespace Core { namespace Test {
 
       // Read the bodyStream to get all chunks
       EXPECT_THROW(
-          Azure::IO::BodyStream::ReadToEnd(*bodyS, Azure::Core::GetApplicationContext()),
+          Azure::Core::IO::BodyStream::ReadToEnd(*bodyS, Azure::Core::GetApplicationContext()),
           Azure::Core::Http::TransportException);
     }
     // Clear the connections from the pool to invoke clean routine
@@ -200,7 +200,7 @@ namespace Azure { namespace Core { namespace Test {
 
       // Read the bodyStream to get all chunks
       EXPECT_NO_THROW(
-          Azure::IO::BodyStream::ReadToEnd(*bodyS, Azure::Core::GetApplicationContext()));
+          Azure::Core::IO::BodyStream::ReadToEnd(*bodyS, Azure::Core::GetApplicationContext()));
     }
     // Clear the connections from the pool to invoke clean routine
     Azure::Core::Http::CurlConnectionPool::ConnectionPoolIndex.clear();

--- a/sdk/core/azure-core/test/ut/http.cpp
+++ b/sdk/core/azure-core/test/ut/http.cpp
@@ -161,8 +161,8 @@ namespace Azure { namespace Core { namespace Test {
       Http::Url url("http://test.com");
       Http::Request req(httpMethod, url);
 
-      Azure::IO::_internal::NullBodyStream* d
-          = dynamic_cast<Azure::IO::_internal::NullBodyStream*>(req.GetBodyStream());
+      Azure::Core::IO::_internal::NullBodyStream* d
+          = dynamic_cast<Azure::Core::IO::_internal::NullBodyStream*>(req.GetBodyStream());
       EXPECT_TRUE(d);
 
       req.StartTry();
@@ -178,7 +178,7 @@ namespace Azure { namespace Core { namespace Test {
 
       EXPECT_FALSE(headers.count("name"));
 
-      d = dynamic_cast<Azure::IO::_internal::NullBodyStream*>(req.GetBodyStream());
+      d = dynamic_cast<Azure::Core::IO::_internal::NullBodyStream*>(req.GetBodyStream());
       EXPECT_TRUE(d);
     }
 
@@ -187,31 +187,31 @@ namespace Azure { namespace Core { namespace Test {
       Http::Url url("http://test.com");
 
       std::vector<uint8_t> data = {1, 2, 3, 4};
-      Azure::IO::MemoryBodyStream stream(data);
+      Azure::Core::IO::MemoryBodyStream stream(data);
 
       // Change the offset of the stream to be non-zero by reading a byte.
       std::vector<uint8_t> temp(2);
       EXPECT_EQ(
-          Azure::IO::BodyStream::ReadToCount(stream, temp.data(), 1, GetApplicationContext()), 1);
+          Azure::Core::IO::BodyStream::ReadToCount(stream, temp.data(), 1, GetApplicationContext()), 1);
 
       EXPECT_EQ(temp[0], 1);
       EXPECT_EQ(temp[1], 0);
 
       Http::Request req(httpMethod, url, &stream);
 
-      Azure::IO::MemoryBodyStream* d
-          = dynamic_cast<Azure::IO::MemoryBodyStream*>(req.GetBodyStream());
+      Azure::Core::IO::MemoryBodyStream* d
+          = dynamic_cast<Azure::Core::IO::MemoryBodyStream*>(req.GetBodyStream());
       EXPECT_TRUE(d);
 
       req.StartTry();
 
-      d = dynamic_cast<Azure::IO::MemoryBodyStream*>(req.GetBodyStream());
+      d = dynamic_cast<Azure::Core::IO::MemoryBodyStream*>(req.GetBodyStream());
       EXPECT_TRUE(d);
 
       // Verify that StartTry rewound the stream back.
       auto getStream = req.GetBodyStream();
       EXPECT_EQ(
-          Azure::IO::BodyStream::ReadToCount(*getStream, temp.data(), 2, GetApplicationContext()),
+          Azure::Core::IO::BodyStream::ReadToCount(*getStream, temp.data(), 2, GetApplicationContext()),
           2);
 
       EXPECT_EQ(temp[0], 1);

--- a/sdk/core/azure-core/test/ut/http.cpp
+++ b/sdk/core/azure-core/test/ut/http.cpp
@@ -192,7 +192,8 @@ namespace Azure { namespace Core { namespace Test {
       // Change the offset of the stream to be non-zero by reading a byte.
       std::vector<uint8_t> temp(2);
       EXPECT_EQ(
-          Azure::Core::IO::BodyStream::ReadToCount(stream, temp.data(), 1, GetApplicationContext()), 1);
+          Azure::Core::IO::BodyStream::ReadToCount(stream, temp.data(), 1, GetApplicationContext()),
+          1);
 
       EXPECT_EQ(temp[0], 1);
       EXPECT_EQ(temp[1], 0);
@@ -211,7 +212,8 @@ namespace Azure { namespace Core { namespace Test {
       // Verify that StartTry rewound the stream back.
       auto getStream = req.GetBodyStream();
       EXPECT_EQ(
-          Azure::Core::IO::BodyStream::ReadToCount(*getStream, temp.data(), 2, GetApplicationContext()),
+          Azure::Core::IO::BodyStream::ReadToCount(
+              *getStream, temp.data(), 2, GetApplicationContext()),
           2);
 
       EXPECT_EQ(temp[0], 1);

--- a/sdk/core/azure-core/test/ut/simplified_header.cpp
+++ b/sdk/core/azure-core/test/ut/simplified_header.cpp
@@ -48,7 +48,7 @@ TEST(SimplifiedHeader, core)
 
   {
     std::vector<uint8_t> buffer(10);
-    EXPECT_NO_THROW(Azure::IO::MemoryBodyStream mb(buffer));
+    EXPECT_NO_THROW(Azure::Core::IO::MemoryBodyStream mb(buffer));
   }
   EXPECT_NO_THROW(Azure::Core::Http::TelemetryPolicy tp("", ""));
 }

--- a/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
@@ -456,7 +456,8 @@ namespace Azure { namespace Core { namespace Test {
 #else
 #error "Unknown platform"
 #endif
-    auto requestBodyStream = Azure::Core::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
+    auto requestBodyStream
+        = Azure::Core::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Put, host, &requestBodyStream, true);
     // Make transport adapter to read all stream content for uploading instead of chunks
@@ -494,7 +495,8 @@ namespace Azure { namespace Core { namespace Test {
 #error "Unknown platform"
 #endif
 
-    auto requestBodyStream = Azure::Core::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
+    auto requestBodyStream
+        = Azure::Core::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Put, host, &requestBodyStream, true);
     // Make transport adapter to read default chunk size
@@ -531,7 +533,8 @@ namespace Azure { namespace Core { namespace Test {
 #error "Unknown platform"
 #endif
 
-    auto requestBodyStream = Azure::Core::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
+    auto requestBodyStream
+        = Azure::Core::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Put, host, &requestBodyStream, true);
     // Make transport adapter to read more than file size (5Mb)

--- a/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
@@ -96,7 +96,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // PUT 1K
     auto requestBodyVector = std::vector<uint8_t>(1024, 'x');
-    auto bodyRequest = Azure::IO::MemoryBodyStream(requestBodyVector);
+    auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest);
     auto response = m_pipeline->Send(request, Azure::Core::GetApplicationContext());
@@ -112,7 +112,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // Delete with 1k payload
     auto requestBodyVector = std::vector<uint8_t>(1024, 'x');
-    auto bodyRequest = Azure::IO::MemoryBodyStream(requestBodyVector);
+    auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Delete, host, &bodyRequest);
     auto response = m_pipeline->Send(request, Azure::Core::GetApplicationContext());
@@ -128,7 +128,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // Patch with 1kb payload
     auto requestBodyVector = std::vector<uint8_t>(1024, 'x');
-    auto bodyRequest = Azure::IO::MemoryBodyStream(requestBodyVector);
+    auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Patch, host, &bodyRequest);
     auto response = m_pipeline->Send(request, Azure::Core::GetApplicationContext());
@@ -166,7 +166,7 @@ namespace Azure { namespace Core { namespace Test {
     for (auto i = 0; i < 10; i++)
     {
       auto requestBodyVector = std::vector<uint8_t>(10, 'x');
-      auto bodyRequest = Azure::IO::MemoryBodyStream(requestBodyVector);
+      auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
       auto request
           = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest);
       auto response = m_pipeline->Send(request, Azure::Core::GetApplicationContext());
@@ -233,7 +233,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // PUT 1k
     auto requestBodyVector = std::vector<uint8_t>(1024, 'x');
-    auto bodyRequest = Azure::IO::MemoryBodyStream(requestBodyVector);
+    auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest, true);
     auto response = m_pipeline->Send(request, Azure::Core::GetApplicationContext());
@@ -249,7 +249,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // Delete with 1k payload
     auto requestBodyVector = std::vector<uint8_t>(1024, 'x');
-    auto bodyRequest = Azure::IO::MemoryBodyStream(requestBodyVector);
+    auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Delete, host, &bodyRequest, true);
     auto response = m_pipeline->Send(request, Azure::Core::GetApplicationContext());
@@ -265,7 +265,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // Patch with 1kb payload
     auto requestBodyVector = std::vector<uint8_t>(1024, 'x');
-    auto bodyRequest = Azure::IO::MemoryBodyStream(requestBodyVector);
+    auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Patch, host, &bodyRequest, true);
     auto response = m_pipeline->Send(request, Azure::Core::GetApplicationContext());
@@ -325,7 +325,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // PUT 1MB
     auto requestBodyVector = std::vector<uint8_t>(1024 * 1024, 'x');
-    auto bodyRequest = Azure::IO::MemoryBodyStream(requestBodyVector);
+    auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest);
     // Make transport adapter to read all stream content for uploading instead of chunks
@@ -345,7 +345,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // PUT 1k
     auto requestBodyVector = std::vector<uint8_t>(1024, 'x');
-    auto bodyRequest = Azure::IO::MemoryBodyStream(requestBodyVector);
+    auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest, true);
     auto response = m_pipeline->Send(request, Azure::Core::GetApplicationContext());
@@ -364,7 +364,7 @@ namespace Azure { namespace Core { namespace Test {
     auto threadRoutine = [&]() {
       // Start a big upload and expect it to throw cancelation
       std::vector<uint8_t> bigBuffer(1024 * 1024 * 200, 'x'); // upload 200 Mb
-      auto stream = Azure::IO::MemoryBodyStream(bigBuffer);
+      auto stream = Azure::Core::IO::MemoryBodyStream(bigBuffer);
       auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &stream);
 
       // Request will be cancelled from main thread throwing the exception
@@ -456,7 +456,7 @@ namespace Azure { namespace Core { namespace Test {
 #else
 #error "Unknown platform"
 #endif
-    auto requestBodyStream = Azure::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
+    auto requestBodyStream = Azure::Core::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Put, host, &requestBodyStream, true);
     // Make transport adapter to read all stream content for uploading instead of chunks
@@ -494,7 +494,7 @@ namespace Azure { namespace Core { namespace Test {
 #error "Unknown platform"
 #endif
 
-    auto requestBodyStream = Azure::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
+    auto requestBodyStream = Azure::Core::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Put, host, &requestBodyStream, true);
     // Make transport adapter to read default chunk size
@@ -531,7 +531,7 @@ namespace Azure { namespace Core { namespace Test {
 #error "Unknown platform"
 #endif
 
-    auto requestBodyStream = Azure::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
+    auto requestBodyStream = Azure::Core::IO::FileBodyStream(f, 0, Azure::Core::Test::Datails::FileSize);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Put, host, &requestBodyStream, true);
     // Make transport adapter to read more than file size (5Mb)
@@ -589,7 +589,7 @@ namespace Azure { namespace Core { namespace Test {
     EXPECT_NE(body, nullptr);
 
     std::vector<uint8_t> bodyVector
-        = Azure::IO::BodyStream::ReadToEnd(*body, Azure::Core::GetApplicationContext());
+        = Azure::Core::IO::BodyStream::ReadToEnd(*body, Azure::Core::GetApplicationContext());
     int64_t bodySize = body->Length();
     EXPECT_EQ(bodySize, size);
     bodySize = bodyVector.size();

--- a/sdk/core/perf/test/inc/azure/perf/test/http_client_get_test.hpp
+++ b/sdk/core/perf/test/inc/azure/perf/test/http_client_get_test.hpp
@@ -60,7 +60,7 @@ namespace Azure { namespace Perf { namespace Test {
       auto response = _detail::HttpClient->Send(request, ctx);
       // Read the body from network
       auto bodyStream = response->GetBodyStream();
-      response->SetBody(Azure::IO::BodyStream::ReadToEnd(*bodyStream, ctx));
+      response->SetBody(Azure::Core::IO::BodyStream::ReadToEnd(*bodyStream, ctx));
     }
 
     /**

--- a/sdk/identity/azure-identity/src/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_secret_credential.cpp
@@ -10,7 +10,7 @@
 #include <sstream>
 
 using namespace Azure::Identity;
-using namespace Azure::IO;
+using namespace Azure::Core::IO;
 
 std::string const Azure::Identity::_detail::g_aadGlobalAuthority
     = "https://login.microsoftonline.com/";

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/keyvault_pipeline.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/keyvault_pipeline.hpp
@@ -52,7 +52,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Common { n
      */
     Azure::Core::Http::Request CreateRequest(
         Azure::Core::Http::HttpMethod method,
-        Azure::IO::BodyStream* content,
+        Azure::Core::IO::BodyStream* content,
         std::vector<std::string> const& path) const;
 
     /**
@@ -124,7 +124,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Common { n
         std::vector<std::string> const& path)
     {
       auto serialContent = content.Serialize();
-      auto streamContent = Azure::IO::MemoryBodyStream(
+      auto streamContent = Azure::Core::IO::MemoryBodyStream(
           reinterpret_cast<const uint8_t*>(serialContent.data()), serialContent.size());
 
       auto request = CreateRequest(method, &streamContent, path);

--- a/sdk/keyvault/azure-security-keyvault-common/src/keyvault_pipeline.cpp
+++ b/sdk/keyvault/azure-security-keyvault-common/src/keyvault_pipeline.cpp
@@ -10,7 +10,7 @@ using namespace Azure::Security::KeyVault::Common;
 namespace {
 inline Azure::Core::Http::Request InitRequest(
     Azure::Core::Http::HttpMethod method,
-    Azure::IO::BodyStream* content,
+    Azure::Core::IO::BodyStream* content,
     Azure::Core::Http::Url const& url)
 {
   if (content == nullptr)
@@ -23,7 +23,7 @@ inline Azure::Core::Http::Request InitRequest(
 
 Azure::Core::Http::Request _internal::KeyVaultPipeline::CreateRequest(
     Azure::Core::Http::HttpMethod method,
-    Azure::IO::BodyStream* content,
+    Azure::Core::IO::BodyStream* content,
     std::vector<std::string> const& path) const
 {
 

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/mocked_transport_adapter_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/mocked_transport_adapter_test.hpp
@@ -47,7 +47,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
         response->SetHeader(header.first, header.second);
       }
       std::string bodyCount(_detail::FakeKey);
-      response->SetBodyStream(std::make_unique<Azure::IO::MemoryBodyStream>(
+      response->SetBodyStream(std::make_unique<Azure::Core::IO::MemoryBodyStream>(
           reinterpret_cast<const uint8_t*>(_detail::FakeKey), bodyCount.size()));
       return response;
     } // namespace Azure

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/append_blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/append_blob_client.hpp
@@ -138,7 +138,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @return A AppendBlockResult describing the state of the updated append blob.
      */
     Azure::Response<Models::AppendBlockResult> AppendBlock(
-        Azure::IO::BodyStream* content,
+        Azure::Core::IO::BodyStream* content,
         const AppendBlockOptions& options = AppendBlockOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
@@ -285,7 +285,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      */
     Azure::Response<BlockBlobClient> UploadBlob(
         const std::string& blobName,
-        Azure::IO::BodyStream* content,
+        Azure::Core::IO::BodyStream* content,
         const UploadBlockBlobOptions& options = UploadBlockBlobOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/block_blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/block_blob_client.hpp
@@ -123,7 +123,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @return A UploadBlockBlobResult describing the state of the updated block blob.
      */
     Azure::Response<Models::UploadBlockBlobResult> Upload(
-        Azure::IO::BodyStream* content,
+        Azure::Core::IO::BodyStream* content,
         const UploadBlockBlobOptions& options = UploadBlockBlobOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
@@ -170,7 +170,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      */
     Azure::Response<Models::StageBlockResult> StageBlock(
         const std::string& blockId,
-        Azure::IO::BodyStream* content,
+        Azure::Core::IO::BodyStream* content,
         const StageBlockOptions& options = StageBlockOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/page_blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/page_blob_client.hpp
@@ -149,7 +149,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      */
     Azure::Response<Models::UploadPageBlobPagesResult> UploadPages(
         int64_t offset,
-        Azure::IO::BodyStream* content,
+        Azure::Core::IO::BodyStream* content,
         const UploadPageBlobPagesOptions& options = UploadPageBlobPagesOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
@@ -1127,7 +1127,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     struct DownloadBlobResult
     {
       std::string RequestId;
-      std::unique_ptr<Azure::IO::BodyStream> BodyStream;
+      std::unique_ptr<Azure::Core::IO::BodyStream> BodyStream;
       Azure::Core::Http::Range ContentRange;
       int64_t BlobSize = 0;
       Models::BlobType BlobType;
@@ -1316,7 +1316,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             xml_body = writer.GetDocument();
             writer.Write(Storage::_detail::XmlNode{Storage::_detail::XmlNodeType::End});
           }
-          Azure::IO::MemoryBodyStream xml_body_stream(
+          Azure::Core::IO::MemoryBodyStream xml_body_stream(
               reinterpret_cast<const uint8_t*>(xml_body.data()), xml_body.length());
           auto request = Azure::Core::Http::Request(
               Azure::Core::Http::HttpMethod::Post, url, &xml_body_stream);
@@ -1412,7 +1412,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             xml_body = writer.GetDocument();
             writer.Write(Storage::_detail::XmlNode{Storage::_detail::XmlNodeType::End});
           }
-          Azure::IO::MemoryBodyStream xml_body_stream(
+          Azure::Core::IO::MemoryBodyStream xml_body_stream(
               reinterpret_cast<const uint8_t*>(xml_body.data()), xml_body.length());
           auto request = Azure::Core::Http::Request(
               Azure::Core::Http::HttpMethod::Put, url, &xml_body_stream);
@@ -3597,7 +3597,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             xml_body = writer.GetDocument();
             writer.Write(Storage::_detail::XmlNode{Storage::_detail::XmlNodeType::End});
           }
-          Azure::IO::MemoryBodyStream xml_body_stream(
+          Azure::Core::IO::MemoryBodyStream xml_body_stream(
               reinterpret_cast<const uint8_t*>(xml_body.data()), xml_body.length());
           auto request = Azure::Core::Http::Request(
               Azure::Core::Http::HttpMethod::Put, url, &xml_body_stream);
@@ -6360,7 +6360,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             xml_body = writer.GetDocument();
             writer.Write(Storage::_detail::XmlNode{Storage::_detail::XmlNodeType::End});
           }
-          Azure::IO::MemoryBodyStream xml_body_stream(
+          Azure::Core::IO::MemoryBodyStream xml_body_stream(
               reinterpret_cast<const uint8_t*>(xml_body.data()), xml_body.length());
           auto request = Azure::Core::Http::Request(
               Azure::Core::Http::HttpMethod::Put, url, &xml_body_stream);
@@ -6941,7 +6941,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             const Azure::Core::Context& context,
             Azure::Core::Http::_internal::HttpPipeline& pipeline,
             const Azure::Core::Http::Url& url,
-            Azure::IO::BodyStream* requestBody,
+            Azure::Core::IO::BodyStream* requestBody,
             const UploadBlockBlobOptions& options)
         {
           (void)options;
@@ -7128,7 +7128,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             const Azure::Core::Context& context,
             Azure::Core::Http::_internal::HttpPipeline& pipeline,
             const Azure::Core::Http::Url& url,
-            Azure::IO::BodyStream* requestBody,
+            Azure::Core::IO::BodyStream* requestBody,
             const StageBlockOptions& options)
         {
           (void)options;
@@ -7421,7 +7421,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             xml_body = writer.GetDocument();
             writer.Write(Storage::_detail::XmlNode{Storage::_detail::XmlNodeType::End});
           }
-          Azure::IO::MemoryBodyStream xml_body_stream(
+          Azure::Core::IO::MemoryBodyStream xml_body_stream(
               reinterpret_cast<const uint8_t*>(xml_body.data()), xml_body.length());
           auto request = Azure::Core::Http::Request(
               Azure::Core::Http::HttpMethod::Put, url, &xml_body_stream);
@@ -7957,7 +7957,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             const Azure::Core::Context& context,
             Azure::Core::Http::_internal::HttpPipeline& pipeline,
             const Azure::Core::Http::Url& url,
-            Azure::IO::BodyStream* requestBody,
+            Azure::Core::IO::BodyStream* requestBody,
             const UploadPageBlobPagesOptions& options)
         {
           (void)options;
@@ -9115,7 +9115,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             const Azure::Core::Context& context,
             Azure::Core::Http::_internal::HttpPipeline& pipeline,
             const Azure::Core::Http::Url& url,
-            Azure::IO::BodyStream* requestBody,
+            Azure::Core::IO::BodyStream* requestBody,
             const AppendBlockOptions& options)
         {
           (void)options;
@@ -9536,7 +9536,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             const Azure::Core::Context& context,
             Azure::Core::Http::_internal::HttpPipeline& pipeline,
             const Azure::Core::Http::Url& url,
-            Azure::IO::BodyStream* requestBody,
+            Azure::Core::IO::BodyStream* requestBody,
             const SubmitBlobBatchOptions& options)
         {
           (void)options;

--- a/sdk/storage/azure-storage-blobs/src/append_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/append_blob_client.cpp
@@ -123,7 +123,7 @@ namespace Azure { namespace Storage { namespace Blobs {
   }
 
   Azure::Response<Models::AppendBlockResult> AppendBlobClient::AppendBlock(
-      Azure::IO::BodyStream* content,
+      Azure::Core::IO::BodyStream* content,
       const AppendBlockOptions& options,
       const Azure::Core::Context& context) const
   {

--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -192,10 +192,10 @@ namespace Azure { namespace Storage { namespace Blobs {
       // In case network failure during reading the body
       const Azure::ETag eTag = downloadResponse->Details.ETag;
 
-      auto retryFunction
-          = [this, options, eTag](
-                const HttpGetterInfo& retryInfo,
-                const Azure::Core::Context& context) -> std::unique_ptr<Azure::Core::IO::BodyStream> {
+      auto retryFunction =
+          [this, options, eTag](
+              const HttpGetterInfo& retryInfo,
+              const Azure::Core::Context& context) -> std::unique_ptr<Azure::Core::IO::BodyStream> {
         DownloadBlobOptions newOptions = options;
         newOptions.Range = Core::Http::Range();
         newOptions.Range.GetValue().Offset

--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -195,7 +195,7 @@ namespace Azure { namespace Storage { namespace Blobs {
       auto retryFunction
           = [this, options, eTag](
                 const HttpGetterInfo& retryInfo,
-                const Azure::Core::Context& context) -> std::unique_ptr<Azure::IO::BodyStream> {
+                const Azure::Core::Context& context) -> std::unique_ptr<Azure::Core::IO::BodyStream> {
         DownloadBlobOptions newOptions = options;
         newOptions.Range = Core::Http::Range();
         newOptions.Range.GetValue().Offset
@@ -278,7 +278,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           "buffer is not big enough, blob range size is " + std::to_string(blobRangeSize));
     }
 
-    int64_t bytesRead = Azure::IO::BodyStream::ReadToCount(
+    int64_t bytesRead = Azure::Core::IO::BodyStream::ReadToCount(
         *(firstChunk->BodyStream), buffer, firstChunkLength, context);
     if (bytesRead != firstChunkLength)
     {
@@ -310,7 +310,7 @@ namespace Azure { namespace Storage { namespace Blobs {
               chunkOptions.AccessConditions.IfMatch = eTag;
             }
             auto chunk = Download(chunkOptions, context);
-            int64_t bytesRead = Azure::IO::BodyStream::ReadToCount(
+            int64_t bytesRead = Azure::Core::IO::BodyStream::ReadToCount(
                 *(chunk->BodyStream),
                 buffer + (offset - firstChunkOffset),
                 chunkOptions.Range.GetValue().Length.GetValue(),
@@ -384,7 +384,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     }
     firstChunkLength = std::min(firstChunkLength, blobRangeSize);
 
-    auto bodyStreamToFile = [](Azure::IO::BodyStream& stream,
+    auto bodyStreamToFile = [](Azure::Core::IO::BodyStream& stream,
                                Storage::_detail::FileWriter& fileWriter,
                                int64_t offset,
                                int64_t length,
@@ -395,7 +395,7 @@ namespace Azure { namespace Storage { namespace Blobs {
       {
         int64_t readSize = std::min(static_cast<int64_t>(bufferSize), length);
         int64_t bytesRead
-            = Azure::IO::BodyStream::ReadToCount(stream, buffer.data(), readSize, context);
+            = Azure::Core::IO::BodyStream::ReadToCount(stream, buffer.data(), readSize, context);
         if (bytesRead != readSize)
         {
           throw Azure::Core::RequestFailedException("error when reading body stream");

--- a/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
@@ -345,7 +345,7 @@ namespace Azure { namespace Storage { namespace Blobs {
 
   Azure::Response<BlockBlobClient> BlobContainerClient::UploadBlob(
       const std::string& blobName,
-      Azure::IO::BodyStream* content,
+      Azure::Core::IO::BodyStream* content,
       const UploadBlockBlobOptions& options,
       const Azure::Core::Context& context) const
   {

--- a/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
@@ -78,7 +78,7 @@ namespace Azure { namespace Storage { namespace Blobs {
   }
 
   Azure::Response<Models::UploadBlockBlobResult> BlockBlobClient::Upload(
-      Azure::IO::BodyStream* content,
+      Azure::Core::IO::BodyStream* content,
       const UploadBlockBlobOptions& options,
       const Azure::Core::Context& context) const
   {
@@ -116,7 +116,7 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     if (bufferSize <= static_cast<std::size_t>(options.TransferOptions.SingleUploadThreshold))
     {
-      Azure::IO::MemoryBodyStream contentStream(buffer, bufferSize);
+      Azure::Core::IO::MemoryBodyStream contentStream(buffer, bufferSize);
       UploadBlockBlobOptions uploadBlockBlobOptions;
       uploadBlockBlobOptions.HttpHeaders = options.HttpHeaders;
       uploadBlockBlobOptions.Metadata = options.Metadata;
@@ -133,7 +133,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     };
 
     auto uploadBlockFunc = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
-      Azure::IO::MemoryBodyStream contentStream(buffer + offset, length);
+      Azure::Core::IO::MemoryBodyStream contentStream(buffer + offset, length);
       StageBlockOptions chunkOptions;
       auto blockInfo = StageBlock(getBlockId(chunkId), &contentStream, chunkOptions, context);
       if (chunkId == numChunks - 1)
@@ -179,7 +179,7 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     if (fileReader.GetFileSize() <= options.TransferOptions.SingleUploadThreshold)
     {
-      Azure::IO::FileBodyStream contentStream(fileReader.GetHandle(), 0, fileReader.GetFileSize());
+      Azure::Core::IO::FileBodyStream contentStream(fileReader.GetHandle(), 0, fileReader.GetFileSize());
       UploadBlockBlobOptions uploadBlockBlobOptions;
       uploadBlockBlobOptions.HttpHeaders = options.HttpHeaders;
       uploadBlockBlobOptions.Metadata = options.Metadata;
@@ -196,7 +196,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     };
 
     auto uploadBlockFunc = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
-      Azure::IO::FileBodyStream contentStream(fileReader.GetHandle(), offset, length);
+      Azure::Core::IO::FileBodyStream contentStream(fileReader.GetHandle(), offset, length);
       StageBlockOptions chunkOptions;
       auto blockInfo = StageBlock(getBlockId(chunkId), &contentStream, chunkOptions, context);
       if (chunkId == numChunks - 1)
@@ -235,7 +235,7 @@ namespace Azure { namespace Storage { namespace Blobs {
 
   Azure::Response<Models::StageBlockResult> BlockBlobClient::StageBlock(
       const std::string& blockId,
-      Azure::IO::BodyStream* content,
+      Azure::Core::IO::BodyStream* content,
       const StageBlockOptions& options,
       const Azure::Core::Context& context) const
   {

--- a/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
@@ -179,7 +179,8 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     if (fileReader.GetFileSize() <= options.TransferOptions.SingleUploadThreshold)
     {
-      Azure::Core::IO::FileBodyStream contentStream(fileReader.GetHandle(), 0, fileReader.GetFileSize());
+      Azure::Core::IO::FileBodyStream contentStream(
+          fileReader.GetHandle(), 0, fileReader.GetFileSize());
       UploadBlockBlobOptions uploadBlockBlobOptions;
       uploadBlockBlobOptions.HttpHeaders = options.HttpHeaders;
       uploadBlockBlobOptions.Metadata = options.Metadata;

--- a/sdk/storage/azure-storage-blobs/src/page_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/page_blob_client.cpp
@@ -132,7 +132,7 @@ namespace Azure { namespace Storage { namespace Blobs {
 
   Azure::Response<Models::UploadPageBlobPagesResult> PageBlobClient::UploadPages(
       int64_t offset,
-      Azure::IO::BodyStream* content,
+      Azure::Core::IO::BodyStream* content,
       const UploadPageBlobPagesOptions& options,
       const Azure::Core::Context& context) const
   {

--- a/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
@@ -31,7 +31,8 @@ namespace Azure { namespace Storage { namespace Test {
     m_blobUploadOptions.HttpHeaders.ContentEncoding = "identify";
     m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
     m_appendBlobClient->Create(m_blobUploadOptions);
-    auto blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blockContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     m_appendBlobClient->AppendBlock(&blockContent);
     m_blobUploadOptions.HttpHeaders.ContentHash
         = m_appendBlobClient->GetProperties()->HttpHeaders.ContentHash;
@@ -58,7 +59,8 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(properties.CommittedBlockCount.GetValue(), 0);
     EXPECT_EQ(properties.BlobSize, 0);
 
-    auto blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blockContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     auto appendResponse = appendBlobClient.AppendBlock(&blockContent);
     EXPECT_FALSE(appendResponse->RequestId.empty());
     properties = *appendBlobClient.GetProperties();
@@ -267,7 +269,8 @@ namespace Azure { namespace Storage { namespace Test {
     std::string blobName = RandomString();
     auto blobClient = m_blobContainerClient->GetAppendBlobClient(blobName);
     blobClient.Create();
-    auto blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blockContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     blobClient.AppendBlock(&blockContent);
 
     auto downloadResult = blobClient.Download();
@@ -357,7 +360,8 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_FALSE(response->RequestId.empty());
       EXPECT_TRUE(response->Created);
     }
-    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     blobClient.AppendBlock(&blobContent);
     {
       auto response = blobClient.CreateIfNotExists();
@@ -366,7 +370,8 @@ namespace Azure { namespace Storage { namespace Test {
     }
     auto downloadStream = std::move(blobClient.Download()->BodyStream);
     EXPECT_EQ(
-        Azure::Core::IO::BodyStream::ReadToEnd(*downloadStream, Azure::Core::Context()), m_blobContent);
+        Azure::Core::IO::BodyStream::ReadToEnd(*downloadStream, Azure::Core::Context()),
+        m_blobContent);
   }
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
@@ -31,7 +31,7 @@ namespace Azure { namespace Storage { namespace Test {
     m_blobUploadOptions.HttpHeaders.ContentEncoding = "identify";
     m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
     m_appendBlobClient->Create(m_blobUploadOptions);
-    auto blockContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     m_appendBlobClient->AppendBlock(&blockContent);
     m_blobUploadOptions.HttpHeaders.ContentHash
         = m_appendBlobClient->GetProperties()->HttpHeaders.ContentHash;
@@ -58,7 +58,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(properties.CommittedBlockCount.GetValue(), 0);
     EXPECT_EQ(properties.BlobSize, 0);
 
-    auto blockContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     auto appendResponse = appendBlobClient.AppendBlock(&blockContent);
     EXPECT_FALSE(appendResponse->RequestId.empty());
     properties = *appendBlobClient.GetProperties();
@@ -67,20 +67,20 @@ namespace Azure { namespace Storage { namespace Test {
 
     Azure::Storage::Blobs::AppendBlockOptions options;
     options.AccessConditions.IfAppendPositionEqual = 1_MB;
-    blockContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     EXPECT_THROW(appendBlobClient.AppendBlock(&blockContent, options), StorageException);
     options.AccessConditions.IfAppendPositionEqual = properties.BlobSize;
-    blockContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     appendBlobClient.AppendBlock(&blockContent, options);
 
     properties = *appendBlobClient.GetProperties();
     options = Azure::Storage::Blobs::AppendBlockOptions();
     options.AccessConditions.IfMaxSizeLessThanOrEqual
         = properties.BlobSize + m_blobContent.size() - 1;
-    blockContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     EXPECT_THROW(appendBlobClient.AppendBlock(&blockContent, options), StorageException);
     options.AccessConditions.IfMaxSizeLessThanOrEqual = properties.BlobSize + m_blobContent.size();
-    blockContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     appendBlobClient.AppendBlock(&blockContent, options);
 
     properties = *appendBlobClient.GetProperties();
@@ -267,7 +267,7 @@ namespace Azure { namespace Storage { namespace Test {
     std::string blobName = RandomString();
     auto blobClient = m_blobContainerClient->GetAppendBlobClient(blobName);
     blobClient.Create();
-    auto blockContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     blobClient.AppendBlock(&blockContent);
 
     auto downloadResult = blobClient.Download();
@@ -357,7 +357,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_FALSE(response->RequestId.empty());
       EXPECT_TRUE(response->Created);
     }
-    auto blobContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     blobClient.AppendBlock(&blobContent);
     {
       auto response = blobClient.CreateIfNotExists();
@@ -366,7 +366,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
     auto downloadStream = std::move(blobClient.Download()->BodyStream);
     EXPECT_EQ(
-        Azure::IO::BodyStream::ReadToEnd(*downloadStream, Azure::Core::Context()), m_blobContent);
+        Azure::Core::IO::BodyStream::ReadToEnd(*downloadStream, Azure::Core::Context()), m_blobContent);
   }
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
@@ -145,7 +145,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       std::string blobName = prefix1 + baseName + std::to_string(i);
       auto blobClient = m_blobContainerClient->GetBlockBlobClient(blobName);
-      auto emptyContent = Azure::IO::MemoryBodyStream(nullptr, 0);
+      auto emptyContent = Azure::Core::IO::MemoryBodyStream(nullptr, 0);
       blobClient.Upload(&emptyContent);
       p1Blobs.insert(blobName);
       p1p2Blobs.insert(blobName);
@@ -161,7 +161,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       std::string blobName = prefix2 + baseName + std::to_string(i);
       auto blobClient = m_blobContainerClient->GetBlockBlobClient(blobName);
-      auto emptyContent = Azure::IO::MemoryBodyStream(nullptr, 0);
+      auto emptyContent = Azure::Core::IO::MemoryBodyStream(nullptr, 0);
       blobClient.Upload(&emptyContent);
       p2Blobs.insert(blobName);
       p1p2Blobs.insert(blobName);
@@ -249,7 +249,7 @@ namespace Azure { namespace Storage { namespace Test {
       {
         std::string blobName = blobNamePrefix + delimiter + RandomString();
         auto blobClient = m_blobContainerClient->GetBlockBlobClient(blobName);
-        auto emptyContent = Azure::IO::MemoryBodyStream(nullptr, 0);
+        auto emptyContent = Azure::Core::IO::MemoryBodyStream(nullptr, 0);
         blobClient.Upload(&emptyContent);
         blobs.insert(blobName);
       }
@@ -317,7 +317,7 @@ namespace Azure { namespace Storage { namespace Test {
     blobClient.CreateSnapshot();
     blobClient.SetMetadata({{"k1", "v1"}});
     std::vector<uint8_t> content(1);
-    auto contentStream = Azure::IO::MemoryBodyStream(content.data(), 1);
+    auto contentStream = Azure::Core::IO::MemoryBodyStream(content.data(), 1);
     blobClient.AppendBlock(&contentStream);
 
     Azure::Storage::Blobs::ListBlobsSinglePageOptions options;
@@ -532,7 +532,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(properties.EncryptionScope.HasValue());
       EXPECT_EQ(properties.EncryptionScope.GetValue(), TestEncryptionScope);
       std::vector<uint8_t> appendContent(1);
-      Azure::IO::MemoryBodyStream bodyStream(appendContent.data(), appendContent.size());
+      Azure::Core::IO::MemoryBodyStream bodyStream(appendContent.data(), appendContent.size());
       EXPECT_NO_THROW(appendBlobClient.AppendBlock(&bodyStream));
 
       bodyStream.Rewind();
@@ -565,7 +565,7 @@ namespace Azure { namespace Storage { namespace Test {
         StandardStorageConnectionString(), m_containerName, options);
 
     std::vector<uint8_t> blobContent(512);
-    Azure::IO::MemoryBodyStream bodyStream(blobContent.data(), blobContent.size());
+    Azure::Core::IO::MemoryBodyStream bodyStream(blobContent.data(), blobContent.size());
     auto copySourceBlob = m_blobContainerClient->GetBlockBlobClient(RandomString());
     copySourceBlob.UploadFrom(blobContent.data(), blobContent.size());
 
@@ -813,7 +813,7 @@ namespace Azure { namespace Storage { namespace Test {
 
     std::vector<uint8_t> contentData(512);
     int64_t contentSize = static_cast<int64_t>(contentData.size());
-    auto content = Azure::IO::MemoryBodyStream(contentData.data(), contentSize);
+    auto content = Azure::Core::IO::MemoryBodyStream(contentData.data(), contentSize);
 
     std::string blobName = RandomString();
     auto appendBlobClient = Azure::Storage::Blobs::AppendBlobClient::CreateFromConnectionString(

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
@@ -77,7 +77,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto verify_blob_add = [&](const std::string& sas) {
       blobClient0.Create();
       std::string content = "Hello world";
-      auto blockContent = Azure::IO::MemoryBodyStream(
+      auto blockContent = Azure::Core::IO::MemoryBodyStream(
           reinterpret_cast<const uint8_t*>(content.data()), content.size());
       auto blobClient = Blobs::AppendBlobClient(blobUrl + sas);
       EXPECT_NO_THROW(blobClient.AppendBlock(&blockContent));

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -50,7 +50,8 @@ namespace Azure { namespace Storage { namespace Test {
     m_blobUploadOptions.HttpHeaders.ContentEncoding = "identity";
     m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
     m_blobUploadOptions.Tier = Azure::Storage::Blobs::Models::AccessTier::Hot;
-    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     m_blockBlobClient->Upload(&blobContent, m_blobUploadOptions);
     m_blobUploadOptions.HttpHeaders.ContentHash
         = m_blockBlobClient->GetProperties()->HttpHeaders.ContentHash;
@@ -62,7 +63,8 @@ namespace Azure { namespace Storage { namespace Test {
   {
     auto blockBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), m_containerName, RandomString());
-    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     auto blobContentInfo = blockBlobClient.Upload(&blobContent, m_blobUploadOptions);
     EXPECT_FALSE(blobContentInfo->RequestId.empty());
     EXPECT_TRUE(blobContentInfo->ETag.HasValue());
@@ -362,7 +364,8 @@ namespace Azure { namespace Storage { namespace Test {
   {
     auto blockBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), m_containerName, RandomString());
-    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     blockBlobClient.Upload(&blobContent);
     blockBlobClient.SetMetadata(m_blobUploadOptions.Metadata);
     blockBlobClient.SetAccessTier(Azure::Storage::Blobs::Models::AccessTier::Cool);
@@ -393,7 +396,8 @@ namespace Azure { namespace Storage { namespace Test {
     std::vector<uint8_t> block1Content;
     block1Content.resize(100);
     RandomBuffer(reinterpret_cast<char*>(&block1Content[0]), block1Content.size());
-    auto blockContent = Azure::Core::IO::MemoryBodyStream(block1Content.data(), block1Content.size());
+    auto blockContent
+        = Azure::Core::IO::MemoryBodyStream(block1Content.data(), block1Content.size());
     blockBlobClient.StageBlock(blockId1, &blockContent);
     Azure::Storage::Blobs::CommitBlockListOptions options;
     options.HttpHeaders = m_blobUploadOptions.HttpHeaders;

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -50,7 +50,7 @@ namespace Azure { namespace Storage { namespace Test {
     m_blobUploadOptions.HttpHeaders.ContentEncoding = "identity";
     m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
     m_blobUploadOptions.Tier = Azure::Storage::Blobs::Models::AccessTier::Hot;
-    auto blobContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     m_blockBlobClient->Upload(&blobContent, m_blobUploadOptions);
     m_blobUploadOptions.HttpHeaders.ContentHash
         = m_blockBlobClient->GetProperties()->HttpHeaders.ContentHash;
@@ -62,7 +62,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     auto blockBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), m_containerName, RandomString());
-    auto blobContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     auto blobContentInfo = blockBlobClient.Upload(&blobContent, m_blobUploadOptions);
     EXPECT_FALSE(blobContentInfo->RequestId.empty());
     EXPECT_TRUE(blobContentInfo->ETag.HasValue());
@@ -177,7 +177,7 @@ namespace Azure { namespace Storage { namespace Test {
     std::vector<uint8_t> emptyContent;
     auto blockBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), m_containerName, RandomString());
-    auto blobContent = Azure::IO::MemoryBodyStream(emptyContent.data(), emptyContent.size());
+    auto blobContent = Azure::Core::IO::MemoryBodyStream(emptyContent.data(), emptyContent.size());
     blockBlobClient.Upload(&blobContent);
     blockBlobClient.SetHttpHeaders(m_blobUploadOptions.HttpHeaders);
     blockBlobClient.SetMetadata(m_blobUploadOptions.Metadata);
@@ -266,7 +266,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(ReadBodyStream(versionClient.Download()->BodyStream), m_blobContent);
     EXPECT_EQ(versionClient.GetProperties()->Metadata, m_blobUploadOptions.Metadata);
     EXPECT_TRUE(versionClient.GetProperties()->IsServerEncrypted);
-    auto emptyContent = Azure::IO::MemoryBodyStream(nullptr, 0);
+    auto emptyContent = Azure::Core::IO::MemoryBodyStream(nullptr, 0);
     EXPECT_THROW(snapshotClient.Upload(&emptyContent), StorageException);
     EXPECT_THROW(snapshotClient.SetMetadata({}), StorageException);
     EXPECT_NO_THROW(snapshotClient.SetAccessTier(Azure::Storage::Blobs::Models::AccessTier::Cool));
@@ -362,7 +362,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     auto blockBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), m_containerName, RandomString());
-    auto blobContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     blockBlobClient.Upload(&blobContent);
     blockBlobClient.SetMetadata(m_blobUploadOptions.Metadata);
     blockBlobClient.SetAccessTier(Azure::Storage::Blobs::Models::AccessTier::Cool);
@@ -393,7 +393,7 @@ namespace Azure { namespace Storage { namespace Test {
     std::vector<uint8_t> block1Content;
     block1Content.resize(100);
     RandomBuffer(reinterpret_cast<char*>(&block1Content[0]), block1Content.size());
-    auto blockContent = Azure::IO::MemoryBodyStream(block1Content.data(), block1Content.size());
+    auto blockContent = Azure::Core::IO::MemoryBodyStream(block1Content.data(), block1Content.size());
     blockBlobClient.StageBlock(blockId1, &blockContent);
     Azure::Storage::Blobs::CommitBlockListOptions options;
     options.HttpHeaders = m_blobUploadOptions.HttpHeaders;
@@ -715,7 +715,7 @@ namespace Azure { namespace Storage { namespace Test {
     std::vector<uint8_t> emptyContent;
     auto blockBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), m_containerName, RandomString());
-    auto blobContent = Azure::IO::MemoryBodyStream(emptyContent.data(), emptyContent.size());
+    auto blobContent = Azure::Core::IO::MemoryBodyStream(emptyContent.data(), emptyContent.size());
     blockBlobClient.Upload(&blobContent);
     blockBlobClient.SetHttpHeaders(m_blobUploadOptions.HttpHeaders);
     blockBlobClient.SetMetadata(m_blobUploadOptions.Metadata);

--- a/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
@@ -37,7 +37,8 @@ namespace Azure { namespace Storage { namespace Test {
     m_blobUploadOptions.HttpHeaders.ContentEncoding = "identity";
     m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
     m_pageBlobClient->Create(m_blobContent.size(), m_blobUploadOptions);
-    auto pageContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto pageContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     m_pageBlobClient->UploadPages(0, &pageContent);
     m_blobUploadOptions.HttpHeaders.ContentHash
         = m_pageBlobClient->GetProperties()->HttpHeaders.ContentHash;
@@ -306,7 +307,8 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(response->Created);
     }
 
-    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     blobClient.UploadPages(0, &blobContent);
     {
       auto response = blobClient.CreateIfNotExists(m_blobContent.size());
@@ -314,7 +316,8 @@ namespace Azure { namespace Storage { namespace Test {
     }
     auto downloadStream = std::move(blobClient.Download()->BodyStream);
     EXPECT_EQ(
-        Azure::Core::IO::BodyStream::ReadToEnd(*downloadStream, Azure::Core::Context()), m_blobContent);
+        Azure::Core::IO::BodyStream::ReadToEnd(*downloadStream, Azure::Core::Context()),
+        m_blobContent);
   }
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
@@ -37,7 +37,7 @@ namespace Azure { namespace Storage { namespace Test {
     m_blobUploadOptions.HttpHeaders.ContentEncoding = "identity";
     m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
     m_pageBlobClient->Create(m_blobContent.size(), m_blobUploadOptions);
-    auto pageContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto pageContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     m_pageBlobClient->UploadPages(0, &pageContent);
     m_blobUploadOptions.HttpHeaders.ContentHash
         = m_pageBlobClient->GetProperties()->HttpHeaders.ContentHash;
@@ -84,7 +84,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto pageBlobClient = Azure::Storage::Blobs::PageBlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), m_containerName, RandomString());
     pageBlobClient.Create(8_KB, m_blobUploadOptions);
-    auto pageContent = Azure::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
+    auto pageContent = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
     pageBlobClient.UploadPages(2_KB, &pageContent);
     // |_|_|x|x|  |x|x|_|_|
     blobContent.insert(blobContent.begin(), static_cast<std::size_t>(2_KB), '\x00');
@@ -119,7 +119,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto snapshot = pageBlobClient.CreateSnapshot()->Snapshot;
     // |_|_|_|x|  |x|x|_|_| This is what's in snapshot
     blobContent.resize(static_cast<std::size_t>(1_KB));
-    auto pageClient = Azure::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
+    auto pageClient = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
     pageBlobClient.UploadPages(0, &pageClient);
     pageBlobClient.ClearPages({3_KB, 1_KB});
     // |x|_|_|_|  |x|x|_|_|
@@ -247,7 +247,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto pageBlobClient = Azure::Storage::Blobs::PageBlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), m_containerName, RandomString());
     pageBlobClient.Create(blobContent.size(), m_blobUploadOptions);
-    auto pageContent = Azure::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
+    auto pageContent = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
 
     Blobs::UploadPageBlobPagesOptions options;
     ContentHash hash;
@@ -275,7 +275,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto pageBlobClient = Azure::Storage::Blobs::PageBlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), m_containerName, RandomString());
     pageBlobClient.Create(blobContent.size(), m_blobUploadOptions);
-    auto pageContent = Azure::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
+    auto pageContent = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
 
     Blobs::UploadPageBlobPagesOptions options;
     ContentHash hash;
@@ -306,7 +306,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(response->Created);
     }
 
-    auto blobContent = Azure::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    auto blobContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     blobClient.UploadPages(0, &blobContent);
     {
       auto response = blobClient.CreateIfNotExists(m_blobContent.size());
@@ -314,7 +314,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
     auto downloadStream = std::move(blobClient.Download()->BodyStream);
     EXPECT_EQ(
-        Azure::IO::BodyStream::ReadToEnd(*downloadStream, Azure::Core::Context()), m_blobContent);
+        Azure::Core::IO::BodyStream::ReadToEnd(*downloadStream, Azure::Core::Context()), m_blobContent);
   }
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-blobs/test/ut/storage_retry_policy_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/storage_retry_policy_test.cpp
@@ -129,7 +129,7 @@ namespace Azure { namespace Storage { namespace Test {
                   Core::Http::RawResponse(1, 1, Core::Http::HttpStatusCode::Ok, "OK"));
               int64_t bodyLength = std::min(
                   static_cast<int64_t>(m_primaryContent->length()) - requestOffset, requestLength);
-              auto bodyStream = std::make_unique<IO::MemoryBodyStream>(
+              auto bodyStream = std::make_unique<Core::IO::MemoryBodyStream>(
                   reinterpret_cast<const uint8_t*>(m_primaryContent->data() + requestOffset),
                   bodyLength);
               response->SetBodyStream(std::move(bodyStream));
@@ -159,7 +159,7 @@ namespace Azure { namespace Storage { namespace Test {
                 Core::Http::RawResponse(1, 1, Core::Http::HttpStatusCode::Ok, "OK"));
             int64_t bodyLength = std::min(
                 static_cast<int64_t>(m_secondaryContent->length()) - requestOffset, requestLength);
-            auto bodyStream = std::make_unique<IO::MemoryBodyStream>(
+            auto bodyStream = std::make_unique<Core::IO::MemoryBodyStream>(
                 reinterpret_cast<const uint8_t*>(m_secondaryContent->data() + requestOffset),
                 bodyLength);
             response->SetBodyStream(std::move(bodyStream));
@@ -256,7 +256,7 @@ namespace Azure { namespace Storage { namespace Test {
         StandardStorageConnectionString(), RandomString(), RandomString(), clientOptions);
     auto ret = blobClient.Download();
     auto responseBody
-        = Azure::IO::BodyStream::ReadToEnd(*(ret->BodyStream), Azure::Core::Context());
+        = Azure::Core::IO::BodyStream::ReadToEnd(*(ret->BodyStream), Azure::Core::Context());
     EXPECT_EQ(std::string(responseBody.begin(), responseBody.end()), primaryContent);
   }
 
@@ -286,7 +286,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto ret = blobClient.Download();
     auto timeEnd = std::chrono::steady_clock::now();
     auto responseBody
-        = Azure::IO::BodyStream::ReadToEnd(*(ret->BodyStream), Azure::Core::Context());
+        = Azure::Core::IO::BodyStream::ReadToEnd(*(ret->BodyStream), Azure::Core::Context());
     EXPECT_EQ(std::string(responseBody.begin(), responseBody.end()), primaryContent);
     EXPECT_EQ(numTrial, 2);
 
@@ -329,7 +329,7 @@ namespace Azure { namespace Storage { namespace Test {
         StandardStorageConnectionString(), RandomString(), RandomString(), clientOptions);
     auto ret = blobClient.Download();
     auto responseBody
-        = Azure::IO::BodyStream::ReadToEnd(*(ret->BodyStream), Azure::Core::Context());
+        = Azure::Core::IO::BodyStream::ReadToEnd(*(ret->BodyStream), Azure::Core::Context());
     EXPECT_EQ(std::string(responseBody.begin(), responseBody.end()), secondaryContent);
   }
 
@@ -378,7 +378,7 @@ namespace Azure { namespace Storage { namespace Test {
         StandardStorageConnectionString(), RandomString(), RandomString(), clientOptions);
     auto ret = blobClient.Download();
     auto responseBody
-        = Azure::IO::BodyStream::ReadToEnd(*(ret->BodyStream), Azure::Core::Context());
+        = Azure::Core::IO::BodyStream::ReadToEnd(*(ret->BodyStream), Azure::Core::Context());
     EXPECT_EQ(std::string(responseBody.begin(), responseBody.end()), primaryContent);
     EXPECT_EQ(numPrimaryTrial, 3);
     EXPECT_EQ(numSecondaryTrial, 1);

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/reliable_stream.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/reliable_stream.hpp
@@ -17,8 +17,9 @@ namespace Azure { namespace Storage {
   };
 
   // Defines a fn signature to be use to get a bodyStream from a specific offset.
-  typedef std::function<
-      std::unique_ptr<Azure::Core::IO::BodyStream>(HttpGetterInfo const&, Azure::Core::Context const&)>
+  typedef std::function<std::unique_ptr<Azure::Core::IO::BodyStream>(
+      HttpGetterInfo const&,
+      Azure::Core::Context const&)>
       HTTPGetter;
 
   // Options used by reliable stream

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/reliable_stream.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/reliable_stream.hpp
@@ -18,7 +18,7 @@ namespace Azure { namespace Storage {
 
   // Defines a fn signature to be use to get a bodyStream from a specific offset.
   typedef std::function<
-      std::unique_ptr<Azure::IO::BodyStream>(HttpGetterInfo const&, Azure::Core::Context const&)>
+      std::unique_ptr<Azure::Core::IO::BodyStream>(HttpGetterInfo const&, Azure::Core::Context const&)>
       HTTPGetter;
 
   // Options used by reliable stream
@@ -40,10 +40,10 @@ namespace Azure { namespace Storage {
    * offset provided by the ReliableStream.
    *
    */
-  class ReliableStream : public Azure::IO::BodyStream {
+  class ReliableStream : public Azure::Core::IO::BodyStream {
   private:
     // initial bodyStream.
-    std::unique_ptr<Azure::IO::BodyStream> m_inner;
+    std::unique_ptr<Azure::Core::IO::BodyStream> m_inner;
     // Configuration for the re-triable stream
     ReliableStreamOptions const m_options;
     // callback to get a bodyStream in case Read operation fails
@@ -55,7 +55,7 @@ namespace Azure { namespace Storage {
 
   public:
     explicit ReliableStream(
-        std::unique_ptr<Azure::IO::BodyStream> inner,
+        std::unique_ptr<Azure::Core::IO::BodyStream> inner,
         ReliableStreamOptions const options,
         HTTPGetter httpGetter)
         : m_inner(std::move(inner)), m_options(options), m_httpGetter(std::move(httpGetter))

--- a/sdk/storage/azure-storage-common/src/reliable_stream.cpp
+++ b/sdk/storage/azure-storage-common/src/reliable_stream.cpp
@@ -6,7 +6,7 @@
 #include <azure/core/http/http.hpp>
 
 using Azure::Core::Context;
-using Azure::IO::BodyStream;
+using Azure::Core::IO::BodyStream;
 
 namespace Azure { namespace Storage {
 

--- a/sdk/storage/azure-storage-common/test/test_base.cpp
+++ b/sdk/storage/azure-storage-common/test/test_base.cpp
@@ -25,14 +25,20 @@
 
 namespace Azure { namespace Storage { namespace Test {
 
-  constexpr static const char* StandardStorageConnectionStringValue = "";
+  constexpr static const char* StandardStorageConnectionStringValue
+      = "DefaultEndpointsProtocol=https;AccountName=storageunittestahkha;AccountKey="
+        "juzH7ITp1FJ1Nr1OZPB3P8b9iJPP/ajMsYVs/"
+        "kQCaiuursVx8txPstvyC3XxeC6R9SaqmWq0mQ4hRLEJRggK+w==;EndpointSuffix=core.windows.net";
   constexpr static const char* PremiumStorageConnectionStringValue = "";
   constexpr static const char* BlobStorageConnectionStringValue = "";
   constexpr static const char* PremiumFileConnectionStringValue = "";
-  constexpr static const char* AdlsGen2ConnectionStringValue = "";
-  constexpr static const char* AadTenantIdValue = "";
-  constexpr static const char* AadClientIdValue = "";
-  constexpr static const char* AadClientSecretValue = "";
+  constexpr static const char* AdlsGen2ConnectionStringValue
+      = "DefaultEndpointsProtocol=https;AccountName=storageunittestdatalake;AccountKey="
+        "Ew7VSFkQy1HUMcnN+t+Fgvn9RbxQYnVicGglVKtbt28N/"
+        "nVfB0N57IyK5jzymU7F5542RKSqmBeNSH91XTzIkg==;EndpointSuffix=core.windows.net";
+  constexpr static const char* AadTenantIdValue = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+  constexpr static const char* AadClientIdValue = "381229fa-de11-41dc-813f-f7d2d784d907";
+  constexpr static const char* AadClientSecretValue = "-.4HT.01.560acJ~7-rsC8z0r3-n2Kgh-j";
 
   std::string GetEnv(const std::string& name)
   {

--- a/sdk/storage/azure-storage-common/test/test_base.hpp
+++ b/sdk/storage/azure-storage-common/test/test_base.hpp
@@ -65,13 +65,13 @@ namespace Azure { namespace Storage { namespace Test {
   }
   std::vector<uint8_t> RandomBuffer(std::size_t length);
 
-  inline std::vector<uint8_t> ReadBodyStream(std::unique_ptr<Azure::IO::BodyStream>& stream)
+  inline std::vector<uint8_t> ReadBodyStream(std::unique_ptr<Azure::Core::IO::BodyStream>& stream)
   {
     Azure::Core::Context context;
-    return Azure::IO::BodyStream::ReadToEnd(*stream, context);
+    return Azure::Core::IO::BodyStream::ReadToEnd(*stream, context);
   }
 
-  inline std::vector<uint8_t> ReadBodyStream(std::unique_ptr<Azure::IO::BodyStream>&& stream)
+  inline std::vector<uint8_t> ReadBodyStream(std::unique_ptr<Azure::Core::IO::BodyStream>&& stream)
   {
     return ReadBodyStream(stream);
   }

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_client.hpp
@@ -93,7 +93,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @remark This request is sent to dfs endpoint.
      */
     Azure::Response<Models::AppendDataLakeFileResult> Append(
-        Azure::IO::BodyStream* content,
+        Azure::Core::IO::BodyStream* content,
         int64_t offset,
         const AppendDataLakeFileOptions& options = AppendDataLakeFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_responses.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_responses.hpp
@@ -249,7 +249,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
 
   struct DownloadDataLakeFileResult
   {
-    std::unique_ptr<Azure::IO::BodyStream> Body;
+    std::unique_ptr<Azure::Core::IO::BodyStream> Body;
     int64_t FileSize = int64_t();
     Azure::Core::Http::Range ContentRange;
     Azure::Core::Nullable<Storage::ContentHash> TransactionalContentHash;

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/protocol/datalake_rest_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/protocol/datalake_rest_client.hpp
@@ -1112,7 +1112,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
 
         static Azure::Response<PathAppendDataResult> AppendData(
             const Azure::Core::Http::Url& url,
-            Azure::IO::BodyStream& bodyStream,
+            Azure::Core::IO::BodyStream& bodyStream,
             Azure::Core::Http::_internal::HttpPipeline& pipeline,
             Azure::Core::Context context,
             const AppendDataOptions& appendDataOptions)

--- a/sdk/storage/azure-storage-files-datalake/sample/datalake_getting_started.cpp
+++ b/sdk/storage/azure-storage-files-datalake/sample/datalake_getting_started.cpp
@@ -64,13 +64,13 @@ void DataLakeGettingStarted()
     std::vector<uint8_t> buffer(str1.begin(), str1.end());
 
     // One way of passing in the buffer, note that the buffer is not copied.
-    auto bufferStream = Azure::IO::MemoryBodyStream(buffer);
+    auto bufferStream = Azure::Core::IO::MemoryBodyStream(buffer);
 
     fileClient.Append(&bufferStream, 0 /* Offset of the position to be appended.*/);
 
     // Another way of passing in the buffer, note that buffer is also not copied.
     bufferStream
-        = Azure::IO::MemoryBodyStream(reinterpret_cast<const uint8_t*>(str2.data()), str2.size());
+        = Azure::Core::IO::MemoryBodyStream(reinterpret_cast<const uint8_t*>(str2.data()), str2.size());
 
     fileClient.Append(&bufferStream, str1.size());
 
@@ -80,7 +80,7 @@ void DataLakeGettingStarted()
     // Read
     auto result = fileClient.Download();
     Azure::Core::Context context;
-    std::vector<uint8_t> downloaded = Azure::IO::BodyStream::ReadToEnd(*(result->Body), context);
+    std::vector<uint8_t> downloaded = Azure::Core::IO::BodyStream::ReadToEnd(*(result->Body), context);
     // downloaded contains your downloaded data.
     std::cout << "Downloaded data was:\n" + std::string(downloaded.begin(), downloaded.end())
               << std::endl;

--- a/sdk/storage/azure-storage-files-datalake/sample/datalake_getting_started.cpp
+++ b/sdk/storage/azure-storage-files-datalake/sample/datalake_getting_started.cpp
@@ -69,8 +69,8 @@ void DataLakeGettingStarted()
     fileClient.Append(&bufferStream, 0 /* Offset of the position to be appended.*/);
 
     // Another way of passing in the buffer, note that buffer is also not copied.
-    bufferStream
-        = Azure::Core::IO::MemoryBodyStream(reinterpret_cast<const uint8_t*>(str2.data()), str2.size());
+    bufferStream = Azure::Core::IO::MemoryBodyStream(
+        reinterpret_cast<const uint8_t*>(str2.data()), str2.size());
 
     fileClient.Append(&bufferStream, str1.size());
 
@@ -80,7 +80,8 @@ void DataLakeGettingStarted()
     // Read
     auto result = fileClient.Download();
     Azure::Core::Context context;
-    std::vector<uint8_t> downloaded = Azure::Core::IO::BodyStream::ReadToEnd(*(result->Body), context);
+    std::vector<uint8_t> downloaded
+        = Azure::Core::IO::BodyStream::ReadToEnd(*(result->Body), context);
     // downloaded contains your downloaded data.
     std::cout << "Downloaded data was:\n" + std::string(downloaded.begin(), downloaded.end())
               << std::endl;

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_client.cpp
@@ -124,7 +124,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   }
 
   Azure::Response<Models::AppendDataLakeFileResult> DataLakeFileClient::Append(
-      Azure::IO::BodyStream* content,
+      Azure::Core::IO::BodyStream* content,
       int64_t offset,
       const AppendDataLakeFileOptions& options,
       const Azure::Core::Context& context) const

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
@@ -303,8 +303,8 @@ namespace Azure { namespace Storage { namespace Test {
   {
     const int32_t bufferSize = 4 * 1024; // 4KB data size
     auto buffer = RandomBuffer(bufferSize);
-    auto bufferStream
-        = std::make_unique<Azure::Core::IO::MemoryBodyStream>(Azure::Core::IO::MemoryBodyStream(buffer));
+    auto bufferStream = std::make_unique<Azure::Core::IO::MemoryBodyStream>(
+        Azure::Core::IO::MemoryBodyStream(buffer));
     auto properties1 = m_fileClient->GetProperties();
 
     // Append
@@ -330,8 +330,8 @@ namespace Azure { namespace Storage { namespace Test {
   {
     const int32_t bufferSize = 4 * 1024; // 4KB data size
     auto buffer = RandomBuffer(bufferSize);
-    auto bufferStream
-        = std::make_unique<Azure::Core::IO::MemoryBodyStream>(Azure::Core::IO::MemoryBodyStream(buffer));
+    auto bufferStream = std::make_unique<Azure::Core::IO::MemoryBodyStream>(
+        Azure::Core::IO::MemoryBodyStream(buffer));
     auto newFileName = RandomString(10);
     auto newFileClient = std::make_shared<Files::DataLake::DataLakeFileClient>(
         m_fileSystemClient->GetFileClient(newFileName));

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
@@ -304,7 +304,7 @@ namespace Azure { namespace Storage { namespace Test {
     const int32_t bufferSize = 4 * 1024; // 4KB data size
     auto buffer = RandomBuffer(bufferSize);
     auto bufferStream
-        = std::make_unique<Azure::IO::MemoryBodyStream>(Azure::IO::MemoryBodyStream(buffer));
+        = std::make_unique<Azure::Core::IO::MemoryBodyStream>(Azure::Core::IO::MemoryBodyStream(buffer));
     auto properties1 = m_fileClient->GetProperties();
 
     // Append
@@ -331,7 +331,7 @@ namespace Azure { namespace Storage { namespace Test {
     const int32_t bufferSize = 4 * 1024; // 4KB data size
     auto buffer = RandomBuffer(bufferSize);
     auto bufferStream
-        = std::make_unique<Azure::IO::MemoryBodyStream>(Azure::IO::MemoryBodyStream(buffer));
+        = std::make_unique<Azure::Core::IO::MemoryBodyStream>(Azure::Core::IO::MemoryBodyStream(buffer));
     auto newFileName = RandomString(10);
     auto newFileClient = std::make_shared<Files::DataLake::DataLakeFileClient>(
         m_fileSystemClient->GetFileClient(newFileName));
@@ -586,7 +586,7 @@ namespace Azure { namespace Storage { namespace Test {
       options.AccessType = Azure::Storage::Blobs::Models::PublicAccessType::Blob;
       containerClient.SetAccessPolicy(options);
       auto blobClient = containerClient.GetBlockBlobClient(objectName);
-      auto memoryStream = Azure::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
+      auto memoryStream = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
       EXPECT_NO_THROW(blobClient.Upload(&memoryStream));
 
       auto anonymousClient = Azure::Storage::Files::DataLake::DataLakeFileClient(

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/protocol/share_rest_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/protocol/share_rest_client.hpp
@@ -893,7 +893,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     struct FileDownloadResult
     {
-      std::unique_ptr<Azure::IO::BodyStream> BodyStream;
+      std::unique_ptr<Azure::Core::IO::BodyStream> BodyStream;
       Core::DateTime LastModified;
       Storage::Metadata Metadata;
       FileHttpHeaders HttpHeaders;
@@ -1127,7 +1127,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             writer.Write(Storage::_detail::XmlNode{Storage::_detail::XmlNodeType::End});
             xml_body = writer.GetDocument();
           }
-          auto body = Azure::IO::MemoryBodyStream(
+          auto body = Azure::Core::IO::MemoryBodyStream(
               reinterpret_cast<const uint8_t*>(xml_body.data()), xml_body.length());
           auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, url, &body);
           request.SetHeader("Content-Length", std::to_string(body.Length()));
@@ -2925,7 +2925,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             SharePermissionToJson(json, createPermissionOptions.Permission);
             json_body = json.dump();
           }
-          auto body = Azure::IO::MemoryBodyStream(
+          auto body = Azure::Core::IO::MemoryBodyStream(
               reinterpret_cast<const uint8_t*>(json_body.data()), json_body.length());
           auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, url, &body);
           request.SetHeader("Content-Length", std::to_string(body.Length()));
@@ -3109,7 +3109,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             writer.Write(Storage::_detail::XmlNode{Storage::_detail::XmlNodeType::End});
             xml_body = writer.GetDocument();
           }
-          auto body = Azure::IO::MemoryBodyStream(
+          auto body = Azure::Core::IO::MemoryBodyStream(
               reinterpret_cast<const uint8_t*>(xml_body.data()), xml_body.length());
           auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, url, &body);
           request.SetHeader("Content-Length", std::to_string(body.Length()));
@@ -5701,7 +5701,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
         static Azure::Response<FileUploadRangeResult> UploadRange(
             const Azure::Core::Http::Url& url,
-            Azure::IO::BodyStream& bodyStream,
+            Azure::Core::IO::BodyStream& bodyStream,
             Azure::Core::Http::_internal::HttpPipeline& pipeline,
             Azure::Core::Context context,
             const UploadRangeOptions& uploadRangeOptions)

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
@@ -268,7 +268,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      */
     Azure::Response<Models::UploadShareFileRangeResult> UploadRange(
         int64_t offset,
-        Azure::IO::BodyStream* content,
+        Azure::Core::IO::BodyStream* content,
         const UploadShareFileRangeOptions& options = UploadShareFileRangeOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -137,7 +137,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     struct DownloadShareFileResult
     {
-      std::unique_ptr<Azure::IO::BodyStream> BodyStream;
+      std::unique_ptr<Azure::Core::IO::BodyStream> BodyStream;
       Azure::Core::Http::Range ContentRange;
       int64_t FileSize = 0;
       Azure::Core::Nullable<Storage::ContentHash> TransactionalContentHash;

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -274,10 +274,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       // In case network failure during reading the body
       auto eTag = downloadResponse->ETag;
 
-      auto retryFunction
-          = [this, options, eTag](
-                const HttpGetterInfo& retryInfo,
-                const Azure::Core::Context& context) -> std::unique_ptr<Azure::Core::IO::BodyStream> {
+      auto retryFunction =
+          [this, options, eTag](
+              const HttpGetterInfo& retryInfo,
+              const Azure::Core::Context& context) -> std::unique_ptr<Azure::Core::IO::BodyStream> {
         DownloadShareFileOptions newOptions = options;
         newOptions.Range = Core::Http::Range();
         newOptions.Range.GetValue().Offset

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -277,7 +277,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       auto retryFunction
           = [this, options, eTag](
                 const HttpGetterInfo& retryInfo,
-                const Azure::Core::Context& context) -> std::unique_ptr<Azure::IO::BodyStream> {
+                const Azure::Core::Context& context) -> std::unique_ptr<Azure::Core::IO::BodyStream> {
         DownloadShareFileOptions newOptions = options;
         newOptions.Range = Core::Http::Range();
         newOptions.Range.GetValue().Offset
@@ -507,7 +507,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
   Azure::Response<Models::UploadShareFileRangeResult> ShareFileClient::UploadRange(
       int64_t offset,
-      Azure::IO::BodyStream* content,
+      Azure::Core::IO::BodyStream* content,
       const UploadShareFileRangeOptions& options,
       const Azure::Core::Context& context) const
   {
@@ -542,7 +542,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.LeaseIdOptional = options.AccessConditions.LeaseId;
     auto response = _detail::ShareRestClient::File::UploadRange(
         m_shareFileUrl,
-        *Azure::IO::_internal::NullBodyStream::GetNullBodyStream(),
+        *Azure::Core::IO::_internal::NullBodyStream::GetNullBodyStream(),
         *m_pipeline,
         context,
         protocolLayerOptions);
@@ -676,7 +676,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           "buffer is not big enough, file range size is " + std::to_string(fileRangeSize));
     }
 
-    int64_t bytesRead = Azure::IO::BodyStream::ReadToCount(
+    int64_t bytesRead = Azure::Core::IO::BodyStream::ReadToCount(
         *(firstChunk->BodyStream), buffer, firstChunkLength, context);
     if (bytesRead != firstChunkLength)
     {
@@ -702,7 +702,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             chunkOptions.Range.GetValue().Offset = offset;
             chunkOptions.Range.GetValue().Length = length;
             auto chunk = Download(chunkOptions, context);
-            int64_t bytesRead = Azure::IO::BodyStream::ReadToCount(
+            int64_t bytesRead = Azure::Core::IO::BodyStream::ReadToCount(
                 *(chunk->BodyStream),
                 buffer + (offset - firstChunkOffset),
                 chunkOptions.Range.GetValue().Length.GetValue(),
@@ -776,7 +776,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     firstChunkLength = std::min(firstChunkLength, fileRangeSize);
 
-    auto bodyStreamToFile = [](Azure::IO::BodyStream& stream,
+    auto bodyStreamToFile = [](Azure::Core::IO::BodyStream& stream,
                                Storage::_detail::FileWriter& fileWriter,
                                int64_t offset,
                                int64_t length,
@@ -787,7 +787,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       {
         int64_t readSize = std::min(static_cast<int64_t>(bufferSize), length);
         int64_t bytesRead
-            = Azure::IO::BodyStream::ReadToCount(stream, buffer.data(), readSize, context);
+            = Azure::Core::IO::BodyStream::ReadToCount(stream, buffer.data(), readSize, context);
         if (bytesRead != readSize)
         {
           throw Azure::Core::RequestFailedException("error when reading body stream");
@@ -928,7 +928,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto uploadPageFunc = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
       (void)chunkId;
       (void)numChunks;
-      Azure::IO::MemoryBodyStream contentStream(buffer + offset, length);
+      Azure::Core::IO::MemoryBodyStream contentStream(buffer + offset, length);
       UploadShareFileRangeOptions uploadRangeOptions;
       UploadRange(offset, &contentStream, uploadRangeOptions, context);
     };
@@ -1034,7 +1034,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto uploadPageFunc = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
       (void)chunkId;
       (void)numChunks;
-      Azure::IO::FileBodyStream contentStream(fileReader.GetHandle(), offset, length);
+      Azure::Core::IO::FileBodyStream contentStream(fileReader.GetHandle(), offset, length);
       UploadShareFileRangeOptions uploadRangeOptions;
       UploadRange(offset, &contentStream, uploadRangeOptions, context);
     };

--- a/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
@@ -613,7 +613,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto rangeSize = 1 * 1024 * 1024;
     auto numOfChunks = 3;
     auto rangeContent = RandomBuffer(rangeSize);
-    auto memBodyStream = IO::MemoryBodyStream(rangeContent);
+    auto memBodyStream = Core::IO::MemoryBodyStream(rangeContent);
     {
       // Simple upload/download.
       auto fileClient
@@ -634,7 +634,7 @@ namespace Azure { namespace Storage { namespace Test {
         downloadOptions.Range.GetValue().Length = rangeSize;
         Files::Shares::Models::DownloadShareFileResult result;
         EXPECT_NO_THROW(result = fileClient.Download(downloadOptions).ExtractValue());
-        auto resultBuffer = IO::BodyStream::ReadToEnd(*(result.BodyStream), Core::Context());
+        auto resultBuffer = Core::IO::BodyStream::ReadToEnd(*(result.BodyStream), Core::Context());
         EXPECT_EQ(rangeContent, resultBuffer);
         EXPECT_EQ(
             downloadOptions.Range.GetValue().Length.GetValue(),
@@ -670,7 +670,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     size_t fileSize = 1 * 1024 * 1024;
     auto fileContent = RandomBuffer(fileSize);
-    auto memBodyStream = IO::MemoryBodyStream(fileContent);
+    auto memBodyStream = Core::IO::MemoryBodyStream(fileContent);
     {
       // Simple copy works.
       auto fileClient
@@ -706,7 +706,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     size_t fileSize = 1 * 1024 * 1024;
     auto fileContent = RandomBuffer(fileSize);
-    auto memBodyStream = IO::MemoryBodyStream(fileContent);
+    auto memBodyStream = Core::IO::MemoryBodyStream(fileContent);
     auto halfContent
         = std::vector<uint8_t>(fileContent.begin(), fileContent.begin() + fileSize / 2);
     halfContent.resize(fileSize);
@@ -736,7 +736,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     size_t fileSize = 1 * 1024 * 1024;
     auto fileContent = RandomBuffer(fileSize);
-    auto memBodyStream = IO::MemoryBodyStream(fileContent);
+    auto memBodyStream = Core::IO::MemoryBodyStream(fileContent);
     auto halfContent
         = std::vector<uint8_t>(fileContent.begin(), fileContent.begin() + fileSize / 2);
     halfContent.resize(fileSize);
@@ -838,7 +838,7 @@ namespace Azure { namespace Storage { namespace Test {
     size_t fileSize = 1 * 1024 * 1024;
     std::string fileName = RandomString();
     auto fileContent = RandomBuffer(fileSize);
-    auto memBodyStream = IO::MemoryBodyStream(fileContent);
+    auto memBodyStream = Core::IO::MemoryBodyStream(fileContent);
     auto sourceFileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(fileName);
     sourceFileClient.Create(fileSize);
     EXPECT_NO_THROW(sourceFileClient.UploadRange(0, &memBodyStream));
@@ -872,7 +872,7 @@ namespace Azure { namespace Storage { namespace Test {
     Files::Shares::DownloadShareFileOptions downloadOptions;
     downloadOptions.Range = destRange;
     EXPECT_NO_THROW(result = destFileClient.Download(downloadOptions).ExtractValue());
-    auto resultBuffer = IO::BodyStream::ReadToEnd(*(result.BodyStream), Core::Context());
+    auto resultBuffer = Core::IO::BodyStream::ReadToEnd(*(result.BodyStream), Core::Context());
     EXPECT_EQ(fileContent, resultBuffer);
     Files::Shares::Models::GetShareFileRangeListResult getRangeResult;
     EXPECT_NO_THROW(getRangeResult = destFileClient.GetRangeList().ExtractValue());


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/1789

From Jeff:
> BodyStream is only exposed to users when uploading/downloading bytes. Except for Storage almost no services do this at all; they read the stream and deserialize into a structure and the customer gets the structure - not the stream. Azure::Core:IO is a fine namespace.