### PR TITLE
Update sdk/storage codeowners list to use the up-to-date GitHub alias

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 /sdk/keyvault/           @vhvb1989 @ahsonkhan @antkmsft @rickwinter
 
 # PRLabel: %Storage
-/sdk/storage/            @vinjiang @katmsft @JinmingHu-MSFT @antkmsft @rickwinter @vhvb1989
+/sdk/storage/            @vinjiang @katmsft @Jinming-Hu @antkmsft @rickwinter @vhvb1989
 
 # PRLabel: %EngSys
 /sdk/template/           @danieljurek @Azure/azure-sdk-eng


### PR DESCRIPTION
Now the codeowner list will add @Jinming-Hu as PR reviewer for changes under sdk/storage:

It wasn't working before. For example: https://github.com/Azure/azure-sdk-for-cpp/pull/1970

The previous GitHub alias 404s since it was renamed: https://github.com/JinmingHu-MSFT