### PR TITLE
Fix to call the instance method on bodystream from recent tests.

### DIFF
--- a/sdk/core/azure-core/test/ut/bodystream.cpp
+++ b/sdk/core/azure-core/test/ut/bodystream.cpp
@@ -69,8 +69,7 @@ TEST(FileBodyStream, Length)
   Azure::Core::IO::FileBodyStream stream(testDataPath);
   EXPECT_EQ(stream.Length(), FileSize);
 
-  auto readResult = Azure::Core::IO::BodyStream::ReadToEnd(
-      stream, Azure::Core::Context::GetApplicationContext());
+  auto readResult = stream.ReadToEnd(Azure::Core::Context::GetApplicationContext());
   EXPECT_EQ(readResult.size(), FileSize);
 
   stream.Rewind();


### PR DESCRIPTION
Resolves the issue introduced by these PRs which were in flight and merged one after the other, since they didn't cause merge conflicts but needed CI to be re-run to observe:
https://github.com/Azure/azure-sdk-for-cpp/pull/1830
https://github.com/Azure/azure-sdk-for-cpp/pull/1863