### PR TITLE
fix poll Internal implementation for DeletedKeyOperation

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/src/delete_key_operation.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/delete_key_operation.cpp
@@ -35,7 +35,7 @@ Azure::Security::KeyVault::Keys::DeleteKeyOperation::PollInternal(Azure::Core::C
   {
     rawResponse = m_pipeline->GetResponse(
         context, Azure::Core::Http::HttpMethod::Get, {_detail::DeletedKeysPath, m_value.Name()});
-    m_status = CheckCompleted(*m_rawResponse);
+    m_status = CheckCompleted(*rawResponse);
   }
 
   // To ensure the success of calling Poll multiple times, even after operation is completed, a

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/CMakeLists.txt
@@ -27,8 +27,11 @@ target_link_libraries(azure-security-keyvault-keys-test PRIVATE azure-security-k
 
 # gtest_add_tests will scan the test from azure-core-test and call add_test
 # for each test to ctest. This enables `ctest -r` to run specific tests directly.
-gtest_add_tests(TARGET azure-security-keyvault-keys-test
-     TEST_PREFIX azure-security-keyvault-keys-unittest.)
+gtest_discover_tests(azure-security-keyvault-keys-test
+  TEST_PREFIX azure-security-keyvault-keys-unittest.
+  NO_PRETTY_TYPES
+  NO_PRETTY_VALUES
+)
 
 
 ################## Live Tests ##########################

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_base_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_base_test.hpp
@@ -44,7 +44,11 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
         Azure::Core::Http::HttpStatusCode expectedCode = Azure::Core::Http::HttpStatusCode::Ok)
     {
       auto rawResponse = response.ExtractRawResponse();
-      EXPECT_EQ(rawResponse->GetStatusCode(), expectedCode);
+      EXPECT_EQ(
+          static_cast<typename std::underlying_type<Azure::Core::Http::HttpStatusCode>::type>(
+              rawResponse->GetStatusCode()),
+          static_cast<typename std::underlying_type<Azure::Core::Http::HttpStatusCode>::type>(
+              expectedCode));
     }
   };
 


### PR DESCRIPTION
After refactoring the Operation base class, this bug was introduced.
The operation status was updated based on the previous raw response instead of using the last rawResponse.

fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/1893