### PR TITLE
Rename the Range type to HttpRange within the Azure::Core::Http namespace.

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Introduced `Azure::Core::Http::LogOptions`, a mandatory parameter for `LogPolicy` construction. Entities that are not specified in the allow lists are hidden in the log.
 - Moved `Azure::Core::Logging` namespace entities to `Azure::Core::Logger` class.
 - Removed `Azure::Core::DateTime::GetRfc3339String()`: `Azure::Core::DateTime::ToString()` was extended to provide the same functionality.
+- Renamed the `Range` type to `HttpRange` within the `Azure::Core::Http` namespace.
 - Moved `Azure::Core::Response<T>` to `Azure::Response<T>`.
 - Moved `Azure::Core::ETag` to `Azure::ETag`.
 

--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -196,7 +196,7 @@ namespace Azure { namespace Core { namespace Http {
    * `Offset + Length - 1` inclusively.
    *
    */
-  struct Range
+  struct HttpRange
   {
     /**
      * @brief The starting point of the HTTP Range.

--- a/sdk/core/azure-core/test/ut/http.cpp
+++ b/sdk/core/azure-core/test/ut/http.cpp
@@ -126,29 +126,29 @@ namespace Azure { namespace Core { namespace Test {
   }
 
   // HTTP Range
-  TEST(TestHttp, Range)
+  TEST(TestHttp, HttpRange)
   {
     {
-      Http::Range r{10, 1};
+      Http::HttpRange r{10, 1};
       EXPECT_EQ(r.Offset, 10);
       EXPECT_TRUE(r.Length.HasValue());
       EXPECT_EQ(r.Length.GetValue(), 1);
     }
     {
-      Http::Range r;
+      Http::HttpRange r;
       r.Offset = 10;
       EXPECT_EQ(r.Offset, 10);
       EXPECT_FALSE(r.Length.HasValue());
     }
     {
-      Http::Range r;
+      Http::HttpRange r;
       r.Length = 10;
       EXPECT_EQ(r.Offset, 0);
       EXPECT_TRUE(r.Length.HasValue());
       EXPECT_EQ(r.Length.GetValue(), 10);
     }
     {
-      Http::Range r;
+      Http::HttpRange r;
       EXPECT_EQ(r.Offset, 0);
       EXPECT_FALSE(r.Length.HasValue());
     }

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
@@ -497,7 +497,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     /**
      * @brief Downloads only the bytes of the blob in the specified range.
      */
-    Azure::Core::Nullable<Core::Http::Range> Range;
+    Azure::Core::Nullable<Core::Http::HttpRange> Range;
 
     /**
      * @brief When specified together with Range, service returns hash for the range as long as the
@@ -519,7 +519,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     /**
      * @brief Downloads only the bytes of the blob in the specified range.
      */
-    Azure::Core::Nullable<Core::Http::Range> Range;
+    Azure::Core::Nullable<Core::Http::HttpRange> Range;
 
     struct
     {
@@ -772,7 +772,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     /**
      * @brief Uploads only the bytes of the source blob in the specified range.
      */
-    Azure::Core::Nullable<Core::Http::Range> SourceRange;
+    Azure::Core::Nullable<Core::Http::HttpRange> SourceRange;
 
     /**
      * @brief Hash of the blob content. This hash is used to verify the integrity of
@@ -886,7 +886,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     /**
      * @brief Uploads only the bytes of the source blob in the specified range.
      */
-    Azure::Core::Nullable<Core::Http::Range> SourceRange;
+    Azure::Core::Nullable<Core::Http::HttpRange> SourceRange;
 
     /**
      * @brief Hash of the blob content. This hash is used to verify the integrity of
@@ -1011,7 +1011,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Optionally specifies the range of bytes over which to list ranges, inclusively. If
      * omitted, then all ranges for the blob are returned.
      */
-    Azure::Core::Nullable<Core::Http::Range> Range;
+    Azure::Core::Nullable<Core::Http::HttpRange> Range;
 
     /**
      * @brief Optional conditions that must be met to perform this operation.

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
@@ -22,7 +22,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     struct DownloadBlobToResult
     {
       Models::BlobType BlobType;
-      Azure::Core::Http::Range ContentRange;
+      Azure::Core::Http::HttpRange ContentRange;
       int64_t BlobSize = 0;
       Azure::Core::Nullable<ContentHash> TransactionalContentHash; // hash for the downloaded range
       DownloadBlobDetails Details;

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/page_blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/page_blob_client.hpp
@@ -172,7 +172,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     Azure::Response<Models::UploadPageBlobPagesFromUriResult> UploadPagesFromUri(
         int64_t destinationOffset,
         std::string sourceUri,
-        Azure::Core::Http::Range sourceRange,
+        Azure::Core::Http::HttpRange sourceRange,
         const UploadPageBlobPagesFromUriOptions& options = UploadPageBlobPagesFromUriOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
@@ -189,7 +189,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @return A ClearPageBlobPagesResult describing the state of the updated pages.
      */
     Azure::Response<Models::ClearPageBlobPagesResult> ClearPages(
-        Azure::Core::Http::Range range,
+        Azure::Core::Http::HttpRange range,
         const ClearPageBlobPagesOptions& options = ClearPageBlobPagesOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
@@ -432,8 +432,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       Azure::ETag ETag;
       Azure::Core::DateTime LastModified;
       int64_t BlobSize = 0;
-      std::vector<Azure::Core::Http::Range> PageRanges;
-      std::vector<Azure::Core::Http::Range> ClearRanges;
+      std::vector<Azure::Core::Http::HttpRange> PageRanges;
+      std::vector<Azure::Core::Http::HttpRange> ClearRanges;
     }; // struct GetPageBlobPageRangesResult
 
     enum class ListBlobContainersIncludeFlags
@@ -1128,7 +1128,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     {
       std::string RequestId;
       std::unique_ptr<Azure::IO::BodyStream> BodyStream;
-      Azure::Core::Http::Range ContentRange;
+      Azure::Core::Http::HttpRange ContentRange;
       int64_t BlobSize = 0;
       Models::BlobType BlobType;
       Azure::Core::Nullable<ContentHash> TransactionalContentHash; // hash for the downloaded range
@@ -4840,7 +4840,7 @@ namespace Azure { namespace Storage { namespace Blobs {
         struct DownloadBlobOptions
         {
           Azure::Core::Nullable<int32_t> Timeout;
-          Azure::Core::Nullable<Azure::Core::Http::Range> Range;
+          Azure::Core::Nullable<Azure::Core::Http::HttpRange> Range;
           Azure::Core::Nullable<HashAlgorithm> RangeHashAlgorithm;
           Azure::Core::Nullable<std::string> EncryptionKey;
           Azure::Core::Nullable<std::vector<uint8_t>> EncryptionKeySha256;
@@ -4977,12 +4977,12 @@ namespace Azure { namespace Storage { namespace Blobs {
                 content_range.begin() + bytes_pos + 6, content_range.begin() + dash_pos));
             int64_t range_end_offset = std::stoll(std::string(
                 content_range.begin() + dash_pos + 1, content_range.begin() + slash_pos));
-            response.ContentRange = Azure::Core::Http::Range{
+            response.ContentRange = Azure::Core::Http::HttpRange{
                 range_start_offset, range_end_offset - range_start_offset + 1};
           }
           else
           {
-            response.ContentRange = Azure::Core::Http::Range{
+            response.ContentRange = Azure::Core::Http::HttpRange{
                 0, std::stoll(httpResponse.GetHeaders().at("content-length"))};
           }
           if (content_range_iterator != httpResponse.GetHeaders().end())
@@ -7235,7 +7235,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           Azure::Core::Nullable<int32_t> Timeout;
           std::string BlockId;
           std::string SourceUri;
-          Azure::Core::Nullable<Azure::Core::Http::Range> SourceRange;
+          Azure::Core::Nullable<Azure::Core::Http::HttpRange> SourceRange;
           Azure::Core::Nullable<ContentHash> TransactionalContentHash;
           Azure::Core::Nullable<std::string> LeaseId;
           Azure::Core::Nullable<std::string> EncryptionKey;
@@ -7936,7 +7936,7 @@ namespace Azure { namespace Storage { namespace Blobs {
         struct UploadPageBlobPagesOptions
         {
           Azure::Core::Nullable<int32_t> Timeout;
-          Azure::Core::Http::Range Range;
+          Azure::Core::Http::HttpRange Range;
           Azure::Core::Nullable<ContentHash> TransactionalContentHash;
           Azure::Core::Nullable<std::string> LeaseId;
           Azure::Core::Nullable<int64_t> IfSequenceNumberLessThanOrEqualTo;
@@ -8122,8 +8122,8 @@ namespace Azure { namespace Storage { namespace Blobs {
         {
           Azure::Core::Nullable<int32_t> Timeout;
           std::string SourceUri;
-          Azure::Core::Http::Range SourceRange;
-          Azure::Core::Http::Range Range;
+          Azure::Core::Http::HttpRange SourceRange;
+          Azure::Core::Http::HttpRange Range;
           Azure::Core::Nullable<ContentHash> TransactionalContentHash;
           Azure::Core::Nullable<std::string> LeaseId;
           Azure::Core::Nullable<int64_t> IfSequenceNumberLessThanOrEqualTo;
@@ -8316,7 +8316,7 @@ namespace Azure { namespace Storage { namespace Blobs {
         struct ClearPageBlobPagesOptions
         {
           Azure::Core::Nullable<int32_t> Timeout;
-          Azure::Core::Http::Range Range;
+          Azure::Core::Http::HttpRange Range;
           Azure::Core::Nullable<std::string> LeaseId;
           Azure::Core::Nullable<int64_t> IfSequenceNumberLessThanOrEqualTo;
           Azure::Core::Nullable<int64_t> IfSequenceNumberLessThan;
@@ -8575,7 +8575,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           Azure::Core::Nullable<int32_t> Timeout;
           Azure::Core::Nullable<std::string> PreviousSnapshot;
           Azure::Core::Nullable<std::string> PreviousSnapshotUrl;
-          Azure::Core::Nullable<Azure::Core::Http::Range> Range;
+          Azure::Core::Nullable<Azure::Core::Http::HttpRange> Range;
           Azure::Core::Nullable<std::string> LeaseId;
           Azure::Core::Nullable<Azure::Core::DateTime> IfModifiedSince;
           Azure::Core::Nullable<Azure::Core::DateTime> IfUnmodifiedSince;
@@ -8827,7 +8827,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           return ret;
         }
 
-        static Azure::Core::Http::Range ClearRangesFromXml(Storage::_detail::XmlReader& reader)
+        static Azure::Core::Http::HttpRange ClearRangesFromXml(Storage::_detail::XmlReader& reader)
         {
           int depth = 0;
           bool is_start = false;
@@ -8876,13 +8876,13 @@ namespace Azure { namespace Storage { namespace Blobs {
               }
             }
           }
-          Azure::Core::Http::Range ret;
+          Azure::Core::Http::HttpRange ret;
           ret.Offset = start;
           ret.Length = end - start + 1;
           return ret;
         }
 
-        static Azure::Core::Http::Range PageRangesFromXml(Storage::_detail::XmlReader& reader)
+        static Azure::Core::Http::HttpRange PageRangesFromXml(Storage::_detail::XmlReader& reader)
         {
           int depth = 0;
           bool is_start = false;
@@ -8931,7 +8931,7 @@ namespace Azure { namespace Storage { namespace Blobs {
               }
             }
           }
-          Azure::Core::Http::Range ret;
+          Azure::Core::Http::HttpRange ret;
           ret.Offset = start;
           ret.Length = end - start + 1;
           return ret;
@@ -9263,7 +9263,7 @@ namespace Azure { namespace Storage { namespace Blobs {
         {
           Azure::Core::Nullable<int32_t> Timeout;
           std::string SourceUri;
-          Azure::Core::Nullable<Azure::Core::Http::Range> SourceRange;
+          Azure::Core::Nullable<Azure::Core::Http::HttpRange> SourceRange;
           Azure::Core::Nullable<ContentHash> TransactionalContentHash;
           Azure::Core::Nullable<std::string> LeaseId;
           Azure::Core::Nullable<int64_t> MaxSize;

--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -197,7 +197,7 @@ namespace Azure { namespace Storage { namespace Blobs {
                 const HttpGetterInfo& retryInfo,
                 const Azure::Core::Context& context) -> std::unique_ptr<Azure::IO::BodyStream> {
         DownloadBlobOptions newOptions = options;
-        newOptions.Range = Core::Http::Range();
+        newOptions.Range = Core::Http::HttpRange();
         newOptions.Range.GetValue().Offset
             = (options.Range.HasValue() ? options.Range.GetValue().Offset : 0) + retryInfo.Offset;
         if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
@@ -302,7 +302,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     auto downloadChunkFunc
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
             DownloadBlobOptions chunkOptions;
-            chunkOptions.Range = Core::Http::Range();
+            chunkOptions.Range = Core::Http::HttpRange();
             chunkOptions.Range.GetValue().Offset = offset;
             chunkOptions.Range.GetValue().Length = length;
             if (!chunkOptions.AccessConditions.IfMatch.HasValue())
@@ -425,7 +425,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     auto downloadChunkFunc
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
             DownloadBlobOptions chunkOptions;
-            chunkOptions.Range = Core::Http::Range();
+            chunkOptions.Range = Core::Http::HttpRange();
             chunkOptions.Range.GetValue().Offset = offset;
             chunkOptions.Range.GetValue().Length = length;
             if (!chunkOptions.AccessConditions.IfMatch.HasValue())

--- a/sdk/storage/azure-storage-blobs/src/page_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/page_blob_client.cpp
@@ -160,7 +160,7 @@ namespace Azure { namespace Storage { namespace Blobs {
   Azure::Response<Models::UploadPageBlobPagesFromUriResult> PageBlobClient::UploadPagesFromUri(
       int64_t destinationOffset,
       std::string sourceUri,
-      Azure::Core::Http::Range sourceRange,
+      Azure::Core::Http::HttpRange sourceRange,
       const UploadPageBlobPagesFromUriOptions& options,
       const Azure::Core::Context& context) const
   {
@@ -188,7 +188,7 @@ namespace Azure { namespace Storage { namespace Blobs {
   }
 
   Azure::Response<Models::ClearPageBlobPagesResult> PageBlobClient::ClearPages(
-      Azure::Core::Http::Range range,
+      Azure::Core::Http::HttpRange range,
       const ClearPageBlobPagesOptions& options,
       const Azure::Core::Context& context) const
   {

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -112,7 +112,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     const int64_t downloadLength = 1024;
     Blobs::DownloadBlobOptions options;
-    options.Range = Azure::Core::Http::Range();
+    options.Range = Azure::Core::Http::HttpRange();
     options.Range.GetValue().Offset = 0;
     options.Range.GetValue().Length = downloadLength;
     options.RangeHashAlgorithm = HashAlgorithm::Md5;
@@ -194,7 +194,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(res->BlobType, Azure::Storage::Blobs::Models::BlobType::BlockBlob);
 
     Azure::Storage::Blobs::DownloadBlobOptions options;
-    options.Range = Core::Http::Range();
+    options.Range = Core::Http::HttpRange();
     options.Range.GetValue().Offset = 0;
     EXPECT_THROW(blockBlobClient.Download(options), StorageException);
     options.Range.GetValue().Length = 1;
@@ -477,7 +477,7 @@ namespace Azure { namespace Storage { namespace Test {
       options.TransferOptions.Concurrency = concurrency;
       if (offset.HasValue() || length.HasValue())
       {
-        options.Range = Core::Http::Range();
+        options.Range = Core::Http::HttpRange();
         options.Range.GetValue().Offset = offset.GetValue();
         options.Range.GetValue().Length = length;
       }
@@ -549,7 +549,7 @@ namespace Azure { namespace Storage { namespace Test {
       options.TransferOptions.Concurrency = concurrency;
       if (offset.HasValue() || length.HasValue())
       {
-        options.Range = Core::Http::Range();
+        options.Range = Core::Http::HttpRange();
         options.Range.GetValue().Offset = offset.GetValue();
         options.Range.GetValue().Length = length;
       }
@@ -634,7 +634,7 @@ namespace Azure { namespace Storage { namespace Test {
       // buffer not big enough
       Blobs::DownloadBlobToOptions options;
       options.TransferOptions.Concurrency = c;
-      options.Range = Core::Http::Range();
+      options.Range = Core::Http::HttpRange();
       options.Range.GetValue().Offset = 1;
       for (int64_t length : {1ULL, 2ULL, 4_KB, 5_KB, 8_KB, 11_KB, 20_KB})
       {
@@ -785,7 +785,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(ReadFile(tempFilename).empty());
       DeleteFile(tempFilename);
 
-      options.Range = Core::Http::Range();
+      options.Range = Core::Http::HttpRange();
       options.Range.GetValue().Offset = 0;
       EXPECT_THROW(
           blockBlobClient.DownloadTo(emptyContent.data(), static_cast<std::size_t>(8_MB), options),

--- a/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
@@ -107,7 +107,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(static_cast<uint64_t>(pageRanges.PageRanges[0].Length.GetValue()), 3_KB);
 
     Azure::Storage::Blobs::GetPageBlobPageRangesOptions options;
-    options.Range = Core::Http::Range();
+    options.Range = Core::Http::HttpRange();
     options.Range.GetValue().Offset = 4_KB;
     options.Range.GetValue().Length = 1_KB;
     pageRanges = *pageBlobClient.GetPageRanges(options);

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_options.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_options.hpp
@@ -470,7 +470,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Specify the range of the resource to be retrieved.
      */
-    Azure::Core::Nullable<Core::Http::Range> Range;
+    Azure::Core::Nullable<Core::Http::HttpRange> Range;
 
     /**
      * @brief The hash algorithm used to calculate the hash for the returned content.

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_responses.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_responses.hpp
@@ -251,7 +251,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
   {
     std::unique_ptr<Azure::IO::BodyStream> Body;
     int64_t FileSize = int64_t();
-    Azure::Core::Http::Range ContentRange;
+    Azure::Core::Http::HttpRange ContentRange;
     Azure::Core::Nullable<Storage::ContentHash> TransactionalContentHash;
     DownloadDataLakeFileDetails Details;
     std::string RequestId;
@@ -266,7 +266,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
   struct DownloadDataLakeFileToResult
   {
     int64_t FileSize = int64_t();
-    Azure::Core::Http::Range ContentRange;
+    Azure::Core::Http::HttpRange ContentRange;
     DownloadDataLakeFileDetails Details;
   };
 

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
@@ -363,7 +363,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       auto firstHalf = std::vector<uint8_t>(buffer.begin(), buffer.begin() + (bufferSize / 2));
       Files::DataLake::DownloadDataLakeFileOptions options;
-      options.Range = Azure::Core::Http::Range();
+      options.Range = Azure::Core::Http::HttpRange();
       options.Range.GetValue().Offset = 0;
       options.Range.GetValue().Length = bufferSize / 2;
       result = newFileClient->Download(options);
@@ -377,7 +377,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       auto secondHalf = std::vector<uint8_t>(buffer.begin() + bufferSize / 2, buffer.end());
       Files::DataLake::DownloadDataLakeFileOptions options;
-      options.Range = Azure::Core::Http::Range();
+      options.Range = Azure::Core::Http::HttpRange();
       options.Range.GetValue().Offset = bufferSize / 2;
       options.Range.GetValue().Length = bufferSize / 2;
       result = newFileClient->Download(options);

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/protocol/share_rest_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/protocol/share_rest_client.hpp
@@ -361,8 +361,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     // The list of file ranges
     struct ShareFileRangeList
     {
-      std::vector<Core::Http::Range> Ranges;
-      std::vector<Core::Http::Range> ClearRanges;
+      std::vector<Core::Http::HttpRange> Ranges;
+      std::vector<Core::Http::HttpRange> ClearRanges;
     };
 
     // Stats for the share.
@@ -897,7 +897,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       Core::DateTime LastModified;
       Storage::Metadata Metadata;
       FileHttpHeaders HttpHeaders;
-      Azure::Core::Http::Range ContentRange;
+      Azure::Core::Http::HttpRange ContentRange;
       int64_t FileSize;
       Azure::ETag ETag;
       Azure::Core::Nullable<Storage::ContentHash> TransactionalContentHash;
@@ -1009,8 +1009,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     struct FileGetRangeListResult
     {
-      std::vector<Core::Http::Range> Ranges;
-      std::vector<Core::Http::Range> ClearRanges;
+      std::vector<Core::Http::HttpRange> Ranges;
+      std::vector<Core::Http::HttpRange> ClearRanges;
       Core::DateTime LastModified;
       Azure::ETag ETag;
       int64_t FileSize = int64_t();
@@ -1049,7 +1049,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     class ShareRestClient {
     private:
-      static Azure::Core::Http::Range HttpRangeFromXml(Storage::_detail::XmlReader& reader)
+      static Azure::Core::Http::HttpRange HttpRangeFromXml(Storage::_detail::XmlReader& reader)
       {
         int depth = 0;
         bool is_start = false;
@@ -1097,7 +1097,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             }
           }
         }
-        Azure::Core::Http::Range ret;
+        Azure::Core::Http::HttpRange ret;
         ret.Offset = start;
         ret.Length = end - start + 1;
         return ret;
@@ -6155,12 +6155,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
                   content_range.begin() + bytes_pos + 6, content_range.begin() + dash_pos));
               int64_t range_end_offset = std::stoll(std::string(
                   content_range.begin() + dash_pos + 1, content_range.begin() + slash_pos));
-              result.ContentRange = Azure::Core::Http::Range{
+              result.ContentRange = Azure::Core::Http::HttpRange{
                   range_start_offset, range_end_offset - range_start_offset + 1};
             }
             else
             {
-              result.ContentRange = Azure::Core::Http::Range{
+              result.ContentRange = Azure::Core::Http::HttpRange{
                   0, std::stoll(response.GetHeaders().at(_detail::HeaderContentLength))};
             }
             if (content_range_iterator != response.GetHeaders().end())
@@ -6317,12 +6317,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
                   content_range.begin() + bytes_pos + 6, content_range.begin() + dash_pos));
               int64_t range_end_offset = std::stoll(std::string(
                   content_range.begin() + dash_pos + 1, content_range.begin() + slash_pos));
-              result.ContentRange = Azure::Core::Http::Range{
+              result.ContentRange = Azure::Core::Http::HttpRange{
                   range_start_offset, range_end_offset - range_start_offset + 1};
             }
             else
             {
-              result.ContentRange = Azure::Core::Http::Range{
+              result.ContentRange = Azure::Core::Http::HttpRange{
                   0, std::stoll(response.GetHeaders().at(_detail::HeaderContentLength))};
             }
             if (content_range_iterator != response.GetHeaders().end())

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
@@ -348,7 +348,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     Azure::Response<Models::UploadFileRangeFromUriResult> UploadRangeFromUri(
         int64_t destinationOffset,
         const std::string& sourceUri,
-        const Azure::Core::Http::Range& sourceRange,
+        const Azure::Core::Http::HttpRange& sourceRange,
         const UploadFileRangeFromUriOptions& options = UploadFileRangeFromUriOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_options.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_options.hpp
@@ -338,7 +338,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Downloads only the bytes of the file from this range.
      */
-    Azure::Core::Nullable<Core::Http::Range> Range;
+    Azure::Core::Nullable<Core::Http::HttpRange> Range;
 
     /**
      * @brief When specified together with Range, service returns hash for the range as long as the
@@ -485,7 +485,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief The range to be get from service.
      */
-    Azure::Core::Nullable<Core::Http::Range> Range;
+    Azure::Core::Nullable<Core::Http::HttpRange> Range;
 
     /**
      * @brief The previous snapshot parameter is an opaque DateTime value that, when present,
@@ -540,7 +540,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Downloads only the bytes of the file from this range.
      */
-    Azure::Core::Nullable<Core::Http::Range> Range;
+    Azure::Core::Nullable<Core::Http::HttpRange> Range;
 
     struct
     {

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -138,7 +138,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     struct DownloadShareFileResult
     {
       std::unique_ptr<Azure::IO::BodyStream> BodyStream;
-      Azure::Core::Http::Range ContentRange;
+      Azure::Core::Http::HttpRange ContentRange;
       int64_t FileSize = 0;
       Azure::Core::Nullable<Storage::ContentHash> TransactionalContentHash;
       FileHttpHeaders HttpHeaders;
@@ -168,7 +168,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     struct DownloadShareFileToResult
     {
       int64_t FileSize = 0;
-      Azure::Core::Http::Range ContentRange;
+      Azure::Core::Http::HttpRange ContentRange;
       FileHttpHeaders HttpHeaders;
       DownloadShareFileDetails Details;
     };

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -279,7 +279,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
                 const HttpGetterInfo& retryInfo,
                 const Azure::Core::Context& context) -> std::unique_ptr<Azure::IO::BodyStream> {
         DownloadShareFileOptions newOptions = options;
-        newOptions.Range = Core::Http::Range();
+        newOptions.Range = Core::Http::HttpRange();
         newOptions.Range.GetValue().Offset
             = (options.Range.HasValue() ? options.Range.GetValue().Offset : 0) + retryInfo.Offset;
         if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
@@ -698,7 +698,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto downloadChunkFunc
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
             DownloadShareFileOptions chunkOptions;
-            chunkOptions.Range = Core::Http::Range();
+            chunkOptions.Range = Core::Http::HttpRange();
             chunkOptions.Range.GetValue().Offset = offset;
             chunkOptions.Range.GetValue().Length = length;
             auto chunk = Download(chunkOptions, context);
@@ -815,7 +815,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto downloadChunkFunc
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
             DownloadShareFileOptions chunkOptions;
-            chunkOptions.Range = Core::Http::Range();
+            chunkOptions.Range = Core::Http::HttpRange();
             chunkOptions.Range.GetValue().Offset = offset;
             chunkOptions.Range.GetValue().Length = length;
             auto chunk = Download(chunkOptions, context);
@@ -1061,7 +1061,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   Azure::Response<Models::UploadFileRangeFromUriResult> ShareFileClient::UploadRangeFromUri(
       int64_t destinationOffset,
       const std::string& sourceUri,
-      const Azure::Core::Http::Range& sourceRange,
+      const Azure::Core::Http::HttpRange& sourceRange,
       const UploadFileRangeFromUriOptions& options,
       const Azure::Core::Context& context) const
   {

--- a/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
@@ -430,7 +430,7 @@ namespace Azure { namespace Storage { namespace Test {
       options.TransferOptions.Concurrency = concurrency;
       if (offset.HasValue())
       {
-        options.Range = Core::Http::Range();
+        options.Range = Core::Http::HttpRange();
         options.Range.GetValue().Offset = offset.GetValue();
         options.Range.GetValue().Length = length;
       }
@@ -500,7 +500,7 @@ namespace Azure { namespace Storage { namespace Test {
       options.TransferOptions.Concurrency = concurrency;
       if (offset.HasValue())
       {
-        options.Range = Core::Http::Range();
+        options.Range = Core::Http::HttpRange();
         options.Range.GetValue().Offset = offset.GetValue();
         options.Range.GetValue().Length = length;
       }
@@ -583,7 +583,7 @@ namespace Azure { namespace Storage { namespace Test {
       // buffer not big enough
       Files::Shares::DownloadShareFileToOptions options;
       options.TransferOptions.Concurrency = c;
-      options.Range = Core::Http::Range();
+      options.Range = Core::Http::HttpRange();
       options.Range.GetValue().Offset = 1;
       for (int64_t length : {1ULL, 2ULL, 4_KB, 5_KB, 8_KB, 11_KB, 20_KB})
       {
@@ -629,7 +629,7 @@ namespace Azure { namespace Storage { namespace Test {
       for (int32_t i = 0; i < numOfChunks; ++i)
       {
         Files::Shares::DownloadShareFileOptions downloadOptions;
-        downloadOptions.Range = Core::Http::Range();
+        downloadOptions.Range = Core::Http::HttpRange();
         downloadOptions.Range.GetValue().Offset = static_cast<int64_t>(rangeSize) * i;
         downloadOptions.Range.GetValue().Length = rangeSize;
         Files::Shares::Models::DownloadShareFileResult result;
@@ -845,8 +845,8 @@ namespace Azure { namespace Storage { namespace Test {
 
     auto destFileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString(10));
     destFileClient.Create(fileSize * 4);
-    Azure::Core::Http::Range sourceRange;
-    Azure::Core::Http::Range destRange;
+    Azure::Core::Http::HttpRange sourceRange;
+    Azure::Core::Http::HttpRange destRange;
     sourceRange.Length = fileSize;
     destRange.Offset = fileSize;
     destRange.Length = fileSize;


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/1789

> We shouldn't have Method, StatusCode, or Range. The way to reason about this is chances of collision and ease of documentation/discover-ability in SEO. RawResponse is specific enough that it doesn't need Http prefix, that's how I would draw the line.