### PR TITLE
Add gcc 4.8 to matrix

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -26,6 +26,14 @@ jobs:
   condition: and(succeededOrFailed(), ne(variables['Skip.Test'], 'true'))
   strategy:
     matrix:
+      Linux_x64_gcc48:
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage: MMSUbuntu18.04
+        VcpkgInstall: 'curl[ssl] libxml2 openssl'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        CC: '/usr/bin/gcc-4.8'
+        CXX: '/usr/bin/g++-4.8'
+        BuildArgs: '-j 10'
       Linux_x64_gcc8:
         Pool: azsdk-pool-mms-ubuntu-1804-general
         OSVmImage: MMSUbuntu18.04
@@ -144,6 +152,17 @@ jobs:
         contains(variables['OSVmImage'], 'Ubuntu'), 
         contains(variables['CC'], 'gcc-8'), 
         contains(variables['CXX'], 'g++-8')
+      )
+
+  # Install gcc and g++ 4.8 if it is needed on the image.
+  - bash: sudo apt-get install gcc-4.8 g++-4.8 -y
+    displayName: Install gcc and g++ 4.8 
+    condition: >-
+      and(
+        succeeded(), 
+        contains(variables['OSVmImage'], 'Ubuntu'), 
+        contains(variables['CC'], 'gcc-4.8'), 
+        contains(variables['CXX'], 'g++-4.8')
       )
 
   # Validate all the files are formatted correctly according to the

--- a/eng/scripts/vcpkg.ps1
+++ b/eng/scripts/vcpkg.ps1
@@ -16,16 +16,24 @@ Param (
 $initialDirectory = Get-Location
 
 try {
+    Write-Host "git clone https://github.com/Microsoft/vcpkg $VcpkgPath"
     git clone https://github.com/Microsoft/vcpkg $VcpkgPath
+    Write-Host "Set-Location $VcpkgPath"
     Set-Location $VcpkgPath
+    Write-Host "git fetch --tags"
     git fetch --tags
+    Write-Host "git checkout $Ref"
     git checkout $Ref
 
     if ($IsWindows) {
+        Write-Host ".\bootstrap-vcpkg.bat"
         .\bootstrap-vcpkg.bat
+        Write-Host ".\vcpkg.exe install $Dependencies.Split(' ')"
         .\vcpkg.exe install $Dependencies.Split(' ')
     } else {
+        Write-Host "./bootstrap-vcpkg.sh"
         ./bootstrap-vcpkg.sh
+        Write-Host "./vcpkg install $Dependencies.Split(' ')"
         ./vcpkg install $Dependencies.Split(' ')
     }
 } finally {


### PR DESCRIPTION
One possible quick fix is to install gcc 4.8 on an Ubuntu build machine to verify that it builds. 