### PR TITLE
Remove duplicated DataLake and Share strings from option and result types for operation models.

### DIFF
--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_directory_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_directory_client.hpp
@@ -93,12 +93,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *        if the destination already exists and has a lease the lease is broken.
      * @param options Optional parameters to create the directory the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateDataLakeDirectoryResult> containing the
+     * @return Azure::Response<Models::CreateDirectoryResult> containing the
      * information of the created directory
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::CreateDataLakeDirectoryResult> Create(
-        const CreateDataLakeDirectoryOptions& options = CreateDataLakeDirectoryOptions(),
+    Azure::Response<Models::CreateDirectoryResult> Create(
+        const CreateDirectoryOptions& options = CreateDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return DataLakePathClient::Create(Models::PathResourceType::Directory, options, context);
@@ -108,12 +108,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Create a directory. If it already exists, nothing will happen.
      * @param options Optional parameters to create the directory the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateDataLakeDirectoryResult> containing the
+     * @return Azure::Response<Models::CreateDirectoryResult> containing the
      * information of the created directory
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::CreateDataLakeDirectoryResult> CreateIfNotExists(
-        const CreateDataLakeDirectoryOptions& options = CreateDataLakeDirectoryOptions(),
+    Azure::Response<Models::CreateDirectoryResult> CreateIfNotExists(
+        const CreateDirectoryOptions& options = CreateDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return DataLakePathClient::CreateIfNotExists(
@@ -133,7 +133,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Azure::Response<DataLakeFileClient> RenameFile(
         const std::string& fileName,
         const std::string& destinationFilePath,
-        const RenameDataLakeFileOptions& options = RenameDataLakeFileOptions(),
+        const RenameFileOptions& options = RenameFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -150,19 +150,19 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Azure::Response<DataLakeDirectoryClient> RenameSubdirectory(
         const std::string& subdirectoryName,
         const std::string& destinationDirectoryPath,
-        const RenameDataLakeSubdirectoryOptions& options = RenameDataLakeSubdirectoryOptions(),
+        const RenameSubdirectoryOptions& options = RenameSubdirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the empty directory. Throws exception if directory is not empty.
      * @param options Optional parameters to delete the directory the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteShareDirectoryResult> containing the information
+     * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::DeleteDataLakeDirectoryResult> DeleteEmpty(
-        const DeleteDataLakeDirectoryOptions& options = DeleteDataLakeDirectoryOptions(),
+    Azure::Response<Models::DeleteDirectoryResult> DeleteEmpty(
+        const DeleteDirectoryOptions& options = DeleteDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return this->Delete(false, options, context);
@@ -173,12 +173,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * empty.
      * @param options Optional parameters to delete the directory the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteShareDirectoryResult> containing the information
+     * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::DeleteDataLakeDirectoryResult> DeleteEmptyIfExists(
-        const DeleteDataLakeDirectoryOptions& options = DeleteDataLakeDirectoryOptions(),
+    Azure::Response<Models::DeleteDirectoryResult> DeleteEmptyIfExists(
+        const DeleteDirectoryOptions& options = DeleteDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return this->DeleteIfExists(false, options, context);
@@ -188,12 +188,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Deletes the directory and all its subdirectories and files.
      * @param options Optional parameters to delete the directory the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteShareDirectoryResult> containing the information
+     * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::DeleteDataLakeDirectoryResult> DeleteRecursive(
-        const DeleteDataLakeDirectoryOptions& options = DeleteDataLakeDirectoryOptions(),
+    Azure::Response<Models::DeleteDirectoryResult> DeleteRecursive(
+        const DeleteDirectoryOptions& options = DeleteDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return this->Delete(true, options, context);
@@ -203,12 +203,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Deletes the directory and all its subdirectories and files if the directory exists.
      * @param options Optional parameters to delete the directory the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteShareDirectoryResult> containing the information
+     * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::DeleteDataLakeDirectoryResult> DeleteRecursiveIfExists(
-        const DeleteDataLakeDirectoryOptions& options = DeleteDataLakeDirectoryOptions(),
+    Azure::Response<Models::DeleteDirectoryResult> DeleteRecursiveIfExists(
+        const DeleteDirectoryOptions& options = DeleteDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return this->DeleteIfExists(true, options, context);
@@ -238,14 +238,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     {
     }
 
-    Azure::Response<Models::DeleteDataLakeDirectoryResult> Delete(
+    Azure::Response<Models::DeleteDirectoryResult> Delete(
         bool recursive,
-        const DeleteDataLakeDirectoryOptions& options = DeleteDataLakeDirectoryOptions(),
+        const DeleteDirectoryOptions& options = DeleteDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
-    Azure::Response<Models::DeleteDataLakeDirectoryResult> DeleteIfExists(
+    Azure::Response<Models::DeleteDirectoryResult> DeleteIfExists(
         bool recursive,
-        const DeleteDataLakeDirectoryOptions& options = DeleteDataLakeDirectoryOptions(),
+        const DeleteDirectoryOptions& options = DeleteDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     friend class DataLakeFileSystemClient;

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_client.hpp
@@ -88,14 +88,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *                 request.
      * @param options Optional parameters to append data to the resource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::AppendDataLakeFileResult> containing the
+     * @return Azure::Response<Models::AppendFileResult> containing the
      * information returned when appending some data to the path.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::AppendDataLakeFileResult> Append(
+    Azure::Response<Models::AppendFileResult> Append(
         Azure::Core::IO::BodyStream* content,
         int64_t offset,
-        const AppendDataLakeFileOptions& options = AppendDataLakeFileOptions(),
+        const AppendFileOptions& options = AppendFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -110,13 +110,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *                 request.
      * @param options Optional parameters to flush data to the resource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::FlushDataLakeFileResult> containing the information
+     * @return Azure::Response<Models::FlushFileResult> containing the information
      * returned when flushing the data appended to the path.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::FlushDataLakeFileResult> Flush(
+    Azure::Response<Models::FlushFileResult> Flush(
         int64_t position,
-        const FlushDataLakeFileOptions& options = FlushDataLakeFileOptions(),
+        const FlushFileOptions& options = FlushFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -124,12 +124,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *        if the destination already exists and has a lease the lease is broken.
      * @param options Optional parameters to create the resource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateDataLakeFileResult> containing the information
+     * @return Azure::Response<Models::CreateFileResult> containing the information
      * returned when creating the file.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::CreateDataLakeFileResult> Create(
-        const CreateDataLakeFileOptions& options = CreateDataLakeFileOptions(),
+    Azure::Response<Models::CreateFileResult> Create(
+        const CreateFileOptions& options = CreateFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return DataLakePathClient::Create(Models::PathResourceType::File, options, context);
@@ -139,12 +139,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Create a file. If it already exists, it will remain unchanged.
      * @param options Optional parameters to create the resource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateDataLakeFileResult> containing the information
+     * @return Azure::Response<Models::CreateFileResult> containing the information
      * returned when creating the file.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::CreateDataLakeFileResult> CreateIfNotExists(
-        const CreateDataLakeFileOptions& options = CreateDataLakeFileOptions(),
+    Azure::Response<Models::CreateFileResult> CreateIfNotExists(
+        const CreateFileOptions& options = CreateFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return DataLakePathClient::CreateIfNotExists(
@@ -155,22 +155,22 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Deletes the file.
      * @param options Optional parameters to delete the file the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteDataLakeFileResult>
+     * @return Azure::Response<Models::DeleteFileResult>
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::DeleteDataLakeFileResult> Delete(
-        const DeleteDataLakeFileOptions& options = DeleteDataLakeFileOptions(),
+    Azure::Response<Models::DeleteFileResult> Delete(
+        const DeleteFileOptions& options = DeleteFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the file if it already exists.
      * @param options Optional parameters to delete the file the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteDataLakeFileResult>
+     * @return Azure::Response<Models::DeleteFileResult>
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::DeleteDataLakeFileResult> DeleteIfExists(
-        const DeleteDataLakeFileOptions& options = DeleteDataLakeFileOptions(),
+    Azure::Response<Models::DeleteFileResult> DeleteIfExists(
+        const DeleteFileOptions& options = DeleteFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -179,12 +179,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param options Optional parameters to download the content from the resource the path points
      * to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DownloadDataLakeFileResult> containing the information
+     * @return Azure::Response<Models::DownloadFileResult> containing the information
      * and content returned when downloading from a file.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::DownloadDataLakeFileResult> Download(
-        const DownloadDataLakeFileOptions& options = DownloadDataLakeFileOptions(),
+    Azure::Response<Models::DownloadFileResult> Download(
+        const DownloadFileOptions& options = DownloadFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -194,14 +194,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param bufferSize Size of the memory buffer.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<UploadDataLakeFileFromResult> containing the information
+     * @return Azure::Response<UploadFileFromResult> containing the information
      * returned when uploading a file from a buffer.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::UploadDataLakeFileFromResult> UploadFrom(
+    Azure::Response<Models::UploadFileFromResult> UploadFrom(
         const uint8_t* buffer,
         std::size_t bufferSize,
-        const UploadDataLakeFileFromOptions& options = UploadDataLakeFileFromOptions(),
+        const UploadFileFromOptions& options = UploadFileFromOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -210,13 +210,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param fileName A file containing the content to upload.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::UploadDataLakeFileFromResult> containing the
+     * @return Azure::Response<Models::UploadFileFromResult> containing the
      * information returned when uploading a file from a local file.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::UploadDataLakeFileFromResult> UploadFrom(
+    Azure::Response<Models::UploadFileFromResult> UploadFrom(
         const std::string& fileName,
-        const UploadDataLakeFileFromOptions& options = UploadDataLakeFileFromOptions(),
+        const UploadFileFromOptions& options = UploadFileFromOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -227,14 +227,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * or file range.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DownloadDataLakeFileToResult> containing the
+     * @return Azure::Response<Models::DownloadFileToResult> containing the
      * information returned when downloading a file to a local buffer.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::DownloadDataLakeFileToResult> DownloadTo(
+    Azure::Response<Models::DownloadFileToResult> DownloadTo(
         uint8_t* buffer,
         std::size_t bufferSize,
-        const DownloadDataLakeFileToOptions& options = DownloadDataLakeFileToOptions(),
+        const DownloadFileToOptions& options = DownloadFileToOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -243,13 +243,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param fileName A file path to write the downloaded content to.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DownloadDataLakeFileToResult> containing the
+     * @return Azure::Response<Models::DownloadFileToResult> containing the
      * information returned when downloading a file to a local file.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::DownloadDataLakeFileToResult> DownloadTo(
+    Azure::Response<Models::DownloadFileToResult> DownloadTo(
         const std::string& fileName,
-        const DownloadDataLakeFileToOptions& options = DownloadDataLakeFileToOptions(),
+        const DownloadFileToOptions& options = DownloadFileToOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -257,13 +257,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param expiryOrigin Specify the origin of expiry.
      * @param options Optional parameters to schedule the file for deletion.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::ScheduleDataLakeFileDeletionResult> containing the
+     * @return Azure::Response<Models::ScheduleFileDeletionResult> containing the
      * information and content returned when schedule the file for deletion.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::ScheduleDataLakeFileDeletionResult> ScheduleDeletion(
-        ScheduleDataLakeFileExpiryOriginType expiryOrigin,
-        const ScheduleDataLakeFileDeletionOptions& options = ScheduleDataLakeFileDeletionOptions(),
+    Azure::Response<Models::ScheduleFileDeletionResult> ScheduleDeletion(
+        ScheduleFileExpiryOriginType expiryOrigin,
+        const ScheduleFileDeletionOptions& options = ScheduleFileDeletionOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
   private:

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_system_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_system_client.hpp
@@ -94,49 +94,49 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Creates the file system.
      * @param options Optional parameters to create this file system.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateDataLakeFileSystemResult> containing the
+     * @return Azure::Response<Models::CreateFileSystemResult> containing the
      * information of create a file system.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::CreateDataLakeFileSystemResult> Create(
-        const CreateDataLakeFileSystemOptions& options = CreateDataLakeFileSystemOptions(),
+    Azure::Response<Models::CreateFileSystemResult> Create(
+        const CreateFileSystemOptions& options = CreateFileSystemOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Creates the file system if it does not exists.
      * @param options Optional parameters to create this file system.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateDataLakeFileSystemResult> containing the
+     * @return Azure::Response<Models::CreateFileSystemResult> containing the
      * information of create a file system. Only valid when successfully created the file system.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::CreateDataLakeFileSystemResult> CreateIfNotExists(
-        const CreateDataLakeFileSystemOptions& options = CreateDataLakeFileSystemOptions(),
+    Azure::Response<Models::CreateFileSystemResult> CreateIfNotExists(
+        const CreateFileSystemOptions& options = CreateFileSystemOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the file system.
      * @param options Optional parameters to delete this file system.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteDataLakeFileSystemResult> containing the
+     * @return Azure::Response<Models::DeleteFileSystemResult> containing the
      * information returned when deleting file systems.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::DeleteDataLakeFileSystemResult> Delete(
-        const DeleteDataLakeFileSystemOptions& options = DeleteDataLakeFileSystemOptions(),
+    Azure::Response<Models::DeleteFileSystemResult> Delete(
+        const DeleteFileSystemOptions& options = DeleteFileSystemOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the file system if it exists.
      * @param options Optional parameters to delete this file system.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteDataLakeFileSystemResult> containing the
+     * @return Azure::Response<Models::DeleteFileSystemResult> containing the
      * information returned when deleting file systems. Only valid when successfully deleted the
      * file system.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::DeleteDataLakeFileSystemResult> DeleteIfExists(
-        const DeleteDataLakeFileSystemOptions& options = DeleteDataLakeFileSystemOptions(),
+    Azure::Response<Models::DeleteFileSystemResult> DeleteIfExists(
+        const DeleteFileSystemOptions& options = DeleteFileSystemOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -145,14 +145,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *                 may only contain ASCII characters in the ISO-8859-1 character set.
      * @param options Optional parameters to set the metadata to this file system.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::SetDataLakeFileSystemMetadataResult> containing the
+     * @return Azure::Response<Models::SetFileSystemMetadataResult> containing the
      * information returned when setting the metadata onto the file system.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::SetDataLakeFileSystemMetadataResult> SetMetadata(
+    Azure::Response<Models::SetFileSystemMetadataResult> SetMetadata(
         Storage::Metadata metadata,
-        const SetDataLakeFileSystemMetadataOptions& options
-        = SetDataLakeFileSystemMetadataOptions(),
+        const SetFileSystemMetadataOptions& options
+        = SetFileSystemMetadataOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -164,8 +164,8 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @remark This request is sent to blob endpoint.
      */
     Azure::Response<Models::DataLakeFileSystemProperties> GetProperties(
-        const GetDataLakeFileSystemPropertiesOptions& options
-        = GetDataLakeFileSystemPropertiesOptions(),
+        const GetFileSystemPropertiesOptions& options
+        = GetFileSystemPropertiesOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -189,12 +189,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return A GetDataLakeFileSystemAccessPolicyResult describing the container's access policy.
+     * @return A GetFileSystemAccessPolicyResult describing the container's access policy.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::GetDataLakeFileSystemAccessPolicyResult> GetAccessPolicy(
-        const GetDataLakeFileSystemAccessPolicyOptions& options
-        = GetDataLakeFileSystemAccessPolicyOptions(),
+    Azure::Response<Models::GetFileSystemAccessPolicyResult> GetAccessPolicy(
+        const GetFileSystemAccessPolicyOptions& options
+        = GetFileSystemAccessPolicyOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -203,12 +203,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return A SetDataLakeFileSystemAccessPolicyResult describing the updated file system.
+     * @return A SetFileSystemAccessPolicyResult describing the updated file system.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::SetDataLakeFileSystemAccessPolicyResult> SetAccessPolicy(
-        const SetDataLakeFileSystemAccessPolicyOptions& options
-        = SetDataLakeFileSystemAccessPolicyOptions(),
+    Azure::Response<Models::SetFileSystemAccessPolicyResult> SetAccessPolicy(
+        const SetFileSystemAccessPolicyOptions& options
+        = SetFileSystemAccessPolicyOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -224,7 +224,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Azure::Response<DataLakeFileClient> RenameFile(
         const std::string& fileName,
         const std::string& destinationFilePath,
-        const RenameDataLakeFileOptions& options = RenameDataLakeFileOptions(),
+        const RenameFileOptions& options = RenameFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -241,7 +241,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Azure::Response<DataLakeDirectoryClient> RenameDirectory(
         const std::string& directoryName,
         const std::string& destinationDirectoryPath,
-        const RenameDataLakeDirectoryOptions& options = RenameDataLakeDirectoryOptions(),
+        const RenameDirectoryOptions& options = RenameDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
   private:

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_system_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_system_client.hpp
@@ -151,8 +151,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      */
     Azure::Response<Models::SetFileSystemMetadataResult> SetMetadata(
         Storage::Metadata metadata,
-        const SetFileSystemMetadataOptions& options
-        = SetFileSystemMetadataOptions(),
+        const SetFileSystemMetadataOptions& options = SetFileSystemMetadataOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -164,8 +163,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @remark This request is sent to blob endpoint.
      */
     Azure::Response<Models::DataLakeFileSystemProperties> GetProperties(
-        const GetFileSystemPropertiesOptions& options
-        = GetFileSystemPropertiesOptions(),
+        const GetFileSystemPropertiesOptions& options = GetFileSystemPropertiesOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -193,8 +191,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @remark This request is sent to blob endpoint.
      */
     Azure::Response<Models::GetFileSystemAccessPolicyResult> GetAccessPolicy(
-        const GetFileSystemAccessPolicyOptions& options
-        = GetFileSystemAccessPolicyOptions(),
+        const GetFileSystemAccessPolicyOptions& options = GetFileSystemAccessPolicyOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -207,8 +204,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @remark This request is sent to blob endpoint.
      */
     Azure::Response<Models::SetFileSystemAccessPolicyResult> SetAccessPolicy(
-        const SetFileSystemAccessPolicyOptions& options
-        = SetFileSystemAccessPolicyOptions(),
+        const SetFileSystemAccessPolicyOptions& options = SetFileSystemAccessPolicyOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_lease_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_lease_client.hpp
@@ -71,11 +71,11 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * changed using renew or change.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return A AcquireDataLakeLeaseResult describing the lease.
+     * @return A AcquireLeaseResult describing the lease.
      */
-    Azure::Response<Models::AcquireDataLakeLeaseResult> Acquire(
+    Azure::Response<Models::AcquireLeaseResult> Acquire(
         std::chrono::seconds duration,
-        const AcquireDataLakeLeaseOptions& options = AcquireDataLakeLeaseOptions(),
+        const AcquireLeaseOptions& options = AcquireLeaseOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return m_blobLeaseClient.Acquire(duration, options, context);
@@ -86,10 +86,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return A RenewDataLakeLeaseResult describing the lease.
+     * @return A RenewLeaseResult describing the lease.
      */
-    Azure::Response<Models::RenewDataLakeLeaseResult> Renew(
-        const RenewDataLakeLeaseOptions& options = RenewDataLakeLeaseOptions(),
+    Azure::Response<Models::RenewLeaseResult> Renew(
+        const RenewLeaseOptions& options = RenewLeaseOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return m_blobLeaseClient.Renew(options, context);
@@ -100,10 +100,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return A ReleaseDataLakeLeaseResult describing the updated container or blob.
+     * @return A ReleaseLeaseResult describing the updated container or blob.
      */
-    Azure::Response<Models::ReleaseDataLakeLeaseResult> Release(
-        const ReleaseDataLakeLeaseOptions& options = ReleaseDataLakeLeaseOptions(),
+    Azure::Response<Models::ReleaseLeaseResult> Release(
+        const ReleaseLeaseOptions& options = ReleaseLeaseOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return m_blobLeaseClient.Release(options, context);
@@ -115,12 +115,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param proposedLeaseId Proposed lease ID, in a GUID string format.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return A ChangeDataLakeLeaseResult describing the changed lease.
+     * @return A ChangeLeaseResult describing the changed lease.
      * @remarks The current DataLakeLeaseClient becomes invalid if this operation succeeds.
      */
-    Azure::Response<Models::ChangeDataLakeLeaseResult> Change(
+    Azure::Response<Models::ChangeLeaseResult> Change(
         const std::string& proposedLeaseId,
-        const ChangeDataLakeLeaseOptions& options = ChangeDataLakeLeaseOptions(),
+        const ChangeLeaseOptions& options = ChangeLeaseOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return m_blobLeaseClient.Change(proposedLeaseId, options, context);
@@ -131,10 +131,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return A BreakDataLakeLeaseResult describing the broken lease.
+     * @return A BreakLeaseResult describing the broken lease.
      */
-    Azure::Response<Models::BreakDataLakeLeaseResult> Break(
-        const BreakDataLakeLeaseOptions& options = BreakDataLakeLeaseOptions(),
+    Azure::Response<Models::BreakLeaseResult> Break(
+        const BreakLeaseOptions& options = BreakLeaseOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return m_blobLeaseClient.Break(options, context);

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_options.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_options.hpp
@@ -17,7 +17,7 @@
 
 namespace Azure { namespace Storage { namespace Files { namespace DataLake {
 
-  using DownloadDataLakeFileToOptions = Blobs::DownloadBlobToOptions;
+  using DownloadFileToOptions = Blobs::DownloadBlobToOptions;
   using GetUserDelegationKeyOptions = Blobs::GetUserDelegationKeyOptions;
 
   /**
@@ -87,14 +87,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Specifies that the filesystem's metadata be returned.
      */
-    Models::ListDataLakeFileSystemsIncludeFlags Include
-        = Models::ListDataLakeFileSystemsIncludeFlags::None;
+    Models::ListFileSystemsIncludeFlags Include
+        = Models::ListFileSystemsIncludeFlags::None;
   };
 
   /**
    * @brief Optional parameters for FileSystemClient::Create
    */
-  struct CreateDataLakeFileSystemOptions
+  struct CreateFileSystemOptions
   {
     /**
      * @brief User-defined metadata to be stored with the filesystem.
@@ -112,7 +112,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for FileSystemClient::Delete
    */
-  struct DeleteDataLakeFileSystemOptions
+  struct DeleteFileSystemOptions
   {
     /**
      * @brief Specify the access condition for the file system.
@@ -123,7 +123,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for FileSystemClient::GetProperties
    */
-  struct GetDataLakeFileSystemPropertiesOptions
+  struct GetFileSystemPropertiesOptions
   {
     /**
      * @brief Specify the lease access conditions.
@@ -134,7 +134,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for FileSystemClient::SetMetadata
    */
-  struct SetDataLakeFileSystemMetadataOptions
+  struct SetFileSystemMetadataOptions
   {
     /**
      * @brief Specify the access condition for the file system.
@@ -179,7 +179,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for FileSystemClient::GetAccessPolicy.
    */
-  struct GetDataLakeFileSystemAccessPolicyOptions
+  struct GetFileSystemAccessPolicyOptions
   {
     /**
      * @brief Optional conditions that must be met to perform this operation.
@@ -190,7 +190,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for FileSystemClient::SetAccessPolicy.
    */
-  struct SetDataLakeFileSystemAccessPolicyOptions
+  struct SetFileSystemAccessPolicyOptions
   {
     /**
      * @brief Specifies whether data in the file system may be accessed publicly and the level
@@ -216,7 +216,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
    *         More details:
    * https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    */
-  struct RenameDataLakeDirectoryOptions
+  struct RenameDirectoryOptions
   {
     /**
      * @brief If not specified, the source's file system is used. Otherwise, rename to destination
@@ -238,7 +238,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for PathClient::Append
    */
-  struct AppendDataLakeFileOptions
+  struct AppendFileOptions
   {
     /**
      * @brief Specify the transactional hash for the body, to be validated by the service.
@@ -254,7 +254,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for PathClient::Flush
    */
-  struct FlushDataLakeFileOptions
+  struct FlushFileOptions
   {
     /**
      * @brief If "true", uncommitted data is retained after the flush operation completes;
@@ -302,7 +302,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for PathClient::SetAccessControlList
    */
-  struct SetDataLakePathAccessControlListOptions
+  struct SetPathAccessControlListOptions
   {
     /**
      * @brief The owner of the path or directory.
@@ -323,7 +323,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for PathClient::SetPermissions
    */
-  struct SetDataLakePathPermissionsOptions
+  struct SetPathPermissionsOptions
   {
     /**
      * @brief The owner of the path or directory.
@@ -344,7 +344,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for PathClient::SetHttpHeaders
    */
-  struct SetDataLakePathHttpHeadersOptions
+  struct SetPathHttpHeadersOptions
   {
     /**
      * @brief Specify the access condition for the path.
@@ -355,7 +355,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for PathClient::SetMetadata
    */
-  struct SetDataLakePathMetadataOptions
+  struct SetPathMetadataOptions
   {
     /**
      * @brief Specify the access condition for the path.
@@ -369,7 +369,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
    *         More details:
    * https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    */
-  struct CreateDataLakePathOptions
+  struct CreatePathOptions
   {
     /**
      * @brief Specify the http headers for this path.
@@ -419,7 +419,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
    *         More details:
    * https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete
    */
-  struct DeleteDataLakePathOptions
+  struct DeletePathOptions
   {
     /**
      * @brief Required and valid only when the resource is a directory. If "true", all paths beneath
@@ -440,7 +440,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
    *         More details:
    * https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties
    */
-  struct GetDataLakePathPropertiesOptions
+  struct GetPathPropertiesOptions
   {
     /**
      * @brief Specify the access condition for the path.
@@ -451,7 +451,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for PathClient::GetAccessControlList
    */
-  struct GetDataLakePathAccessControlListOptions
+  struct GetPathAccessControlListOptions
   {
     /**
      * @brief Specify the access condition for the path.
@@ -465,7 +465,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
    *         More details:
    * https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/read
    */
-  struct DownloadDataLakeFileOptions
+  struct DownloadFileOptions
   {
     /**
      * @brief Specify the range of the resource to be retrieved.
@@ -486,7 +486,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for FileClient::Create
    */
-  struct RenameDataLakeFileOptions
+  struct RenameFileOptions
   {
     /**
      * @brief If not specified, the source's file system is used. Otherwise, rename to destination
@@ -508,7 +508,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for FileClient::Delete
    */
-  struct DeleteDataLakeFileOptions
+  struct DeleteFileOptions
   {
     /**
      * @brief Specify the access condition for the path.
@@ -516,12 +516,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     PathAccessConditions AccessConditions;
   };
 
-  using RenameDataLakeSubdirectoryOptions = RenameDataLakeDirectoryOptions;
+  using RenameSubdirectoryOptions = RenameDirectoryOptions;
 
   /**
    * @brief Optional parameters for DirectoryClient::Delete
    */
-  struct DeleteDataLakeDirectoryOptions
+  struct DeleteDirectoryOptions
   {
     /**
      * @brief Specify the access condition for the path.
@@ -532,7 +532,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   /**
    * @brief Optional parameters for DirectoryClient::SetAccessControlListRecursiveSinglePage
    */
-  struct SetDataLakePathAccessControlListRecursiveSinglePageOptions
+  struct SetPathAccessControlListRecursiveSinglePageOptions
   {
     /**
      * @brief When performing setAccessControlRecursive on a directory, the number of paths that
@@ -561,19 +561,19 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Azure::Nullable<bool> ContinueOnFailure;
   };
 
-  using UpdateDataLakePathAccessControlListRecursiveSinglePageOptions
-      = SetDataLakePathAccessControlListRecursiveSinglePageOptions;
+  using UpdatePathAccessControlListRecursiveSinglePageOptions
+      = SetPathAccessControlListRecursiveSinglePageOptions;
 
-  using RemoveDataLakePathAccessControlListRecursiveSinglePageOptions
-      = SetDataLakePathAccessControlListRecursiveSinglePageOptions;
+  using RemovePathAccessControlListRecursiveSinglePageOptions
+      = SetPathAccessControlListRecursiveSinglePageOptions;
 
-  using CreateDataLakeFileOptions = CreateDataLakePathOptions;
-  using CreateDataLakeDirectoryOptions = CreateDataLakePathOptions;
+  using CreateFileOptions = CreatePathOptions;
+  using CreateDirectoryOptions = CreatePathOptions;
 
   /**
    * @brief Optional parameters for FileClient::UploadFromBuffer and FileClient::UploadFromFile
    */
-  struct UploadDataLakeFileFromOptions
+  struct UploadFileFromOptions
   {
     /**
      * @brief The standard HTTP header system properties to set.
@@ -606,12 +606,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     } TransferOptions;
   };
 
-  using ScheduleDataLakeFileExpiryOriginType = Blobs::Models::ScheduleBlobExpiryOriginType;
+  using ScheduleFileExpiryOriginType = Blobs::Models::ScheduleBlobExpiryOriginType;
 
   /**
    * @brief Optional parameters for FileClient::UploadFromBuffer and FileClient::UploadFromFile
    */
-  struct ScheduleDataLakeFileDeletionOptions
+  struct ScheduleFileDeletionOptions
   {
     /**
      * @brief The expiry time from the specified origin. Only work if ExpiryOrigin is
@@ -627,10 +627,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Azure::Nullable<DateTime> ExpiresOn;
   };
 
-  using AcquireDataLakeLeaseOptions = Blobs::AcquireBlobLeaseOptions;
-  using BreakDataLakeLeaseOptions = Blobs::BreakBlobLeaseOptions;
-  using RenewDataLakeLeaseOptions = Blobs::RenewBlobLeaseOptions;
-  using ReleaseDataLakeLeaseOptions = Blobs::ReleaseBlobLeaseOptions;
-  using ChangeDataLakeLeaseOptions = Blobs::ChangeBlobLeaseOptions;
+  using AcquireLeaseOptions = Blobs::AcquireBlobLeaseOptions;
+  using BreakLeaseOptions = Blobs::BreakBlobLeaseOptions;
+  using RenewLeaseOptions = Blobs::RenewBlobLeaseOptions;
+  using ReleaseLeaseOptions = Blobs::ReleaseBlobLeaseOptions;
+  using ChangeLeaseOptions = Blobs::ChangeBlobLeaseOptions;
 
 }}}} // namespace Azure::Storage::Files::DataLake

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_options.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_options.hpp
@@ -87,8 +87,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Specifies that the filesystem's metadata be returned.
      */
-    Models::ListFileSystemsIncludeFlags Include
-        = Models::ListFileSystemsIncludeFlags::None;
+    Models::ListFileSystemsIncludeFlags Include = Models::ListFileSystemsIncludeFlags::None;
   };
 
   /**

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_path_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_path_client.hpp
@@ -81,13 +81,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *        if the destination already exists and has a lease the lease is broken.
      * @param options Optional parameters to create the resource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateDataLakePathResult> containing the information
+     * @return Azure::Response<Models::CreatePathResult> containing the information
      * returned when creating a path.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::CreateDataLakePathResult> Create(
+    Azure::Response<Models::CreatePathResult> Create(
         Models::PathResourceType type,
-        const CreateDataLakePathOptions& options = CreateDataLakePathOptions(),
+        const CreatePathOptions& options = CreatePathOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -95,38 +95,38 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * exists.
      * @param options Optional parameters to create the resource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateDataLakePathResult> containing the information
+     * @return Azure::Response<Models::CreatePathResult> containing the information
      * returned when creating a path, the information will only be valid when the create operation
      * is successful.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::CreateDataLakePathResult> CreateIfNotExists(
+    Azure::Response<Models::CreatePathResult> CreateIfNotExists(
         Models::PathResourceType type,
-        const CreateDataLakePathOptions& options = CreateDataLakePathOptions(),
+        const CreatePathOptions& options = CreatePathOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the resource the path points to.
      * @param options Optional parameters to delete the reource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteDataLakePathResult> which is current empty but
+     * @return Azure::Response<Models::DeletePathResult> which is current empty but
      * preserved for future usage.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::DeleteDataLakePathResult> Delete(
-        const DeleteDataLakePathOptions& options = DeleteDataLakePathOptions(),
+    Azure::Response<Models::DeletePathResult> Delete(
+        const DeletePathOptions& options = DeletePathOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the resource the path points to if it exists.
      * @param options Optional parameters to delete the reource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteDataLakePathResult> which is current empty but
+     * @return Azure::Response<Models::DeletePathResult> which is current empty but
      * preserved for future usage. The result will only valid if the delete operation is successful.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::DeleteDataLakePathResult> DeleteIfExists(
-        const DeleteDataLakePathOptions& options = DeleteDataLakePathOptions(),
+    Azure::Response<Models::DeletePathResult> DeleteIfExists(
+        const DeletePathOptions& options = DeletePathOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -139,14 +139,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param options Optional parameters to set an access control to the resource the path points
      *                to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::SetDataLakePathAccessControlListResult> containing the
+     * @return Azure::Response<Models::SetPathAccessControlListResult> containing the
      * information returned when setting path's access control.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::SetDataLakePathAccessControlListResult> SetAccessControlList(
+    Azure::Response<Models::SetPathAccessControlListResult> SetAccessControlList(
         std::vector<Models::Acl> acls,
-        const SetDataLakePathAccessControlListOptions& options
-        = SetDataLakePathAccessControlListOptions(),
+        const SetPathAccessControlListOptions& options
+        = SetPathAccessControlListOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -156,13 +156,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param permissions Sets the permissions on the path
      * @param options Optional parameters to set permissions to the resource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::SetDataLakePathPermissionsResult> containing the
+     * @return Azure::Response<Models::SetPathPermissionsResult> containing the
      * information returned when setting path's permissions.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::SetDataLakePathPermissionsResult> SetPermissions(
+    Azure::Response<Models::SetPathPermissionsResult> SetPermissions(
         std::string permissions,
-        const SetDataLakePathPermissionsOptions& options = SetDataLakePathPermissionsOptions(),
+        const SetPathPermissionsOptions& options = SetPathPermissionsOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -170,13 +170,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param options Optional parameters to set the http headers to the resource the path points
      * to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<SetDataLakePathHttpHeadersResult> containing the information
+     * @return Azure::Response<SetPathHttpHeadersResult> containing the information
      * returned when setting the path's Http headers.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::SetDataLakePathHttpHeadersResult> SetHttpHeaders(
+    Azure::Response<Models::SetPathHttpHeadersResult> SetHttpHeaders(
         Models::PathHttpHeaders httpHeaders,
-        const SetDataLakePathHttpHeadersOptions& options = SetDataLakePathHttpHeadersOptions(),
+        const SetPathHttpHeadersOptions& options = SetPathHttpHeadersOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -191,20 +191,20 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @remark This request is sent to blob endpoint.
      */
     Azure::Response<Models::DataLakePathProperties> GetProperties(
-        const GetDataLakePathPropertiesOptions& options = GetDataLakePathPropertiesOptions(),
+        const GetPathPropertiesOptions& options = GetPathPropertiesOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Returns all access control list stored for the given path.
      * @param options Optional parameters to get the ACLs from the resource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::GetDataLakePathAccessControlListResult> containing the
+     * @return Azure::Response<Models::GetPathAccessControlListResult> containing the
      * access control list of the path.
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::GetDataLakePathAccessControlListResult> GetAccessControlList(
-        const GetDataLakePathAccessControlListOptions& options
-        = GetDataLakePathAccessControlListOptions(),
+    Azure::Response<Models::GetPathAccessControlListResult> GetAccessControlList(
+        const GetPathAccessControlListOptions& options
+        = GetPathAccessControlListOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -213,13 +213,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *                 may only contain ASCII characters in the ISO-8859-1 character set.
      * @param options Optional parameters to set the metadata to the resource the path points to.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::SetDataLakePathMetadataResult> containing the
+     * @return Azure::Response<Models::SetPathMetadataResult> containing the
      * information returned when setting the metadata.
      * @remark This request is sent to blob endpoint.
      */
-    Azure::Response<Models::SetDataLakePathMetadataResult> SetMetadata(
+    Azure::Response<Models::SetPathMetadataResult> SetMetadata(
         Storage::Metadata metadata,
-        const SetDataLakePathMetadataOptions& options = SetDataLakePathMetadataOptions(),
+        const SetPathMetadataOptions& options = SetPathMetadataOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -231,14 +231,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * directory points to.
      * @param context Context for cancelling long running operations.
      * @return
-     * Azure::Response<Models::SetDataLakePathAccessControlListRecursiveSinglePageResult>
+     * Azure::Response<Models::SetPathAccessControlListRecursiveSinglePageResult>
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::SetDataLakePathAccessControlListRecursiveSinglePageResult>
+    Azure::Response<Models::SetPathAccessControlListRecursiveSinglePageResult>
     SetAccessControlListRecursiveSinglePage(
         const std::vector<Models::Acl>& acls,
-        const SetDataLakePathAccessControlListRecursiveSinglePageOptions& options
-        = SetDataLakePathAccessControlListRecursiveSinglePageOptions(),
+        const SetPathAccessControlListRecursiveSinglePageOptions& options
+        = SetPathAccessControlListRecursiveSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return SetAccessControlListRecursiveSinglePageInternal(
@@ -254,14 +254,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * directory points to.
      * @param context Context for cancelling long running operations.
      * @return
-     * Azure::Response<Models::UpdateDataLakePathAccessControlListRecursiveSinglePageResult>
+     * Azure::Response<Models::UpdatePathAccessControlListRecursiveSinglePageResult>
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::UpdateDataLakePathAccessControlListRecursiveSinglePageResult>
+    Azure::Response<Models::UpdatePathAccessControlListRecursiveSinglePageResult>
     UpdateAccessControlListRecursiveSinglePage(
         const std::vector<Models::Acl>& acls,
-        const UpdateDataLakePathAccessControlListRecursiveSinglePageOptions& options
-        = UpdateDataLakePathAccessControlListRecursiveSinglePageOptions(),
+        const UpdatePathAccessControlListRecursiveSinglePageOptions& options
+        = UpdatePathAccessControlListRecursiveSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return SetAccessControlListRecursiveSinglePageInternal(
@@ -277,14 +277,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * directory points to.
      * @param context Context for cancelling long running operations.
      * @return
-     * Azure::Response<Models::RemoveDataLakePathAccessControlListRecursiveSinglePageResult>
+     * Azure::Response<Models::RemovePathAccessControlListRecursiveSinglePageResult>
      * @remark This request is sent to dfs endpoint.
      */
-    Azure::Response<Models::RemoveDataLakePathAccessControlListRecursiveSinglePageResult>
+    Azure::Response<Models::RemovePathAccessControlListRecursiveSinglePageResult>
     RemoveAccessControlListRecursiveSinglePage(
         const std::vector<Models::Acl>& acls,
-        const RemoveDataLakePathAccessControlListRecursiveSinglePageOptions& options
-        = RemoveDataLakePathAccessControlListRecursiveSinglePageOptions(),
+        const RemovePathAccessControlListRecursiveSinglePageOptions& options
+        = RemovePathAccessControlListRecursiveSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const
     {
       return SetAccessControlListRecursiveSinglePageInternal(
@@ -305,12 +305,12 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     {
     }
 
-    Azure::Response<Models::SetDataLakePathAccessControlListRecursiveSinglePageResult>
+    Azure::Response<Models::SetPathAccessControlListRecursiveSinglePageResult>
     SetAccessControlListRecursiveSinglePageInternal(
         Models::PathSetAccessControlRecursiveMode mode,
         const std::vector<Models::Acl>& acls,
-        const SetDataLakePathAccessControlListRecursiveSinglePageOptions& options
-        = SetDataLakePathAccessControlListRecursiveSinglePageOptions(),
+        const SetPathAccessControlListRecursiveSinglePageOptions& options
+        = SetPathAccessControlListRecursiveSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     friend class DataLakeFileSystemClient;

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_path_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_path_client.hpp
@@ -145,8 +145,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      */
     Azure::Response<Models::SetPathAccessControlListResult> SetAccessControlList(
         std::vector<Models::Acl> acls,
-        const SetPathAccessControlListOptions& options
-        = SetPathAccessControlListOptions(),
+        const SetPathAccessControlListOptions& options = SetPathAccessControlListOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -203,8 +202,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @remark This request is sent to dfs endpoint.
      */
     Azure::Response<Models::GetPathAccessControlListResult> GetAccessControlList(
-        const GetPathAccessControlListOptions& options
-        = GetPathAccessControlListOptions(),
+        const GetPathAccessControlListOptions& options = GetPathAccessControlListOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_responses.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_responses.hpp
@@ -49,9 +49,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
 
   using ListPathsSinglePageResult = _detail::FileSystemListPathsResult;
   using DataLakeSignedIdentifier = Blobs::Models::BlobSignedIdentifier;
-  using ListDataLakeFileSystemsIncludeFlags = Blobs::Models::ListBlobContainersIncludeFlags;
+  using ListFileSystemsIncludeFlags = Blobs::Models::ListBlobContainersIncludeFlags;
 
-  struct GetDataLakeFileSystemAccessPolicyResult
+  struct GetFileSystemAccessPolicyResult
   {
     std::string RequestId;
     Azure::ETag ETag;
@@ -60,7 +60,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
     std::vector<DataLakeSignedIdentifier> SignedIdentifiers;
   }; // struct DataLakeFileSystemAccessPolciy
 
-  using SetDataLakeFileSystemAccessPolicyResult = Blobs::Models::SetBlobContainerAccessPolicyResult;
+  using SetFileSystemAccessPolicyResult = Blobs::Models::SetBlobContainerAccessPolicyResult;
 
   struct DataLakeFileSystemProperties
   {
@@ -69,7 +69,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
     Storage::Metadata Metadata;
   };
 
-  struct CreateDataLakeFileSystemResult
+  struct CreateFileSystemResult
   {
     bool Created = true;
     Azure::ETag ETag;
@@ -77,13 +77,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
     std::string RequestId;
   };
 
-  struct DeleteDataLakeFileSystemResult
+  struct DeleteFileSystemResult
   {
     bool Deleted = true;
     std::string RequestId;
   };
 
-  struct SetDataLakeFileSystemMetadataResult
+  struct SetFileSystemMetadataResult
   {
     Azure::ETag ETag;
     DateTime LastModified;
@@ -92,17 +92,17 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
 
   // PathClient models:
 
-  struct DeleteDataLakePathResult
+  struct DeletePathResult
   {
     bool Deleted = true;
     std::string RequestId;
   };
 
-  using AcquireDataLakeLeaseResult = Blobs::Models::AcquireBlobLeaseResult;
-  using RenewDataLakeLeaseResult = Blobs::Models::RenewBlobLeaseResult;
-  using ReleaseDataLakeLeaseResult = Blobs::Models::ReleaseBlobLeaseResult;
-  using ChangeDataLakeLeaseResult = Blobs::Models::ChangeBlobLeaseResult;
-  using BreakDataLakeLeaseResult = Blobs::Models::BreakBlobLeaseResult;
+  using AcquireLeaseResult = Blobs::Models::AcquireBlobLeaseResult;
+  using RenewLeaseResult = Blobs::Models::RenewBlobLeaseResult;
+  using ReleaseLeaseResult = Blobs::Models::ReleaseBlobLeaseResult;
+  using ChangeLeaseResult = Blobs::Models::ChangeBlobLeaseResult;
+  using BreakLeaseResult = Blobs::Models::BreakBlobLeaseResult;
   using RehydratePriority = Blobs::Models::RehydratePriority;
   using DataLakeArchiveStatus = Blobs::Models::BlobArchiveStatus;
 
@@ -174,7 +174,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
     Azure::Nullable<bool> IsCurrentVersion;
   };
 
-  struct GetDataLakePathAccessControlListResult
+  struct GetPathAccessControlListResult
   {
     Azure::ETag ETag;
     DateTime LastModified;
@@ -185,21 +185,21 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
     std::string RequestId;
   };
 
-  struct SetDataLakePathHttpHeadersResult
+  struct SetPathHttpHeadersResult
   {
     Azure::ETag ETag;
     DateTime LastModified;
     std::string RequestId;
   };
 
-  struct SetDataLakePathMetadataResult
+  struct SetPathMetadataResult
   {
     Azure::ETag ETag;
     DateTime LastModified;
     std::string RequestId;
   };
 
-  struct CreateDataLakePathResult
+  struct CreatePathResult
   {
     bool Created = true;
     Azure::ETag ETag;
@@ -208,18 +208,18 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
     std::string RequestId;
   };
 
-  using SetDataLakePathAccessControlListResult = _detail::PathSetAccessControlResult;
-  using SetDataLakePathPermissionsResult = _detail::PathSetAccessControlResult;
+  using SetPathAccessControlListResult = _detail::PathSetAccessControlResult;
+  using SetPathPermissionsResult = _detail::PathSetAccessControlResult;
 
   // FileClient models:
 
-  using UploadDataLakeFileFromResult = Blobs::Models::UploadBlockBlobResult;
-  using AppendDataLakeFileResult = _detail::PathAppendDataResult;
-  using FlushDataLakeFileResult = _detail::PathFlushDataResult;
-  using ScheduleDataLakeFileDeletionResult = Blobs::Models::SetBlobExpiryResult;
+  using UploadFileFromResult = Blobs::Models::UploadBlockBlobResult;
+  using AppendFileResult = _detail::PathAppendDataResult;
+  using FlushFileResult = _detail::PathFlushDataResult;
+  using ScheduleFileDeletionResult = Blobs::Models::SetBlobExpiryResult;
   using CopyStatus = Blobs::Models::CopyStatus;
 
-  struct DownloadDataLakeFileDetails
+  struct DownloadFileDetails
   {
     Azure::ETag ETag;
     DateTime LastModified;
@@ -244,46 +244,46 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake { nam
     Azure::Nullable<std::string> EncryptionScope;
   };
 
-  struct DownloadDataLakeFileResult
+  struct DownloadFileResult
   {
     std::unique_ptr<Azure::Core::IO::BodyStream> Body;
     int64_t FileSize = int64_t();
     Azure::Core::Http::HttpRange ContentRange;
     Azure::Nullable<Storage::ContentHash> TransactionalContentHash;
-    DownloadDataLakeFileDetails Details;
+    DownloadFileDetails Details;
     std::string RequestId;
   };
 
-  struct DeleteDataLakeFileResult
+  struct DeleteFileResult
   {
     bool Deleted = true;
     std::string RequestId;
   };
 
-  struct DownloadDataLakeFileToResult
+  struct DownloadFileToResult
   {
     int64_t FileSize = int64_t();
     Azure::Core::Http::HttpRange ContentRange;
-    DownloadDataLakeFileDetails Details;
+    DownloadFileDetails Details;
   };
 
-  using CreateDataLakeFileResult = CreateDataLakePathResult;
+  using CreateFileResult = CreatePathResult;
 
   // DirectoryClient models:
 
-  struct RenameDataLakeDirectoryResult
+  struct RenameDirectoryResult
   {
     Azure::Nullable<std::string> ContinuationToken;
     std::string RequestId;
   };
 
-  using SetDataLakePathAccessControlListRecursiveSinglePageResult
+  using SetPathAccessControlListRecursiveSinglePageResult
       = _detail::PathSetAccessControlRecursiveResult;
-  using UpdateDataLakePathAccessControlListRecursiveSinglePageResult
-      = SetDataLakePathAccessControlListRecursiveSinglePageResult;
-  using RemoveDataLakePathAccessControlListRecursiveSinglePageResult
-      = SetDataLakePathAccessControlListRecursiveSinglePageResult;
-  using CreateDataLakeDirectoryResult = CreateDataLakePathResult;
-  using DeleteDataLakeDirectoryResult = DeleteDataLakePathResult;
+  using UpdatePathAccessControlListRecursiveSinglePageResult
+      = SetPathAccessControlListRecursiveSinglePageResult;
+  using RemovePathAccessControlListRecursiveSinglePageResult
+      = SetPathAccessControlListRecursiveSinglePageResult;
+  using CreateDirectoryResult = CreatePathResult;
+  using DeleteDirectoryResult = DeletePathResult;
 
 }}}}} // namespace Azure::Storage::Files::DataLake::Models

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_directory_client.cpp
@@ -83,7 +83,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   Azure::Response<DataLakeFileClient> DataLakeDirectoryClient::RenameFile(
       const std::string& fileName,
       const std::string& destinationFilePath,
-      const RenameDataLakeFileOptions& options,
+      const RenameFileOptions& options,
       const Azure::Core::Context& context) const
   {
     Azure::Nullable<std::string> destinationFileSystem = options.DestinationFileSystem;
@@ -126,7 +126,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   Azure::Response<DataLakeDirectoryClient> DataLakeDirectoryClient::RenameSubdirectory(
       const std::string& subdirectoryName,
       const std::string& destinationDirectoryPath,
-      const RenameDataLakeSubdirectoryOptions& options,
+      const RenameSubdirectoryOptions& options,
       const Azure::Core::Context& context) const
   {
     Azure::Nullable<std::string> destinationFileSystem = options.DestinationFileSystem;
@@ -167,23 +167,23 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         std::move(renamedDirectoryClient), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::DeleteDataLakeDirectoryResult> DataLakeDirectoryClient::Delete(
+  Azure::Response<Models::DeleteDirectoryResult> DataLakeDirectoryClient::Delete(
       bool recursive,
-      const DeleteDataLakeDirectoryOptions& options,
+      const DeleteDirectoryOptions& options,
       const Azure::Core::Context& context) const
   {
-    DeleteDataLakePathOptions deleteOptions;
+    DeletePathOptions deleteOptions;
     deleteOptions.AccessConditions = options.AccessConditions;
     deleteOptions.Recursive = recursive;
     return DataLakePathClient::Delete(deleteOptions, context);
   }
 
-  Azure::Response<Models::DeleteDataLakeDirectoryResult> DataLakeDirectoryClient::DeleteIfExists(
+  Azure::Response<Models::DeleteDirectoryResult> DataLakeDirectoryClient::DeleteIfExists(
       bool recursive,
-      const DeleteDataLakeDirectoryOptions& options,
+      const DeleteDirectoryOptions& options,
       const Azure::Core::Context& context) const
   {
-    DeleteDataLakePathOptions deleteOptions;
+    DeletePathOptions deleteOptions;
     deleteOptions.AccessConditions = options.AccessConditions;
     deleteOptions.Recursive = recursive;
     return DataLakePathClient::DeleteIfExists(deleteOptions, context);

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_client.cpp
@@ -123,10 +123,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   {
   }
 
-  Azure::Response<Models::AppendDataLakeFileResult> DataLakeFileClient::Append(
+  Azure::Response<Models::AppendFileResult> DataLakeFileClient::Append(
       Azure::Core::IO::BodyStream* content,
       int64_t offset,
-      const AppendDataLakeFileOptions& options,
+      const AppendFileOptions& options,
       const Azure::Core::Context& context) const
   {
     _detail::DataLakeRestClient::Path::AppendDataOptions protocolLayerOptions;
@@ -148,9 +148,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         m_pathUrl, *content, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::FlushDataLakeFileResult> DataLakeFileClient::Flush(
+  Azure::Response<Models::FlushFileResult> DataLakeFileClient::Flush(
       int64_t position,
-      const FlushDataLakeFileOptions& options,
+      const FlushFileOptions& options,
       const Azure::Core::Context& context) const
   {
     _detail::DataLakeRestClient::Path::FlushDataOptions protocolLayerOptions;
@@ -178,36 +178,36 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         m_pathUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::DeleteDataLakeFileResult> DataLakeFileClient::Delete(
-      const DeleteDataLakeFileOptions& options,
+  Azure::Response<Models::DeleteFileResult> DataLakeFileClient::Delete(
+      const DeleteFileOptions& options,
       const Azure::Core::Context& context) const
   {
-    DeleteDataLakePathOptions deleteOptions;
+    DeletePathOptions deleteOptions;
     deleteOptions.AccessConditions = options.AccessConditions;
     auto result = DataLakePathClient::Delete(deleteOptions, context);
-    Models::DeleteDataLakeFileResult ret;
+    Models::DeleteFileResult ret;
     ret.Deleted = true;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DeleteDataLakeFileResult>(
+    return Azure::Response<Models::DeleteFileResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::DeleteDataLakeFileResult> DataLakeFileClient::DeleteIfExists(
-      const DeleteDataLakeFileOptions& options,
+  Azure::Response<Models::DeleteFileResult> DataLakeFileClient::DeleteIfExists(
+      const DeleteFileOptions& options,
       const Azure::Core::Context& context) const
   {
-    DeleteDataLakePathOptions deleteOptions;
+    DeletePathOptions deleteOptions;
     deleteOptions.AccessConditions = options.AccessConditions;
     auto result = DataLakePathClient::DeleteIfExists(deleteOptions, context);
-    Models::DeleteDataLakeFileResult ret;
+    Models::DeleteFileResult ret;
     ret.Deleted = result->Deleted;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DeleteDataLakeFileResult>(
+    return Azure::Response<Models::DeleteFileResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::DownloadDataLakeFileResult> DataLakeFileClient::Download(
-      const DownloadDataLakeFileOptions& options,
+  Azure::Response<Models::DownloadFileResult> DataLakeFileClient::Download(
+      const DownloadFileOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::DownloadBlobOptions blobOptions;
@@ -220,7 +220,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     blobOptions.AccessConditions.IfUnmodifiedSince = options.AccessConditions.IfUnmodifiedSince;
     blobOptions.AccessConditions.LeaseId = options.AccessConditions.LeaseId;
     auto result = m_blobClient.Download(blobOptions, context);
-    Models::DownloadDataLakeFileResult ret;
+    Models::DownloadFileResult ret;
     ret.Body = std::move(result->BodyStream);
     ret.Details.HttpHeaders = FromBlobHttpHeaders(std::move(result->Details.HttpHeaders));
     ret.ContentRange = std::move(result->ContentRange);
@@ -255,13 +255,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     ret.Details.EncryptionScope = std::move(result->Details.EncryptionScope);
     ret.Details.IsServerEncrypted = result->Details.IsServerEncrypted;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DownloadDataLakeFileResult>(
+    return Azure::Response<Models::DownloadFileResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::UploadDataLakeFileFromResult> DataLakeFileClient::UploadFrom(
+  Azure::Response<Models::UploadFileFromResult> DataLakeFileClient::UploadFrom(
       const std::string& fileName,
-      const UploadDataLakeFileFromOptions& options,
+      const UploadFileFromOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::UploadBlockBlobFromOptions blobOptions;
@@ -274,10 +274,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     return m_blobClient.AsBlockBlobClient().UploadFrom(fileName, blobOptions, context);
   }
 
-  Azure::Response<Models::UploadDataLakeFileFromResult> DataLakeFileClient::UploadFrom(
+  Azure::Response<Models::UploadFileFromResult> DataLakeFileClient::UploadFrom(
       const uint8_t* buffer,
       std::size_t bufferSize,
-      const UploadDataLakeFileFromOptions& options,
+      const UploadFileFromOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::UploadBlockBlobFromOptions blobOptions;
@@ -290,14 +290,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     return m_blobClient.AsBlockBlobClient().UploadFrom(buffer, bufferSize, blobOptions, context);
   }
 
-  Azure::Response<Models::DownloadDataLakeFileToResult> DataLakeFileClient::DownloadTo(
+  Azure::Response<Models::DownloadFileToResult> DataLakeFileClient::DownloadTo(
       uint8_t* buffer,
       std::size_t bufferSize,
-      const DownloadDataLakeFileToOptions& options,
+      const DownloadFileToOptions& options,
       const Azure::Core::Context& context) const
   {
     auto result = m_blobClient.AsBlockBlobClient().DownloadTo(buffer, bufferSize, options, context);
-    Models::DownloadDataLakeFileToResult ret;
+    Models::DownloadFileToResult ret;
     ret.ContentRange = std::move(result->ContentRange);
     ret.FileSize = result->BlobSize;
     ret.Details.HttpHeaders = FromBlobHttpHeaders(std::move(result->Details.HttpHeaders));
@@ -329,17 +329,17 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     ret.Details.EncryptionKeySha256 = std::move(result->Details.EncryptionKeySha256);
     ret.Details.EncryptionScope = std::move(result->Details.EncryptionScope);
     ret.Details.IsServerEncrypted = result->Details.IsServerEncrypted;
-    return Azure::Response<Models::DownloadDataLakeFileToResult>(
+    return Azure::Response<Models::DownloadFileToResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::DownloadDataLakeFileToResult> DataLakeFileClient::DownloadTo(
+  Azure::Response<Models::DownloadFileToResult> DataLakeFileClient::DownloadTo(
       const std::string& fileName,
-      const DownloadDataLakeFileToOptions& options,
+      const DownloadFileToOptions& options,
       const Azure::Core::Context& context) const
   {
     auto result = m_blobClient.AsBlockBlobClient().DownloadTo(fileName, options, context);
-    Models::DownloadDataLakeFileToResult ret;
+    Models::DownloadFileToResult ret;
     ret.ContentRange = std::move(result->ContentRange);
     ret.FileSize = result->BlobSize;
     ret.Details.HttpHeaders = FromBlobHttpHeaders(std::move(result->Details.HttpHeaders));
@@ -371,13 +371,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     ret.Details.EncryptionKeySha256 = std::move(result->Details.EncryptionKeySha256);
     ret.Details.EncryptionScope = std::move(result->Details.EncryptionScope);
     ret.Details.IsServerEncrypted = result->Details.IsServerEncrypted;
-    return Azure::Response<Models::DownloadDataLakeFileToResult>(
+    return Azure::Response<Models::DownloadFileToResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::ScheduleDataLakeFileDeletionResult> DataLakeFileClient::ScheduleDeletion(
-      ScheduleDataLakeFileExpiryOriginType expiryOrigin,
-      const ScheduleDataLakeFileDeletionOptions& options,
+  Azure::Response<Models::ScheduleFileDeletionResult> DataLakeFileClient::ScheduleDeletion(
+      ScheduleFileExpiryOriginType expiryOrigin,
+      const ScheduleFileDeletionOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::_detail::BlobRestClient::Blob::SetBlobExpiryOptions protocolLayerOptions;

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_client.cpp
@@ -188,8 +188,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Models::DeleteFileResult ret;
     ret.Deleted = true;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DeleteFileResult>(
-        std::move(ret), result.ExtractRawResponse());
+    return Azure::Response<Models::DeleteFileResult>(std::move(ret), result.ExtractRawResponse());
   }
 
   Azure::Response<Models::DeleteFileResult> DataLakeFileClient::DeleteIfExists(
@@ -202,8 +201,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Models::DeleteFileResult ret;
     ret.Deleted = result->Deleted;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DeleteFileResult>(
-        std::move(ret), result.ExtractRawResponse());
+    return Azure::Response<Models::DeleteFileResult>(std::move(ret), result.ExtractRawResponse());
   }
 
   Azure::Response<Models::DownloadFileResult> DataLakeFileClient::Download(
@@ -255,8 +253,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     ret.Details.EncryptionScope = std::move(result->Details.EncryptionScope);
     ret.Details.IsServerEncrypted = result->Details.IsServerEncrypted;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DownloadFileResult>(
-        std::move(ret), result.ExtractRawResponse());
+    return Azure::Response<Models::DownloadFileResult>(std::move(ret), result.ExtractRawResponse());
   }
 
   Azure::Response<Models::UploadFileFromResult> DataLakeFileClient::UploadFrom(

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
@@ -173,8 +173,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::CreateFileSystemResult>
-  DataLakeFileSystemClient::CreateIfNotExists(
+  Azure::Response<Models::CreateFileSystemResult> DataLakeFileSystemClient::CreateIfNotExists(
       const CreateFileSystemOptions& options,
       const Azure::Core::Context& context) const
   {
@@ -225,8 +224,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       {
         Models::DeleteFileSystemResult ret;
         ret.Deleted = false;
-        return Azure::Response<Models::DeleteFileSystemResult>(
-            ret, std::move(e.RawResponse));
+        return Azure::Response<Models::DeleteFileSystemResult>(ret, std::move(e.RawResponse));
       }
       throw;
     }
@@ -247,8 +245,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::SetFileSystemMetadataResult>
-  DataLakeFileSystemClient::SetMetadata(
+  Azure::Response<Models::SetFileSystemMetadataResult> DataLakeFileSystemClient::SetMetadata(
       Storage::Metadata metadata,
       const SetFileSystemMetadataOptions& options,
       const Azure::Core::Context& context) const

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
@@ -141,8 +141,8 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         builder, m_blobContainerClient.GetBlobClient(directoryName), m_pipeline);
   }
 
-  Azure::Response<Models::CreateDataLakeFileSystemResult> DataLakeFileSystemClient::Create(
-      const CreateDataLakeFileSystemOptions& options,
+  Azure::Response<Models::CreateFileSystemResult> DataLakeFileSystemClient::Create(
+      const CreateFileSystemOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::CreateBlobContainerOptions blobOptions;
@@ -164,18 +164,18 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       blobOptions.AccessType = Blobs::Models::PublicAccessType(options.AccessType.ToString());
     }
     auto result = m_blobContainerClient.Create(blobOptions, context);
-    Models::CreateDataLakeFileSystemResult ret;
+    Models::CreateFileSystemResult ret;
     ret.ETag = std::move(result->ETag);
     ret.LastModified = std::move(result->LastModified);
     ret.Created = true;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::CreateDataLakeFileSystemResult>(
+    return Azure::Response<Models::CreateFileSystemResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::CreateDataLakeFileSystemResult>
+  Azure::Response<Models::CreateFileSystemResult>
   DataLakeFileSystemClient::CreateIfNotExists(
-      const CreateDataLakeFileSystemOptions& options,
+      const CreateFileSystemOptions& options,
       const Azure::Core::Context& context) const
   {
     try
@@ -186,17 +186,17 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     {
       if (e.ErrorCode == _detail::ContainerAlreadyExists)
       {
-        Models::CreateDataLakeFileSystemResult ret;
+        Models::CreateFileSystemResult ret;
         ret.Created = false;
-        return Azure::Response<Models::CreateDataLakeFileSystemResult>(
+        return Azure::Response<Models::CreateFileSystemResult>(
             std::move(ret), std::move(e.RawResponse));
       }
       throw;
     }
   }
 
-  Azure::Response<Models::DeleteDataLakeFileSystemResult> DataLakeFileSystemClient::Delete(
-      const DeleteDataLakeFileSystemOptions& options,
+  Azure::Response<Models::DeleteFileSystemResult> DataLakeFileSystemClient::Delete(
+      const DeleteFileSystemOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::DeleteBlobContainerOptions blobOptions;
@@ -204,15 +204,15 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     blobOptions.AccessConditions.IfUnmodifiedSince = options.AccessConditions.IfUnmodifiedSince;
     blobOptions.AccessConditions.LeaseId = options.AccessConditions.LeaseId;
     auto result = m_blobContainerClient.Delete(blobOptions, context);
-    Models::DeleteDataLakeFileSystemResult ret;
+    Models::DeleteFileSystemResult ret;
     ret.Deleted = true;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DeleteDataLakeFileSystemResult>(
+    return Azure::Response<Models::DeleteFileSystemResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::DeleteDataLakeFileSystemResult> DataLakeFileSystemClient::DeleteIfExists(
-      const DeleteDataLakeFileSystemOptions& options,
+  Azure::Response<Models::DeleteFileSystemResult> DataLakeFileSystemClient::DeleteIfExists(
+      const DeleteFileSystemOptions& options,
       const Azure::Core::Context& context) const
   {
     try
@@ -223,9 +223,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     {
       if (e.ErrorCode == _detail::ContainerNotFound)
       {
-        Models::DeleteDataLakeFileSystemResult ret;
+        Models::DeleteFileSystemResult ret;
         ret.Deleted = false;
-        return Azure::Response<Models::DeleteDataLakeFileSystemResult>(
+        return Azure::Response<Models::DeleteFileSystemResult>(
             ret, std::move(e.RawResponse));
       }
       throw;
@@ -233,7 +233,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   }
 
   Azure::Response<Models::DataLakeFileSystemProperties> DataLakeFileSystemClient::GetProperties(
-      const GetDataLakeFileSystemPropertiesOptions& options,
+      const GetFileSystemPropertiesOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::GetBlobContainerPropertiesOptions blobOptions;
@@ -247,10 +247,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::SetDataLakeFileSystemMetadataResult>
+  Azure::Response<Models::SetFileSystemMetadataResult>
   DataLakeFileSystemClient::SetMetadata(
       Storage::Metadata metadata,
-      const SetDataLakeFileSystemMetadataOptions& options,
+      const SetFileSystemMetadataOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::SetBlobContainerMetadataOptions blobOptions;
@@ -260,11 +260,11 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       std::abort();
     }
     auto result = m_blobContainerClient.SetMetadata(std::move(metadata), blobOptions, context);
-    Models::SetDataLakeFileSystemMetadataResult ret;
+    Models::SetFileSystemMetadataResult ret;
     ret.ETag = std::move(result->ETag);
     ret.LastModified = std::move(result->LastModified);
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::SetDataLakeFileSystemMetadataResult>(
+    return Azure::Response<Models::SetFileSystemMetadataResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
@@ -283,15 +283,15 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         m_fileSystemUrl, *m_pipeline, _internal::WithReplicaStatus(context), protocolLayerOptions);
   }
 
-  Azure::Response<Models::GetDataLakeFileSystemAccessPolicyResult>
+  Azure::Response<Models::GetFileSystemAccessPolicyResult>
   DataLakeFileSystemClient::GetAccessPolicy(
-      const GetDataLakeFileSystemAccessPolicyOptions& options,
+      const GetFileSystemAccessPolicyOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::GetBlobContainerAccessPolicyOptions blobOptions;
     blobOptions.AccessConditions.LeaseId = options.AccessConditions.LeaseId;
     auto response = m_blobContainerClient.GetAccessPolicy(blobOptions, context);
-    Models::GetDataLakeFileSystemAccessPolicyResult ret;
+    Models::GetFileSystemAccessPolicyResult ret;
     ret.RequestId = std::move(response->RequestId);
     ret.ETag = std::move(response->ETag);
     ret.LastModified = std::move(response->LastModified);
@@ -312,13 +312,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       ret.AccessType = Models::PublicAccessType(response->AccessType.ToString());
     }
     ret.SignedIdentifiers = std::move(response->SignedIdentifiers);
-    return Azure::Response<Models::GetDataLakeFileSystemAccessPolicyResult>(
+    return Azure::Response<Models::GetFileSystemAccessPolicyResult>(
         std::move(ret), response.ExtractRawResponse());
   }
 
-  Azure::Response<Models::SetDataLakeFileSystemAccessPolicyResult>
+  Azure::Response<Models::SetFileSystemAccessPolicyResult>
   DataLakeFileSystemClient::SetAccessPolicy(
-      const SetDataLakeFileSystemAccessPolicyOptions& options,
+      const SetFileSystemAccessPolicyOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::SetBlobContainerAccessPolicyOptions blobOptions;
@@ -343,19 +343,19 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       blobOptions.AccessType = Blobs::Models::PublicAccessType(options.AccessType.ToString());
     }
     auto result = m_blobContainerClient.SetAccessPolicy(blobOptions, context);
-    Models::SetDataLakeFileSystemAccessPolicyResult ret;
+    Models::SetFileSystemAccessPolicyResult ret;
 
     ret.ETag = std::move(result->ETag);
     ret.LastModified = std::move(result->LastModified);
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::SetDataLakeFileSystemAccessPolicyResult>(
+    return Azure::Response<Models::SetFileSystemAccessPolicyResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
   Azure::Response<DataLakeFileClient> DataLakeFileSystemClient::RenameFile(
       const std::string& fileName,
       const std::string& destinationFilePath,
-      const RenameDataLakeFileOptions& options,
+      const RenameFileOptions& options,
       const Azure::Core::Context& context) const
   {
     return this->GetDirectoryClient("").RenameFile(fileName, destinationFilePath, options, context);
@@ -364,7 +364,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   Azure::Response<DataLakeDirectoryClient> DataLakeFileSystemClient::RenameDirectory(
       const std::string& directoryName,
       const std::string& destinationDirectoryPath,
-      const RenameDataLakeDirectoryOptions& options,
+      const RenameDirectoryOptions& options,
       const Azure::Core::Context& context) const
   {
     return this->GetDirectoryClient("").RenameSubdirectory(

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_path_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_path_client.cpp
@@ -160,8 +160,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         std::move(perOperationPolicies));
   }
 
-  Azure::Response<Models::SetPathAccessControlListResult>
-  DataLakePathClient::SetAccessControlList(
+  Azure::Response<Models::SetPathAccessControlListResult> DataLakePathClient::SetAccessControlList(
       std::vector<Models::Acl> acls,
       const SetPathAccessControlListOptions& options,
       const Azure::Core::Context& context) const
@@ -250,8 +249,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     ret.LastModified = std::move(result->LastModified.GetValue());
     ret.FileSize = std::move(result->ContentLength);
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::CreatePathResult>(
-        std::move(ret), result.ExtractRawResponse());
+    return Azure::Response<Models::CreatePathResult>(std::move(ret), result.ExtractRawResponse());
   }
 
   Azure::Response<Models::CreatePathResult> DataLakePathClient::CreateIfNotExists(
@@ -271,8 +269,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       {
         Models::CreatePathResult ret;
         ret.Created = false;
-        return Azure::Response<Models::CreatePathResult>(
-            std::move(ret), std::move(e.RawResponse));
+        return Azure::Response<Models::CreatePathResult>(std::move(ret), std::move(e.RawResponse));
       }
       throw;
     }
@@ -294,8 +291,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Models::DeletePathResult ret;
     ret.Deleted = true;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DeletePathResult>(
-        std::move(ret), result.ExtractRawResponse());
+    return Azure::Response<Models::DeletePathResult>(std::move(ret), result.ExtractRawResponse());
   }
 
   Azure::Response<Models::DeletePathResult> DataLakePathClient::DeleteIfExists(
@@ -313,8 +309,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       {
         Models::DeletePathResult ret;
         ret.Deleted = false;
-        return Azure::Response<Models::DeletePathResult>(
-            std::move(ret), std::move(e.RawResponse));
+        return Azure::Response<Models::DeletePathResult>(std::move(ret), std::move(e.RawResponse));
       }
       throw;
     }
@@ -375,8 +370,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::GetPathAccessControlListResult>
-  DataLakePathClient::GetAccessControlList(
+  Azure::Response<Models::GetPathAccessControlListResult> DataLakePathClient::GetAccessControlList(
       const GetPathAccessControlListOptions& options,
       const Azure::Core::Context& context) const
   {

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_path_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_path_client.cpp
@@ -160,10 +160,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         std::move(perOperationPolicies));
   }
 
-  Azure::Response<Models::SetDataLakePathAccessControlListResult>
+  Azure::Response<Models::SetPathAccessControlListResult>
   DataLakePathClient::SetAccessControlList(
       std::vector<Models::Acl> acls,
-      const SetDataLakePathAccessControlListOptions& options,
+      const SetPathAccessControlListOptions& options,
       const Azure::Core::Context& context) const
   {
     _detail::DataLakeRestClient::Path::SetAccessControlOptions protocolLayerOptions;
@@ -179,9 +179,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         m_pathUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::SetDataLakePathPermissionsResult> DataLakePathClient::SetPermissions(
+  Azure::Response<Models::SetPathPermissionsResult> DataLakePathClient::SetPermissions(
       std::string permissions,
-      const SetDataLakePathPermissionsOptions& options,
+      const SetPathPermissionsOptions& options,
       const Azure::Core::Context& context) const
   {
     _detail::DataLakeRestClient::Path::SetAccessControlOptions protocolLayerOptions;
@@ -197,9 +197,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         m_pathUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::SetDataLakePathHttpHeadersResult> DataLakePathClient::SetHttpHeaders(
+  Azure::Response<Models::SetPathHttpHeadersResult> DataLakePathClient::SetHttpHeaders(
       Models::PathHttpHeaders httpHeaders,
-      const SetDataLakePathHttpHeadersOptions& options,
+      const SetPathHttpHeadersOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::SetBlobHttpHeadersOptions blobOptions;
@@ -215,17 +215,17 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     blobOptions.AccessConditions.IfUnmodifiedSince = options.AccessConditions.IfUnmodifiedSince;
     blobOptions.AccessConditions.LeaseId = options.AccessConditions.LeaseId;
     auto result = m_blobClient.SetHttpHeaders(blobHttpHeaders, blobOptions, context);
-    Models::SetDataLakePathHttpHeadersResult ret;
+    Models::SetPathHttpHeadersResult ret;
     ret.ETag = std::move(result->ETag);
     ret.LastModified = std::move(result->LastModified);
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::SetDataLakePathHttpHeadersResult>(
+    return Azure::Response<Models::SetPathHttpHeadersResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::CreateDataLakePathResult> DataLakePathClient::Create(
+  Azure::Response<Models::CreatePathResult> DataLakePathClient::Create(
       Models::PathResourceType type,
-      const CreateDataLakePathOptions& options,
+      const CreatePathOptions& options,
       const Azure::Core::Context& context) const
   {
     _detail::DataLakeRestClient::Path::CreateOptions protocolLayerOptions;
@@ -245,18 +245,18 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     protocolLayerOptions.Permissions = options.Permissions;
     auto result = _detail::DataLakeRestClient::Path::Create(
         m_pathUrl, *m_pipeline, context, protocolLayerOptions);
-    Models::CreateDataLakePathResult ret;
+    Models::CreatePathResult ret;
     ret.ETag = std::move(result->ETag);
     ret.LastModified = std::move(result->LastModified.GetValue());
     ret.FileSize = std::move(result->ContentLength);
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::CreateDataLakePathResult>(
+    return Azure::Response<Models::CreatePathResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::CreateDataLakePathResult> DataLakePathClient::CreateIfNotExists(
+  Azure::Response<Models::CreatePathResult> DataLakePathClient::CreateIfNotExists(
       Models::PathResourceType type,
-      const CreateDataLakePathOptions& options,
+      const CreatePathOptions& options,
       const Azure::Core::Context& context) const
   {
     try
@@ -269,17 +269,17 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     {
       if (e.ErrorCode == _detail::DataLakePathAlreadyExists)
       {
-        Models::CreateDataLakePathResult ret;
+        Models::CreatePathResult ret;
         ret.Created = false;
-        return Azure::Response<Models::CreateDataLakePathResult>(
+        return Azure::Response<Models::CreatePathResult>(
             std::move(ret), std::move(e.RawResponse));
       }
       throw;
     }
   }
 
-  Azure::Response<Models::DeleteDataLakePathResult> DataLakePathClient::Delete(
-      const DeleteDataLakePathOptions& options,
+  Azure::Response<Models::DeletePathResult> DataLakePathClient::Delete(
+      const DeletePathOptions& options,
       const Azure::Core::Context& context) const
   {
     _detail::DataLakeRestClient::Path::DeleteOptions protocolLayerOptions;
@@ -291,15 +291,15 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     protocolLayerOptions.RecursiveOptional = options.Recursive;
     auto result = _detail::DataLakeRestClient::Path::Delete(
         m_pathUrl, *m_pipeline, context, protocolLayerOptions);
-    Models::DeleteDataLakePathResult ret;
+    Models::DeletePathResult ret;
     ret.Deleted = true;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DeleteDataLakePathResult>(
+    return Azure::Response<Models::DeletePathResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::DeleteDataLakePathResult> DataLakePathClient::DeleteIfExists(
-      const DeleteDataLakePathOptions& options,
+  Azure::Response<Models::DeletePathResult> DataLakePathClient::DeleteIfExists(
+      const DeletePathOptions& options,
       const Azure::Core::Context& context) const
   {
     try
@@ -311,9 +311,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       if (e.ErrorCode == _detail::DataLakeFilesystemNotFound
           || e.ErrorCode == _detail::DataLakePathNotFound)
       {
-        Models::DeleteDataLakePathResult ret;
+        Models::DeletePathResult ret;
         ret.Deleted = false;
-        return Azure::Response<Models::DeleteDataLakePathResult>(
+        return Azure::Response<Models::DeletePathResult>(
             std::move(ret), std::move(e.RawResponse));
       }
       throw;
@@ -321,7 +321,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
   }
 
   Azure::Response<Models::DataLakePathProperties> DataLakePathClient::GetProperties(
-      const GetDataLakePathPropertiesOptions& options,
+      const GetPathPropertiesOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::GetBlobPropertiesOptions blobOptions;
@@ -375,9 +375,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::GetDataLakePathAccessControlListResult>
+  Azure::Response<Models::GetPathAccessControlListResult>
   DataLakePathClient::GetAccessControlList(
-      const GetDataLakePathAccessControlListOptions& options,
+      const GetPathAccessControlListOptions& options,
       const Azure::Core::Context& context) const
   {
     _detail::DataLakeRestClient::Path::GetPropertiesOptions protocolLayerOptions;
@@ -394,7 +394,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     {
       acl = Models::Acl::DeserializeAcls(result->Acl.GetValue());
     }
-    Models::GetDataLakePathAccessControlListResult ret;
+    Models::GetPathAccessControlListResult ret;
     ret.ETag = std::move(result->ETag);
     ret.LastModified = std::move(result->LastModified);
     if (!acl.HasValue())
@@ -416,13 +416,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       ret.Permissions = result->Permissions.GetValue();
     }
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::GetDataLakePathAccessControlListResult>(
+    return Azure::Response<Models::GetPathAccessControlListResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::SetDataLakePathMetadataResult> DataLakePathClient::SetMetadata(
+  Azure::Response<Models::SetPathMetadataResult> DataLakePathClient::SetMetadata(
       Storage::Metadata metadata,
-      const SetDataLakePathMetadataOptions& options,
+      const SetPathMetadataOptions& options,
       const Azure::Core::Context& context) const
   {
     Blobs::SetBlobMetadataOptions blobOptions;
@@ -432,19 +432,19 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     blobOptions.AccessConditions.IfUnmodifiedSince = options.AccessConditions.IfUnmodifiedSince;
     blobOptions.AccessConditions.LeaseId = options.AccessConditions.LeaseId;
     auto result = m_blobClient.SetMetadata(std::move(metadata), blobOptions, context);
-    Models::SetDataLakePathMetadataResult ret;
+    Models::SetPathMetadataResult ret;
     ret.ETag = std::move(result->ETag);
     ret.LastModified = std::move(result->LastModified);
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::SetDataLakePathMetadataResult>(
+    return Azure::Response<Models::SetPathMetadataResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::SetDataLakePathAccessControlListRecursiveSinglePageResult>
+  Azure::Response<Models::SetPathAccessControlListRecursiveSinglePageResult>
   DataLakePathClient::SetAccessControlListRecursiveSinglePageInternal(
       Models::PathSetAccessControlRecursiveMode mode,
       const std::vector<Models::Acl>& acls,
-      const SetDataLakePathAccessControlListRecursiveSinglePageOptions& options,
+      const SetPathAccessControlListRecursiveSinglePageOptions& options,
       const Azure::Core::Context& context) const
   {
     _detail::DataLakeRestClient::Path::SetAccessControlRecursiveOptions protocolLayerOptions;

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_directory_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_directory_client_test.cpp
@@ -59,11 +59,11 @@ namespace Azure { namespace Storage { namespace Test {
       for (const auto& client : directoryClient)
       {
         auto response = client.GetProperties();
-        Files::DataLake::DeleteDataLakeDirectoryOptions options1;
+        Files::DataLake::DeleteDirectoryOptions options1;
         options1.AccessConditions.IfModifiedSince = response->LastModified;
         EXPECT_TRUE(IsValidTime(response->LastModified));
         EXPECT_THROW(client.DeleteEmpty(options1), StorageException);
-        Files::DataLake::DeleteDataLakeDirectoryOptions options2;
+        Files::DataLake::DeleteDirectoryOptions options2;
         options2.AccessConditions.IfUnmodifiedSince = response->LastModified;
         EXPECT_NO_THROW(client.DeleteEmpty(options2));
       }
@@ -81,10 +81,10 @@ namespace Azure { namespace Storage { namespace Test {
       {
         auto response = client.GetProperties();
         EXPECT_TRUE(response->IsDirectory);
-        Files::DataLake::DeleteDataLakeDirectoryOptions options1;
+        Files::DataLake::DeleteDirectoryOptions options1;
         options1.AccessConditions.IfNoneMatch = response->ETag;
         EXPECT_THROW(client.DeleteEmpty(options1), StorageException);
-        Files::DataLake::DeleteDataLakeDirectoryOptions options2;
+        Files::DataLake::DeleteDirectoryOptions options2;
         options2.AccessConditions.IfMatch = response->ETag;
         EXPECT_NO_THROW(client.DeleteEmpty(options2));
       }
@@ -170,11 +170,11 @@ namespace Azure { namespace Storage { namespace Test {
       for (auto& client : directoryClient)
       {
         auto response = client.GetProperties();
-        Files::DataLake::RenameDataLakeDirectoryOptions options1;
+        Files::DataLake::RenameDirectoryOptions options1;
         options1.SourceAccessConditions.IfModifiedSince = response->LastModified;
         EXPECT_TRUE(IsValidTime(response->LastModified));
         EXPECT_THROW(client.RenameSubdirectory("", RandomString(), options1), StorageException);
-        Files::DataLake::RenameDataLakeDirectoryOptions options2;
+        Files::DataLake::RenameDirectoryOptions options2;
         options2.SourceAccessConditions.IfUnmodifiedSince = response->LastModified;
         auto newPath = RandomString();
         EXPECT_NO_THROW(
@@ -193,10 +193,10 @@ namespace Azure { namespace Storage { namespace Test {
       for (auto& client : directoryClient)
       {
         auto response = client.GetProperties();
-        Files::DataLake::RenameDataLakeDirectoryOptions options1;
+        Files::DataLake::RenameDirectoryOptions options1;
         options1.SourceAccessConditions.IfNoneMatch = response->ETag;
         EXPECT_THROW(client.RenameSubdirectory("", RandomString(), options1), StorageException);
-        Files::DataLake::RenameDataLakeDirectoryOptions options2;
+        Files::DataLake::RenameDirectoryOptions options2;
         options2.SourceAccessConditions.IfMatch = response->ETag;
         auto newPath = RandomString();
         EXPECT_NO_THROW(
@@ -214,7 +214,7 @@ namespace Azure { namespace Storage { namespace Test {
       }
       {
         // Rename to a non-existing file system will fail and source is not changed.
-        Files::DataLake::RenameDataLakeDirectoryOptions options;
+        Files::DataLake::RenameDirectoryOptions options;
         options.DestinationFileSystem = LowercaseRandomString();
         for (auto& client : directoryClient)
         {
@@ -229,7 +229,7 @@ namespace Azure { namespace Storage { namespace Test {
             Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
                 AdlsGen2ConnectionString(), newfileSystemName));
         newfileSystemClient->Create();
-        Files::DataLake::RenameDataLakeDirectoryOptions options;
+        Files::DataLake::RenameDirectoryOptions options;
         options.DestinationFileSystem = newfileSystemName;
         for (auto& client : directoryClient)
         {
@@ -259,8 +259,8 @@ namespace Azure { namespace Storage { namespace Test {
       // Create path with metadata works
       auto client1 = m_fileSystemClient->GetDirectoryClient(RandomString());
       auto client2 = m_fileSystemClient->GetDirectoryClient(RandomString());
-      Files::DataLake::CreateDataLakePathOptions options1;
-      Files::DataLake::CreateDataLakePathOptions options2;
+      Files::DataLake::CreatePathOptions options1;
+      Files::DataLake::CreatePathOptions options2;
       options1.Metadata = metadata1;
       options2.Metadata = metadata2;
 
@@ -311,7 +311,7 @@ namespace Azure { namespace Storage { namespace Test {
       for (int32_t i = 0; i < 2; ++i)
       {
         auto client = m_fileSystemClient->GetDirectoryClient(RandomString());
-        Files::DataLake::CreateDataLakePathOptions options;
+        Files::DataLake::CreatePathOptions options;
         options.HttpHeaders = httpHeader;
         EXPECT_NO_THROW(client.Create(options));
         directoryClient.emplace_back(std::move(client));

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
@@ -419,8 +419,8 @@ namespace Azure { namespace Storage { namespace Test {
     {
       auto client = m_fileSystemClient->GetFileClient(RandomString());
       EXPECT_NO_THROW(client.Create());
-      EXPECT_NO_THROW(client.ScheduleDeletion(
-          Files::DataLake::ScheduleFileExpiryOriginType::NeverExpire));
+      EXPECT_NO_THROW(
+          client.ScheduleDeletion(Files::DataLake::ScheduleFileExpiryOriginType::NeverExpire));
     }
     {
       auto client = m_fileSystemClient->GetFileClient(RandomString());
@@ -439,13 +439,11 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(client.Create());
       Files::DataLake::ScheduleFileDeletionOptions options;
       EXPECT_THROW(
-          client.ScheduleDeletion(
-              Files::DataLake::ScheduleFileExpiryOriginType::Absolute, options),
+          client.ScheduleDeletion(Files::DataLake::ScheduleFileExpiryOriginType::Absolute, options),
           StorageException);
       options.TimeToExpire = std::chrono::milliseconds(1000);
       EXPECT_THROW(
-          client.ScheduleDeletion(
-              Files::DataLake::ScheduleFileExpiryOriginType::Absolute, options),
+          client.ScheduleDeletion(Files::DataLake::ScheduleFileExpiryOriginType::Absolute, options),
           StorageException);
       options.ExpiresOn = Azure::DateTime::Parse(
           "Wed, 29 Sep 2100 09:53:03 GMT", Azure::DateTime::DateFormat::Rfc1123);

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
@@ -75,11 +75,11 @@ namespace Azure { namespace Storage { namespace Test {
       {
         auto response = client.GetProperties();
         EXPECT_FALSE(response->IsDirectory);
-        Files::DataLake::DeleteDataLakeFileOptions options1;
+        Files::DataLake::DeleteFileOptions options1;
         options1.AccessConditions.IfModifiedSince = response->LastModified;
         EXPECT_TRUE(IsValidTime(response->LastModified));
         EXPECT_THROW(client.Delete(options1), StorageException);
-        Files::DataLake::DeleteDataLakeFileOptions options2;
+        Files::DataLake::DeleteFileOptions options2;
         options2.AccessConditions.IfUnmodifiedSince = response->LastModified;
         EXPECT_NO_THROW(client.Delete(options2));
       }
@@ -96,10 +96,10 @@ namespace Azure { namespace Storage { namespace Test {
       for (const auto& client : fileClient)
       {
         auto response = client.GetProperties();
-        Files::DataLake::DeleteDataLakeFileOptions options1;
+        Files::DataLake::DeleteFileOptions options1;
         options1.AccessConditions.IfNoneMatch = response->ETag;
         EXPECT_THROW(client.Delete(options1), StorageException);
-        Files::DataLake::DeleteDataLakeFileOptions options2;
+        Files::DataLake::DeleteFileOptions options2;
         options2.AccessConditions.IfMatch = response->ETag;
         EXPECT_NO_THROW(client.Delete(options2));
       }
@@ -149,11 +149,11 @@ namespace Azure { namespace Storage { namespace Test {
       auto fileClient = m_fileSystemClient->GetFileClient(fileName);
       EXPECT_NO_THROW(fileClient.Create());
       auto response = fileClient.GetProperties();
-      Files::DataLake::RenameDataLakeFileOptions options1;
+      Files::DataLake::RenameFileOptions options1;
       options1.SourceAccessConditions.IfModifiedSince = response->LastModified;
       EXPECT_THROW(
           m_fileSystemClient->RenameFile(fileName, RandomString(), options1), StorageException);
-      Files::DataLake::RenameDataLakeFileOptions options2;
+      Files::DataLake::RenameFileOptions options2;
       options2.SourceAccessConditions.IfUnmodifiedSince = response->LastModified;
       std::shared_ptr<Files::DataLake::DataLakeFileClient> ret;
       EXPECT_NO_THROW(
@@ -168,11 +168,11 @@ namespace Azure { namespace Storage { namespace Test {
       auto fileClient = m_fileSystemClient->GetFileClient(fileName);
       EXPECT_NO_THROW(fileClient.Create());
       auto response = fileClient.GetProperties();
-      Files::DataLake::RenameDataLakeFileOptions options1;
+      Files::DataLake::RenameFileOptions options1;
       options1.SourceAccessConditions.IfNoneMatch = response->ETag;
       EXPECT_THROW(
           m_fileSystemClient->RenameFile(fileName, RandomString(), options1), StorageException);
-      Files::DataLake::RenameDataLakeFileOptions options2;
+      Files::DataLake::RenameFileOptions options2;
       options2.SourceAccessConditions.IfMatch = response->ETag;
       std::shared_ptr<Files::DataLake::DataLakeFileClient> ret;
       EXPECT_NO_THROW(
@@ -189,7 +189,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(fileClient.Create());
       {
         // Rename to a non-existing file system will fail but will not change URI.
-        Files::DataLake::RenameDataLakeFileOptions options;
+        Files::DataLake::RenameFileOptions options;
         options.DestinationFileSystem = LowercaseRandomString();
         EXPECT_THROW(
             m_fileSystemClient->RenameFile(fileName, RandomString(), options), StorageException);
@@ -202,7 +202,7 @@ namespace Azure { namespace Storage { namespace Test {
             Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
                 AdlsGen2ConnectionString(), newfileSystemName));
         newfileSystemClient->Create();
-        Files::DataLake::RenameDataLakeFileOptions options;
+        Files::DataLake::RenameFileOptions options;
         options.DestinationFileSystem = newfileSystemName;
         std::shared_ptr<Files::DataLake::DataLakeFileClient> ret;
         EXPECT_NO_THROW(
@@ -232,8 +232,8 @@ namespace Azure { namespace Storage { namespace Test {
       // Create path with metadata works
       auto client1 = m_fileSystemClient->GetFileClient(RandomString());
       auto client2 = m_fileSystemClient->GetFileClient(RandomString());
-      Files::DataLake::CreateDataLakeFileOptions options1;
-      Files::DataLake::CreateDataLakeFileOptions options2;
+      Files::DataLake::CreateFileOptions options1;
+      Files::DataLake::CreateFileOptions options2;
       options1.Metadata = metadata1;
       options2.Metadata = metadata2;
 
@@ -282,7 +282,7 @@ namespace Azure { namespace Storage { namespace Test {
       for (int32_t i = 0; i < 2; ++i)
       {
         auto client = m_fileSystemClient->GetFileClient(RandomString());
-        Files::DataLake::CreateDataLakeFileOptions options;
+        Files::DataLake::CreateFileOptions options;
         options.HttpHeaders = httpHeader;
         EXPECT_NO_THROW(client.Create(options));
         fileClient.emplace_back(std::move(client));
@@ -362,7 +362,7 @@ namespace Azure { namespace Storage { namespace Test {
     // Read Range
     {
       auto firstHalf = std::vector<uint8_t>(buffer.begin(), buffer.begin() + (bufferSize / 2));
-      Files::DataLake::DownloadDataLakeFileOptions options;
+      Files::DataLake::DownloadFileOptions options;
       options.Range = Azure::Core::Http::HttpRange();
       options.Range.GetValue().Offset = 0;
       options.Range.GetValue().Length = bufferSize / 2;
@@ -376,7 +376,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
     {
       auto secondHalf = std::vector<uint8_t>(buffer.begin() + bufferSize / 2, buffer.end());
-      Files::DataLake::DownloadDataLakeFileOptions options;
+      Files::DataLake::DownloadFileOptions options;
       options.Range = Azure::Core::Http::HttpRange();
       options.Range.GetValue().Offset = bufferSize / 2;
       options.Range.GetValue().Length = bufferSize / 2;
@@ -390,11 +390,11 @@ namespace Azure { namespace Storage { namespace Test {
     {
       // Read with last modified access condition.
       auto response = newFileClient->GetProperties();
-      Files::DataLake::DownloadDataLakeFileOptions options1;
+      Files::DataLake::DownloadFileOptions options1;
       options1.AccessConditions.IfModifiedSince = response->LastModified;
       EXPECT_TRUE(IsValidTime(response->LastModified));
       EXPECT_THROW(newFileClient->Download(options1), StorageException);
-      Files::DataLake::DownloadDataLakeFileOptions options2;
+      Files::DataLake::DownloadFileOptions options2;
       options2.AccessConditions.IfUnmodifiedSince = response->LastModified;
       EXPECT_NO_THROW(result = newFileClient->Download(options2));
       downloaded = ReadBodyStream(result->Body);
@@ -403,10 +403,10 @@ namespace Azure { namespace Storage { namespace Test {
     {
       // Read with if match access condition.
       auto response = newFileClient->GetProperties();
-      Files::DataLake::DownloadDataLakeFileOptions options1;
+      Files::DataLake::DownloadFileOptions options1;
       options1.AccessConditions.IfNoneMatch = response->ETag;
       EXPECT_THROW(newFileClient->Download(options1), StorageException);
-      Files::DataLake::DownloadDataLakeFileOptions options2;
+      Files::DataLake::DownloadFileOptions options2;
       options2.AccessConditions.IfMatch = response->ETag;
       EXPECT_NO_THROW(result = newFileClient->Download(options2));
       downloaded = ReadBodyStream(result->Body);
@@ -420,38 +420,38 @@ namespace Azure { namespace Storage { namespace Test {
       auto client = m_fileSystemClient->GetFileClient(RandomString());
       EXPECT_NO_THROW(client.Create());
       EXPECT_NO_THROW(client.ScheduleDeletion(
-          Files::DataLake::ScheduleDataLakeFileExpiryOriginType::NeverExpire));
+          Files::DataLake::ScheduleFileExpiryOriginType::NeverExpire));
     }
     {
       auto client = m_fileSystemClient->GetFileClient(RandomString());
       EXPECT_NO_THROW(client.Create());
-      Files::DataLake::ScheduleDataLakeFileDeletionOptions options;
+      Files::DataLake::ScheduleFileDeletionOptions options;
       EXPECT_THROW(
           client.ScheduleDeletion(
-              Files::DataLake::ScheduleDataLakeFileExpiryOriginType::RelativeToNow, options),
+              Files::DataLake::ScheduleFileExpiryOriginType::RelativeToNow, options),
           StorageException);
       options.TimeToExpire = std::chrono::milliseconds(1000);
       EXPECT_NO_THROW(client.ScheduleDeletion(
-          Files::DataLake::ScheduleDataLakeFileExpiryOriginType::RelativeToNow, options));
+          Files::DataLake::ScheduleFileExpiryOriginType::RelativeToNow, options));
     }
     {
       auto client = m_fileSystemClient->GetFileClient(RandomString());
       EXPECT_NO_THROW(client.Create());
-      Files::DataLake::ScheduleDataLakeFileDeletionOptions options;
+      Files::DataLake::ScheduleFileDeletionOptions options;
       EXPECT_THROW(
           client.ScheduleDeletion(
-              Files::DataLake::ScheduleDataLakeFileExpiryOriginType::Absolute, options),
+              Files::DataLake::ScheduleFileExpiryOriginType::Absolute, options),
           StorageException);
       options.TimeToExpire = std::chrono::milliseconds(1000);
       EXPECT_THROW(
           client.ScheduleDeletion(
-              Files::DataLake::ScheduleDataLakeFileExpiryOriginType::Absolute, options),
+              Files::DataLake::ScheduleFileExpiryOriginType::Absolute, options),
           StorageException);
       options.ExpiresOn = Azure::DateTime::Parse(
           "Wed, 29 Sep 2100 09:53:03 GMT", Azure::DateTime::DateFormat::Rfc1123);
       options.TimeToExpire = Azure::Nullable<std::chrono::milliseconds>();
       EXPECT_NO_THROW(client.ScheduleDeletion(
-          Files::DataLake::ScheduleDataLakeFileExpiryOriginType::Absolute, options));
+          Files::DataLake::ScheduleFileExpiryOriginType::Absolute, options));
     }
   }
 
@@ -462,7 +462,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto testUploadFromBuffer = [&](int concurrency, int64_t fileSize) {
       auto fileClient = m_fileSystemClient->GetFileClient(RandomString());
 
-      Azure::Storage::Files::DataLake::UploadDataLakeFileFromOptions options;
+      Azure::Storage::Files::DataLake::UploadFileFromOptions options;
       options.TransferOptions.ChunkSize = 1_MB;
       options.TransferOptions.Concurrency = concurrency;
       options.HttpHeaders = GetInterestingHttpHeaders();
@@ -491,7 +491,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto testUploadFromFile = [&](int concurrency, int64_t fileSize) {
       auto fileClient = m_fileSystemClient->GetFileClient(RandomString());
 
-      Azure::Storage::Files::DataLake::UploadDataLakeFileFromOptions options;
+      Azure::Storage::Files::DataLake::UploadFileFromOptions options;
       options.TransferOptions.ChunkSize = 1_MB;
       options.TransferOptions.Concurrency = concurrency;
       options.HttpHeaders = GetInterestingHttpHeaders();

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_file_system_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_file_system_client_test.cpp
@@ -140,10 +140,10 @@ namespace Azure { namespace Storage { namespace Test {
       for (const auto& client : fileSystemClient)
       {
         auto response = client.GetProperties();
-        Files::DataLake::DeleteDataLakeFileSystemOptions options1;
+        Files::DataLake::DeleteFileSystemOptions options1;
         options1.AccessConditions.IfModifiedSince = response->LastModified;
         EXPECT_THROW(client.Delete(options1), StorageException);
-        Files::DataLake::DeleteDataLakeFileSystemOptions options2;
+        Files::DataLake::DeleteFileSystemOptions options2;
         options2.AccessConditions.IfUnmodifiedSince = response->LastModified;
         EXPECT_NO_THROW(client.Delete(options2));
       }
@@ -206,8 +206,8 @@ namespace Azure { namespace Storage { namespace Test {
           AdlsGen2ConnectionString(), LowercaseRandomString());
       auto client2 = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
           AdlsGen2ConnectionString(), LowercaseRandomString());
-      Files::DataLake::CreateDataLakeFileSystemOptions options1;
-      Files::DataLake::CreateDataLakeFileSystemOptions options2;
+      Files::DataLake::CreateFileSystemOptions options1;
+      Files::DataLake::CreateFileSystemOptions options2;
       options1.Metadata = metadata1;
       options2.Metadata = metadata2;
 
@@ -220,7 +220,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
-  TEST_F(DataLakeFileSystemClientTest, GetDataLakeFileSystemPropertiesResult)
+  TEST_F(DataLakeFileSystemClientTest, GetFileSystemPropertiesResult)
   {
     auto metadata1 = RandomMetadata();
     auto metadata2 = RandomMetadata();
@@ -371,7 +371,7 @@ namespace Azure { namespace Storage { namespace Test {
           AdlsGen2ConnectionString(), LowercaseRandomString());
       fileSystem.Create();
 
-      Files::DataLake::SetDataLakeFileSystemAccessPolicyOptions options;
+      Files::DataLake::SetFileSystemAccessPolicyOptions options;
       options.AccessType = Files::DataLake::Models::PublicAccessType::Path;
       Files::DataLake::Models::DataLakeSignedIdentifier identifier;
       identifier.Id = RandomString(64);
@@ -417,7 +417,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       auto fileSystem = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
           AdlsGen2ConnectionString(), LowercaseRandomString());
-      Files::DataLake::CreateDataLakeFileSystemOptions options;
+      Files::DataLake::CreateFileSystemOptions options;
       options.AccessType = Files::DataLake::Models::PublicAccessType::FileSystem;
       fileSystem.Create(options);
       auto ret = fileSystem.GetAccessPolicy();
@@ -426,7 +426,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       auto fileSystem = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
           AdlsGen2ConnectionString(), LowercaseRandomString());
-      Files::DataLake::CreateDataLakeFileSystemOptions options;
+      Files::DataLake::CreateFileSystemOptions options;
       options.AccessType = Files::DataLake::Models::PublicAccessType::Path;
       fileSystem.Create(options);
       auto ret = fileSystem.GetAccessPolicy();
@@ -435,7 +435,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       auto fileSystem = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
           AdlsGen2ConnectionString(), LowercaseRandomString());
-      Files::DataLake::CreateDataLakeFileSystemOptions options;
+      Files::DataLake::CreateFileSystemOptions options;
       options.AccessType = Files::DataLake::Models::PublicAccessType::Path;
       fileSystem.Create(options);
       auto ret = fileSystem.GetAccessPolicy();

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_path_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_path_client_test.cpp
@@ -76,8 +76,8 @@ namespace Azure { namespace Storage { namespace Test {
       // Create path with metadata works
       auto client1 = m_fileSystemClient->GetFileClient(LowercaseRandomString());
       auto client2 = m_fileSystemClient->GetFileClient(LowercaseRandomString());
-      Files::DataLake::CreateDataLakePathOptions options1;
-      Files::DataLake::CreateDataLakePathOptions options2;
+      Files::DataLake::CreatePathOptions options1;
+      Files::DataLake::CreatePathOptions options2;
       options1.Metadata = metadata1;
       options2.Metadata = metadata2;
 
@@ -90,7 +90,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
-  TEST_F(DataLakePathClientTest, GetDataLakePathPropertiesResult)
+  TEST_F(DataLakePathClientTest, GetPathPropertiesResult)
   {
     auto metadata1 = RandomMetadata();
     auto metadata2 = RandomMetadata();
@@ -129,7 +129,7 @@ namespace Azure { namespace Storage { namespace Test {
       for (int32_t i = 0; i < 2; ++i)
       {
         auto client = m_fileSystemClient->GetFileClient(LowercaseRandomString());
-        Files::DataLake::CreateDataLakePathOptions options;
+        Files::DataLake::CreatePathOptions options;
         options.HttpHeaders = httpHeader;
         EXPECT_NO_THROW(client.Create(options));
         pathClient.emplace_back(std::move(client));
@@ -168,11 +168,11 @@ namespace Azure { namespace Storage { namespace Test {
     {
       // Set http headers work with last modified access condition.
       auto response = m_pathClient->GetProperties();
-      Files::DataLake::SetDataLakePathHttpHeadersOptions options1;
+      Files::DataLake::SetPathHttpHeadersOptions options1;
       options1.AccessConditions.IfModifiedSince = response->LastModified;
       EXPECT_THROW(
           m_pathClient->SetHttpHeaders(GetInterestingHttpHeaders(), options1), StorageException);
-      Files::DataLake::SetDataLakePathHttpHeadersOptions options2;
+      Files::DataLake::SetPathHttpHeadersOptions options2;
       options2.AccessConditions.IfUnmodifiedSince = response->LastModified;
       EXPECT_NO_THROW(m_pathClient->SetHttpHeaders(GetInterestingHttpHeaders(), options2));
     }
@@ -180,11 +180,11 @@ namespace Azure { namespace Storage { namespace Test {
     {
       // Set http headers work with last modified access condition.
       auto response = m_pathClient->GetProperties();
-      Files::DataLake::SetDataLakePathHttpHeadersOptions options1;
+      Files::DataLake::SetPathHttpHeadersOptions options1;
       options1.AccessConditions.IfNoneMatch = response->ETag;
       EXPECT_THROW(
           m_pathClient->SetHttpHeaders(GetInterestingHttpHeaders(), options1), StorageException);
-      Files::DataLake::SetDataLakePathHttpHeadersOptions options2;
+      Files::DataLake::SetPathHttpHeadersOptions options2;
       options2.AccessConditions.IfMatch = response->ETag;
       EXPECT_NO_THROW(m_pathClient->SetHttpHeaders(GetInterestingHttpHeaders(), options2));
     }
@@ -218,10 +218,10 @@ namespace Azure { namespace Storage { namespace Test {
       std::vector<Files::DataLake::Models::Acl> acls = GetValidAcls();
 
       auto response = m_pathClient->GetProperties();
-      Files::DataLake::SetDataLakePathAccessControlListOptions options1;
+      Files::DataLake::SetPathAccessControlListOptions options1;
       options1.AccessConditions.IfModifiedSince = response->LastModified;
       EXPECT_THROW(m_pathClient->SetAccessControlList(acls, options1), StorageException);
-      Files::DataLake::SetDataLakePathAccessControlListOptions options2;
+      Files::DataLake::SetPathAccessControlListOptions options2;
       options2.AccessConditions.IfUnmodifiedSince = response->LastModified;
       EXPECT_NO_THROW(m_pathClient->SetAccessControlList(acls, options2));
     }
@@ -230,10 +230,10 @@ namespace Azure { namespace Storage { namespace Test {
       // Set/Get Acls works with if match access condition.
       std::vector<Files::DataLake::Models::Acl> acls = GetValidAcls();
       auto response = m_pathClient->GetProperties();
-      Files::DataLake::SetDataLakePathAccessControlListOptions options1;
+      Files::DataLake::SetPathAccessControlListOptions options1;
       options1.AccessConditions.IfNoneMatch = response->ETag;
       EXPECT_THROW(m_pathClient->SetAccessControlList(acls, options1), StorageException);
-      Files::DataLake::SetDataLakePathAccessControlListOptions options2;
+      Files::DataLake::SetPathAccessControlListOptions options2;
       options2.AccessConditions.IfMatch = response->ETag;
       EXPECT_NO_THROW(m_pathClient->SetAccessControlList(acls, options2));
     }
@@ -264,7 +264,7 @@ namespace Azure { namespace Storage { namespace Test {
       auto pathClient = Files::DataLake::DataLakePathClient::CreateFromConnectionString(
           AdlsGen2ConnectionString(), m_fileSystemName, RandomString());
       auto response = pathClient.Create(Files::DataLake::Models::PathResourceType::File);
-      Files::DataLake::SetDataLakePathPermissionsOptions options1, options2;
+      Files::DataLake::SetPathPermissionsOptions options1, options2;
       options1.AccessConditions.IfUnmodifiedSince = response->LastModified;
       options2.AccessConditions.IfModifiedSince = response->LastModified;
       std::string pathPermissions = "rwxrw-rw-";
@@ -276,7 +276,7 @@ namespace Azure { namespace Storage { namespace Test {
       auto pathClient = Files::DataLake::DataLakePathClient::CreateFromConnectionString(
           AdlsGen2ConnectionString(), m_fileSystemName, RandomString());
       auto response = pathClient.Create(Files::DataLake::Models::PathResourceType::File);
-      Files::DataLake::SetDataLakePathPermissionsOptions options1, options2;
+      Files::DataLake::SetPathPermissionsOptions options1, options2;
       options1.AccessConditions.IfMatch = response->ETag;
       options2.AccessConditions.IfNoneMatch = response->ETag;
       std::string pathPermissions = "rwxrw-rw-";
@@ -333,7 +333,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(brokenLease.LeaseTime, 0);
 
     aLease = *m_pathClient->AcquireLease(CreateUniqueLeaseId(), leaseDuration);
-    Files::DataLake::BreakDataLakePathLeaseOptions breakOptions;
+    Files::DataLake::BreakPathLeaseOptions breakOptions;
     breakOptions.BreakPeriod = 30;
     lastModified = m_pathClient->GetProperties()->LastModified;
     brokenLease = *m_pathClient->BreakLease(breakOptions);
@@ -341,7 +341,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(brokenLease.LastModified > lastModified);
     EXPECT_NE(brokenLease.LeaseTime, 0);
 
-    Files::DataLake::BreakDataLakePathLeaseOptions options;
+    Files::DataLake::BreakPathLeaseOptions options;
     options.BreakPeriod = 0;
     m_pathClient->BreakLease(options);
   }

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_directory_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_directory_client.hpp
@@ -211,8 +211,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      */
     Azure::Response<Models::ForceCloseDirectoryHandleResult> ForceCloseHandle(
         const std::string& handleId,
-        const ForceCloseDirectoryHandleOptions& options
-        = ForceCloseDirectoryHandleOptions(),
+        const ForceCloseDirectoryHandleOptions& options = ForceCloseDirectoryHandleOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_directory_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_directory_client.hpp
@@ -96,46 +96,46 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Creates the directory.
      * @param options Optional parameters to create this directory.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateShareDirectoryResult> containing the information
+     * @return Azure::Response<Models::CreateDirectoryResult> containing the information
      * returned when creating the directory.
      */
-    Azure::Response<Models::CreateShareDirectoryResult> Create(
-        const CreateShareDirectoryOptions& options = CreateShareDirectoryOptions(),
+    Azure::Response<Models::CreateDirectoryResult> Create(
+        const CreateDirectoryOptions& options = CreateDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Creates the directory if it does not exist.
      * @param options Optional parameters to create this directory.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::CreateShareDirectoryResult> containing the information
+     * @return Azure::Response<Models::CreateDirectoryResult> containing the information
      * returned when creating the directory if successfully created.
      */
-    Azure::Response<Models::CreateShareDirectoryResult> CreateIfNotExists(
-        const CreateShareDirectoryOptions& options = CreateShareDirectoryOptions(),
+    Azure::Response<Models::CreateDirectoryResult> CreateIfNotExists(
+        const CreateDirectoryOptions& options = CreateDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the directory.
      * @param options Optional parameters to delete this directory.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteShareDirectoryResult> containing the information
+     * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory. Currently empty but preserved for future usage.
      */
-    Azure::Response<Models::DeleteShareDirectoryResult> Delete(
-        const DeleteShareDirectoryOptions& options = DeleteShareDirectoryOptions(),
+    Azure::Response<Models::DeleteDirectoryResult> Delete(
+        const DeleteDirectoryOptions& options = DeleteDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the directory if it exists.
      * @param options Optional parameters to delete this directory.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DeleteShareDirectoryResult> containing the information
+     * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory. Currently empty but preserved for future usage.
      * Only when the delete operation if successful, the returned information other than 'Deleted'
      * is valid.
      */
-    Azure::Response<Models::DeleteShareDirectoryResult> DeleteIfExists(
-        const DeleteShareDirectoryOptions& options = DeleteShareDirectoryOptions(),
+    Azure::Response<Models::DeleteDirectoryResult> DeleteIfExists(
+        const DeleteDirectoryOptions& options = DeleteDirectoryOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -146,7 +146,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * properties of the directory returned from the server.
      */
     Azure::Response<Models::ShareDirectoryProperties> GetProperties(
-        const GetShareDirectoryPropertiesOptions& options = GetShareDirectoryPropertiesOptions(),
+        const GetDirectoryPropertiesOptions& options = GetDirectoryPropertiesOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -154,12 +154,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param smbProperties The SMB properties to be set to the directory.
      * @param options Optional parameters to set this directory's properties.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::SetShareDirectoryPropertiesResult> containing the
+     * @return Azure::Response<Models::SetDirectoryPropertiesResult> containing the
      * properties of the directory returned from the server.
      */
-    Azure::Response<Models::SetShareDirectoryPropertiesResult> SetProperties(
+    Azure::Response<Models::SetDirectoryPropertiesResult> SetProperties(
         Models::FileSmbProperties smbProperties,
-        const SetShareDirectoryPropertiesOptions& options = SetShareDirectoryPropertiesOptions(),
+        const SetDirectoryPropertiesOptions& options = SetDirectoryPropertiesOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -168,12 +168,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      *                 may only contain ASCII characters in the ISO-8859-1 character set.
      * @param options Optional parameters to set this directory's metadata.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::SetShareDirectoryMetadataResult> containing the
+     * @return Azure::Response<Models::SetDirectoryMetadataResult> containing the
      * information of the directory returned from the server.
      */
-    Azure::Response<Models::SetShareDirectoryMetadataResult> SetMetadata(
+    Azure::Response<Models::SetDirectoryMetadataResult> SetMetadata(
         Storage::Metadata metadata,
-        const SetShareDirectoryMetadataOptions& options = SetShareDirectoryMetadataOptions(),
+        const SetDirectoryMetadataOptions& options = SetDirectoryMetadataOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -193,12 +193,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief List open handles on the directory.
      * @param options Optional parameters to list this directory's open handles.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::ListShareDirectoryHandlesSinglePageResult> containing
+     * @return Azure::Response<Models::ListDirectoryHandlesSinglePageResult> containing
      * the information of the operation and the open handles of this directory
      */
-    Azure::Response<Models::ListShareDirectoryHandlesSinglePageResult> ListHandlesSinglePage(
-        const ListShareDirectoryHandlesSinglePageOptions& options
-        = ListShareDirectoryHandlesSinglePageOptions(),
+    Azure::Response<Models::ListDirectoryHandlesSinglePageResult> ListHandlesSinglePage(
+        const ListDirectoryHandlesSinglePageOptions& options
+        = ListDirectoryHandlesSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -206,27 +206,27 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param handleId The ID of the handle to be closed.
      * @param options Optional parameters to close one of this directory's open handles.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::ForceCloseShareDirectoryHandleResult> containing the
+     * @return Azure::Response<Models::ForceCloseDirectoryHandleResult> containing the
      * information of the closed handle. Current empty but preserved for future usage.
      */
-    Azure::Response<Models::ForceCloseShareDirectoryHandleResult> ForceCloseHandle(
+    Azure::Response<Models::ForceCloseDirectoryHandleResult> ForceCloseHandle(
         const std::string& handleId,
-        const ForceCloseShareDirectoryHandleOptions& options
-        = ForceCloseShareDirectoryHandleOptions(),
+        const ForceCloseDirectoryHandleOptions& options
+        = ForceCloseDirectoryHandleOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Closes all handles opened on a directory at the service.
      * @param options Optional parameters to close all this directory's open handles.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::ForceCloseAllShareDirectoryHandlesSinglePageResult>
+     * @return Azure::Response<Models::ForceCloseAllDirectoryHandlesSinglePageResult>
      * containing the information of the closed handles
      * @remark This operation may return a marker showing that the operation can be continued.
      */
-    Azure::Response<Models::ForceCloseAllShareDirectoryHandlesSinglePageResult>
+    Azure::Response<Models::ForceCloseAllDirectoryHandlesSinglePageResult>
     ForceCloseAllHandlesSinglePage(
-        const ForceCloseAllShareDirectoryHandlesSinglePageOptions& options
-        = ForceCloseAllShareDirectoryHandlesSinglePageOptions(),
+        const ForceCloseAllDirectoryHandlesSinglePageOptions& options
+        = ForceCloseAllDirectoryHandlesSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
   private:

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
@@ -79,34 +79,34 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param fileSize Size of the file in bytes.
      * @param options Optional parameters to create this file.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<CreateShareFileResult> containing the information returned when
+     * @return Azure::Response<CreateFileResult> containing the information returned when
      * creating the file.
      */
-    Azure::Response<Models::CreateShareFileResult> Create(
+    Azure::Response<Models::CreateFileResult> Create(
         int64_t fileSize,
-        const CreateShareFileOptions& options = CreateShareFileOptions(),
+        const CreateFileOptions& options = CreateFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the file.
      * @param options Optional parameters to delete this file.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<DeleteShareFileResult> containing the information returned when
+     * @return Azure::Response<DeleteFileResult> containing the information returned when
      * deleting the file.
      */
-    Azure::Response<Models::DeleteShareFileResult> Delete(
-        const DeleteShareFileOptions& options = DeleteShareFileOptions(),
+    Azure::Response<Models::DeleteFileResult> Delete(
+        const DeleteFileOptions& options = DeleteFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Deletes the file if it exists.
      * @param options Optional parameters to delete this file.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<DeleteShareFileResult> containing the information returned when
+     * @return Azure::Response<DeleteFileResult> containing the information returned when
      * deleting the file. Only valid when successfully deleted.
      */
-    Azure::Response<Models::DeleteShareFileResult> DeleteIfExists(
-        const DeleteShareFileOptions& options = DeleteShareFileOptions(),
+    Azure::Response<Models::DeleteFileResult> DeleteIfExists(
+        const DeleteFileOptions& options = DeleteFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -114,11 +114,11 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * used to download the server end data.
      * @param options Optional parameters to get the content of this file.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DownloadShareFileResult> containing the range or full
+     * @return Azure::Response<Models::DownloadFileResult> containing the range or full
      * content and the information of the file.
      */
-    Azure::Response<Models::DownloadShareFileResult> Download(
-        const DownloadShareFileOptions& options = DownloadShareFileOptions(),
+    Azure::Response<Models::DownloadFileResult> Download(
+        const DownloadFileOptions& options = DownloadFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -130,13 +130,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * or file range.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DownloadShareFileToResult> containing the information
+     * @return Azure::Response<Models::DownloadFileToResult> containing the information
      * of the downloaded file/file range.
      */
-    Azure::Response<Models::DownloadShareFileToResult> DownloadTo(
+    Azure::Response<Models::DownloadFileToResult> DownloadTo(
         uint8_t* buffer,
         std::size_t bufferSize,
-        const DownloadShareFileToOptions& options = DownloadShareFileToOptions(),
+        const DownloadFileToOptions& options = DownloadFileToOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -146,12 +146,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param fileName A file path to write the downloaded content to.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::DownloadShareFileToResult> containing the information
+     * @return Azure::Response<Models::DownloadFileToResult> containing the information
      * of the downloaded file/file range.
      */
-    Azure::Response<Models::DownloadShareFileToResult> DownloadTo(
+    Azure::Response<Models::DownloadFileToResult> DownloadTo(
         const std::string& fileName,
-        const DownloadShareFileToOptions& options = DownloadShareFileToOptions(),
+        const DownloadFileToOptions& options = DownloadFileToOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -162,13 +162,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param bufferSize Size of the memory buffer.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::UploadShareFileFromResult> describing the state of the
+     * @return Azure::Response<Models::UploadFileFromResult> describing the state of the
      * updated file.
      */
-    Azure::Response<Models::UploadShareFileFromResult> UploadFrom(
+    Azure::Response<Models::UploadFileFromResult> UploadFrom(
         const uint8_t* buffer,
         std::size_t bufferSize,
-        const UploadShareFileFromOptions& options = UploadShareFileFromOptions(),
+        const UploadFileFromOptions& options = UploadFileFromOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -178,12 +178,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param fileName A file containing the content to upload.
      * @param options Optional parameters to execute this function.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::UploadShareFileFromResult> describing the state of the
+     * @return Azure::Response<Models::UploadFileFromResult> describing the state of the
      * updated file.
      */
-    Azure::Response<Models::UploadShareFileFromResult> UploadFrom(
+    Azure::Response<Models::UploadFileFromResult> UploadFrom(
         const std::string& fileName,
-        const UploadShareFileFromOptions& options = UploadShareFileFromOptions(),
+        const UploadFileFromOptions& options = UploadFileFromOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -201,21 +201,21 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      */
     StartCopyShareFileOperation StartCopy(
         std::string copySource,
-        const StartCopyShareFileOptions& options = StartCopyShareFileOptions(),
+        const StartCopyFileOptions& options = StartCopyFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Aborts copying the file specified with the copy ID.
-     * @param copyId The copy identifier provided in the StartCopyShareFileResult of the original
+     * @param copyId The copy identifier provided in the StartCopyFileResult of the original
      * StartCopy operation.
      * @param options Optional parameters to abort copying the content of this file.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::AbortCopyShareFileResult> containing the abort copy
+     * @return Azure::Response<Models::AbortCopyFileResult> containing the abort copy
      * related information, current empty but preserved for future usage.
      */
-    Azure::Response<Models::AbortCopyShareFileResult> AbortCopy(
+    Azure::Response<Models::AbortCopyFileResult> AbortCopy(
         std::string copyId,
-        const AbortCopyShareFileOptions& options = AbortCopyShareFileOptions(),
+        const AbortCopyFileOptions& options = AbortCopyFileOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -226,7 +226,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * properties.
      */
     Azure::Response<Models::ShareFileProperties> GetProperties(
-        const GetShareFilePropertiesOptions& options = GetShareFilePropertiesOptions(),
+        const GetFilePropertiesOptions& options = GetFilePropertiesOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -235,13 +235,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param smbProperties The SMB properties to be set to the file.
      * @param options Optional parameters to set this file's properties.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::SetShareFilePropertiesResult> containing the properties
+     * @return Azure::Response<Models::SetFilePropertiesResult> containing the properties
      * of the file returned from the server.
      */
-    Azure::Response<Models::SetShareFilePropertiesResult> SetProperties(
+    Azure::Response<Models::SetFilePropertiesResult> SetProperties(
         const Models::FileHttpHeaders& httpHeaders,
         const Models::FileSmbProperties& smbProperties,
-        const SetShareFilePropertiesOptions& options = SetShareFilePropertiesOptions(),
+        const SetFilePropertiesOptions& options = SetFilePropertiesOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -250,12 +250,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      *                 may only contain ASCII characters in the ISO-8859-1 character set.
      * @param options Optional parameters to set this file's metadata.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::SetShareFileMetadataResult> containing the information
+     * @return Azure::Response<Models::SetFileMetadataResult> containing the information
      * of the file returned from the server.
      */
-    Azure::Response<Models::SetShareFileMetadataResult> SetMetadata(
+    Azure::Response<Models::SetFileMetadataResult> SetMetadata(
         Storage::Metadata metadata,
-        const SetShareFileMetadataOptions& options = SetShareFileMetadataOptions(),
+        const SetFileMetadataOptions& options = SetFileMetadataOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -266,10 +266,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @return Azure::Response<Models::UploadFileRange> containing the information of the
      * uploaded range and the file returned from the server.
      */
-    Azure::Response<Models::UploadShareFileRangeResult> UploadRange(
+    Azure::Response<Models::UploadFileRangeResult> UploadRange(
         int64_t offset,
         Azure::Core::IO::BodyStream* content,
-        const UploadShareFileRangeOptions& options = UploadShareFileRangeOptions(),
+        const UploadFileRangeOptions& options = UploadFileRangeOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -277,23 +277,23 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param offset Specifies the starting offset for the content to be cleared within the file.
      * @param length Specifies the length for the content to be cleared within the file.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::ClearShareFileRangeResult> containing the information
+     * @return Azure::Response<Models::ClearFileRangeResult> containing the information
      * of the cleared range returned from the server.
      */
-    Azure::Response<Models::ClearShareFileRangeResult> ClearRange(
+    Azure::Response<Models::ClearFileRangeResult> ClearRange(
         int64_t offset,
         int64_t length,
-        const ClearShareFileRangeOptions& options = ClearShareFileRangeOptions(),
+        const ClearFileRangeOptions& options = ClearFileRangeOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Gets the list of valid range from the file within specified range.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::GetShareFileRangeListResult> containing the valid
+     * @return Azure::Response<Models::GetFileRangeListResult> containing the valid
      * ranges within the file for the specified range.
      */
-    Azure::Response<Models::GetShareFileRangeListResult> GetRangeList(
-        const GetShareFileRangeListOptions& options = GetShareFileRangeListOptions(),
+    Azure::Response<Models::GetFileRangeListResult> GetRangeList(
+        const GetFileRangeListOptions& options = GetFileRangeListOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -301,24 +301,24 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * since previousShareSnapshot was taken.
      * @param previousShareSnapshot Specifies the previous snapshot.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::GetShareFileRangeListResult> containing the valid
+     * @return Azure::Response<Models::GetFileRangeListResult> containing the valid
      * ranges within the file for the specified range.
      */
-    Azure::Response<Models::GetShareFileRangeListResult> GetRangeListDiff(
+    Azure::Response<Models::GetFileRangeListResult> GetRangeListDiff(
         std::string previousShareSnapshot,
-        const GetShareFileRangeListOptions& options = GetShareFileRangeListOptions(),
+        const GetFileRangeListOptions& options = GetFileRangeListOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief List open handles on the file.
      * @param options Optional parameters to list this file's open handles.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::ListShareFileHandlesSinglePageResult> containing the
+     * @return Azure::Response<Models::ListFileHandlesSinglePageResult> containing the
      * information of the operation and the open handles of this file
      */
-    Azure::Response<Models::ListShareFileHandlesSinglePageResult> ListHandlesSinglePage(
-        const ListShareFileHandlesSinglePageOptions& options
-        = ListShareFileHandlesSinglePageOptions(),
+    Azure::Response<Models::ListFileHandlesSinglePageResult> ListHandlesSinglePage(
+        const ListFileHandlesSinglePageOptions& options
+        = ListFileHandlesSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
@@ -326,26 +326,26 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param handleId The ID of the handle to be closed.
      * @param options Optional parameters to close one of this file's open handles.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::ForceCloseShareFileHandleResult> containing the
+     * @return Azure::Response<Models::ForceCloseFileHandleResult> containing the
      * information of the closed handle. Current empty but preserved for future usage.
      */
-    Azure::Response<Models::ForceCloseShareFileHandleResult> ForceCloseHandle(
+    Azure::Response<Models::ForceCloseFileHandleResult> ForceCloseHandle(
         const std::string& handleId,
-        const ForceCloseShareFileHandleOptions& options = ForceCloseShareFileHandleOptions(),
+        const ForceCloseFileHandleOptions& options = ForceCloseFileHandleOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**
      * @brief Closes all handles opened on a file at the service.
      * @param options Optional parameters to close all this file's open handles.
      * @param context Context for cancelling long running operations.
-     * @return Azure::Response<Models::ForceCloseAllShareFileHandlesSinglePageResult>
+     * @return Azure::Response<Models::ForceCloseAllFileHandlesSinglePageResult>
      * containing the information of the closed handles
      * @remark This operation may return a marker showing that the operation can be continued.
      */
-    Azure::Response<Models::ForceCloseAllShareFileHandlesSinglePageResult>
+    Azure::Response<Models::ForceCloseAllFileHandlesSinglePageResult>
     ForceCloseAllHandlesSinglePage(
-        const ForceCloseAllShareFileHandlesSinglePageOptions& options
-        = ForceCloseAllShareFileHandlesSinglePageOptions(),
+        const ForceCloseAllFileHandlesSinglePageOptions& options
+        = ForceCloseAllFileHandlesSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
@@ -317,8 +317,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * information of the operation and the open handles of this file
      */
     Azure::Response<Models::ListFileHandlesSinglePageResult> ListHandlesSinglePage(
-        const ListFileHandlesSinglePageOptions& options
-        = ListFileHandlesSinglePageOptions(),
+        const ListFileHandlesSinglePageOptions& options = ListFileHandlesSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
     /**

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_options.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_options.hpp
@@ -185,7 +185,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
   };
 
-  struct CreateShareDirectoryOptions
+  struct CreateDirectoryOptions
   {
     /**
      * @brief A name-value pair to associate with a directory object.
@@ -204,15 +204,15 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     Models::FileSmbProperties SmbProperties;
   };
 
-  struct DeleteShareDirectoryOptions
+  struct DeleteDirectoryOptions
   {
   };
 
-  struct GetShareDirectoryPropertiesOptions
+  struct GetDirectoryPropertiesOptions
   {
   };
 
-  struct SetShareDirectoryPropertiesOptions
+  struct SetDirectoryPropertiesOptions
   {
     /**
      * @brief If specified the permission (security descriptor) shall be set for the directory.
@@ -223,7 +223,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     Azure::Nullable<std::string> FilePermission;
   };
 
-  struct SetShareDirectoryMetadataOptions
+  struct SetDirectoryMetadataOptions
   {
   };
 
@@ -251,7 +251,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     Azure::Nullable<int32_t> PageSizeHint;
   };
 
-  struct ListShareDirectoryHandlesSinglePageOptions
+  struct ListDirectoryHandlesSinglePageOptions
   {
     /**
      * @brief A string value that identifies the portion of the list to be returned with the next
@@ -275,11 +275,11 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     Azure::Nullable<bool> Recursive;
   };
 
-  struct ForceCloseShareDirectoryHandleOptions
+  struct ForceCloseDirectoryHandleOptions
   {
   };
 
-  struct ForceCloseAllShareDirectoryHandlesSinglePageOptions
+  struct ForceCloseAllDirectoryHandlesSinglePageOptions
   {
     /**
      * @brief A string value that identifies the portion of the list to be returned with the next
@@ -296,7 +296,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     Azure::Nullable<bool> Recursive;
   };
 
-  struct CreateShareFileOptions
+  struct CreateFileOptions
   {
     /**
      * @brief This permission is the security descriptor for the file specified in the Security
@@ -325,7 +325,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct DeleteShareFileOptions
+  struct DeleteFileOptions
   {
     /**
      * @brief The operation will only succeed if the access condition is met.
@@ -333,7 +333,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct DownloadShareFileOptions
+  struct DownloadFileOptions
   {
     /**
      * @brief Downloads only the bytes of the file from this range.
@@ -352,7 +352,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct StartCopyShareFileOptions
+  struct StartCopyFileOptions
   {
     /**
      * @brief A name-value pair to associate with a file storage object.
@@ -394,7 +394,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct AbortCopyShareFileOptions
+  struct AbortCopyFileOptions
   {
     /**
      * @brief The operation will only succeed if the access condition is met.
@@ -402,7 +402,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct GetShareFilePropertiesOptions
+  struct GetFilePropertiesOptions
   {
     /**
      * @brief The operation will only succeed if the access condition is met.
@@ -410,7 +410,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct SetShareFilePropertiesOptions
+  struct SetFilePropertiesOptions
   {
     /**
      * @brief This permission is the security descriptor for the file specified in the Security
@@ -429,7 +429,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct SetShareFileMetadataOptions
+  struct SetFileMetadataOptions
   {
     /**
      * @brief The operation will only succeed if the access condition is met.
@@ -437,7 +437,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct UploadShareFileRangeOptions
+  struct UploadFileRangeOptions
   {
     /**
      * @brief An MD5 hash of the content. This hash is used to verify the integrity of the data
@@ -453,7 +453,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct ClearShareFileRangeOptions
+  struct ClearFileRangeOptions
   {
     /**
      * @brief The operation will only succeed if the access condition is met.
@@ -480,7 +480,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct GetShareFileRangeListOptions
+  struct GetFileRangeListOptions
   {
     /**
      * @brief The range to be get from service.
@@ -493,7 +493,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     LeaseAccessConditions AccessConditions;
   };
 
-  struct ListShareFileHandlesSinglePageOptions
+  struct ListFileHandlesSinglePageOptions
   {
     /**
      * @brief A string value that identifies the portion of the list to be returned with the next
@@ -511,11 +511,11 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     Azure::Nullable<int32_t> PageSizeHint;
   };
 
-  struct ForceCloseShareFileHandleOptions
+  struct ForceCloseFileHandleOptions
   {
   };
 
-  struct ForceCloseAllShareFileHandlesSinglePageOptions
+  struct ForceCloseAllFileHandlesSinglePageOptions
   {
     /**
      * @brief A string value that identifies the portion of the list to be returned with the next
@@ -529,7 +529,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   /**
    * @brief Optional parameters for FileClient::DownloadTo.
    */
-  struct DownloadShareFileToOptions
+  struct DownloadFileToOptions
   {
     /**
      * @brief Downloads only the bytes of the file from this range.
@@ -560,7 +560,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   /**
    * @brief Optional parameters for FileClient::UploadFrom.
    */
-  struct UploadShareFileFromOptions
+  struct UploadFileFromOptions
   {
     /**
      * @brief The standard HTTP header system properties to set.

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -69,8 +69,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     using ShareDirectoryProperties = _detail::DirectoryGetPropertiesResult;
     using SetDirectoryPropertiesResult = _detail::DirectorySetPropertiesResult;
     using SetDirectoryMetadataResult = _detail::DirectorySetMetadataResult;
-    using ForceCloseAllDirectoryHandlesSinglePageResult
-        = _detail::DirectoryForceCloseHandlesResult;
+    using ForceCloseAllDirectoryHandlesSinglePageResult = _detail::DirectoryForceCloseHandlesResult;
 
     struct ForceCloseDirectoryHandleResult
     {

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -49,7 +49,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     // DirectoryClient models:
 
-    struct CreateShareDirectoryResult
+    struct CreateDirectoryResult
     {
       Azure::ETag ETag;
       DateTime LastModified;
@@ -60,19 +60,19 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       bool Created = false;
     };
 
-    struct DeleteShareDirectoryResult
+    struct DeleteDirectoryResult
     {
       bool Deleted = true;
       std::string RequestId;
     };
 
     using ShareDirectoryProperties = _detail::DirectoryGetPropertiesResult;
-    using SetShareDirectoryPropertiesResult = _detail::DirectorySetPropertiesResult;
-    using SetShareDirectoryMetadataResult = _detail::DirectorySetMetadataResult;
-    using ForceCloseAllShareDirectoryHandlesSinglePageResult
+    using SetDirectoryPropertiesResult = _detail::DirectorySetPropertiesResult;
+    using SetDirectoryMetadataResult = _detail::DirectorySetMetadataResult;
+    using ForceCloseAllDirectoryHandlesSinglePageResult
         = _detail::DirectoryForceCloseHandlesResult;
 
-    struct ForceCloseShareDirectoryHandleResult
+    struct ForceCloseDirectoryHandleResult
     {
       std::string RequestId;
     };
@@ -91,7 +91,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       std::string RequestId;
     };
 
-    struct ListShareDirectoryHandlesSinglePageResult
+    struct ListDirectoryHandlesSinglePageResult
     {
       std::vector<HandleItem> Handles;
       Nullable<std::string> ContinuationToken;
@@ -99,7 +99,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     };
 
     // FileClient models:
-    struct CreateShareFileResult
+    struct CreateFileResult
     {
       bool Created = true;
       Azure::ETag ETag;
@@ -109,7 +109,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       std::string RequestId;
     };
 
-    struct DeleteShareFileResult
+    struct DeleteFileResult
     {
       bool Deleted = true;
       std::string RequestId;
@@ -133,7 +133,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       Nullable<LeaseStatusType> LeaseStatus;
     };
 
-    struct DownloadShareFileResult
+    struct DownloadFileResult
     {
       std::unique_ptr<Azure::Core::IO::BodyStream> BodyStream;
       Azure::Core::Http::HttpRange ContentRange;
@@ -144,14 +144,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       std::string RequestId;
     };
 
-    using StartCopyShareFileResult = _detail::FileStartCopyResult;
-    using AbortCopyShareFileResult = _detail::FileAbortCopyResult;
+    using StartCopyFileResult = _detail::FileStartCopyResult;
+    using AbortCopyFileResult = _detail::FileAbortCopyResult;
     using ShareFileProperties = _detail::FileGetPropertiesResult;
-    using SetShareFilePropertiesResult = _detail::FileSetHttpHeadersResult;
+    using SetFilePropertiesResult = _detail::FileSetHttpHeadersResult;
     using ResizeFileResult = _detail::FileSetHttpHeadersResult;
-    using SetShareFileMetadataResult = _detail::FileSetMetadataResult;
-    using UploadShareFileRangeResult = _detail::FileUploadRangeResult;
-    struct ClearShareFileRangeResult
+    using SetFileMetadataResult = _detail::FileSetMetadataResult;
+    using UploadFileRangeResult = _detail::FileUploadRangeResult;
+    struct ClearFileRangeResult
     {
       Azure::ETag ETag;
       DateTime LastModified;
@@ -159,11 +159,11 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       bool IsServerEncrypted = bool();
     };
     using UploadFileRangeFromUriResult = _detail::FileUploadRangeFromUrlResult;
-    using GetShareFileRangeListResult = _detail::FileGetRangeListResult;
-    using ListShareFileHandlesSinglePageResult = ListShareDirectoryHandlesSinglePageResult;
-    using ForceCloseAllShareFileHandlesSinglePageResult = _detail::FileForceCloseHandlesResult;
+    using GetFileRangeListResult = _detail::FileGetRangeListResult;
+    using ListFileHandlesSinglePageResult = ListDirectoryHandlesSinglePageResult;
+    using ForceCloseAllFileHandlesSinglePageResult = _detail::FileForceCloseHandlesResult;
 
-    struct DownloadShareFileToResult
+    struct DownloadFileToResult
     {
       int64_t FileSize = 0;
       Azure::Core::Http::HttpRange ContentRange;
@@ -171,12 +171,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       DownloadShareFileDetails Details;
     };
 
-    struct ForceCloseShareFileHandleResult
+    struct ForceCloseFileHandleResult
     {
       std::string RequestId;
     };
 
-    struct UploadShareFileFromResult
+    struct UploadFileFromResult
     {
       bool IsServerEncrypted = false;
     };

--- a/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
@@ -336,8 +336,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::ForceCloseDirectoryHandleResult>
-  ShareDirectoryClient::ForceCloseHandle(
+  Azure::Response<Models::ForceCloseDirectoryHandleResult> ShareDirectoryClient::ForceCloseHandle(
       const std::string& handleId,
       const ForceCloseDirectoryHandleOptions& options,
       const Azure::Core::Context& context) const

--- a/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
@@ -111,8 +111,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     return newClient;
   }
 
-  Azure::Response<Models::CreateShareDirectoryResult> ShareDirectoryClient::Create(
-      const CreateShareDirectoryOptions& options,
+  Azure::Response<Models::CreateDirectoryResult> ShareDirectoryClient::Create(
+      const CreateDirectoryOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::Directory::CreateOptions();
@@ -155,7 +155,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     auto result = _detail::ShareRestClient::Directory::Create(
         m_shareDirectoryUrl, *m_pipeline, context, protocolLayerOptions);
-    Models::CreateShareDirectoryResult ret;
+    Models::CreateDirectoryResult ret;
     ret.Created = true;
     ret.ETag = std::move(result->ETag);
     ret.IsServerEncrypted = result->IsServerEncrypted;
@@ -163,12 +163,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     ret.RequestId = std::move(result->RequestId);
     ret.SmbProperties = std::move(result->SmbProperties);
 
-    return Azure::Response<Models::CreateShareDirectoryResult>(
+    return Azure::Response<Models::CreateDirectoryResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::CreateShareDirectoryResult> ShareDirectoryClient::CreateIfNotExists(
-      const CreateShareDirectoryOptions& options,
+  Azure::Response<Models::CreateDirectoryResult> ShareDirectoryClient::CreateIfNotExists(
+      const CreateDirectoryOptions& options,
       const Azure::Core::Context& context) const
 
   {
@@ -180,32 +180,32 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       if (e.ErrorCode == _detail::ResourceAlreadyExists)
       {
-        Models::CreateShareDirectoryResult ret;
+        Models::CreateDirectoryResult ret;
         ret.Created = false;
         ret.RequestId = std::move(e.RequestId);
-        return Azure::Response<Models::CreateShareDirectoryResult>(
+        return Azure::Response<Models::CreateDirectoryResult>(
             std::move(ret), std::move(e.RawResponse));
       }
       throw;
     }
   }
 
-  Azure::Response<Models::DeleteShareDirectoryResult> ShareDirectoryClient::Delete(
-      const DeleteShareDirectoryOptions& options,
+  Azure::Response<Models::DeleteDirectoryResult> ShareDirectoryClient::Delete(
+      const DeleteDirectoryOptions& options,
       const Azure::Core::Context& context) const
   {
     (void)options;
     auto protocolLayerOptions = _detail::ShareRestClient::Directory::DeleteOptions();
     auto result = _detail::ShareRestClient::Directory::Delete(
         m_shareDirectoryUrl, *m_pipeline, context, protocolLayerOptions);
-    Models::DeleteShareDirectoryResult ret;
+    Models::DeleteDirectoryResult ret;
     ret.Deleted = true;
-    return Azure::Response<Models::DeleteShareDirectoryResult>(
+    return Azure::Response<Models::DeleteDirectoryResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::DeleteShareDirectoryResult> ShareDirectoryClient::DeleteIfExists(
-      const DeleteShareDirectoryOptions& options,
+  Azure::Response<Models::DeleteDirectoryResult> ShareDirectoryClient::DeleteIfExists(
+      const DeleteDirectoryOptions& options,
       const Azure::Core::Context& context) const
   {
     try
@@ -217,10 +217,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       if (e.ErrorCode == _detail::ShareNotFound || e.ErrorCode == _detail::ParentNotFound
           || e.ErrorCode == _detail::ResourceNotFound)
       {
-        Models::DeleteShareDirectoryResult ret;
+        Models::DeleteDirectoryResult ret;
         ret.Deleted = false;
         ret.RequestId = std::move(e.RequestId);
-        return Azure::Response<Models::DeleteShareDirectoryResult>(
+        return Azure::Response<Models::DeleteDirectoryResult>(
             std::move(ret), std::move(e.RawResponse));
       }
       throw;
@@ -228,7 +228,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   }
 
   Azure::Response<Models::ShareDirectoryProperties> ShareDirectoryClient::GetProperties(
-      const GetShareDirectoryPropertiesOptions& options,
+      const GetDirectoryPropertiesOptions& options,
       const Azure::Core::Context& context) const
   {
     (void)options;
@@ -237,9 +237,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareDirectoryUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::SetShareDirectoryPropertiesResult> ShareDirectoryClient::SetProperties(
+  Azure::Response<Models::SetDirectoryPropertiesResult> ShareDirectoryClient::SetProperties(
       Models::FileSmbProperties smbProperties,
-      const SetShareDirectoryPropertiesOptions& options,
+      const SetDirectoryPropertiesOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::Directory::SetPropertiesOptions();
@@ -278,9 +278,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareDirectoryUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::SetShareDirectoryMetadataResult> ShareDirectoryClient::SetMetadata(
+  Azure::Response<Models::SetDirectoryMetadataResult> ShareDirectoryClient::SetMetadata(
       Storage::Metadata metadata,
-      const SetShareDirectoryMetadataOptions& options,
+      const SetDirectoryMetadataOptions& options,
       const Azure::Core::Context& context) const
   {
     (void)options;
@@ -317,9 +317,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::ListShareDirectoryHandlesSinglePageResult>
+  Azure::Response<Models::ListDirectoryHandlesSinglePageResult>
   ShareDirectoryClient::ListHandlesSinglePage(
-      const ListShareDirectoryHandlesSinglePageOptions& options,
+      const ListDirectoryHandlesSinglePageOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::Directory::ListHandlesOptions();
@@ -328,18 +328,18 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.Recursive = options.Recursive;
     auto result = _detail::ShareRestClient::Directory::ListHandles(
         m_shareDirectoryUrl, *m_pipeline, context, protocolLayerOptions);
-    Models::ListShareDirectoryHandlesSinglePageResult ret;
+    Models::ListDirectoryHandlesSinglePageResult ret;
     ret.ContinuationToken = std::move(result->ContinuationToken);
     ret.Handles = std::move(result->HandleList);
 
-    return Azure::Response<Models::ListShareDirectoryHandlesSinglePageResult>(
+    return Azure::Response<Models::ListDirectoryHandlesSinglePageResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::ForceCloseShareDirectoryHandleResult>
+  Azure::Response<Models::ForceCloseDirectoryHandleResult>
   ShareDirectoryClient::ForceCloseHandle(
       const std::string& handleId,
-      const ForceCloseShareDirectoryHandleOptions& options,
+      const ForceCloseDirectoryHandleOptions& options,
       const Azure::Core::Context& context) const
   {
     (void)options;
@@ -347,15 +347,15 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.HandleId = handleId;
     auto result = _detail::ShareRestClient::File::ForceCloseHandles(
         m_shareDirectoryUrl, *m_pipeline, context, protocolLayerOptions);
-    Models::ForceCloseShareDirectoryHandleResult ret;
+    Models::ForceCloseDirectoryHandleResult ret;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::ForceCloseShareDirectoryHandleResult>(
+    return Azure::Response<Models::ForceCloseDirectoryHandleResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::ForceCloseAllShareDirectoryHandlesSinglePageResult>
+  Azure::Response<Models::ForceCloseAllDirectoryHandlesSinglePageResult>
   ShareDirectoryClient::ForceCloseAllHandlesSinglePage(
-      const ForceCloseAllShareDirectoryHandlesSinglePageOptions& options,
+      const ForceCloseAllDirectoryHandlesSinglePageOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::Directory::ForceCloseHandlesOptions();

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -100,9 +100,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     return newClient;
   }
 
-  Azure::Response<Models::CreateShareFileResult> ShareFileClient::Create(
+  Azure::Response<Models::CreateFileResult> ShareFileClient::Create(
       int64_t fileSize,
-      const CreateShareFileOptions& options,
+      const CreateFileOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::CreateOptions();
@@ -175,7 +175,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.LeaseIdOptional = options.AccessConditions.LeaseId;
     auto result = _detail::ShareRestClient::File::Create(
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
-    Models::CreateShareFileResult ret;
+    Models::CreateFileResult ret;
     ret.Created = true;
     ret.ETag = std::move(result->ETag);
     ret.SmbProperties = std::move(result->SmbProperties);
@@ -183,27 +183,27 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     ret.LastModified = std::move(result->LastModified);
     ret.RequestId = std::move(result->RequestId);
 
-    return Azure::Response<Models::CreateShareFileResult>(
+    return Azure::Response<Models::CreateFileResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::DeleteShareFileResult> ShareFileClient::Delete(
-      const DeleteShareFileOptions& options,
+  Azure::Response<Models::DeleteFileResult> ShareFileClient::Delete(
+      const DeleteFileOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::DeleteOptions();
     protocolLayerOptions.LeaseIdOptional = options.AccessConditions.LeaseId;
     auto result = _detail::ShareRestClient::File::Delete(
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
-    Models::DeleteShareFileResult ret;
+    Models::DeleteFileResult ret;
     ret.Deleted = true;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DeleteShareFileResult>(
+    return Azure::Response<Models::DeleteFileResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::DeleteShareFileResult> ShareFileClient::DeleteIfExists(
-      const DeleteShareFileOptions& options,
+  Azure::Response<Models::DeleteFileResult> ShareFileClient::DeleteIfExists(
+      const DeleteFileOptions& options,
       const Azure::Core::Context& context) const
   {
     try
@@ -215,18 +215,18 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       if (e.ErrorCode == _detail::ShareNotFound || e.ErrorCode == _detail::ParentNotFound
           || e.ErrorCode == _detail::ResourceNotFound)
       {
-        Models::DeleteShareFileResult ret;
+        Models::DeleteFileResult ret;
         ret.Deleted = false;
         ret.RequestId = std::move(e.RequestId);
-        return Azure::Response<Models::DeleteShareFileResult>(
+        return Azure::Response<Models::DeleteFileResult>(
             std::move(ret), std::move(e.RawResponse));
       }
       throw;
     }
   }
 
-  Azure::Response<Models::DownloadShareFileResult> ShareFileClient::Download(
-      const DownloadShareFileOptions& options,
+  Azure::Response<Models::DownloadFileResult> ShareFileClient::Download(
+      const DownloadFileOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::DownloadOptions();
@@ -269,7 +269,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           [this, options, eTag](
               const HttpGetterInfo& retryInfo,
               const Azure::Core::Context& context) -> std::unique_ptr<Azure::Core::IO::BodyStream> {
-        DownloadShareFileOptions newOptions = options;
+        DownloadFileOptions newOptions = options;
         newOptions.Range = Core::Http::HttpRange();
         newOptions.Range.GetValue().Offset
             = (options.Range.HasValue() ? options.Range.GetValue().Offset : 0) + retryInfo.Offset;
@@ -293,7 +293,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       downloadResponse->BodyStream = std::make_unique<ReliableStream>(
           std::move(downloadResponse->BodyStream), reliableStreamOptions, retryFunction);
     }
-    Models::DownloadShareFileResult ret;
+    Models::DownloadFileResult ret;
     ret.BodyStream = std::move(downloadResponse->BodyStream);
     ret.ContentRange = std::move(downloadResponse->ContentRange);
     ret.FileSize = downloadResponse->FileSize;
@@ -313,13 +313,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     ret.Details.LeaseDuration = std::move(downloadResponse->LeaseDuration);
     ret.Details.LeaseState = std::move(downloadResponse->LeaseState);
     ret.Details.LeaseStatus = std::move(downloadResponse->LeaseStatus);
-    return Azure::Response<Models::DownloadShareFileResult>(
+    return Azure::Response<Models::DownloadFileResult>(
         std::move(ret), downloadResponse.ExtractRawResponse());
   }
 
   StartCopyShareFileOperation ShareFileClient::StartCopy(
       std::string copySource,
-      const StartCopyShareFileOptions& options,
+      const StartCopyFileOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::StartCopyOptions();
@@ -388,9 +388,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     return res;
   }
 
-  Azure::Response<Models::AbortCopyShareFileResult> ShareFileClient::AbortCopy(
+  Azure::Response<Models::AbortCopyFileResult> ShareFileClient::AbortCopy(
       std::string copyId,
-      const AbortCopyShareFileOptions& options,
+      const AbortCopyFileOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::AbortCopyOptions();
@@ -401,7 +401,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   }
 
   Azure::Response<Models::ShareFileProperties> ShareFileClient::GetProperties(
-      const GetShareFilePropertiesOptions& options,
+      const GetFilePropertiesOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::GetPropertiesOptions();
@@ -410,10 +410,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::SetShareFilePropertiesResult> ShareFileClient::SetProperties(
+  Azure::Response<Models::SetFilePropertiesResult> ShareFileClient::SetProperties(
       const Models::FileHttpHeaders& httpHeaders,
       const Models::FileSmbProperties& smbProperties,
-      const SetShareFilePropertiesOptions& options,
+      const SetFilePropertiesOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::SetHttpHeadersOptions();
@@ -480,9 +480,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::SetShareFileMetadataResult> ShareFileClient::SetMetadata(
+  Azure::Response<Models::SetFileMetadataResult> ShareFileClient::SetMetadata(
       Storage::Metadata metadata,
-      const SetShareFileMetadataOptions& options,
+      const SetFileMetadataOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::SetMetadataOptions();
@@ -492,10 +492,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::UploadShareFileRangeResult> ShareFileClient::UploadRange(
+  Azure::Response<Models::UploadFileRangeResult> ShareFileClient::UploadRange(
       int64_t offset,
       Azure::Core::IO::BodyStream* content,
-      const UploadShareFileRangeOptions& options,
+      const UploadFileRangeOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::UploadRangeOptions();
@@ -514,10 +514,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareFileUrl, *content, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::ClearShareFileRangeResult> ShareFileClient::ClearRange(
+  Azure::Response<Models::ClearFileRangeResult> ShareFileClient::ClearRange(
       int64_t offset,
       int64_t length,
-      const ClearShareFileRangeOptions& options,
+      const ClearFileRangeOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::UploadRangeOptions();
@@ -533,17 +533,17 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         *m_pipeline,
         context,
         protocolLayerOptions);
-    Models::ClearShareFileRangeResult ret;
+    Models::ClearFileRangeResult ret;
     ret.ETag = std::move(response->ETag);
     ret.IsServerEncrypted = response->IsServerEncrypted;
     ret.LastModified = std::move(response->LastModified);
     ret.RequestId = std::move(response->RequestId);
-    return Azure::Response<Models::ClearShareFileRangeResult>(
+    return Azure::Response<Models::ClearFileRangeResult>(
         std::move(ret), response.ExtractRawResponse());
   }
 
-  Azure::Response<Models::GetShareFileRangeListResult> ShareFileClient::GetRangeList(
-      const GetShareFileRangeListOptions& options,
+  Azure::Response<Models::GetFileRangeListResult> ShareFileClient::GetRangeList(
+      const GetFileRangeListOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::GetRangeListOptions();
@@ -568,9 +568,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::GetShareFileRangeListResult> ShareFileClient::GetRangeListDiff(
+  Azure::Response<Models::GetFileRangeListResult> ShareFileClient::GetRangeListDiff(
       std::string previousShareSnapshot,
-      const GetShareFileRangeListOptions& options,
+      const GetFileRangeListOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::GetRangeListOptions();
@@ -596,9 +596,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::ListShareFileHandlesSinglePageResult>
+  Azure::Response<Models::ListFileHandlesSinglePageResult>
   ShareFileClient::ListHandlesSinglePage(
-      const ListShareFileHandlesSinglePageOptions& options,
+      const ListFileHandlesSinglePageOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::ListHandlesOptions();
@@ -606,17 +606,17 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.MaxResults = options.PageSizeHint;
     auto result = _detail::ShareRestClient::File::ListHandles(
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
-    Models::ListShareFileHandlesSinglePageResult ret;
+    Models::ListFileHandlesSinglePageResult ret;
     ret.ContinuationToken = std::move(result->ContinuationToken);
     ret.Handles = std::move(result->HandleList);
 
-    return Azure::Response<Models::ListShareFileHandlesSinglePageResult>(
+    return Azure::Response<Models::ListFileHandlesSinglePageResult>(
         std::move(ret), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::ForceCloseShareFileHandleResult> ShareFileClient::ForceCloseHandle(
+  Azure::Response<Models::ForceCloseFileHandleResult> ShareFileClient::ForceCloseHandle(
       const std::string& handleId,
-      const ForceCloseShareFileHandleOptions& options,
+      const ForceCloseFileHandleOptions& options,
       const Azure::Core::Context& context) const
   {
     (void)options;
@@ -624,13 +624,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.HandleId = handleId;
     auto result = _detail::ShareRestClient::File::ForceCloseHandles(
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
-    return Azure::Response<Models::ForceCloseShareFileHandleResult>(
-        Models::ForceCloseShareFileHandleResult(), result.ExtractRawResponse());
+    return Azure::Response<Models::ForceCloseFileHandleResult>(
+        Models::ForceCloseFileHandleResult(), result.ExtractRawResponse());
   }
 
-  Azure::Response<Models::ForceCloseAllShareFileHandlesSinglePageResult>
+  Azure::Response<Models::ForceCloseAllFileHandlesSinglePageResult>
   ShareFileClient::ForceCloseAllHandlesSinglePage(
-      const ForceCloseAllShareFileHandlesSinglePageOptions& options,
+      const ForceCloseAllFileHandlesSinglePageOptions& options,
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::File::ForceCloseHandlesOptions();
@@ -640,10 +640,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::DownloadShareFileToResult> ShareFileClient::DownloadTo(
+  Azure::Response<Models::DownloadFileToResult> ShareFileClient::DownloadTo(
       uint8_t* buffer,
       std::size_t bufferSize,
-      const DownloadShareFileToOptions& options,
+      const DownloadFileToOptions& options,
       const Azure::Core::Context& context) const
   {
     // Just start downloading using an initial chunk. If it's a small file, we'll get the whole
@@ -657,7 +657,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       firstChunkLength = std::min(firstChunkLength, options.Range.GetValue().Length.GetValue());
     }
 
-    DownloadShareFileOptions firstChunkOptions;
+    DownloadFileOptions firstChunkOptions;
     firstChunkOptions.Range = options.Range;
     if (firstChunkOptions.Range.HasValue())
     {
@@ -697,12 +697,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     firstChunk->BodyStream.reset();
 
-    auto returnTypeConverter = [](Azure::Response<Models::DownloadShareFileResult>& response) {
-      Models::DownloadShareFileToResult ret;
+    auto returnTypeConverter = [](Azure::Response<Models::DownloadFileResult>& response) {
+      Models::DownloadFileToResult ret;
       ret.FileSize = response->FileSize;
       ret.HttpHeaders = std::move(response->HttpHeaders);
       ret.Details = std::move(response->Details);
-      return Azure::Response<Models::DownloadShareFileToResult>(
+      return Azure::Response<Models::DownloadFileToResult>(
           std::move(ret), response.ExtractRawResponse());
     };
     auto ret = returnTypeConverter(firstChunk);
@@ -710,7 +710,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     // Keep downloading the remaining in parallel
     auto downloadChunkFunc
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
-            DownloadShareFileOptions chunkOptions;
+            DownloadFileOptions chunkOptions;
             chunkOptions.Range = Core::Http::HttpRange();
             chunkOptions.Range.GetValue().Offset = offset;
             chunkOptions.Range.GetValue().Length = length;
@@ -744,9 +744,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     return ret;
   }
 
-  Azure::Response<Models::DownloadShareFileToResult> ShareFileClient::DownloadTo(
+  Azure::Response<Models::DownloadFileToResult> ShareFileClient::DownloadTo(
       const std::string& fileName,
-      const DownloadShareFileToOptions& options,
+      const DownloadFileToOptions& options,
       const Azure::Core::Context& context) const
   {
     // Just start downloading using an initial chunk. If it's a small file, we'll get the whole
@@ -759,7 +759,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       firstChunkLength = std::min(firstChunkLength, options.Range.GetValue().Length.GetValue());
     }
 
-    DownloadShareFileOptions firstChunkOptions;
+    DownloadFileOptions firstChunkOptions;
     firstChunkOptions.Range = options.Range;
     if (firstChunkOptions.Range.HasValue())
     {
@@ -812,12 +812,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     bodyStreamToFile(*(firstChunk->BodyStream), fileWriter, 0, firstChunkLength, context);
     firstChunk->BodyStream.reset();
 
-    auto returnTypeConverter = [](Azure::Response<Models::DownloadShareFileResult>& response) {
-      Models::DownloadShareFileToResult ret;
+    auto returnTypeConverter = [](Azure::Response<Models::DownloadFileResult>& response) {
+      Models::DownloadFileToResult ret;
       ret.FileSize = response->FileSize;
       ret.HttpHeaders = std::move(response->HttpHeaders);
       ret.Details = std::move(response->Details);
-      return Azure::Response<Models::DownloadShareFileToResult>(
+      return Azure::Response<Models::DownloadFileToResult>(
           std::move(ret), response.ExtractRawResponse());
     };
     auto ret = returnTypeConverter(firstChunk);
@@ -825,7 +825,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     // Keep downloading the remaining in parallel
     auto downloadChunkFunc
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
-            DownloadShareFileOptions chunkOptions;
+            DownloadFileOptions chunkOptions;
             chunkOptions.Range = Core::Http::HttpRange();
             chunkOptions.Range.GetValue().Offset = offset;
             chunkOptions.Range.GetValue().Length = length;
@@ -857,10 +857,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     return ret;
   }
 
-  Azure::Response<Models::UploadShareFileFromResult> ShareFileClient::UploadFrom(
+  Azure::Response<Models::UploadFileFromResult> ShareFileClient::UploadFrom(
       const uint8_t* buffer,
       std::size_t bufferSize,
-      const UploadShareFileFromOptions& options,
+      const UploadFileFromOptions& options,
       const Azure::Core::Context& context) const
   {
     _detail::ShareRestClient::File::CreateOptions protocolLayerOptions;
@@ -938,7 +938,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       (void)chunkId;
       (void)numChunks;
       Azure::Core::IO::MemoryBodyStream contentStream(buffer + offset, length);
-      UploadShareFileRangeOptions uploadRangeOptions;
+      UploadFileRangeOptions uploadRangeOptions;
       UploadRange(offset, &contentStream, uploadRangeOptions, context);
     };
 
@@ -954,15 +954,15 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           0, bufferSize, chunkSize, options.TransferOptions.Concurrency, uploadPageFunc);
     }
 
-    Models::UploadShareFileFromResult result;
+    Models::UploadFileFromResult result;
     result.IsServerEncrypted = createResult->IsServerEncrypted;
-    return Azure::Response<Models::UploadShareFileFromResult>(
+    return Azure::Response<Models::UploadFileFromResult>(
         std::move(result), createResult.ExtractRawResponse());
   }
 
-  Azure::Response<Models::UploadShareFileFromResult> ShareFileClient::UploadFrom(
+  Azure::Response<Models::UploadFileFromResult> ShareFileClient::UploadFrom(
       const std::string& fileName,
-      const UploadShareFileFromOptions& options,
+      const UploadFileFromOptions& options,
       const Azure::Core::Context& context) const
   {
     _internal::FileReader fileReader(fileName);
@@ -1043,7 +1043,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       (void)numChunks;
       Azure::Core::IO::_internal::RandomAccessFileBodyStream contentStream(
           fileReader.GetHandle(), offset, length);
-      UploadShareFileRangeOptions uploadRangeOptions;
+      UploadFileRangeOptions uploadRangeOptions;
       UploadRange(offset, &contentStream, uploadRangeOptions, context);
     };
 
@@ -1060,9 +1060,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           0, fileSize, chunkSize, options.TransferOptions.Concurrency, uploadPageFunc);
     }
 
-    Models::UploadShareFileFromResult result;
+    Models::UploadFileFromResult result;
     result.IsServerEncrypted = createResult->IsServerEncrypted;
-    return Azure::Response<Models::UploadShareFileFromResult>(
+    return Azure::Response<Models::UploadFileFromResult>(
         std::move(result), createResult.ExtractRawResponse());
   }
 

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -183,8 +183,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     ret.LastModified = std::move(result->LastModified);
     ret.RequestId = std::move(result->RequestId);
 
-    return Azure::Response<Models::CreateFileResult>(
-        std::move(ret), result.ExtractRawResponse());
+    return Azure::Response<Models::CreateFileResult>(std::move(ret), result.ExtractRawResponse());
   }
 
   Azure::Response<Models::DeleteFileResult> ShareFileClient::Delete(
@@ -198,8 +197,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     Models::DeleteFileResult ret;
     ret.Deleted = true;
     ret.RequestId = std::move(result->RequestId);
-    return Azure::Response<Models::DeleteFileResult>(
-        std::move(ret), result.ExtractRawResponse());
+    return Azure::Response<Models::DeleteFileResult>(std::move(ret), result.ExtractRawResponse());
   }
 
   Azure::Response<Models::DeleteFileResult> ShareFileClient::DeleteIfExists(
@@ -218,8 +216,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         Models::DeleteFileResult ret;
         ret.Deleted = false;
         ret.RequestId = std::move(e.RequestId);
-        return Azure::Response<Models::DeleteFileResult>(
-            std::move(ret), std::move(e.RawResponse));
+        return Azure::Response<Models::DeleteFileResult>(std::move(ret), std::move(e.RawResponse));
       }
       throw;
     }
@@ -596,8 +593,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_shareFileUrl, *m_pipeline, context, protocolLayerOptions);
   }
 
-  Azure::Response<Models::ListFileHandlesSinglePageResult>
-  ShareFileClient::ListHandlesSinglePage(
+  Azure::Response<Models::ListFileHandlesSinglePageResult> ShareFileClient::ListHandlesSinglePage(
       const ListFileHandlesSinglePageOptions& options,
       const Azure::Core::Context& context) const
   {

--- a/sdk/storage/azure-storage-files-shares/test/share_directory_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_directory_client_test.cpp
@@ -174,8 +174,8 @@ namespace Azure { namespace Storage { namespace Test {
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
       auto client2
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
-      Files::Shares::CreateShareDirectoryOptions options1;
-      Files::Shares::CreateShareDirectoryOptions options2;
+      Files::Shares::CreateDirectoryOptions options1;
+      Files::Shares::CreateDirectoryOptions options2;
       options1.Metadata = metadata1;
       options2.Metadata = metadata2;
 
@@ -200,8 +200,8 @@ namespace Azure { namespace Storage { namespace Test {
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
       auto client2
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
-      Files::Shares::CreateShareDirectoryOptions options1;
-      Files::Shares::CreateShareDirectoryOptions options2;
+      Files::Shares::CreateDirectoryOptions options1;
+      Files::Shares::CreateDirectoryOptions options2;
       options1.DirectoryPermission = permission;
       options2.DirectoryPermission = permission;
 
@@ -213,7 +213,7 @@ namespace Azure { namespace Storage { namespace Test {
 
       auto client3
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
-      Files::Shares::CreateShareDirectoryOptions options3;
+      Files::Shares::CreateDirectoryOptions options3;
       options3.SmbProperties.PermissionKey = result1;
       EXPECT_NO_THROW(client3.Create(options3));
       auto result3 = client3.GetProperties()->SmbProperties.PermissionKey;
@@ -235,8 +235,8 @@ namespace Azure { namespace Storage { namespace Test {
 
       EXPECT_NO_THROW(client1.Create());
       EXPECT_NO_THROW(client2.Create());
-      Files::Shares::SetShareDirectoryPropertiesOptions options1;
-      Files::Shares::SetShareDirectoryPropertiesOptions options2;
+      Files::Shares::SetDirectoryPropertiesOptions options1;
+      Files::Shares::SetDirectoryPropertiesOptions options2;
       options1.FilePermission = permission;
       options2.FilePermission = permission;
       EXPECT_NO_THROW(client1.SetProperties(properties, options1));
@@ -247,7 +247,7 @@ namespace Azure { namespace Storage { namespace Test {
 
       auto client3
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
-      Files::Shares::CreateShareDirectoryOptions options3;
+      Files::Shares::CreateDirectoryOptions options3;
       options3.SmbProperties.PermissionKey = result1;
       std::string permissionKey;
       EXPECT_NO_THROW(
@@ -272,8 +272,8 @@ namespace Azure { namespace Storage { namespace Test {
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
       auto client2
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
-      Files::Shares::CreateShareDirectoryOptions options1;
-      Files::Shares::CreateShareDirectoryOptions options2;
+      Files::Shares::CreateDirectoryOptions options1;
+      Files::Shares::CreateDirectoryOptions options2;
       options1.SmbProperties = properties;
       options2.SmbProperties = properties;
 

--- a/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
@@ -120,8 +120,8 @@ namespace Azure { namespace Storage { namespace Test {
       // Create directory with metadata works
       auto client1 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
       auto client2 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
-      Files::Shares::CreateShareFileOptions options1;
-      Files::Shares::CreateShareFileOptions options2;
+      Files::Shares::CreateFileOptions options1;
+      Files::Shares::CreateFileOptions options2;
       options1.Metadata = metadata1;
       options2.Metadata = metadata2;
 
@@ -144,8 +144,8 @@ namespace Azure { namespace Storage { namespace Test {
       // Create directory with permission/permission key works
       auto client1 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
       auto client2 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
-      Files::Shares::CreateShareFileOptions options1;
-      Files::Shares::CreateShareFileOptions options2;
+      Files::Shares::CreateFileOptions options1;
+      Files::Shares::CreateFileOptions options2;
       options1.Permission = permission;
       options2.Permission = permission;
 
@@ -158,7 +158,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(result1.GetValue(), result2.GetValue());
 
       auto client3 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
-      Files::Shares::CreateShareFileOptions options3;
+      Files::Shares::CreateFileOptions options3;
       options3.SmbProperties.PermissionKey = result1;
       EXPECT_NO_THROW(client3.Create(1024, options3));
       auto result3 = client3.GetProperties()->SmbProperties.PermissionKey;
@@ -179,8 +179,8 @@ namespace Azure { namespace Storage { namespace Test {
 
       EXPECT_NO_THROW(client1.Create(1024));
       EXPECT_NO_THROW(client2.Create(1024));
-      Files::Shares::SetShareFilePropertiesOptions options1;
-      Files::Shares::SetShareFilePropertiesOptions options2;
+      Files::Shares::SetFilePropertiesOptions options1;
+      Files::Shares::SetFilePropertiesOptions options2;
       options1.Permission = permission;
       options2.Permission = permission;
       EXPECT_NO_THROW(client1.SetProperties(GetInterestingHttpHeaders(), properties, options1));
@@ -192,7 +192,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(result1.GetValue(), result2.GetValue());
 
       auto client3 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
-      Files::Shares::CreateShareFileOptions options3;
+      Files::Shares::CreateFileOptions options3;
       options3.SmbProperties.PermissionKey = result1;
       std::string permissionKey;
       EXPECT_NO_THROW(
@@ -215,8 +215,8 @@ namespace Azure { namespace Storage { namespace Test {
       // Create directory with SmbProperties works
       auto client1 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
       auto client2 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
-      Files::Shares::CreateShareFileOptions options1;
-      Files::Shares::CreateShareFileOptions options2;
+      Files::Shares::CreateFileOptions options1;
+      Files::Shares::CreateFileOptions options2;
       options1.SmbProperties = properties;
       options2.SmbProperties = properties;
 
@@ -316,7 +316,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto testUploadFromBuffer = [&](int concurrency, int64_t fileSize) {
       auto fileClient = m_fileShareDirectoryClient->GetFileClient(RandomString());
 
-      Files::Shares::UploadShareFileFromOptions options;
+      Files::Shares::UploadFileFromOptions options;
       options.TransferOptions.ChunkSize = 512_KB;
       options.TransferOptions.Concurrency = concurrency;
       options.HttpHeaders = GetInterestingHttpHeaders();
@@ -339,7 +339,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto testUploadFromFile = [&](int concurrency, int64_t fileSize) {
       auto fileClient = m_fileShareDirectoryClient->GetFileClient(RandomString());
 
-      Files::Shares::UploadShareFileFromOptions options;
+      Files::Shares::UploadFileFromOptions options;
       options.TransferOptions.ChunkSize = 512_KB;
       options.TransferOptions.Concurrency = concurrency;
       options.HttpHeaders = GetInterestingHttpHeaders();
@@ -426,7 +426,7 @@ namespace Azure { namespace Storage { namespace Test {
         }
       }
       downloadBuffer.resize(static_cast<std::size_t>(downloadSize), '\x00');
-      Files::Shares::DownloadShareFileToOptions options;
+      Files::Shares::DownloadFileToOptions options;
       options.TransferOptions.Concurrency = concurrency;
       if (offset.HasValue())
       {
@@ -496,7 +496,7 @@ namespace Azure { namespace Storage { namespace Test {
           expectedData.clear();
         }
       }
-      Files::Shares::DownloadShareFileToOptions options;
+      Files::Shares::DownloadFileToOptions options;
       options.TransferOptions.Concurrency = concurrency;
       if (offset.HasValue())
       {
@@ -581,7 +581,7 @@ namespace Azure { namespace Storage { namespace Test {
           std::async(std::launch::async, testDownloadToFile, c, fileSize, fileSize + 1, 2));
 
       // buffer not big enough
-      Files::Shares::DownloadShareFileToOptions options;
+      Files::Shares::DownloadFileToOptions options;
       options.TransferOptions.Concurrency = c;
       options.Range = Core::Http::HttpRange();
       options.Range.GetValue().Offset = 1;
@@ -628,11 +628,11 @@ namespace Azure { namespace Storage { namespace Test {
 
       for (int32_t i = 0; i < numOfChunks; ++i)
       {
-        Files::Shares::DownloadShareFileOptions downloadOptions;
+        Files::Shares::DownloadFileOptions downloadOptions;
         downloadOptions.Range = Core::Http::HttpRange();
         downloadOptions.Range.GetValue().Offset = static_cast<int64_t>(rangeSize) * i;
         downloadOptions.Range.GetValue().Length = rangeSize;
-        Files::Shares::Models::DownloadShareFileResult result;
+        Files::Shares::Models::DownloadFileResult result;
         EXPECT_NO_THROW(result = fileClient.Download(downloadOptions).ExtractValue());
         auto resultBuffer = result.BodyStream->ReadToEnd(Core::Context());
         EXPECT_EQ(rangeContent, resultBuffer);
@@ -652,7 +652,7 @@ namespace Azure { namespace Storage { namespace Test {
       auto invalidMd5 = Hash(std::string("This is garbage."));
       auto fileClient
           = m_shareClient->GetRootDirectoryClient().GetFileClient(LowercaseRandomString(10));
-      Files::Shares::UploadShareFileRangeOptions uploadOptions;
+      Files::Shares::UploadFileRangeOptions uploadOptions;
       fileClient.Create(static_cast<int64_t>(numOfChunks) * rangeSize);
       ContentHash hash;
       hash.Value = md5;
@@ -723,7 +723,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(halfContent, downloadContent);
 
     EXPECT_NO_THROW(fileClient.ClearRange(512, 512));
-    Files::Shares::Models::GetShareFileRangeListResult result;
+    Files::Shares::Models::GetFileRangeListResult result;
     EXPECT_NO_THROW(result = fileClient.GetRangeList().ExtractValue());
     EXPECT_EQ(2U, result.Ranges.size());
     EXPECT_EQ(0, result.Ranges[0].Offset);
@@ -755,8 +755,8 @@ namespace Azure { namespace Storage { namespace Test {
     auto snapshot1 = m_shareClient->CreateSnapshot()->Snapshot;
     EXPECT_NO_THROW(fileClient.ClearRange(500, 2048));
     auto snapshot2 = m_shareClient->CreateSnapshot()->Snapshot;
-    Files::Shares::Models::GetShareFileRangeListResult result;
-    Files::Shares::GetShareFileRangeListOptions options;
+    Files::Shares::Models::GetFileRangeListResult result;
+    Files::Shares::GetFileRangeListOptions options;
     EXPECT_NO_THROW(result = fileClient.GetRangeListDiff(snapshot1, options).ExtractValue());
     EXPECT_EQ(2U, result.Ranges.size());
     EXPECT_EQ(0, result.Ranges[0].Offset);
@@ -868,13 +868,13 @@ namespace Azure { namespace Storage { namespace Test {
         uploadResult = *destFileClient.UploadRangeFromUri(
             destRange.Offset, sourceFileClient.GetUrl() + sourceSas, sourceRange));
 
-    Files::Shares::Models::DownloadShareFileResult result;
-    Files::Shares::DownloadShareFileOptions downloadOptions;
+    Files::Shares::Models::DownloadFileResult result;
+    Files::Shares::DownloadFileOptions downloadOptions;
     downloadOptions.Range = destRange;
     EXPECT_NO_THROW(result = destFileClient.Download(downloadOptions).ExtractValue());
     auto resultBuffer = result.BodyStream->ReadToEnd(Core::Context());
     EXPECT_EQ(fileContent, resultBuffer);
-    Files::Shares::Models::GetShareFileRangeListResult getRangeResult;
+    Files::Shares::Models::GetFileRangeListResult getRangeResult;
     EXPECT_NO_THROW(getRangeResult = destFileClient.GetRangeList().ExtractValue());
     EXPECT_EQ(1U, getRangeResult.Ranges.size());
     EXPECT_EQ(static_cast<int64_t>(fileSize), getRangeResult.Ranges[0].Offset);


### PR DESCRIPTION
The intention of this PR is just to showcase the types of changes we'd want to make to avoid long result and option type names which duplicate the namespace name in it (such as ::DataLake and ::Share).

I don't intend to merge this PR.

**Used these regexes in VS Code**

Find: `([a-zA-z])DataLake([a-zA-z])`
Replace: `$1$2`

Find: `([a-zA-z])ShareDirectory([a-zA-z]*)Options`
Replace: `$1Directory$2Options`
Find: `([a-zA-z])ShareDirectory([a-zA-z]*)Result`
Replace: `$1Directory$2Result`

Find: `([a-zA-z])ShareFile([a-zA-z]*)Result`
Replace: `$1File$2Result`
Find: `([a-zA-z])ShareFile([a-zA-z]*)Options`
Replace: `$1File$2Options`

cc @Jinming-Hu 