### PR TITLE
Renamed `Azure::Nullable<T>::GetValue()` to `Value()`.

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -14,6 +14,7 @@
   - `SetHeader(uint8_t const* const first, uint8_t const* const last)`.
   - `GetMajorVersion`.
   - `GetMinorVersion`.
+- Renamed `Azure::Nullable<T>::GetValue()` to `Value()`.
 - Removed from `Azure::Core::Http::Policies` namespace: `HttpPolicyOrder`, `TransportPolicy`, `RetryPolicy`, `RequestIdPolicy`, `TelemetryPolicy`, `BearerTokenAuthenticationPolicy`, `LogPolicy`.
 - Renamed `Azure::Core::Http::RawResponse::GetBodyStream()` to `ExtractBodyStream()`.
 

--- a/sdk/core/azure-core/inc/azure/core/etag.hpp
+++ b/sdk/core/azure-core/inc/azure/core/etag.hpp
@@ -92,7 +92,7 @@ public:
         // If either is weak then there is no match
         //  else tags must match character for character
         return !left.IsWeak() && !right.IsWeak()
-            && (left.m_value.GetValue().compare(right.m_value.GetValue()) == 0);
+            && (left.m_value.Value().compare(right.m_value.Value()) == 0);
         break;
 
       case ETagComparison::Weak:
@@ -100,8 +100,8 @@ public:
         auto leftStart = left.IsWeak() ? 2 : 0;
         auto rightStart = right.IsWeak() ? 2 : 0;
 
-        auto leftVal = left.m_value.GetValue();
-        auto rightVal = right.m_value.GetValue();
+        auto leftVal = left.m_value.Value();
+        auto rightVal = right.m_value.Value();
 
         // Compare if lengths are equal
         //   Compare the strings character by character
@@ -141,7 +141,7 @@ public:
     {
       abort();
     }
-    return m_value.GetValue();
+    return m_value.Value();
   }
 
   /**
@@ -171,10 +171,10 @@ public:
     //  W/""
     // Valid weak format must start with W/"
     //   Must end with a /"
-    const bool weak = m_value && (m_value.GetValue().length() >= 4)
-        && ((m_value.GetValue()[0] == 'W') && (m_value.GetValue()[1] == '/')
-            && (m_value.GetValue()[2] == '"')
-            && (m_value.GetValue()[m_value.GetValue().size() - 1] == '"'));
+    const bool weak = m_value && (m_value.Value().length() >= 4)
+        && ((m_value.Value()[0] == 'W') && (m_value.Value()[1] == '/')
+            && (m_value.Value()[2] == '"')
+            && (m_value.Value()[m_value.Value().size() - 1] == '"'));
 
     return weak;
   }

--- a/sdk/core/azure-core/inc/azure/core/etag.hpp
+++ b/sdk/core/azure-core/inc/azure/core/etag.hpp
@@ -173,8 +173,7 @@ public:
     //   Must end with a /"
     const bool weak = m_value && (m_value.Value().length() >= 4)
         && ((m_value.Value()[0] == 'W') && (m_value.Value()[1] == '/')
-            && (m_value.Value()[2] == '"')
-            && (m_value.Value()[m_value.Value().size() - 1] == '"'));
+            && (m_value.Value()[2] == '"') && (m_value.Value()[m_value.Value().size() - 1] == '"'));
 
     return weak;
   }

--- a/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
@@ -110,7 +110,7 @@ namespace Azure { namespace Core { namespace Json { namespace _internal {
   {
     if (source)
     {
-      jsonKey[keyName] = factory(source.GetValue());
+      jsonKey[keyName] = factory(source.Value());
     }
   }
 
@@ -122,7 +122,7 @@ namespace Azure { namespace Core { namespace Json { namespace _internal {
   {
     if (source)
     {
-      jsonKey[keyName] = source.GetValue();
+      jsonKey[keyName] = source.Value();
     }
   }
 

--- a/sdk/core/azure-core/inc/azure/core/nullable.hpp
+++ b/sdk/core/azure-core/inc/azure/core/nullable.hpp
@@ -218,7 +218,7 @@ public:
   /**
    * @brief Get the contained value.
    */
-  const T& GetValue() const& noexcept
+  const T& Value() const& noexcept
   {
     if (!m_hasValue)
     {
@@ -233,7 +233,7 @@ public:
   /**
    * @brief Get the contained value reference.
    */
-  T& GetValue() & noexcept
+  T& Value() & noexcept
   {
     if (!m_hasValue)
     {
@@ -248,7 +248,7 @@ public:
   /**
    * @brief Get the contained value (as rvalue reference).
    */
-  T&& GetValue() && noexcept
+  T&& Value() && noexcept
   {
     if (!m_hasValue)
     {

--- a/sdk/core/azure-core/test/perf/inc/azure/core/test/nullable.hpp
+++ b/sdk/core/azure-core/test/perf/inc/azure/core/test/nullable.hpp
@@ -43,7 +43,7 @@ namespace Azure { namespace Core { namespace Test {
       {
         n = 0;
       }
-      auto v = n.GetValue();
+      auto v = n.Value();
       if (n)
       {
         n.Reset();

--- a/sdk/core/azure-core/test/ut/http.cpp
+++ b/sdk/core/azure-core/test/ut/http.cpp
@@ -126,7 +126,7 @@ namespace Azure { namespace Core { namespace Test {
       Http::HttpRange r{10, 1};
       EXPECT_EQ(r.Offset, 10);
       EXPECT_TRUE(r.Length.HasValue());
-      EXPECT_EQ(r.Length.GetValue(), 1);
+      EXPECT_EQ(r.Length.Value(), 1);
     }
     {
       Http::HttpRange r;
@@ -139,7 +139,7 @@ namespace Azure { namespace Core { namespace Test {
       r.Length = 10;
       EXPECT_EQ(r.Offset, 0);
       EXPECT_TRUE(r.Length.HasValue());
-      EXPECT_EQ(r.Length.GetValue(), 10);
+      EXPECT_EQ(r.Length.Value(), 10);
     }
     {
       Http::HttpRange r;

--- a/sdk/core/azure-core/test/ut/nullable.cpp
+++ b/sdk/core/azure-core/test/ut/nullable.cpp
@@ -12,15 +12,15 @@ TEST(Nullable, Basic)
 {
   Nullable<std::string> testString{"hello world"};
   EXPECT_TRUE(testString.HasValue());
-  EXPECT_TRUE(testString.GetValue() == "hello world");
+  EXPECT_TRUE(testString.Value() == "hello world");
 
   Nullable<int> testInt{54321};
   EXPECT_TRUE(testInt.HasValue());
-  EXPECT_TRUE(testInt.GetValue() == 54321);
+  EXPECT_TRUE(testInt.Value() == 54321);
 
   Nullable<double> testDouble{10.0};
   EXPECT_TRUE(testDouble.HasValue());
-  EXPECT_TRUE(testDouble.GetValue() == 10.0);
+  EXPECT_TRUE(testDouble.Value() == 10.0);
 }
 
 TEST(Nullable, Empty)
@@ -55,18 +55,18 @@ TEST(Nullable, Assignment)
   Nullable<std::string> instance{"hello world"};
   auto instance2 = instance;
   EXPECT_TRUE(instance2.HasValue());
-  EXPECT_TRUE(instance2.GetValue() == "hello world");
+  EXPECT_TRUE(instance2.Value() == "hello world");
 
   auto instance3 = std::move(instance);
   EXPECT_TRUE(instance3.HasValue());
-  EXPECT_TRUE(instance3.GetValue() == "hello world");
+  EXPECT_TRUE(instance3.Value() == "hello world");
 
   EXPECT_TRUE(instance.HasValue());
 
   // This is not a guarantee that the string will be empty
   //  It is an implementation detail that the contents are moved
   //  Should a future compiler change this assumption this test will need updates
-  EXPECT_TRUE(instance.GetValue() == "");
+  EXPECT_TRUE(instance.Value() == "");
   EXPECT_TRUE(instance.HasValue());
 }
 
@@ -76,22 +76,22 @@ TEST(Nullable, ValueAssignment)
   EXPECT_FALSE(intVal.HasValue());
   intVal = 7;
   EXPECT_TRUE(intVal.HasValue());
-  EXPECT_TRUE(intVal.GetValue() == 7);
+  EXPECT_TRUE(intVal.Value() == 7);
 
   Nullable<double> doubleVal;
   EXPECT_FALSE(doubleVal.HasValue());
   doubleVal = 10.12345;
   EXPECT_TRUE(doubleVal.HasValue());
-  EXPECT_TRUE(doubleVal.GetValue() == 10.12345);
+  EXPECT_TRUE(doubleVal.Value() == 10.12345);
 
   Nullable<std::string> strVal;
   EXPECT_FALSE(strVal.HasValue());
   strVal = std::string("Hello World");
   EXPECT_TRUE(strVal.HasValue());
-  EXPECT_TRUE(strVal.GetValue() == "Hello World");
+  EXPECT_TRUE(strVal.Value() == "Hello World");
 
   strVal = "New String";
-  EXPECT_TRUE(strVal.GetValue() == "New String");
+  EXPECT_TRUE(strVal.Value() == "New String");
 
   strVal.Reset();
   EXPECT_FALSE(strVal.HasValue());
@@ -111,13 +111,13 @@ TEST(Nullable, Swap)
   val3.Swap(val4);
   EXPECT_TRUE(val3);
   EXPECT_TRUE(val4);
-  EXPECT_TRUE(val3.GetValue() == 678910);
-  EXPECT_TRUE(val4.GetValue() == 12345);
+  EXPECT_TRUE(val3.Value() == 678910);
+  EXPECT_TRUE(val4.Value() == 12345);
 
   val1.Swap(val3);
   EXPECT_TRUE(val1);
   EXPECT_FALSE(val3);
-  EXPECT_TRUE(val1.GetValue() == 678910);
+  EXPECT_TRUE(val1.Value() == 678910);
   EXPECT_FALSE(val3.HasValue());
 }
 
@@ -134,19 +134,19 @@ TEST(Nullable, CopyConstruction)
   Nullable<int> val4(val3);
   EXPECT_TRUE(val3);
   EXPECT_TRUE(val4);
-  EXPECT_TRUE(val3.GetValue() == 12345);
-  EXPECT_TRUE(val4.GetValue() == 12345);
+  EXPECT_TRUE(val3.Value() == 12345);
+  EXPECT_TRUE(val4.Value() == 12345);
 
   // Literal
   Nullable<int> val5 = 54321;
   EXPECT_TRUE(val5);
-  EXPECT_TRUE(val5.GetValue() == 54321);
+  EXPECT_TRUE(val5.Value() == 54321);
 
   // Value
   const int i = 1;
   Nullable<int> val6(i);
   EXPECT_TRUE(val6);
-  EXPECT_TRUE(val6.GetValue() == 1);
+  EXPECT_TRUE(val6.Value() == 1);
 }
 
 TEST(Nullable, Disengage)
@@ -164,7 +164,7 @@ TEST(Nullable, ValueOr)
   EXPECT_TRUE(val1);
   EXPECT_TRUE(val1.ValueOr(678910) == 12345);
   // Ensure the value was unmodified in ValueOr
-  EXPECT_TRUE(val1.GetValue() == 12345);
+  EXPECT_TRUE(val1.Value() == 12345);
 
   EXPECT_FALSE(val2);
   EXPECT_TRUE(val2.ValueOr(678910) == 678910);

--- a/sdk/core/perf/src/options.cpp
+++ b/sdk/core/perf/src/options.cpp
@@ -19,7 +19,7 @@ void Azure::Perf::to_json(Azure::Core::Json::_internal::json& j, const GlobalTes
       {"Warmup", p.Warmup}};
   if (p.Port)
   {
-    j["Port"] = p.Port.GetValue();
+    j["Port"] = p.Port.Value();
   }
   else
   {
@@ -27,7 +27,7 @@ void Azure::Perf::to_json(Azure::Core::Json::_internal::json& j, const GlobalTes
   }
   if (p.Rate)
   {
-    j["Rate"] = p.Rate.GetValue();
+    j["Rate"] = p.Rate.Value();
   }
   else
   {

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/details/key_request_parameters.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/details/key_request_parameters.hpp
@@ -42,15 +42,15 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
     {
       if (key.Enabled)
       {
-        m_options.Enabled = key.Enabled.GetValue();
+        m_options.Enabled = key.Enabled.Value();
       }
       if (key.ExpiresOn)
       {
-        m_options.ExpiresOn = key.ExpiresOn.GetValue();
+        m_options.ExpiresOn = key.ExpiresOn.Value();
       }
       if (key.NotBefore)
       {
-        m_options.NotBefore = key.NotBefore.GetValue();
+        m_options.NotBefore = key.NotBefore.Value();
       }
       if (key.Tags.size() > 0)
       {
@@ -58,7 +58,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
       }
       if (operations)
       {
-        m_options.KeyOperations = std::list<KeyOperation>(operations.GetValue());
+        m_options.KeyOperations = std::list<KeyOperation>(operations.Value());
       }
     }
 
@@ -72,7 +72,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
     {
       if (ecKey.CurveName.HasValue())
       {
-        Curve = ecKey.CurveName.GetValue();
+        Curve = ecKey.CurveName.Value();
       }
     }
 
@@ -81,11 +81,11 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
     {
       if (rsaKey.KeySize.HasValue())
       {
-        KeySize = rsaKey.KeySize.GetValue();
+        KeySize = rsaKey.KeySize.Value();
       }
       if (rsaKey.PublicExponent.HasValue())
       {
-        PublicExponent = rsaKey.PublicExponent.GetValue();
+        PublicExponent = rsaKey.PublicExponent.Value();
       }
     }
 
@@ -94,7 +94,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
     {
       if (octKey.KeySize.HasValue())
       {
-        KeySize = octKey.KeySize.GetValue();
+        KeySize = octKey.KeySize.Value();
       }
     }
 

--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -37,7 +37,7 @@ static inline RequestWithContinuationToken BuildRequestFromContinuationToken(
   {
     // Using a continuation token requires to send the request to the continuation token url instead
     // of the default url which is used only for the first page.
-    Azure::Core::Url nextPageUrl(options.ContinuationToken.GetValue());
+    Azure::Core::Url nextPageUrl(options.ContinuationToken.Value());
     request.Query
         = std::make_unique<std::map<std::string, std::string>>(nextPageUrl.GetQueryParameters());
     request.Path.clear();
@@ -49,7 +49,7 @@ static inline RequestWithContinuationToken BuildRequestFromContinuationToken(
     {
       request.Query = std::make_unique<std::map<std::string, std::string>>();
     }
-    request.Query->emplace("maxResults", std::to_string(options.MaxResults.GetValue()));
+    request.Query->emplace("maxResults", std::to_string(options.MaxResults.Value()));
   }
   return request;
 }

--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_request_parameters.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_request_parameters.cpp
@@ -60,7 +60,7 @@ std::string KeyRequestParameters::Serialize() const
   // crv
   if (Curve.HasValue())
   {
-    payload[_detail::CurveNamePropertyName] = Curve.GetValue().ToString();
+    payload[_detail::CurveNamePropertyName] = Curve.Value().ToString();
   }
 
   // release_policy

--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample1-hello-world/sample1_hello_world.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample1-hello-world/sample1_hello_world.cpp
@@ -52,7 +52,7 @@ int main()
               << KeyType::KeyTypeToString(cloudRsaKey.GetKeyType()) << std::endl;
 
     cloudRsaKey.Properties.ExpiresOn
-        = cloudRsaKey.Properties.ExpiresOn.GetValue() + std::chrono::hours(24 * 365);
+        = cloudRsaKey.Properties.ExpiresOn.Value() + std::chrono::hours(24 * 365);
     KeyVaultKey updatedKey = keyClient.UpdateKeyProperties(cloudRsaKey.Properties).Value;
     std::cout << "Key's updated expiry time is " << updatedKey.Properties.ExpiresOn->ToString()
               << std::endl;

--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
@@ -124,7 +124,7 @@ static inline bool CompareNullableT(Azure::Nullable<T> const& left, Azure::Nulla
   {
     return false;
   }
-  return left.GetValue() == right.GetValue();
+  return left.Value() == right.Value();
 }
 
 void AssertKeysEqual(KeyProperties const& expected, KeyProperties const& actual)

--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample3-get-keys/sample3_get_keys.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample3-get-keys/sample3_get_keys.cpp
@@ -78,7 +78,7 @@ int main()
 
       // Get the next page
       GetPropertiesOfKeysSinglePageOptions options;
-      options.ContinuationToken = keysSinglePage.ContinuationToken.GetValue();
+      options.ContinuationToken = keysSinglePage.ContinuationToken.Value();
       keysSinglePage = keyClient.GetPropertiesOfKeysSinglePage(options).Value;
     }
 
@@ -108,7 +108,7 @@ int main()
 
       // Get the next page
       GetPropertiesOfKeyVersionsSinglePageOptions options;
-      options.ContinuationToken = keyVersionsSinglePage.ContinuationToken.GetValue();
+      options.ContinuationToken = keyVersionsSinglePage.ContinuationToken.Value();
       keyVersionsSinglePage
           = keyClient.GetPropertiesOfKeyVersionsSinglePage(rsaKeyName, options).Value;
     }
@@ -141,7 +141,7 @@ int main()
 
       // Get the next page
       GetDeletedKeysSinglePageOptions options;
-      options.ContinuationToken = keysDeletedPage.ContinuationToken.GetValue();
+      options.ContinuationToken = keysDeletedPage.ContinuationToken.Value();
       keysDeletedPage = keyClient.GetDeletedKeysSinglePage(options).Value;
     }
 
@@ -179,5 +179,5 @@ static inline bool CompareNullableT(Azure::Nullable<T> const& left, Azure::Nulla
   {
     return false;
   }
-  return left.GetValue() == right.GetValue();
+  return left.Value() == right.Value();
 }

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_create_test_live.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_create_test_live.cpp
@@ -142,7 +142,7 @@ TEST_F(KeyVaultClientTest, CreateEcKeyWithCurve)
     EXPECT_EQ(keyVaultKey.Name(), keyName);
     EXPECT_TRUE(keyVaultKey.Key.CurveName.HasValue());
     EXPECT_EQ(
-        keyVaultKey.Key.CurveName.GetValue().ToString(),
+        keyVaultKey.Key.CurveName.Value().ToString(),
         Azure::Security::KeyVault::Keys::KeyCurveName::P384().ToString());
   }
 }

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_update_test_live.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_update_test_live.cpp
@@ -30,7 +30,7 @@ TEST_F(KeyVaultClientTest, UpdateProperties)
     auto keyVaultKey = keyResponse.Value;
     EXPECT_EQ(keyVaultKey.Name(), keyName);
     EXPECT_TRUE(keyVaultKey.Properties.Enabled);
-    EXPECT_TRUE(keyVaultKey.Properties.Enabled.GetValue());
+    EXPECT_TRUE(keyVaultKey.Properties.Enabled.Value());
 
     // Update Key
     keyVaultKey.Properties.Enabled = false;
@@ -44,6 +44,6 @@ TEST_F(KeyVaultClientTest, UpdateProperties)
     CheckValidResponse(updatedKey);
     auto key = updatedKey.Value;
     EXPECT_TRUE(key.Properties.Enabled);
-    EXPECT_FALSE(key.Properties.Enabled.GetValue());
+    EXPECT_FALSE(key.Properties.Enabled.Value());
   }
 }

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
@@ -1172,23 +1172,23 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "list");
           if (options.Prefix.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "prefix", _internal::UrlEncodeQueryParameter(options.Prefix.GetValue()));
+                "prefix", _internal::UrlEncodeQueryParameter(options.Prefix.Value()));
           }
           if (options.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "marker", _internal::UrlEncodeQueryParameter(options.ContinuationToken.GetValue()));
+                "marker", _internal::UrlEncodeQueryParameter(options.ContinuationToken.Value()));
           }
           if (options.MaxResults.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "maxresults", std::to_string(options.MaxResults.GetValue()));
+                "maxresults", std::to_string(options.MaxResults.Value()));
           }
           std::string list_blob_containers_include_flags
               = ListBlobContainersIncludeFlagsToString(options.Include);
@@ -1249,7 +1249,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -1289,7 +1289,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -1342,7 +1342,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -1377,7 +1377,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -1415,7 +1415,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -1456,7 +1456,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "blobs");
           request.GetUrl().AppendQueryParameter(
@@ -1464,12 +1464,12 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "marker", _internal::UrlEncodeQueryParameter(options.ContinuationToken.GetValue()));
+                "marker", _internal::UrlEncodeQueryParameter(options.ContinuationToken.Value()));
           }
           if (options.MaxResults.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "maxresults", std::to_string(options.MaxResults.GetValue()));
+                "maxresults", std::to_string(options.MaxResults.Value()));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -2786,7 +2786,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             writer.Write(_internal::XmlNode{
                 _internal::XmlNodeType::Text,
                 nullptr,
-                options.DefaultServiceVersion.GetValue().data()});
+                options.DefaultServiceVersion.Value().data()});
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
           }
           writer.Write(
@@ -2867,7 +2867,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             writer.Write(_internal::XmlNode{
                 _internal::XmlNodeType::Text,
                 nullptr,
-                options.IncludeApis.GetValue() ? "true" : "false"});
+                options.IncludeApis.Value() ? "true" : "false"});
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
           }
           writer.Write(_internal::XmlNode{_internal::XmlNodeType::StartTag, "RetentionPolicy"});
@@ -2889,7 +2889,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             writer.Write(_internal::XmlNode{
                 _internal::XmlNodeType::Text,
                 nullptr,
-                std::to_string(options.Days.GetValue()).data()});
+                std::to_string(options.Days.Value()).data()});
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
           }
         }
@@ -2904,7 +2904,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::StartTag, "IndexDocument"});
             writer.Write(_internal::XmlNode{
-                _internal::XmlNodeType::Text, nullptr, options.IndexDocument.GetValue().data()});
+                _internal::XmlNodeType::Text, nullptr, options.IndexDocument.Value().data()});
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
           }
           if (options.DefaultIndexDocumentPath.HasValue())
@@ -2914,7 +2914,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             writer.Write(_internal::XmlNode{
                 _internal::XmlNodeType::Text,
                 nullptr,
-                options.DefaultIndexDocumentPath.GetValue().data()});
+                options.DefaultIndexDocumentPath.Value().data()});
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
           }
           if (options.ErrorDocument404Path.HasValue())
@@ -2924,7 +2924,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             writer.Write(_internal::XmlNode{
                 _internal::XmlNodeType::Text,
                 nullptr,
-                options.ErrorDocument404Path.GetValue().data()});
+                options.ErrorDocument404Path.Value().data()});
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
           }
         }
@@ -2956,7 +2956,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           for (const auto& pair : options.Metadata)
           {
@@ -2969,13 +2969,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.DefaultEncryptionScope.HasValue())
           {
             request.SetHeader(
-                "x-ms-default-encryption-scope", options.DefaultEncryptionScope.GetValue());
+                "x-ms-default-encryption-scope", options.DefaultEncryptionScope.Value());
           }
           if (options.PreventEncryptionScopeOverride.HasValue())
           {
             request.SetHeader(
                 "x-ms-deny-encryption-scope-override",
-                options.PreventEncryptionScopeOverride.GetValue() ? "true" : "false");
+                options.PreventEncryptionScopeOverride.Value() ? "true" : "false");
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -3015,23 +3015,23 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
@@ -3070,7 +3070,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.SetHeader("x-ms-deleted-container-name", options.DeletedBlobContainerName);
           request.SetHeader("x-ms-deleted-container-version", options.DeletedBlobContainerVersion);
@@ -3107,11 +3107,11 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -3180,7 +3180,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           for (const auto& pair : options.Metadata)
           {
@@ -3188,13 +3188,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -3234,24 +3234,24 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("restype", "container");
           request.GetUrl().AppendQueryParameter("comp", "list");
           if (options.Prefix.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "prefix", _internal::UrlEncodeQueryParameter(options.Prefix.GetValue()));
+                "prefix", _internal::UrlEncodeQueryParameter(options.Prefix.Value()));
           }
           if (options.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "marker", _internal::UrlEncodeQueryParameter(options.ContinuationToken.GetValue()));
+                "marker", _internal::UrlEncodeQueryParameter(options.ContinuationToken.Value()));
           }
           if (options.MaxResults.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "maxresults", std::to_string(options.MaxResults.GetValue()));
+                "maxresults", std::to_string(options.MaxResults.Value()));
           }
           std::string list_blobs_include_flags = ListBlobsIncludeFlagsToString(options.Include);
           if (!list_blobs_include_flags.empty())
@@ -3301,29 +3301,29 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("restype", "container");
           request.GetUrl().AppendQueryParameter("comp", "list");
           if (options.Prefix.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "prefix", _internal::UrlEncodeQueryParameter(options.Prefix.GetValue()));
+                "prefix", _internal::UrlEncodeQueryParameter(options.Prefix.Value()));
           }
           if (options.Delimiter.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "delimiter", _internal::UrlEncodeQueryParameter(options.Delimiter.GetValue()));
+                "delimiter", _internal::UrlEncodeQueryParameter(options.Delimiter.Value()));
           }
           if (options.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "marker", _internal::UrlEncodeQueryParameter(options.ContinuationToken.GetValue()));
+                "marker", _internal::UrlEncodeQueryParameter(options.ContinuationToken.Value()));
           }
           if (options.MaxResults.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "maxresults", std::to_string(options.MaxResults.GetValue()));
+                "maxresults", std::to_string(options.MaxResults.Value()));
           }
           std::string list_blobs_include_flags = ListBlobsIncludeFlagsToString(options.Include);
           if (!list_blobs_include_flags.empty())
@@ -3369,7 +3369,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("restype", "container");
           request.GetUrl().AppendQueryParameter("comp", "acl");
@@ -3432,7 +3432,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("restype", "container");
           request.GetUrl().AppendQueryParameter("comp", "acl");
@@ -3442,19 +3442,19 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
@@ -3496,7 +3496,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("restype", "container");
           request.GetUrl().AppendQueryParameter("comp", "lease");
@@ -3504,19 +3504,19 @@ namespace Azure { namespace Storage { namespace Blobs {
           request.SetHeader("x-ms-lease-duration", std::to_string(options.LeaseDuration.count()));
           if (options.ProposedLeaseId.HasValue())
           {
-            request.SetHeader("x-ms-proposed-lease-id", options.ProposedLeaseId.GetValue());
+            request.SetHeader("x-ms-proposed-lease-id", options.ProposedLeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
@@ -3558,7 +3558,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("restype", "container");
           request.GetUrl().AppendQueryParameter("comp", "lease");
@@ -3568,13 +3568,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
@@ -3617,7 +3617,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("restype", "container");
           request.GetUrl().AppendQueryParameter("comp", "lease");
@@ -3628,13 +3628,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
@@ -3676,7 +3676,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("restype", "container");
           request.GetUrl().AppendQueryParameter("comp", "lease");
@@ -3686,13 +3686,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
@@ -3733,7 +3733,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("restype", "container");
           request.GetUrl().AppendQueryParameter("comp", "lease");
@@ -3741,19 +3741,19 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.BreakPeriod.HasValue())
           {
             request.SetHeader(
-                "x-ms-lease-break-period", std::to_string(options.BreakPeriod.GetValue().count()));
+                "x-ms-lease-break-period", std::to_string(options.BreakPeriod.Value().count()));
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
@@ -4669,45 +4669,45 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.Range.HasValue())
           {
             std::string headerValue
-                = "bytes=" + std::to_string(options.Range.GetValue().Offset) + "-";
-            if (options.Range.GetValue().Length.HasValue())
+                = "bytes=" + std::to_string(options.Range.Value().Offset) + "-";
+            if (options.Range.Value().Length.HasValue())
             {
               headerValue += std::to_string(
-                  options.Range.GetValue().Offset + options.Range.GetValue().Length.GetValue() - 1);
+                  options.Range.Value().Offset + options.Range.Value().Length.Value() - 1);
             }
             request.SetHeader("x-ms-range", std::move(headerValue));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -4720,19 +4720,19 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.RangeHashAlgorithm.HasValue())
           {
-            if (options.RangeHashAlgorithm.GetValue() == HashAlgorithm::Md5)
+            if (options.RangeHashAlgorithm.Value() == HashAlgorithm::Md5)
             {
               request.SetHeader("x-ms-range-get-content-md5", "true");
             }
-            else if (options.RangeHashAlgorithm.GetValue() == HashAlgorithm::Crc64)
+            else if (options.RangeHashAlgorithm.Value() == HashAlgorithm::Crc64)
             {
               request.SetHeader("x-ms-range-get-content-crc64", "true");
             }
@@ -5021,28 +5021,28 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.DeleteSnapshots.HasValue())
           {
             request.SetHeader(
-                "x-ms-delete-snapshots", options.DeleteSnapshots.GetValue().ToString());
+                "x-ms-delete-snapshots", options.DeleteSnapshots.Value().ToString());
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -5055,7 +5055,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           return request;
         }
@@ -5108,13 +5108,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "expiry");
           request.SetHeader("x-ms-expiry-option", options.ExpiryOrigin.ToString());
           if (options.ExpiryTime.HasValue())
           {
-            request.SetHeader("x-ms-expiry-time", options.ExpiryTime.GetValue());
+            request.SetHeader("x-ms-expiry-time", options.ExpiryTime.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -5148,7 +5148,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "undelete");
           auto pHttpResponse = pipeline.Send(request, context);
@@ -5190,38 +5190,38 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -5234,7 +5234,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -5518,7 +5518,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (!options.HttpHeaders.ContentType.empty())
           {
@@ -5549,19 +5549,19 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -5574,7 +5574,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -5629,7 +5629,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           for (const auto& pair : options.Metadata)
           {
@@ -5637,38 +5637,38 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -5681,7 +5681,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -5720,17 +5720,17 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.SetHeader("x-ms-access-tier", options.AccessTier.ToString());
           if (options.RehydratePriority.HasValue())
           {
             request.SetHeader(
-                "x-ms-rehydrate-priority", options.RehydratePriority.GetValue().ToString());
+                "x-ms-rehydrate-priority", options.RehydratePriority.Value().ToString());
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           return request;
         }
@@ -5799,7 +5799,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           for (const auto& pair : options.Metadata)
           {
@@ -5808,37 +5808,37 @@ namespace Azure { namespace Storage { namespace Blobs {
           request.SetHeader("x-ms-copy-source", options.SourceUri);
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.SourceLeaseId.HasValue())
           {
-            request.SetHeader("x-ms-source-lease-id", options.SourceLeaseId.GetValue());
+            request.SetHeader("x-ms-source-lease-id", options.SourceLeaseId.Value());
           }
           if (options.AccessTier.HasValue())
           {
-            request.SetHeader("x-ms-access-tier", options.AccessTier.GetValue().ToString());
+            request.SetHeader("x-ms-access-tier", options.AccessTier.Value().ToString());
           }
           if (options.RehydratePriority.HasValue())
           {
             request.SetHeader(
-                "x-ms-rehydrate-priority", options.RehydratePriority.GetValue().ToString());
+                "x-ms-rehydrate-priority", options.RehydratePriority.Value().ToString());
           }
           if (options.ShouldSealDestination.HasValue())
           {
             request.SetHeader(
-                "x-ms-seal-blob", options.ShouldSealDestination.GetValue() ? "true" : "false");
+                "x-ms-seal-blob", options.ShouldSealDestination.Value() ? "true" : "false");
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -5851,20 +5851,20 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           if (options.SourceIfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "x-ms-source-if-modified-since",
-                options.SourceIfModifiedSince.GetValue().ToString(
+                options.SourceIfModifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.SourceIfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "x-ms-source-if-unmodified-since",
-                options.SourceIfUnmodifiedSince.GetValue().ToString(
+                options.SourceIfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.SourceIfMatch.HasValue() && !options.SourceIfMatch.ToString().empty())
@@ -5877,7 +5877,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.SourceIfTags.HasValue())
           {
-            request.SetHeader("x-ms-source-if-tags", options.SourceIfTags.GetValue());
+            request.SetHeader("x-ms-source-if-tags", options.SourceIfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -5923,7 +5923,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "copy");
           request.GetUrl().AppendQueryParameter(
@@ -5931,7 +5931,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           request.SetHeader("x-ms-copy-action", "abort");
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -5977,26 +5977,26 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           for (const auto& pair : options.Metadata)
           {
@@ -6004,19 +6004,19 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -6029,7 +6029,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -6087,12 +6087,12 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "tags");
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -6143,13 +6143,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "tags");
           request.SetHeader("Content-Type", "application/xml; charset=UTF-8");
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -6189,26 +6189,26 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "lease");
           request.SetHeader("x-ms-lease-action", "acquire");
           request.SetHeader("x-ms-lease-duration", std::to_string(options.LeaseDuration.count()));
           if (options.ProposedLeaseId.HasValue())
           {
-            request.SetHeader("x-ms-proposed-lease-id", options.ProposedLeaseId.GetValue());
+            request.SetHeader("x-ms-proposed-lease-id", options.ProposedLeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -6221,7 +6221,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -6265,7 +6265,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "lease");
           request.SetHeader("x-ms-lease-action", "renew");
@@ -6274,13 +6274,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -6293,7 +6293,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -6338,7 +6338,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "lease");
           request.SetHeader("x-ms-lease-action", "change");
@@ -6348,13 +6348,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -6367,7 +6367,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -6411,7 +6411,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "lease");
           request.SetHeader("x-ms-lease-action", "release");
@@ -6420,13 +6420,13 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -6439,7 +6439,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -6488,26 +6488,26 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.GetUrl().AppendQueryParameter("comp", "lease");
           request.SetHeader("x-ms-lease-action", "break");
           if (options.BreakPeriod.HasValue())
           {
             request.SetHeader(
-                "x-ms-lease-break-period", std::to_string(options.BreakPeriod.GetValue().count()));
+                "x-ms-lease-break-period", std::to_string(options.BreakPeriod.Value().count()));
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -6520,7 +6520,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -6707,42 +6707,42 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.TransactionalContentHash.HasValue())
           {
-            if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Md5)
+            if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
             {
               request.SetHeader(
                   "Content-MD5",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
-            else if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Crc64)
+            else if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Crc64)
             {
               request.SetHeader(
                   "x-ms-content-crc64",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
           }
           if (!options.HttpHeaders.ContentType.empty())
@@ -6778,24 +6778,24 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           request.SetHeader("x-ms-blob-type", "BlockBlob");
           if (options.AccessTier.HasValue())
           {
-            request.SetHeader("x-ms-access-tier", options.AccessTier.GetValue().ToString());
+            request.SetHeader("x-ms-access-tier", options.AccessTier.Value().ToString());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -6808,7 +6808,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -6896,47 +6896,47 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.TransactionalContentHash.HasValue())
           {
-            if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Md5)
+            if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
             {
               request.SetHeader(
                   "Content-MD5",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
-            else if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Crc64)
+            else if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Crc64)
             {
               request.SetHeader(
                   "x-ms-content-crc64",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -7019,73 +7019,73 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.SetHeader("x-ms-copy-source", options.SourceUri);
           if (options.SourceRange.HasValue())
           {
             std::string headerValue
-                = "bytes=" + std::to_string(options.SourceRange.GetValue().Offset) + "-";
-            if (options.SourceRange.GetValue().Length.HasValue())
+                = "bytes=" + std::to_string(options.SourceRange.Value().Offset) + "-";
+            if (options.SourceRange.Value().Length.HasValue())
             {
               headerValue += std::to_string(
-                  options.SourceRange.GetValue().Offset
-                  + options.SourceRange.GetValue().Length.GetValue() - 1);
+                  options.SourceRange.Value().Offset
+                  + options.SourceRange.Value().Length.Value() - 1);
             }
             request.SetHeader("x-ms-source_range", std::move(headerValue));
           }
           if (options.TransactionalContentHash.HasValue())
           {
-            if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Md5)
+            if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
             {
               request.SetHeader(
                   "x-ms-source-content-md5",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
-            else if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Crc64)
+            else if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Crc64)
             {
               request.SetHeader(
                   "x-ms-source-content-crc64",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.SourceIfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "x-ms-source-if-modified-since",
-                options.SourceIfModifiedSince.GetValue().ToString(
+                options.SourceIfModifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.SourceIfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "x-ms-source-if-unmodified-since",
-                options.SourceIfUnmodifiedSince.GetValue().ToString(
+                options.SourceIfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.SourceIfMatch.HasValue() && !options.SourceIfMatch.ToString().empty())
@@ -7187,7 +7187,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (!options.HttpHeaders.ContentType.empty())
           {
@@ -7222,42 +7222,42 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.AccessTier.HasValue())
           {
-            request.SetHeader("x-ms-access-tier", options.AccessTier.GetValue().ToString());
+            request.SetHeader("x-ms-access-tier", options.AccessTier.Value().ToString());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -7270,7 +7270,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -7332,15 +7332,15 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -7548,7 +7548,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (!options.HttpHeaders.ContentType.empty())
           {
@@ -7583,49 +7583,49 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           request.SetHeader("x-ms-blob-type", "PageBlob");
           request.SetHeader("x-ms-blob-content-length", std::to_string(options.BlobSize));
           if (options.SequenceNumber.HasValue())
           {
             request.SetHeader(
-                "x-ms-blob-sequence-number", std::to_string(options.SequenceNumber.GetValue()));
+                "x-ms-blob-sequence-number", std::to_string(options.SequenceNumber.Value()));
           }
           if (options.AccessTier.HasValue())
           {
-            request.SetHeader("x-ms-access-tier", options.AccessTier.GetValue().ToString());
+            request.SetHeader("x-ms-access-tier", options.AccessTier.Value().ToString());
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -7638,7 +7638,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -7713,87 +7713,87 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           {
             std::string headerValue = "bytes=" + std::to_string(options.Range.Offset) + "-";
             if (options.Range.Length.HasValue())
             {
               headerValue
-                  += std::to_string(options.Range.Offset + options.Range.Length.GetValue() - 1);
+                  += std::to_string(options.Range.Offset + options.Range.Length.Value() - 1);
             }
             request.SetHeader("x-ms-range", std::move(headerValue));
           }
           if (options.TransactionalContentHash.HasValue())
           {
-            if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Md5)
+            if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
             {
               request.SetHeader(
                   "Content-MD5",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
-            else if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Crc64)
+            else if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Crc64)
             {
               request.SetHeader(
                   "x-ms-content-crc64",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
           }
           request.SetHeader("x-ms-page-write", "update");
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfSequenceNumberLessThanOrEqualTo.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-le",
-                std::to_string(options.IfSequenceNumberLessThanOrEqualTo.GetValue()));
+                std::to_string(options.IfSequenceNumberLessThanOrEqualTo.Value()));
           }
           if (options.IfSequenceNumberLessThan.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-lt",
-                std::to_string(options.IfSequenceNumberLessThan.GetValue()));
+                std::to_string(options.IfSequenceNumberLessThan.Value()));
           }
           if (options.IfSequenceNumberEqualTo.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-eq",
-                std::to_string(options.IfSequenceNumberEqualTo.GetValue()));
+                std::to_string(options.IfSequenceNumberEqualTo.Value()));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -7806,7 +7806,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -7896,14 +7896,14 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           {
             std::string headerValue = "bytes=" + std::to_string(options.Range.Offset) + "-";
             if (options.Range.Length.HasValue())
             {
               headerValue
-                  += std::to_string(options.Range.Offset + options.Range.Length.GetValue() - 1);
+                  += std::to_string(options.Range.Offset + options.Range.Length.Value() - 1);
             }
             request.SetHeader("x-ms-range", std::move(headerValue));
           }
@@ -7913,80 +7913,80 @@ namespace Azure { namespace Storage { namespace Blobs {
             if (options.SourceRange.Length.HasValue())
             {
               headerValue += std::to_string(
-                  options.SourceRange.Offset + options.SourceRange.Length.GetValue() - 1);
+                  options.SourceRange.Offset + options.SourceRange.Length.Value() - 1);
             }
             request.SetHeader("x-ms-source-range", std::move(headerValue));
           }
           if (options.TransactionalContentHash.HasValue())
           {
-            if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Md5)
+            if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
             {
               request.SetHeader(
                   "x-ms-source-content-md5",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
-            else if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Crc64)
+            else if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Crc64)
             {
               request.SetHeader(
                   "x-ms-source-content-crc64",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
           }
           request.SetHeader("x-ms-page-write", "update");
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfSequenceNumberLessThanOrEqualTo.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-le",
-                std::to_string(options.IfSequenceNumberLessThanOrEqualTo.GetValue()));
+                std::to_string(options.IfSequenceNumberLessThanOrEqualTo.Value()));
           }
           if (options.IfSequenceNumberLessThan.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-lt",
-                std::to_string(options.IfSequenceNumberLessThan.GetValue()));
+                std::to_string(options.IfSequenceNumberLessThan.Value()));
           }
           if (options.IfSequenceNumberEqualTo.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-eq",
-                std::to_string(options.IfSequenceNumberEqualTo.GetValue()));
+                std::to_string(options.IfSequenceNumberEqualTo.Value()));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -7999,7 +7999,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -8087,70 +8087,70 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           {
             std::string headerValue = "bytes=" + std::to_string(options.Range.Offset) + "-";
             if (options.Range.Length.HasValue())
             {
               headerValue
-                  += std::to_string(options.Range.Offset + options.Range.Length.GetValue() - 1);
+                  += std::to_string(options.Range.Offset + options.Range.Length.Value() - 1);
             }
             request.SetHeader("x-ms-range", std::move(headerValue));
           }
           request.SetHeader("x-ms-page-write", "clear");
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfSequenceNumberLessThanOrEqualTo.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-le",
-                std::to_string(options.IfSequenceNumberLessThanOrEqualTo.GetValue()));
+                std::to_string(options.IfSequenceNumberLessThanOrEqualTo.Value()));
           }
           if (options.IfSequenceNumberLessThan.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-lt",
-                std::to_string(options.IfSequenceNumberLessThan.GetValue()));
+                std::to_string(options.IfSequenceNumberLessThan.Value()));
           }
           if (options.IfSequenceNumberEqualTo.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-eq",
-                std::to_string(options.IfSequenceNumberEqualTo.GetValue()));
+                std::to_string(options.IfSequenceNumberEqualTo.Value()));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -8163,7 +8163,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -8216,61 +8216,61 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.SetHeader("x-ms-blob-content-length", std::to_string(options.BlobSize));
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfSequenceNumberLessThanOrEqualTo.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-le",
-                std::to_string(options.IfSequenceNumberLessThanOrEqualTo.GetValue()));
+                std::to_string(options.IfSequenceNumberLessThanOrEqualTo.Value()));
           }
           if (options.IfSequenceNumberLessThan.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-lt",
-                std::to_string(options.IfSequenceNumberLessThan.GetValue()));
+                std::to_string(options.IfSequenceNumberLessThan.Value()));
           }
           if (options.IfSequenceNumberEqualTo.HasValue())
           {
             request.SetHeader(
                 "x-ms-if-sequence-number-eq",
-                std::to_string(options.IfSequenceNumberEqualTo.GetValue()));
+                std::to_string(options.IfSequenceNumberEqualTo.Value()));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -8283,7 +8283,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -8331,44 +8331,44 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.GetUrl().AppendQueryParameter(
                 "prevsnapshot",
-                _internal::UrlEncodeQueryParameter(options.PreviousSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(options.PreviousSnapshot.Value()));
           }
           request.SetHeader("x-ms-version", "2020-02-10");
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.Range.HasValue())
           {
             std::string headerValue
-                = "bytes=" + std::to_string(options.Range.GetValue().Offset) + "-";
-            if (options.Range.GetValue().Length.HasValue())
+                = "bytes=" + std::to_string(options.Range.Value().Offset) + "-";
+            if (options.Range.Value().Length.HasValue())
             {
               headerValue += std::to_string(
-                  options.Range.GetValue().Offset + options.Range.GetValue().Length.GetValue() - 1);
+                  options.Range.Value().Offset + options.Range.Value().Length.Value() - 1);
             }
             request.SetHeader("x-ms-range", std::move(headerValue));
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.PreviousSnapshotUrl.HasValue())
           {
-            request.SetHeader("x-ms-previous-snapshot-url", options.PreviousSnapshotUrl.GetValue());
+            request.SetHeader("x-ms-previous-snapshot-url", options.PreviousSnapshotUrl.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -8381,7 +8381,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -8433,20 +8433,20 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.SetHeader("x-ms-copy-source", options.CopySource);
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -8459,7 +8459,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -8692,7 +8692,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (!options.HttpHeaders.ContentType.empty())
           {
@@ -8727,39 +8727,39 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           request.SetHeader("x-ms-blob-type", "AppendBlob");
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -8772,7 +8772,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -8845,69 +8845,69 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.TransactionalContentHash.HasValue())
           {
-            if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Md5)
+            if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
             {
               request.SetHeader(
                   "Content-MD5",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
-            else if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Crc64)
+            else if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Crc64)
             {
               request.SetHeader(
                   "x-ms-content-crc64",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.MaxSize.HasValue())
           {
             request.SetHeader(
-                "x-ms-blob-condition-maxsize", std::to_string(options.MaxSize.GetValue()));
+                "x-ms-blob-condition-maxsize", std::to_string(options.MaxSize.Value()));
           }
           if (options.AppendPosition.HasValue())
           {
             request.SetHeader(
-                "x-ms-blob-condition-appendpos", std::to_string(options.AppendPosition.GetValue()));
+                "x-ms-blob-condition-appendpos", std::to_string(options.AppendPosition.Value()));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -8920,7 +8920,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -9010,82 +9010,82 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.SetHeader("x-ms-copy-source", options.SourceUri);
           if (options.SourceRange.HasValue())
           {
             std::string headerValue
-                = "bytes=" + std::to_string(options.SourceRange.GetValue().Offset) + "-";
-            if (options.SourceRange.GetValue().Length.HasValue())
+                = "bytes=" + std::to_string(options.SourceRange.Value().Offset) + "-";
+            if (options.SourceRange.Value().Length.HasValue())
             {
               headerValue += std::to_string(
-                  options.SourceRange.GetValue().Offset
-                  + options.SourceRange.GetValue().Length.GetValue() - 1);
+                  options.SourceRange.Value().Offset
+                  + options.SourceRange.Value().Length.Value() - 1);
             }
             request.SetHeader("x-ms-source-range", std::move(headerValue));
           }
           if (options.TransactionalContentHash.HasValue())
           {
-            if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Md5)
+            if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
             {
               request.SetHeader(
                   "x-ms-source-content-md5",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
-            else if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Crc64)
+            else if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Crc64)
             {
               request.SetHeader(
                   "x-ms-source-content-crc64",
                   Azure::Core::Convert::Base64Encode(
-                      options.TransactionalContentHash.GetValue().Value));
+                      options.TransactionalContentHash.Value().Value));
             }
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.MaxSize.HasValue())
           {
             request.SetHeader(
-                "x-ms-blob-condition-maxsize", std::to_string(options.MaxSize.GetValue()));
+                "x-ms-blob-condition-maxsize", std::to_string(options.MaxSize.Value()));
           }
           if (options.AppendPosition.HasValue())
           {
             request.SetHeader(
-                "x-ms-blob-condition-appendpos", std::to_string(options.AppendPosition.GetValue()));
+                "x-ms-blob-condition-appendpos", std::to_string(options.AppendPosition.Value()));
           }
           if (options.EncryptionKey.HasValue())
           {
-            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.GetValue());
+            request.SetHeader("x-ms-encryption-key", options.EncryptionKey.Value());
           }
           if (options.EncryptionKeySha256.HasValue())
           {
             request.SetHeader(
                 "x-ms-encryption-key-sha256",
-                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.GetValue()));
+                Azure::Core::Convert::Base64Encode(options.EncryptionKeySha256.Value()));
           }
           if (options.EncryptionAlgorithm.HasValue())
           {
             request.SetHeader(
-                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.GetValue().ToString());
+                "x-ms-encryption-algorithm", options.EncryptionAlgorithm.Value().ToString());
           }
           if (options.EncryptionScope.HasValue())
           {
-            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.GetValue());
+            request.SetHeader("x-ms-encryption-scope", options.EncryptionScope.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -9098,7 +9098,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -9181,23 +9181,23 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           if (options.LeaseId.HasValue())
           {
-            request.SetHeader("x-ms-lease-id", options.LeaseId.GetValue());
+            request.SetHeader("x-ms-lease-id", options.LeaseId.Value());
           }
           if (options.IfModifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Modified-Since",
-                options.IfModifiedSince.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123));
+                options.IfModifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.GetValue().ToString(
+                options.IfUnmodifiedSince.Value().ToString(
                     Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
@@ -9210,12 +9210,12 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.IfTags.HasValue())
           {
-            request.SetHeader("x-ms-if-tags", options.IfTags.GetValue());
+            request.SetHeader("x-ms-if-tags", options.IfTags.Value());
           }
           if (options.AppendPosition.HasValue())
           {
             request.SetHeader(
-                "x-ms-blob-condition-appendpos", std::to_string(options.AppendPosition.GetValue()));
+                "x-ms-blob-condition-appendpos", std::to_string(options.AppendPosition.Value()));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -9261,7 +9261,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           if (options.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
-                "timeout", std::to_string(options.Timeout.GetValue()));
+                "timeout", std::to_string(options.Timeout.Value()));
           }
           request.SetHeader("Content-Type", options.ContentType);
           auto pHttpResponse = pipeline.Send(request, context);

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/protocol/blob_rest_client.hpp
@@ -3031,8 +3031,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -3454,8 +3453,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -3516,8 +3514,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -3574,8 +3571,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -3634,8 +3630,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -3692,8 +3687,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -3753,8 +3747,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           auto pHttpResponse = pipeline.Send(request, context);
           Azure::Core::Http::RawResponse& httpResponse = *pHttpResponse;
@@ -4673,8 +4666,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.Range.HasValue())
           {
-            std::string headerValue
-                = "bytes=" + std::to_string(options.Range.Value().Offset) + "-";
+            std::string headerValue = "bytes=" + std::to_string(options.Range.Value().Offset) + "-";
             if (options.Range.Value().Length.HasValue())
             {
               headerValue += std::to_string(
@@ -4707,8 +4699,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -5025,8 +5016,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.DeleteSnapshots.HasValue())
           {
-            request.SetHeader(
-                "x-ms-delete-snapshots", options.DeleteSnapshots.Value().ToString());
+            request.SetHeader("x-ms-delete-snapshots", options.DeleteSnapshots.Value().ToString());
           }
           if (options.LeaseId.HasValue())
           {
@@ -5042,8 +5032,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -5221,8 +5210,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -5561,8 +5549,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -5668,8 +5655,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -5838,8 +5824,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -6016,8 +6001,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -6208,8 +6192,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -6280,8 +6263,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -6354,8 +6336,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -6426,8 +6407,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -6507,8 +6487,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -6795,8 +6774,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -7029,8 +7007,8 @@ namespace Azure { namespace Storage { namespace Blobs {
             if (options.SourceRange.Value().Length.HasValue())
             {
               headerValue += std::to_string(
-                  options.SourceRange.Value().Offset
-                  + options.SourceRange.Value().Length.Value() - 1);
+                  options.SourceRange.Value().Offset + options.SourceRange.Value().Length.Value()
+                  - 1);
             }
             request.SetHeader("x-ms-source_range", std::move(headerValue));
           }
@@ -7257,8 +7235,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -7625,8 +7602,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -7793,8 +7769,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -7986,8 +7961,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -8150,8 +8124,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -8270,8 +8243,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -8341,8 +8313,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           }
           if (options.Range.HasValue())
           {
-            std::string headerValue
-                = "bytes=" + std::to_string(options.Range.Value().Offset) + "-";
+            std::string headerValue = "bytes=" + std::to_string(options.Range.Value().Offset) + "-";
             if (options.Range.Value().Length.HasValue())
             {
               headerValue += std::to_string(
@@ -8368,8 +8339,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -8446,8 +8416,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -8759,8 +8728,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -8907,8 +8875,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -9020,8 +8987,8 @@ namespace Azure { namespace Storage { namespace Blobs {
             if (options.SourceRange.Value().Length.HasValue())
             {
               headerValue += std::to_string(
-                  options.SourceRange.Value().Offset
-                  + options.SourceRange.Value().Length.Value() - 1);
+                  options.SourceRange.Value().Offset + options.SourceRange.Value().Length.Value()
+                  - 1);
             }
             request.SetHeader("x-ms-source-range", std::move(headerValue));
           }
@@ -9085,8 +9052,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {
@@ -9197,8 +9163,7 @@ namespace Azure { namespace Storage { namespace Blobs {
           {
             request.SetHeader(
                 "If-Unmodified-Since",
-                options.IfUnmodifiedSince.Value().ToString(
-                    Azure::DateTime::DateFormat::Rfc1123));
+                options.IfUnmodifiedSince.Value().ToString(Azure::DateTime::DateFormat::Rfc1123));
           }
           if (options.IfMatch.HasValue() && !options.IfMatch.ToString().empty())
           {

--- a/sdk/storage/azure-storage-blobs/src/append_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/append_blob_client.cpp
@@ -87,9 +87,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::AppendBlob::Create(
@@ -137,9 +137,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::AppendBlob::AppendBlock(
@@ -165,9 +165,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::AppendBlob::AppendBlockFromUri(

--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -165,9 +165,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
 
     auto downloadResponse = _detail::BlobRestClient::Blob::Download(
@@ -183,12 +183,12 @@ namespace Azure { namespace Storage { namespace Blobs {
               const Azure::Core::Context& context) -> std::unique_ptr<Azure::Core::IO::BodyStream> {
         DownloadBlobOptions newOptions = options;
         newOptions.Range = Core::Http::HttpRange();
-        newOptions.Range.GetValue().Offset
-            = (options.Range.HasValue() ? options.Range.GetValue().Offset : 0) + retryInfo.Offset;
-        if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
+        newOptions.Range.Value().Offset
+            = (options.Range.HasValue() ? options.Range.Value().Offset : 0) + retryInfo.Offset;
+        if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
         {
-          newOptions.Range.GetValue().Length
-              = options.Range.GetValue().Length.GetValue() - retryInfo.Offset;
+          newOptions.Range.Value().Length
+              = options.Range.Value().Length.Value() - retryInfo.Offset;
         }
         if (!newOptions.AccessConditions.IfMatch.HasValue())
         {
@@ -224,18 +224,18 @@ namespace Azure { namespace Storage { namespace Blobs {
     // Just start downloading using an initial chunk. If it's a small blob, we'll get the whole
     // thing in one shot. If it's a large blob, we'll get its full size in Content-Range and can
     // keep downloading it in chunks.
-    const int64_t firstChunkOffset = options.Range.HasValue() ? options.Range.GetValue().Offset : 0;
+    const int64_t firstChunkOffset = options.Range.HasValue() ? options.Range.Value().Offset : 0;
     int64_t firstChunkLength = options.TransferOptions.InitialChunkSize;
-    if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
+    if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
     {
-      firstChunkLength = std::min(firstChunkLength, options.Range.GetValue().Length.GetValue());
+      firstChunkLength = std::min(firstChunkLength, options.Range.Value().Length.Value());
     }
 
     DownloadBlobOptions firstChunkOptions;
     firstChunkOptions.Range = options.Range;
     if (firstChunkOptions.Range.HasValue())
     {
-      firstChunkOptions.Range.GetValue().Length = firstChunkLength;
+      firstChunkOptions.Range.Value().Length = firstChunkLength;
     }
 
     auto firstChunk = Download(firstChunkOptions, context);
@@ -246,9 +246,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     if (firstChunkOptions.Range.HasValue())
     {
       blobRangeSize = blobSize - firstChunkOffset;
-      if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
+      if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
       {
-        blobRangeSize = std::min(blobRangeSize, options.Range.GetValue().Length.GetValue());
+        blobRangeSize = std::min(blobRangeSize, options.Range.Value().Length.Value());
       }
     }
     else
@@ -287,8 +287,8 @@ namespace Azure { namespace Storage { namespace Blobs {
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
             DownloadBlobOptions chunkOptions;
             chunkOptions.Range = Core::Http::HttpRange();
-            chunkOptions.Range.GetValue().Offset = offset;
-            chunkOptions.Range.GetValue().Length = length;
+            chunkOptions.Range.Value().Offset = offset;
+            chunkOptions.Range.Value().Length = length;
             if (!chunkOptions.AccessConditions.IfMatch.HasValue())
             {
               chunkOptions.AccessConditions.IfMatch = eTag;
@@ -296,9 +296,9 @@ namespace Azure { namespace Storage { namespace Blobs {
             auto chunk = Download(chunkOptions, context);
             int64_t bytesRead = chunk.Value.BodyStream->ReadToCount(
                 buffer + (offset - firstChunkOffset),
-                chunkOptions.Range.GetValue().Length.GetValue(),
+                chunkOptions.Range.Value().Length.Value(),
                 context);
-            if (bytesRead != chunkOptions.Range.GetValue().Length.GetValue())
+            if (bytesRead != chunkOptions.Range.Value().Length.Value())
             {
               throw Azure::Core::RequestFailedException("error when reading body stream");
             }
@@ -332,18 +332,18 @@ namespace Azure { namespace Storage { namespace Blobs {
     // Just start downloading using an initial chunk. If it's a small blob, we'll get the whole
     // thing in one shot. If it's a large blob, we'll get its full size in Content-Range and can
     // keep downloading it in chunks.
-    const int64_t firstChunkOffset = options.Range.HasValue() ? options.Range.GetValue().Offset : 0;
+    const int64_t firstChunkOffset = options.Range.HasValue() ? options.Range.Value().Offset : 0;
     int64_t firstChunkLength = options.TransferOptions.InitialChunkSize;
-    if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
+    if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
     {
-      firstChunkLength = std::min(firstChunkLength, options.Range.GetValue().Length.GetValue());
+      firstChunkLength = std::min(firstChunkLength, options.Range.Value().Length.Value());
     }
 
     DownloadBlobOptions firstChunkOptions;
     firstChunkOptions.Range = options.Range;
     if (firstChunkOptions.Range.HasValue())
     {
-      firstChunkOptions.Range.GetValue().Length = firstChunkLength;
+      firstChunkOptions.Range.Value().Length = firstChunkLength;
     }
 
     _internal::FileWriter fileWriter(fileName);
@@ -356,9 +356,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     if (firstChunkOptions.Range.HasValue())
     {
       blobRangeSize = blobSize - firstChunkOffset;
-      if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
+      if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
       {
-        blobRangeSize = std::min(blobRangeSize, options.Range.GetValue().Length.GetValue());
+        blobRangeSize = std::min(blobRangeSize, options.Range.Value().Length.Value());
       }
     }
     else
@@ -408,8 +408,8 @@ namespace Azure { namespace Storage { namespace Blobs {
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
             DownloadBlobOptions chunkOptions;
             chunkOptions.Range = Core::Http::HttpRange();
-            chunkOptions.Range.GetValue().Offset = offset;
-            chunkOptions.Range.GetValue().Length = length;
+            chunkOptions.Range.Value().Offset = offset;
+            chunkOptions.Range.Value().Length = length;
             if (!chunkOptions.AccessConditions.IfMatch.HasValue())
             {
               chunkOptions.AccessConditions.IfMatch = eTag;
@@ -419,7 +419,7 @@ namespace Azure { namespace Storage { namespace Blobs {
                 *(chunk.Value.BodyStream),
                 fileWriter,
                 offset - firstChunkOffset,
-                chunkOptions.Range.GetValue().Length.GetValue(),
+                chunkOptions.Range.Value().Length.Value(),
                 context);
 
             if (chunkId == numChunks - 1)
@@ -456,9 +456,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     auto response = _detail::BlobRestClient::Blob::GetProperties(
         *m_pipeline, m_blobUrl, protocolLayerOptions, _internal::WithReplicaStatus(context));
@@ -514,9 +514,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::Blob::SetMetadata(
@@ -593,9 +593,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::Blob::CreateSnapshot(

--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -187,8 +187,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             = (options.Range.HasValue() ? options.Range.Value().Offset : 0) + retryInfo.Offset;
         if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
         {
-          newOptions.Range.Value().Length
-              = options.Range.Value().Length.Value() - retryInfo.Offset;
+          newOptions.Range.Value().Length = options.Range.Value().Length.Value() - retryInfo.Offset;
         }
         if (!newOptions.AccessConditions.IfMatch.HasValue())
         {

--- a/sdk/storage/azure-storage-blobs/src/blob_lease_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_lease_client.cpp
@@ -31,8 +31,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
 
       auto response = _detail::BlobRestClient::Blob::AcquireLease(
-          *(m_blobClient.GetValue().m_pipeline),
-          m_blobClient.GetValue().m_blobUrl,
+          *(m_blobClient.Value().m_pipeline),
+          m_blobClient.Value().m_blobUrl,
           protocolLayerOptions,
           context);
 
@@ -59,8 +59,8 @@ namespace Azure { namespace Storage { namespace Blobs {
         std::abort();
       }
       auto response = _detail::BlobRestClient::BlobContainer::AcquireLease(
-          *(m_blobContainerClient.GetValue().m_pipeline),
-          m_blobContainerClient.GetValue().m_blobContainerUrl,
+          *(m_blobContainerClient.Value().m_pipeline),
+          m_blobContainerClient.Value().m_blobContainerUrl,
           protocolLayerOptions,
           context);
 
@@ -93,8 +93,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
 
       auto response = _detail::BlobRestClient::Blob::RenewLease(
-          *(m_blobClient.GetValue().m_pipeline),
-          m_blobClient.GetValue().m_blobUrl,
+          *(m_blobClient.Value().m_pipeline),
+          m_blobClient.Value().m_blobUrl,
           protocolLayerOptions,
           context);
 
@@ -121,8 +121,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       }
 
       auto response = _detail::BlobRestClient::BlobContainer::RenewLease(
-          *(m_blobContainerClient.GetValue().m_pipeline),
-          m_blobContainerClient.GetValue().m_blobContainerUrl,
+          *(m_blobContainerClient.Value().m_pipeline),
+          m_blobContainerClient.Value().m_blobContainerUrl,
           protocolLayerOptions,
           context);
 
@@ -155,8 +155,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
 
       auto response = _detail::BlobRestClient::Blob::ReleaseLease(
-          *(m_blobClient.GetValue().m_pipeline),
-          m_blobClient.GetValue().m_blobUrl,
+          *(m_blobClient.Value().m_pipeline),
+          m_blobClient.Value().m_blobUrl,
           protocolLayerOptions,
           context);
 
@@ -182,8 +182,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       }
 
       auto response = _detail::BlobRestClient::BlobContainer::ReleaseLease(
-          *(m_blobContainerClient.GetValue().m_pipeline),
-          m_blobContainerClient.GetValue().m_blobContainerUrl,
+          *(m_blobContainerClient.Value().m_pipeline),
+          m_blobContainerClient.Value().m_blobContainerUrl,
           protocolLayerOptions,
           context);
 
@@ -217,8 +217,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
 
       auto response = _detail::BlobRestClient::Blob::ChangeLease(
-          *(m_blobClient.GetValue().m_pipeline),
-          m_blobClient.GetValue().m_blobUrl,
+          *(m_blobClient.Value().m_pipeline),
+          m_blobClient.Value().m_blobUrl,
           protocolLayerOptions,
           context);
 
@@ -246,8 +246,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       }
 
       auto response = _detail::BlobRestClient::BlobContainer::ChangeLease(
-          *(m_blobContainerClient.GetValue().m_pipeline),
-          m_blobContainerClient.GetValue().m_blobContainerUrl,
+          *(m_blobContainerClient.Value().m_pipeline),
+          m_blobContainerClient.Value().m_blobContainerUrl,
           protocolLayerOptions,
           context);
 
@@ -280,8 +280,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
 
       auto response = _detail::BlobRestClient::Blob::BreakLease(
-          *(m_blobClient.GetValue().m_pipeline),
-          m_blobClient.GetValue().m_blobUrl,
+          *(m_blobClient.Value().m_pipeline),
+          m_blobClient.Value().m_blobUrl,
           protocolLayerOptions,
           context);
 
@@ -307,8 +307,8 @@ namespace Azure { namespace Storage { namespace Blobs {
       }
 
       auto response = _detail::BlobRestClient::BlobContainer::BreakLease(
-          *(m_blobContainerClient.GetValue().m_pipeline),
-          m_blobContainerClient.GetValue().m_blobContainerUrl,
+          *(m_blobContainerClient.Value().m_pipeline),
+          m_blobContainerClient.Value().m_blobContainerUrl,
           protocolLayerOptions,
           context);
 

--- a/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
@@ -16,11 +16,11 @@ namespace Azure { namespace Storage { namespace Blobs {
     {
       m_status = Azure::Core::OperationStatus::Failed;
     }
-    else if (response.Value.CopyStatus.GetValue() == Models::CopyStatus::Pending)
+    else if (response.Value.CopyStatus.Value() == Models::CopyStatus::Pending)
     {
       m_status = Azure::Core::OperationStatus::Running;
     }
-    else if (response.Value.CopyStatus.GetValue() == Models::CopyStatus::Success)
+    else if (response.Value.CopyStatus.Value() == Models::CopyStatus::Success)
     {
       m_status = Azure::Core::OperationStatus::Succeeded;
     }

--- a/sdk/storage/azure-storage-blobs/src/blob_sas_builder.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_sas_builder.cpp
@@ -129,7 +129,7 @@ namespace Azure { namespace Storage { namespace Sas {
     }
 
     std::string startsOnStr = StartsOn.HasValue()
-        ? StartsOn.GetValue().ToString(
+        ? StartsOn.Value().ToString(
             Azure::DateTime::DateFormat::Rfc3339, Azure::DateTime::TimeFractionFormat::Truncate)
         : "";
     std::string expiresOnStr = Identifier.empty()
@@ -138,7 +138,7 @@ namespace Azure { namespace Storage { namespace Sas {
         : "";
 
     std::string stringToSign = Permissions + "\n" + startsOnStr + "\n" + expiresOnStr + "\n"
-        + canonicalName + "\n" + Identifier + "\n" + (IPRange.HasValue() ? IPRange.GetValue() : "")
+        + canonicalName + "\n" + Identifier + "\n" + (IPRange.HasValue() ? IPRange.Value() : "")
         + "\n" + protocol + "\n" + _internal::DefaultSasVersion + "\n" + resource + "\n"
         + snapshotVersion + "\n" + CacheControl + "\n" + ContentDisposition + "\n" + ContentEncoding
         + "\n" + ContentLanguage + "\n" + ContentType;
@@ -161,7 +161,7 @@ namespace Azure { namespace Storage { namespace Sas {
     }
     if (IPRange.HasValue())
     {
-      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.GetValue()));
+      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.Value()));
     }
     if (!Identifier.empty())
     {
@@ -221,7 +221,7 @@ namespace Azure { namespace Storage { namespace Sas {
     }
 
     std::string startsOnStr = StartsOn.HasValue()
-        ? StartsOn.GetValue().ToString(
+        ? StartsOn.Value().ToString(
             Azure::DateTime::DateFormat::Rfc3339, Azure::DateTime::TimeFractionFormat::Truncate)
         : "";
     std::string expiresOnStr = ExpiresOn.ToString(
@@ -235,7 +235,7 @@ namespace Azure { namespace Storage { namespace Sas {
         + canonicalName + "\n" + userDelegationKey.SignedObjectId + "\n"
         + userDelegationKey.SignedTenantId + "\n" + signedStartsOnStr + "\n" + signedExpiresOnStr
         + "\n" + userDelegationKey.SignedService + "\n" + userDelegationKey.SignedVersion
-        + "\n\n\n\n" + (IPRange.HasValue() ? IPRange.GetValue() : "") + "\n" + protocol + "\n"
+        + "\n\n\n\n" + (IPRange.HasValue() ? IPRange.Value() : "") + "\n" + protocol + "\n"
         + _internal::DefaultSasVersion + "\n" + resource + "\n" + snapshotVersion + "\n"
         + CacheControl + "\n" + ContentDisposition + "\n" + ContentEncoding + "\n" + ContentLanguage
         + "\n" + ContentType;
@@ -256,7 +256,7 @@ namespace Azure { namespace Storage { namespace Sas {
     builder.AppendQueryParameter("sp", _internal::UrlEncodeQueryParameter(Permissions));
     if (IPRange.HasValue())
     {
-      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.GetValue()));
+      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.Value()));
     }
     builder.AppendQueryParameter("spr", _internal::UrlEncodeQueryParameter(protocol));
     builder.AppendQueryParameter(

--- a/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
@@ -225,7 +225,7 @@ namespace Azure { namespace Storage { namespace Blobs {
       const Azure::Core::Context& context) const
   {
     std::string destinationBlobContainerName = options.DestinationBlobContainerName.HasValue()
-        ? options.DestinationBlobContainerName.GetValue()
+        ? options.DestinationBlobContainerName.Value()
         : deletedBlobContainerName;
     auto blobContainerClient = GetBlobContainerClient(destinationBlobContainerName);
 

--- a/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
@@ -95,9 +95,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::BlockBlob::Upload(
@@ -251,9 +251,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::BlockBlob::StageBlock(
@@ -278,9 +278,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.SourceIfNoneMatch = options.SourceAccessConditions.IfNoneMatch;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::BlockBlob::StageBlockFromUri(
@@ -309,9 +309,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::BlockBlob::CommitBlockList(

--- a/sdk/storage/azure-storage-blobs/src/page_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/page_blob_client.cpp
@@ -94,9 +94,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::PageBlob::Create(
@@ -146,9 +146,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::PageBlob::UploadPages(
@@ -165,7 +165,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     _detail::BlobRestClient::PageBlob::UploadPageBlobPagesFromUriOptions protocolLayerOptions;
     protocolLayerOptions.SourceUri = sourceUri;
     protocolLayerOptions.Range.Offset = destinationOffset;
-    protocolLayerOptions.Range.Length = sourceRange.Length.GetValue();
+    protocolLayerOptions.Range.Length = sourceRange.Length.Value();
     protocolLayerOptions.SourceRange = std::move(sourceRange);
     protocolLayerOptions.TransactionalContentHash = options.TransactionalContentHash;
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
@@ -176,9 +176,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::PageBlob::UploadPagesFromUri(
@@ -200,9 +200,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::PageBlob::ClearPages(
@@ -224,9 +224,9 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
     if (m_customerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.GetValue().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.GetValue().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.GetValue().Algorithm;
+      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm;
     }
     protocolLayerOptions.EncryptionScope = m_encryptionScope;
     return _detail::BlobRestClient::PageBlob::Resize(

--- a/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
@@ -48,20 +48,20 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_TRUE(blobContentInfo.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(blobContentInfo.Value.LastModified));
     EXPECT_TRUE(blobContentInfo.Value.VersionId.HasValue());
-    EXPECT_FALSE(blobContentInfo.Value.VersionId.GetValue().empty());
+    EXPECT_FALSE(blobContentInfo.Value.VersionId.Value().empty());
     EXPECT_FALSE(blobContentInfo.Value.EncryptionScope.HasValue());
     EXPECT_FALSE(blobContentInfo.Value.EncryptionKeySha256.HasValue());
 
     auto properties = appendBlobClient.GetProperties().Value;
     EXPECT_TRUE(properties.CommittedBlockCount.HasValue());
-    EXPECT_EQ(properties.CommittedBlockCount.GetValue(), 0);
+    EXPECT_EQ(properties.CommittedBlockCount.Value(), 0);
     EXPECT_EQ(properties.BlobSize, 0);
 
     auto blockContent
         = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     auto appendResponse = appendBlobClient.AppendBlock(blockContent);
     properties = appendBlobClient.GetProperties().Value;
-    EXPECT_EQ(properties.CommittedBlockCount.GetValue(), 1);
+    EXPECT_EQ(properties.CommittedBlockCount.Value(), 1);
     EXPECT_EQ(properties.BlobSize, static_cast<int64_t>(m_blobContent.size()));
 
     Azure::Storage::Blobs::AppendBlockOptions options;
@@ -271,11 +271,11 @@ namespace Azure { namespace Storage { namespace Test {
 
     auto downloadResult = blobClient.Download();
     EXPECT_TRUE(downloadResult.Value.Details.IsSealed.HasValue());
-    EXPECT_FALSE(downloadResult.Value.Details.IsSealed.GetValue());
+    EXPECT_FALSE(downloadResult.Value.Details.IsSealed.Value());
 
     auto getPropertiesResult = blobClient.GetProperties();
     EXPECT_TRUE(getPropertiesResult.Value.IsSealed.HasValue());
-    EXPECT_FALSE(getPropertiesResult.Value.IsSealed.GetValue());
+    EXPECT_FALSE(getPropertiesResult.Value.IsSealed.Value());
 
     Azure::Storage::Blobs::ListBlobsSinglePageOptions options;
     options.Prefix = blobName;
@@ -288,7 +288,7 @@ namespace Azure { namespace Storage { namespace Test {
         if (blob.Name == blobName)
         {
           EXPECT_TRUE(blob.Details.IsSealed.HasValue());
-          EXPECT_FALSE(blob.Details.IsSealed.GetValue());
+          EXPECT_FALSE(blob.Details.IsSealed.Value());
         }
       }
     } while (options.ContinuationToken.HasValue());
@@ -305,11 +305,11 @@ namespace Azure { namespace Storage { namespace Test {
 
     downloadResult = blobClient.Download();
     EXPECT_TRUE(downloadResult.Value.Details.IsSealed.HasValue());
-    EXPECT_TRUE(downloadResult.Value.Details.IsSealed.GetValue());
+    EXPECT_TRUE(downloadResult.Value.Details.IsSealed.Value());
 
     getPropertiesResult = blobClient.GetProperties();
     EXPECT_TRUE(getPropertiesResult.Value.IsSealed.HasValue());
-    EXPECT_TRUE(getPropertiesResult.Value.IsSealed.GetValue());
+    EXPECT_TRUE(getPropertiesResult.Value.IsSealed.Value());
 
     do
     {
@@ -320,7 +320,7 @@ namespace Azure { namespace Storage { namespace Test {
         if (blob.Name == blobName)
         {
           EXPECT_TRUE(blob.Details.IsSealed.HasValue());
-          EXPECT_TRUE(blob.Details.IsSealed.GetValue());
+          EXPECT_TRUE(blob.Details.IsSealed.Value());
         }
       }
     } while (options.ContinuationToken.HasValue());
@@ -332,16 +332,16 @@ namespace Azure { namespace Storage { namespace Test {
     auto copyResult = blobClient2.StartCopyFromUri(blobClient.GetUrl() + GetSas(), copyOptions);
     getPropertiesResult = copyResult.PollUntilDone(std::chrono::seconds(1));
     ASSERT_TRUE(getPropertiesResult.Value.CopyStatus.HasValue());
-    EXPECT_EQ(getPropertiesResult.Value.CopyStatus.GetValue(), Blobs::Models::CopyStatus::Success);
-    EXPECT_FALSE(getPropertiesResult.Value.IsSealed.GetValue());
+    EXPECT_EQ(getPropertiesResult.Value.CopyStatus.Value(), Blobs::Models::CopyStatus::Success);
+    EXPECT_FALSE(getPropertiesResult.Value.IsSealed.Value());
 
     copyOptions.ShouldSealDestination = true;
     copyResult = blobClient2.StartCopyFromUri(blobClient.GetUrl() + GetSas(), copyOptions);
     getPropertiesResult = copyResult.PollUntilDone(std::chrono::seconds(1));
     EXPECT_TRUE(getPropertiesResult.Value.IsSealed.HasValue());
-    EXPECT_TRUE(getPropertiesResult.Value.IsSealed.GetValue());
+    EXPECT_TRUE(getPropertiesResult.Value.IsSealed.Value());
     ASSERT_TRUE(getPropertiesResult.Value.CopyStatus.HasValue());
-    EXPECT_EQ(getPropertiesResult.Value.CopyStatus.GetValue(), Blobs::Models::CopyStatus::Success);
+    EXPECT_EQ(getPropertiesResult.Value.CopyStatus.Value(), Blobs::Models::CopyStatus::Success);
   }
 
   TEST_F(AppendBlobClientTest, CreateIfNotExists)

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
@@ -186,13 +186,13 @@ namespace Azure { namespace Storage { namespace Test {
         }
         if (blob.Details.AccessTier.HasValue())
         {
-          EXPECT_FALSE(blob.Details.AccessTier.GetValue().ToString().empty());
+          EXPECT_FALSE(blob.Details.AccessTier.Value().ToString().empty());
         }
         if (blob.BlobType == Blobs::Models::BlobType::AppendBlob)
         {
           if (blob.Details.IsSealed.HasValue())
           {
-            EXPECT_FALSE(blob.Details.IsSealed.GetValue());
+            EXPECT_FALSE(blob.Details.IsSealed.Value());
           }
         }
         else
@@ -253,7 +253,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       auto res = m_blobContainerClient->ListBlobsByHierarchySinglePage(delimiter, options);
       EXPECT_EQ(res.Value.Delimiter, delimiter);
-      EXPECT_EQ(res.Value.Prefix, options.Prefix.GetValue());
+      EXPECT_EQ(res.Value.Prefix, options.Prefix.Value());
       EXPECT_TRUE(res.Value.Items.empty());
       for (const auto& p : res.Value.BlobPrefixes)
       {
@@ -278,7 +278,7 @@ namespace Azure { namespace Storage { namespace Test {
       {
         auto res = m_blobContainerClient->ListBlobsByHierarchySinglePage(delimiter, options);
         EXPECT_EQ(res.Value.Delimiter, delimiter);
-        EXPECT_EQ(res.Value.Prefix, options.Prefix.GetValue());
+        EXPECT_EQ(res.Value.Prefix, options.Prefix.Value());
         EXPECT_TRUE(res.Value.BlobPrefixes.empty());
         for (const auto& i : res.Value.Items)
         {
@@ -334,12 +334,12 @@ namespace Azure { namespace Storage { namespace Test {
         }
         if (blob.VersionId.HasValue())
         {
-          EXPECT_FALSE(blob.VersionId.GetValue().empty());
+          EXPECT_FALSE(blob.VersionId.Value().empty());
           foundVersions = true;
         }
         if (blob.IsCurrentVersion.HasValue())
         {
-          if (blob.IsCurrentVersion.GetValue())
+          if (blob.IsCurrentVersion.Value())
           {
             foundCurrentVersion = true;
           }
@@ -420,7 +420,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto properties = containerClient.GetProperties().Value;
     EXPECT_EQ(properties.LeaseState, Blobs::Models::LeaseState::Leased);
     EXPECT_EQ(properties.LeaseStatus, Blobs::Models::LeaseStatus::Locked);
-    EXPECT_EQ(properties.LeaseDuration.GetValue(), Blobs::Models::LeaseDurationType::Fixed);
+    EXPECT_EQ(properties.LeaseDuration.Value(), Blobs::Models::LeaseDurationType::Fixed);
 
     auto rLease = leaseClient.Renew().Value;
     EXPECT_TRUE(rLease.ETag.HasValue());
@@ -444,7 +444,7 @@ namespace Azure { namespace Storage { namespace Test {
         = Blobs::BlobLeaseClient(containerClient, Blobs::BlobLeaseClient::CreateUniqueLeaseId());
     aLease = leaseClient.Acquire(Blobs::BlobLeaseClient::InfiniteLeaseDuration).Value;
     properties = containerClient.GetProperties().Value;
-    EXPECT_EQ(properties.LeaseDuration.GetValue(), Blobs::Models::LeaseDurationType::Infinite);
+    EXPECT_EQ(properties.LeaseDuration.Value(), Blobs::Models::LeaseDurationType::Infinite);
     auto brokenLease = leaseClient.Break().Value;
     EXPECT_TRUE(brokenLease.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(brokenLease.LastModified));
@@ -481,22 +481,22 @@ namespace Azure { namespace Storage { namespace Test {
       createOptions.PreventEncryptionScopeOverride = true;
       EXPECT_NO_THROW(containerClient.Create(createOptions));
       auto properties = containerClient.GetProperties().Value;
-      EXPECT_EQ(properties.DefaultEncryptionScope, createOptions.DefaultEncryptionScope.GetValue());
+      EXPECT_EQ(properties.DefaultEncryptionScope, createOptions.DefaultEncryptionScope.Value());
       EXPECT_EQ(
           properties.PreventEncryptionScopeOverride,
-          createOptions.PreventEncryptionScopeOverride.GetValue());
+          createOptions.PreventEncryptionScopeOverride.Value());
       auto appendBlobClient = containerClient.GetAppendBlobClient(blobName);
       auto blobContentInfo = appendBlobClient.Create();
       appendBlobClient.Delete();
       EXPECT_TRUE(blobContentInfo.Value.EncryptionScope.HasValue());
-      EXPECT_EQ(blobContentInfo.Value.EncryptionScope.GetValue(), TestEncryptionScope);
+      EXPECT_EQ(blobContentInfo.Value.EncryptionScope.Value(), TestEncryptionScope);
       auto appendBlobClientWithoutEncryptionScope
           = Azure::Storage::Blobs::AppendBlobClient::CreateFromConnectionString(
               StandardStorageConnectionString(), containerName, blobName);
       blobContentInfo = appendBlobClientWithoutEncryptionScope.Create();
       appendBlobClientWithoutEncryptionScope.Delete();
       EXPECT_TRUE(blobContentInfo.Value.EncryptionScope.HasValue());
-      EXPECT_EQ(blobContentInfo.Value.EncryptionScope.GetValue(), TestEncryptionScope);
+      EXPECT_EQ(blobContentInfo.Value.EncryptionScope.Value(), TestEncryptionScope);
       containerClient.Delete();
     }
     {
@@ -507,10 +507,10 @@ namespace Azure { namespace Storage { namespace Test {
           StandardStorageConnectionString(), m_containerName, blobName, options);
       auto blobContentInfo = appendBlobClient.Create();
       EXPECT_TRUE(blobContentInfo.Value.EncryptionScope.HasValue());
-      EXPECT_EQ(blobContentInfo.Value.EncryptionScope.GetValue(), TestEncryptionScope);
+      EXPECT_EQ(blobContentInfo.Value.EncryptionScope.Value(), TestEncryptionScope);
       auto properties = appendBlobClient.GetProperties().Value;
       EXPECT_TRUE(properties.EncryptionScope.HasValue());
-      EXPECT_EQ(properties.EncryptionScope.GetValue(), TestEncryptionScope);
+      EXPECT_EQ(properties.EncryptionScope.Value(), TestEncryptionScope);
       std::vector<uint8_t> appendContent(1);
       Azure::Core::IO::MemoryBodyStream bodyStream(appendContent.data(), appendContent.size());
       EXPECT_NO_THROW(appendBlobClient.AppendBlock(bodyStream));
@@ -578,8 +578,8 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(blobContentInfo.IsServerEncrypted);
       EXPECT_TRUE(blobContentInfo.EncryptionKeySha256.HasValue());
       EXPECT_EQ(
-          blobContentInfo.EncryptionKeySha256.GetValue(),
-          options.CustomerProvidedKey.GetValue().KeyHash);
+          blobContentInfo.EncryptionKeySha256.Value(),
+          options.CustomerProvidedKey.Value().KeyHash);
 
       bodyStream.Rewind();
       EXPECT_NO_THROW(appendBlob.AppendBlock(bodyStream));
@@ -616,8 +616,8 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(blobContentInfo.IsServerEncrypted);
       EXPECT_TRUE(blobContentInfo.EncryptionKeySha256.HasValue());
       EXPECT_EQ(
-          blobContentInfo.EncryptionKeySha256.GetValue(),
-          options.CustomerProvidedKey.GetValue().KeyHash);
+          blobContentInfo.EncryptionKeySha256.Value(),
+          options.CustomerProvidedKey.Value().KeyHash);
       bodyStream.Rewind();
       EXPECT_NO_THROW(pageBlob.Resize(blobContent.size()));
       EXPECT_NO_THROW(pageBlob.UploadPages(0, bodyStream));
@@ -734,11 +734,11 @@ namespace Azure { namespace Storage { namespace Test {
 
     properties = blobClient.GetProperties().Value;
     EXPECT_TRUE(properties.TagCount.HasValue());
-    EXPECT_EQ(properties.TagCount.GetValue(), static_cast<int64_t>(tags.size()));
+    EXPECT_EQ(properties.TagCount.Value(), static_cast<int64_t>(tags.size()));
 
     downloadRet = blobClient.Download();
     EXPECT_TRUE(downloadRet.Value.Details.TagCount.HasValue());
-    EXPECT_EQ(downloadRet.Value.Details.TagCount.GetValue(), static_cast<int64_t>(tags.size()));
+    EXPECT_EQ(downloadRet.Value.Details.TagCount.Value(), static_cast<int64_t>(tags.size()));
 
     auto blobServiceClient = Azure::Storage::Blobs::BlobServiceClient::CreateFromConnectionString(
         StandardStorageConnectionString());

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
@@ -578,8 +578,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(blobContentInfo.IsServerEncrypted);
       EXPECT_TRUE(blobContentInfo.EncryptionKeySha256.HasValue());
       EXPECT_EQ(
-          blobContentInfo.EncryptionKeySha256.Value(),
-          options.CustomerProvidedKey.Value().KeyHash);
+          blobContentInfo.EncryptionKeySha256.Value(), options.CustomerProvidedKey.Value().KeyHash);
 
       bodyStream.Rewind();
       EXPECT_NO_THROW(appendBlob.AppendBlock(bodyStream));
@@ -616,8 +615,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(blobContentInfo.IsServerEncrypted);
       EXPECT_TRUE(blobContentInfo.EncryptionKeySha256.HasValue());
       EXPECT_EQ(
-          blobContentInfo.EncryptionKeySha256.Value(),
-          options.CustomerProvidedKey.Value().KeyHash);
+          blobContentInfo.EncryptionKeySha256.Value(), options.CustomerProvidedKey.Value().KeyHash);
       bodyStream.Rewind();
       EXPECT_NO_THROW(pageBlob.Resize(blobContent.size()));
       EXPECT_NO_THROW(pageBlob.UploadPages(0, bodyStream));

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
@@ -493,7 +493,7 @@ namespace Azure { namespace Storage { namespace Test {
     std::string blobVersionUrl;
 
     auto create_version = [&]() {
-      std::string versionId = blobClient0.CreateSnapshot().Value.VersionId.GetValue();
+      std::string versionId = blobClient0.CreateSnapshot().Value.VersionId.Value();
       BlobVersionSasBuilder.BlobVersionId = versionId;
       blobVersionUrl = blobClient0.WithVersionId(versionId).GetUrl();
       blobClient0.SetMetadata({});

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
@@ -20,7 +20,7 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Models {
     {
       return false;
     }
-    if (lhs.Days.HasValue() && rhs.Days.HasValue() && lhs.Days.GetValue() != rhs.Days.GetValue())
+    if (lhs.Days.HasValue() && rhs.Days.HasValue() && lhs.Days.Value() != rhs.Days.Value())
     {
       return false;
     }
@@ -45,7 +45,7 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Models {
       return false;
     }
     if (lhs.DefaultIndexDocumentPath.HasValue() && rhs.DefaultIndexDocumentPath.HasValue()
-        && lhs.DefaultIndexDocumentPath.GetValue() != rhs.DefaultIndexDocumentPath.GetValue())
+        && lhs.DefaultIndexDocumentPath.Value() != rhs.DefaultIndexDocumentPath.Value())
     {
       return false;
     }
@@ -54,12 +54,12 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Models {
       return false;
     }
     if (lhs.ErrorDocument404Path.HasValue() && rhs.ErrorDocument404Path.HasValue()
-        && lhs.ErrorDocument404Path.GetValue() != rhs.ErrorDocument404Path.GetValue())
+        && lhs.ErrorDocument404Path.Value() != rhs.ErrorDocument404Path.Value())
     {
       return false;
     }
     if (lhs.IndexDocument.HasValue() && rhs.IndexDocument.HasValue()
-        && lhs.IndexDocument.GetValue() != rhs.IndexDocument.GetValue())
+        && lhs.IndexDocument.Value() != rhs.IndexDocument.Value())
     {
       return false;
     }
@@ -276,8 +276,8 @@ namespace Azure { namespace Storage { namespace Test {
         == properties.HourMetrics.IncludeApis.HasValue())
     {
       EXPECT_EQ(
-          downloadedProperties.HourMetrics.IncludeApis.GetValue(),
-          properties.HourMetrics.IncludeApis.GetValue());
+          downloadedProperties.HourMetrics.IncludeApis.Value(),
+          properties.HourMetrics.IncludeApis.Value());
     }
     EXPECT_EQ(
         downloadedProperties.HourMetrics.RetentionPolicy, properties.HourMetrics.RetentionPolicy);
@@ -291,8 +291,8 @@ namespace Azure { namespace Storage { namespace Test {
         == properties.MinuteMetrics.IncludeApis.HasValue())
     {
       EXPECT_EQ(
-          downloadedProperties.MinuteMetrics.IncludeApis.GetValue(),
-          properties.MinuteMetrics.IncludeApis.GetValue());
+          downloadedProperties.MinuteMetrics.IncludeApis.Value(),
+          properties.MinuteMetrics.IncludeApis.Value());
     }
     EXPECT_EQ(
         downloadedProperties.MinuteMetrics.RetentionPolicy,
@@ -304,8 +304,8 @@ namespace Azure { namespace Storage { namespace Test {
     if (downloadedProperties.DefaultServiceVersion.HasValue())
     {
       EXPECT_EQ(
-          downloadedProperties.DefaultServiceVersion.GetValue(),
-          properties.DefaultServiceVersion.GetValue());
+          downloadedProperties.DefaultServiceVersion.Value(),
+          properties.DefaultServiceVersion.Value());
     }
     EXPECT_EQ(downloadedProperties.Cors, properties.Cors);
 
@@ -341,7 +341,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(serviceStatistics.GeoReplication.Status.ToString().empty());
     if (serviceStatistics.GeoReplication.LastSyncedOn.HasValue())
     {
-      EXPECT_TRUE(IsValidTime(serviceStatistics.GeoReplication.LastSyncedOn.GetValue()));
+      EXPECT_TRUE(IsValidTime(serviceStatistics.GeoReplication.LastSyncedOn.Value()));
     }
   }
 
@@ -384,11 +384,11 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(deletedContainerItem.Name, containerName);
     EXPECT_TRUE(deletedContainerItem.IsDeleted);
     EXPECT_TRUE(deletedContainerItem.VersionId.HasValue());
-    EXPECT_FALSE(deletedContainerItem.VersionId.GetValue().empty());
+    EXPECT_FALSE(deletedContainerItem.VersionId.Value().empty());
     EXPECT_TRUE(deletedContainerItem.Details.DeletedOn.HasValue());
-    EXPECT_TRUE(IsValidTime(deletedContainerItem.Details.DeletedOn.GetValue()));
+    EXPECT_TRUE(IsValidTime(deletedContainerItem.Details.DeletedOn.Value()));
     EXPECT_TRUE(deletedContainerItem.Details.RemainingRetentionDays.HasValue());
-    EXPECT_GE(deletedContainerItem.Details.RemainingRetentionDays.GetValue(), 0);
+    EXPECT_GE(deletedContainerItem.Details.RemainingRetentionDays.Value(), 0);
 
     std::string containerName2 = LowercaseRandomString();
     for (int i = 0; i < 60; ++i)
@@ -398,7 +398,7 @@ namespace Azure { namespace Storage { namespace Test {
         Azure::Storage::Blobs::UndeleteBlobContainerOptions options;
         options.DestinationBlobContainerName = containerName2;
         m_blobServiceClient.UndeleteBlobContainer(
-            deletedContainerItem.Name, deletedContainerItem.VersionId.GetValue(), options);
+            deletedContainerItem.Name, deletedContainerItem.VersionId.Value(), options);
         break;
       }
       catch (StorageException& e)

--- a/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
@@ -54,7 +54,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_TRUE(blobContentInfo.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(blobContentInfo.Value.LastModified));
     EXPECT_TRUE(blobContentInfo.Value.VersionId.HasValue());
-    EXPECT_FALSE(blobContentInfo.Value.VersionId.GetValue().empty());
+    EXPECT_FALSE(blobContentInfo.Value.VersionId.Value().empty());
     EXPECT_FALSE(blobContentInfo.Value.EncryptionScope.HasValue());
     EXPECT_FALSE(blobContentInfo.Value.EncryptionKeySha256.HasValue());
 
@@ -103,17 +103,17 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_TRUE(pageRanges.ClearRanges.empty());
     ASSERT_FALSE(pageRanges.PageRanges.empty());
     EXPECT_EQ(static_cast<uint64_t>(pageRanges.PageRanges[0].Offset), 3_KB);
-    EXPECT_EQ(static_cast<uint64_t>(pageRanges.PageRanges[0].Length.GetValue()), 3_KB);
+    EXPECT_EQ(static_cast<uint64_t>(pageRanges.PageRanges[0].Length.Value()), 3_KB);
 
     Azure::Storage::Blobs::GetPageRangesOptions options;
     options.Range = Core::Http::HttpRange();
-    options.Range.GetValue().Offset = 4_KB;
-    options.Range.GetValue().Length = 1_KB;
+    options.Range.Value().Offset = 4_KB;
+    options.Range.Value().Length = 1_KB;
     pageRanges = pageBlobClient.GetPageRanges(options).Value;
     EXPECT_TRUE(pageRanges.ClearRanges.empty());
     ASSERT_FALSE(pageRanges.PageRanges.empty());
     EXPECT_EQ(static_cast<uint64_t>(pageRanges.PageRanges[0].Offset), 4_KB);
-    EXPECT_EQ(static_cast<uint64_t>(pageRanges.PageRanges[0].Length.GetValue()), 1_KB);
+    EXPECT_EQ(static_cast<uint64_t>(pageRanges.PageRanges[0].Length.Value()), 1_KB);
 
     auto snapshot = pageBlobClient.CreateSnapshot().Value.Snapshot;
     // |_|_|_|x|  |x|x|_|_| This is what's in snapshot
@@ -127,9 +127,9 @@ namespace Azure { namespace Storage { namespace Test {
     ASSERT_FALSE(pageRanges.ClearRanges.empty());
     ASSERT_FALSE(pageRanges.PageRanges.empty());
     EXPECT_EQ(pageRanges.PageRanges[0].Offset, 0);
-    EXPECT_EQ(static_cast<uint64_t>(pageRanges.PageRanges[0].Length.GetValue()), 1_KB);
+    EXPECT_EQ(static_cast<uint64_t>(pageRanges.PageRanges[0].Length.Value()), 1_KB);
     EXPECT_EQ(static_cast<uint64_t>(pageRanges.ClearRanges[0].Offset), 3_KB);
-    EXPECT_EQ(static_cast<uint64_t>(pageRanges.ClearRanges[0].Length.GetValue()), 1_KB);
+    EXPECT_EQ(static_cast<uint64_t>(pageRanges.ClearRanges[0].Length.Value()), 1_KB);
   }
 
   TEST_F(PageBlobClientTest, UploadFromUri)
@@ -153,19 +153,19 @@ namespace Azure { namespace Storage { namespace Test {
         copyInfo.GetRawResponse().GetStatusCode(), Azure::Core::Http::HttpStatusCode::Accepted);
     auto getPropertiesResult = copyInfo.PollUntilDone(std::chrono::seconds(1));
     ASSERT_TRUE(getPropertiesResult.Value.CopyStatus.HasValue());
-    EXPECT_EQ(getPropertiesResult.Value.CopyStatus.GetValue(), Blobs::Models::CopyStatus::Success);
+    EXPECT_EQ(getPropertiesResult.Value.CopyStatus.Value(), Blobs::Models::CopyStatus::Success);
     ASSERT_TRUE(getPropertiesResult.Value.CopyId.HasValue());
-    EXPECT_FALSE(getPropertiesResult.Value.CopyId.GetValue().empty());
+    EXPECT_FALSE(getPropertiesResult.Value.CopyId.Value().empty());
     ASSERT_TRUE(getPropertiesResult.Value.CopySource.HasValue());
-    EXPECT_FALSE(getPropertiesResult.Value.CopySource.GetValue().empty());
+    EXPECT_FALSE(getPropertiesResult.Value.CopySource.Value().empty());
     ASSERT_TRUE(getPropertiesResult.Value.IsIncrementalCopy.HasValue());
-    EXPECT_TRUE(getPropertiesResult.Value.IsIncrementalCopy.GetValue());
+    EXPECT_TRUE(getPropertiesResult.Value.IsIncrementalCopy.Value());
     ASSERT_TRUE(getPropertiesResult.Value.IncrementalCopyDestinationSnapshot.HasValue());
-    EXPECT_FALSE(getPropertiesResult.Value.IncrementalCopyDestinationSnapshot.GetValue().empty());
+    EXPECT_FALSE(getPropertiesResult.Value.IncrementalCopyDestinationSnapshot.Value().empty());
     ASSERT_TRUE(getPropertiesResult.Value.CopyCompletedOn.HasValue());
-    EXPECT_TRUE(IsValidTime(getPropertiesResult.Value.CopyCompletedOn.GetValue()));
+    EXPECT_TRUE(IsValidTime(getPropertiesResult.Value.CopyCompletedOn.Value()));
     ASSERT_TRUE(getPropertiesResult.Value.CopyProgress.HasValue());
-    EXPECT_FALSE(getPropertiesResult.Value.CopyProgress.GetValue().empty());
+    EXPECT_FALSE(getPropertiesResult.Value.CopyProgress.Value().empty());
   }
 
   TEST_F(PageBlobClientTest, Lease)
@@ -184,9 +184,9 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(aLease.LeaseId, leaseId1);
 
     auto properties = m_pageBlobClient->GetProperties().Value;
-    EXPECT_EQ(properties.LeaseState.GetValue(), Blobs::Models::LeaseState::Leased);
-    EXPECT_EQ(properties.LeaseStatus.GetValue(), Blobs::Models::LeaseStatus::Locked);
-    EXPECT_EQ(properties.LeaseDuration.GetValue(), Blobs::Models::LeaseDurationType::Fixed);
+    EXPECT_EQ(properties.LeaseState.Value(), Blobs::Models::LeaseState::Leased);
+    EXPECT_EQ(properties.LeaseStatus.Value(), Blobs::Models::LeaseStatus::Locked);
+    EXPECT_EQ(properties.LeaseDuration.Value(), Blobs::Models::LeaseDurationType::Fixed);
 
     auto rLease = leaseClient.Renew().Value;
     EXPECT_TRUE(rLease.ETag.HasValue());
@@ -210,7 +210,7 @@ namespace Azure { namespace Storage { namespace Test {
         = Blobs::BlobLeaseClient(*m_pageBlobClient, Blobs::BlobLeaseClient::CreateUniqueLeaseId());
     aLease = leaseClient.Acquire(Blobs::BlobLeaseClient::InfiniteLeaseDuration).Value;
     properties = m_pageBlobClient->GetProperties().Value;
-    EXPECT_EQ(properties.LeaseDuration.GetValue(), Blobs::Models::LeaseDurationType::Infinite);
+    EXPECT_EQ(properties.LeaseDuration.Value(), Blobs::Models::LeaseDurationType::Infinite);
     auto brokenLease = leaseClient.Break().Value;
     EXPECT_TRUE(brokenLease.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(brokenLease.LastModified));

--- a/sdk/storage/azure-storage-common/src/account_sas_builder.cpp
+++ b/sdk/storage/azure-storage-common/src/account_sas_builder.cpp
@@ -92,7 +92,7 @@ namespace Azure { namespace Storage { namespace Sas {
     }
 
     std::string startsOnStr = StartsOn.HasValue()
-        ? StartsOn.GetValue().ToString(
+        ? StartsOn.Value().ToString(
             Azure::DateTime::DateFormat::Rfc3339, Azure::DateTime::TimeFractionFormat::Truncate)
         : "";
     std::string expiresOnStr = ExpiresOn.ToString(
@@ -100,7 +100,7 @@ namespace Azure { namespace Storage { namespace Sas {
 
     std::string stringToSign = credential.AccountName + "\n" + Permissions + "\n" + services + "\n"
         + resourceTypes + "\n" + startsOnStr + "\n" + expiresOnStr + "\n"
-        + (IPRange.HasValue() ? IPRange.GetValue() : "") + "\n" + protocol + "\n"
+        + (IPRange.HasValue() ? IPRange.Value() : "") + "\n" + protocol + "\n"
         + _internal::DefaultSasVersion + "\n";
 
     std::string signature = Azure::Core::Convert::Base64Encode(_internal::HmacSha256(
@@ -120,7 +120,7 @@ namespace Azure { namespace Storage { namespace Sas {
     builder.AppendQueryParameter("se", expiresOnStr);
     if (IPRange.HasValue())
     {
-      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.GetValue()));
+      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.Value()));
     }
     builder.AppendQueryParameter("spr", _internal::UrlEncodeQueryParameter(protocol));
     builder.AppendQueryParameter("sig", _internal::UrlEncodeQueryParameter(signature));

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/protocol/datalake_rest_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/protocol/datalake_rest_client.hpp
@@ -544,8 +544,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
-                _internal::UrlEncodeQueryParameter(
-                    std::to_string(createOptions.Timeout.Value())));
+                _internal::UrlEncodeQueryParameter(std::to_string(createOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, createOptions.ApiVersionParameter);
           if (createOptions.Resource.HasValue())
@@ -691,8 +690,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPathGetPropertiesAction,
-                _internal::UrlEncodeQueryParameter(
-                    getPropertiesOptions.Action.Value().ToString()));
+                _internal::UrlEncodeQueryParameter(getPropertiesOptions.Action.Value().ToString()));
           }
           if (getPropertiesOptions.Upn.HasValue())
           {
@@ -703,8 +701,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           }
           if (getPropertiesOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.Value());
+            request.SetHeader(_detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.Value());
           }
           if (getPropertiesOptions.IfMatch.HasValue())
           {
@@ -756,8 +753,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
-                _internal::UrlEncodeQueryParameter(
-                    std::to_string(deleteOptions.Timeout.Value())));
+                _internal::UrlEncodeQueryParameter(std::to_string(deleteOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, deleteOptions.ApiVersionParameter);
           if (deleteOptions.RecursiveOptional.HasValue())
@@ -1013,8 +1009,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           }
           if (flushDataOptions.CacheControl.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderCacheControl, flushDataOptions.CacheControl.Value());
+            request.SetHeader(_detail::HeaderCacheControl, flushDataOptions.CacheControl.Value());
           }
           if (flushDataOptions.ContentType.HasValue())
           {
@@ -1047,15 +1042,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.SetHeader(
                 _detail::HeaderIfModifiedSince,
-                flushDataOptions.IfModifiedSince.Value().ToString(
-                    DateTime::DateFormat::Rfc1123));
+                flushDataOptions.IfModifiedSince.Value().ToString(DateTime::DateFormat::Rfc1123));
           }
           if (flushDataOptions.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderIfUnmodifiedSince,
-                flushDataOptions.IfUnmodifiedSince.Value().ToString(
-                    DateTime::DateFormat::Rfc1123));
+                flushDataOptions.IfUnmodifiedSince.Value().ToString(DateTime::DateFormat::Rfc1123));
           }
           request.SetHeader(_detail::HeaderVersion, flushDataOptions.ApiVersionParameter);
           return FlushDataParseResult(context, pipeline.Send(request, context));

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/protocol/datalake_rest_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/protocol/datalake_rest_client.hpp
@@ -397,20 +397,20 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(listPathsOptions.Timeout.GetValue())));
+                    std::to_string(listPathsOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, listPathsOptions.ApiVersionParameter);
           if (listPathsOptions.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
-                _internal::UrlEncodeQueryParameter(listPathsOptions.ContinuationToken.GetValue()));
+                _internal::UrlEncodeQueryParameter(listPathsOptions.ContinuationToken.Value()));
           }
           if (listPathsOptions.Directory.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPath,
-                _internal::UrlEncodeQueryParameter(listPathsOptions.Directory.GetValue()));
+                _internal::UrlEncodeQueryParameter(listPathsOptions.Directory.Value()));
           }
           request.GetUrl().AppendQueryParameter(
               _detail::QueryRecursive,
@@ -421,14 +421,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPageSizeHint,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(listPathsOptions.MaxResults.GetValue())));
+                    std::to_string(listPathsOptions.MaxResults.Value())));
           }
           if (listPathsOptions.Upn.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryUpn,
                 _internal::UrlEncodeQueryParameter(
-                    (listPathsOptions.Upn.GetValue() ? "true" : "false")));
+                    (listPathsOptions.Upn.Value() ? "true" : "false")));
           }
           return ListPathsParseResult(context, pipeline.Send(request, context));
         }
@@ -545,73 +545,73 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(createOptions.Timeout.GetValue())));
+                    std::to_string(createOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, createOptions.ApiVersionParameter);
           if (createOptions.Resource.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPathResourceType,
-                _internal::UrlEncodeQueryParameter(createOptions.Resource.GetValue().ToString()));
+                _internal::UrlEncodeQueryParameter(createOptions.Resource.Value().ToString()));
           }
           if (createOptions.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
-                _internal::UrlEncodeQueryParameter(createOptions.ContinuationToken.GetValue()));
+                _internal::UrlEncodeQueryParameter(createOptions.ContinuationToken.Value()));
           }
           if (createOptions.Mode.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPathRenameMode,
-                _internal::UrlEncodeQueryParameter(createOptions.Mode.GetValue().ToString()));
+                _internal::UrlEncodeQueryParameter(createOptions.Mode.Value().ToString()));
           }
           if (createOptions.CacheControl.HasValue())
           {
-            request.SetHeader(_detail::HeaderCacheControl, createOptions.CacheControl.GetValue());
+            request.SetHeader(_detail::HeaderCacheControl, createOptions.CacheControl.Value());
           }
           if (createOptions.ContentEncoding.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderContentEncoding, createOptions.ContentEncoding.GetValue());
+                _detail::HeaderContentEncoding, createOptions.ContentEncoding.Value());
           }
           if (createOptions.ContentLanguage.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderContentLanguage, createOptions.ContentLanguage.GetValue());
+                _detail::HeaderContentLanguage, createOptions.ContentLanguage.Value());
           }
           if (createOptions.ContentDisposition.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderContentDisposition, createOptions.ContentDisposition.GetValue());
+                _detail::HeaderContentDisposition, createOptions.ContentDisposition.Value());
           }
           if (createOptions.ContentType.HasValue())
           {
-            request.SetHeader(_detail::HeaderContentType, createOptions.ContentType.GetValue());
+            request.SetHeader(_detail::HeaderContentType, createOptions.ContentType.Value());
           }
           if (createOptions.RenameSource.HasValue())
           {
-            request.SetHeader(_detail::HeaderRenameSource, createOptions.RenameSource.GetValue());
+            request.SetHeader(_detail::HeaderRenameSource, createOptions.RenameSource.Value());
           }
           if (createOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, createOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, createOptions.LeaseIdOptional.Value());
           }
           if (createOptions.SourceLeaseId.HasValue())
           {
-            request.SetHeader(_detail::HeaderSourceLeaseId, createOptions.SourceLeaseId.GetValue());
+            request.SetHeader(_detail::HeaderSourceLeaseId, createOptions.SourceLeaseId.Value());
           }
           if (createOptions.Properties.HasValue())
           {
-            request.SetHeader(_detail::HeaderProperties, createOptions.Properties.GetValue());
+            request.SetHeader(_detail::HeaderProperties, createOptions.Properties.Value());
           }
           if (createOptions.Permissions.HasValue())
           {
-            request.SetHeader(_detail::HeaderPermissions, createOptions.Permissions.GetValue());
+            request.SetHeader(_detail::HeaderPermissions, createOptions.Permissions.Value());
           }
           if (createOptions.Umask.HasValue())
           {
-            request.SetHeader(_detail::HeaderUmask, createOptions.Umask.GetValue());
+            request.SetHeader(_detail::HeaderUmask, createOptions.Umask.Value());
           }
           if (createOptions.IfMatch.HasValue())
           {
@@ -625,13 +625,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.SetHeader(
                 _detail::HeaderIfModifiedSince,
-                createOptions.IfModifiedSince.GetValue().ToString(DateTime::DateFormat::Rfc1123));
+                createOptions.IfModifiedSince.Value().ToString(DateTime::DateFormat::Rfc1123));
           }
           if (createOptions.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderIfUnmodifiedSince,
-                createOptions.IfUnmodifiedSince.GetValue().ToString(DateTime::DateFormat::Rfc1123));
+                createOptions.IfUnmodifiedSince.Value().ToString(DateTime::DateFormat::Rfc1123));
           }
           if (createOptions.SourceIfMatch.HasValue())
           {
@@ -646,14 +646,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.SetHeader(
                 _detail::HeaderSourceIfModifiedSince,
-                createOptions.SourceIfModifiedSince.GetValue().ToString(
+                createOptions.SourceIfModifiedSince.Value().ToString(
                     DateTime::DateFormat::Rfc1123));
           }
           if (createOptions.SourceIfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderSourceIfUnmodifiedSince,
-                createOptions.SourceIfUnmodifiedSince.GetValue().ToString(
+                createOptions.SourceIfUnmodifiedSince.Value().ToString(
                     DateTime::DateFormat::Rfc1123));
           }
           return CreateParseResult(context, pipeline.Send(request, context));
@@ -684,7 +684,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(getPropertiesOptions.Timeout.GetValue())));
+                    std::to_string(getPropertiesOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, getPropertiesOptions.ApiVersionParameter);
           if (getPropertiesOptions.Action.HasValue())
@@ -692,19 +692,19 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPathGetPropertiesAction,
                 _internal::UrlEncodeQueryParameter(
-                    getPropertiesOptions.Action.GetValue().ToString()));
+                    getPropertiesOptions.Action.Value().ToString()));
           }
           if (getPropertiesOptions.Upn.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryUpn,
                 _internal::UrlEncodeQueryParameter(
-                    (getPropertiesOptions.Upn.GetValue() ? "true" : "false")));
+                    (getPropertiesOptions.Upn.Value() ? "true" : "false")));
           }
           if (getPropertiesOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.Value());
           }
           if (getPropertiesOptions.IfMatch.HasValue())
           {
@@ -719,14 +719,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.SetHeader(
                 _detail::HeaderIfModifiedSince,
-                getPropertiesOptions.IfModifiedSince.GetValue().ToString(
+                getPropertiesOptions.IfModifiedSince.Value().ToString(
                     DateTime::DateFormat::Rfc1123));
           }
           if (getPropertiesOptions.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderIfUnmodifiedSince,
-                getPropertiesOptions.IfUnmodifiedSince.GetValue().ToString(
+                getPropertiesOptions.IfUnmodifiedSince.Value().ToString(
                     DateTime::DateFormat::Rfc1123));
           }
           return GetPropertiesParseResult(context, pipeline.Send(request, context));
@@ -757,7 +757,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(deleteOptions.Timeout.GetValue())));
+                    std::to_string(deleteOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, deleteOptions.ApiVersionParameter);
           if (deleteOptions.RecursiveOptional.HasValue())
@@ -765,17 +765,17 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryRecursive,
                 _internal::UrlEncodeQueryParameter(
-                    (deleteOptions.RecursiveOptional.GetValue() ? "true" : "false")));
+                    (deleteOptions.RecursiveOptional.Value() ? "true" : "false")));
           }
           if (deleteOptions.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
-                _internal::UrlEncodeQueryParameter(deleteOptions.ContinuationToken.GetValue()));
+                _internal::UrlEncodeQueryParameter(deleteOptions.ContinuationToken.Value()));
           }
           if (deleteOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, deleteOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, deleteOptions.LeaseIdOptional.Value());
           }
           if (deleteOptions.IfMatch.HasValue())
           {
@@ -789,13 +789,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.SetHeader(
                 _detail::HeaderIfModifiedSince,
-                deleteOptions.IfModifiedSince.GetValue().ToString(DateTime::DateFormat::Rfc1123));
+                deleteOptions.IfModifiedSince.Value().ToString(DateTime::DateFormat::Rfc1123));
           }
           if (deleteOptions.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderIfUnmodifiedSince,
-                deleteOptions.IfUnmodifiedSince.GetValue().ToString(DateTime::DateFormat::Rfc1123));
+                deleteOptions.IfUnmodifiedSince.Value().ToString(DateTime::DateFormat::Rfc1123));
           }
           return DeleteParseResult(context, pipeline.Send(request, context));
         }
@@ -828,29 +828,29 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setAccessControlOptions.Timeout.GetValue())));
+                    std::to_string(setAccessControlOptions.Timeout.Value())));
           }
           if (setAccessControlOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, setAccessControlOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, setAccessControlOptions.LeaseIdOptional.Value());
           }
           if (setAccessControlOptions.Owner.HasValue())
           {
-            request.SetHeader(_detail::HeaderOwner, setAccessControlOptions.Owner.GetValue());
+            request.SetHeader(_detail::HeaderOwner, setAccessControlOptions.Owner.Value());
           }
           if (setAccessControlOptions.Group.HasValue())
           {
-            request.SetHeader(_detail::HeaderGroup, setAccessControlOptions.Group.GetValue());
+            request.SetHeader(_detail::HeaderGroup, setAccessControlOptions.Group.Value());
           }
           if (setAccessControlOptions.Permissions.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderPermissions, setAccessControlOptions.Permissions.GetValue());
+                _detail::HeaderPermissions, setAccessControlOptions.Permissions.Value());
           }
           if (setAccessControlOptions.Acl.HasValue())
           {
-            request.SetHeader(_detail::HeaderAcl, setAccessControlOptions.Acl.GetValue());
+            request.SetHeader(_detail::HeaderAcl, setAccessControlOptions.Acl.Value());
           }
           if (setAccessControlOptions.IfMatch.HasValue())
           {
@@ -865,14 +865,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.SetHeader(
                 _detail::HeaderIfModifiedSince,
-                setAccessControlOptions.IfModifiedSince.GetValue().ToString(
+                setAccessControlOptions.IfModifiedSince.Value().ToString(
                     DateTime::DateFormat::Rfc1123));
           }
           if (setAccessControlOptions.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderIfUnmodifiedSince,
-                setAccessControlOptions.IfUnmodifiedSince.GetValue().ToString(
+                setAccessControlOptions.IfUnmodifiedSince.Value().ToString(
                     DateTime::DateFormat::Rfc1123));
           }
           request.SetHeader(_detail::HeaderVersion, setAccessControlOptions.ApiVersionParameter);
@@ -903,14 +903,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setAccessControlRecursiveOptions.Timeout.GetValue())));
+                    std::to_string(setAccessControlRecursiveOptions.Timeout.Value())));
           }
           if (setAccessControlRecursiveOptions.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
                 _internal::UrlEncodeQueryParameter(
-                    setAccessControlRecursiveOptions.ContinuationToken.GetValue()));
+                    setAccessControlRecursiveOptions.ContinuationToken.Value()));
           }
           request.GetUrl().AppendQueryParameter(
               _detail::QueryPathSetAccessControlRecursiveMode,
@@ -920,18 +920,18 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryForceFlag,
                 _internal::UrlEncodeQueryParameter(
-                    (setAccessControlRecursiveOptions.ForceFlag.GetValue() ? "true" : "false")));
+                    (setAccessControlRecursiveOptions.ForceFlag.Value() ? "true" : "false")));
           }
           if (setAccessControlRecursiveOptions.MaxRecords.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryMaxRecords,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setAccessControlRecursiveOptions.MaxRecords.GetValue())));
+                    std::to_string(setAccessControlRecursiveOptions.MaxRecords.Value())));
           }
           if (setAccessControlRecursiveOptions.Acl.HasValue())
           {
-            request.SetHeader(_detail::HeaderAcl, setAccessControlRecursiveOptions.Acl.GetValue());
+            request.SetHeader(_detail::HeaderAcl, setAccessControlRecursiveOptions.Acl.Value());
           }
           request.SetHeader(
               _detail::HeaderVersion, setAccessControlRecursiveOptions.ApiVersionParameter);
@@ -972,68 +972,68 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(flushDataOptions.Timeout.GetValue())));
+                    std::to_string(flushDataOptions.Timeout.Value())));
           }
           if (flushDataOptions.Position.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPosition,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(flushDataOptions.Position.GetValue())));
+                    std::to_string(flushDataOptions.Position.Value())));
           }
           if (flushDataOptions.RetainUncommittedData.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryRetainUncommittedData,
                 _internal::UrlEncodeQueryParameter(
-                    (flushDataOptions.RetainUncommittedData.GetValue() ? "true" : "false")));
+                    (flushDataOptions.RetainUncommittedData.Value() ? "true" : "false")));
           }
           if (flushDataOptions.Close.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryClose,
                 _internal::UrlEncodeQueryParameter(
-                    (flushDataOptions.Close.GetValue() ? "true" : "false")));
+                    (flushDataOptions.Close.Value() ? "true" : "false")));
           }
           if (flushDataOptions.ContentLength.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderContentLength,
-                std::to_string(flushDataOptions.ContentLength.GetValue()));
+                std::to_string(flushDataOptions.ContentLength.Value()));
           }
           if (flushDataOptions.ContentMd5.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderContentHashMd5,
-                _internal::ToBase64String(flushDataOptions.ContentMd5.GetValue()));
+                _internal::ToBase64String(flushDataOptions.ContentMd5.Value()));
           }
           if (flushDataOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, flushDataOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, flushDataOptions.LeaseIdOptional.Value());
           }
           if (flushDataOptions.CacheControl.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderCacheControl, flushDataOptions.CacheControl.GetValue());
+                _detail::HeaderCacheControl, flushDataOptions.CacheControl.Value());
           }
           if (flushDataOptions.ContentType.HasValue())
           {
-            request.SetHeader(_detail::HeaderContentType, flushDataOptions.ContentType.GetValue());
+            request.SetHeader(_detail::HeaderContentType, flushDataOptions.ContentType.Value());
           }
           if (flushDataOptions.ContentDisposition.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderContentDisposition, flushDataOptions.ContentDisposition.GetValue());
+                _detail::HeaderContentDisposition, flushDataOptions.ContentDisposition.Value());
           }
           if (flushDataOptions.ContentEncoding.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderContentEncoding, flushDataOptions.ContentEncoding.GetValue());
+                _detail::HeaderContentEncoding, flushDataOptions.ContentEncoding.Value());
           }
           if (flushDataOptions.ContentLanguage.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderContentLanguage, flushDataOptions.ContentLanguage.GetValue());
+                _detail::HeaderContentLanguage, flushDataOptions.ContentLanguage.Value());
           }
           if (flushDataOptions.IfMatch.HasValue())
           {
@@ -1047,14 +1047,14 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           {
             request.SetHeader(
                 _detail::HeaderIfModifiedSince,
-                flushDataOptions.IfModifiedSince.GetValue().ToString(
+                flushDataOptions.IfModifiedSince.Value().ToString(
                     DateTime::DateFormat::Rfc1123));
           }
           if (flushDataOptions.IfUnmodifiedSince.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderIfUnmodifiedSince,
-                flushDataOptions.IfUnmodifiedSince.GetValue().ToString(
+                flushDataOptions.IfUnmodifiedSince.Value().ToString(
                     DateTime::DateFormat::Rfc1123));
           }
           request.SetHeader(_detail::HeaderVersion, flushDataOptions.ApiVersionParameter);
@@ -1087,36 +1087,36 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPosition,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(appendDataOptions.Position.GetValue())));
+                    std::to_string(appendDataOptions.Position.Value())));
           }
           if (appendDataOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(appendDataOptions.Timeout.GetValue())));
+                    std::to_string(appendDataOptions.Timeout.Value())));
           }
           if (appendDataOptions.ContentLength.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderContentLength,
-                std::to_string(appendDataOptions.ContentLength.GetValue()));
+                std::to_string(appendDataOptions.ContentLength.Value()));
           }
           if (appendDataOptions.TransactionalContentMd5.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderTransactionalContentHashMd5,
-                _internal::ToBase64String(appendDataOptions.TransactionalContentMd5.GetValue()));
+                _internal::ToBase64String(appendDataOptions.TransactionalContentMd5.Value()));
           }
           if (appendDataOptions.TransactionalContentCrc64.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderTransactionalContentHashCrc64,
-                _internal::ToBase64String(appendDataOptions.TransactionalContentCrc64.GetValue()));
+                _internal::ToBase64String(appendDataOptions.TransactionalContentCrc64.Value()));
           }
           if (appendDataOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, appendDataOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, appendDataOptions.LeaseIdOptional.Value());
           }
           request.SetHeader(_detail::HeaderVersion, appendDataOptions.ApiVersionParameter);
           return AppendDataParseResult(context, pipeline.Send(request, context));

--- a/sdk/storage/azure-storage-files-datalake/sample/datalake_getting_started.cpp
+++ b/sdk/storage/azure-storage-files-datalake/sample/datalake_getting_started.cpp
@@ -93,7 +93,7 @@ void DataLakeGettingStarted()
       auto response = serviceClient.ListFileSystemsSinglePage();
       if (response.Value.ContinuationToken.HasValue())
       {
-        continuation = response.Value.ContinuationToken.GetValue();
+        continuation = response.Value.ContinuationToken.Value();
       }
       fileSystems.insert(
           fileSystems.end(), response.Value.Items.begin(), response.Value.Items.end());

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_directory_client.cpp
@@ -89,7 +89,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     std::string destinationFileSystem;
     if (options.DestinationFileSystem.HasValue())
     {
-      destinationFileSystem = options.DestinationFileSystem.GetValue();
+      destinationFileSystem = options.DestinationFileSystem.Value();
     }
     else
     {
@@ -137,7 +137,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     std::string destinationFileSystem;
     if (options.DestinationFileSystem.HasValue())
     {
-      destinationFileSystem = options.DestinationFileSystem.GetValue();
+      destinationFileSystem = options.DestinationFileSystem.Value();
     }
     else
     {
@@ -224,7 +224,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           = currentPath.substr(firstSlashPos + 1U, currentPath.size() - firstSlashPos - 1U);
       auto fileSystemUrl = m_pathUrl;
       fileSystemUrl.SetPath(currentPath.substr(
-          0U, currentPath.size() - protocolLayerOptions.Directory.GetValue().size() - 1U));
+          0U, currentPath.size() - protocolLayerOptions.Directory.Value().size() - 1U));
       return _detail::DataLakeRestClient::FileSystem::ListPaths(
           fileSystemUrl, *m_pipeline, _internal::WithReplicaStatus(context), protocolLayerOptions);
     }

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_client.cpp
@@ -134,7 +134,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     protocolLayerOptions.ContentLength = content.Length();
     if (options.TransactionalContentHash.HasValue())
     {
-      if (options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Crc64)
+      if (options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Crc64)
       {
         protocolLayerOptions.TransactionalContentCrc64 = options.TransactionalContentHash;
       }
@@ -159,7 +159,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     protocolLayerOptions.Close = options.Close;
     protocolLayerOptions.ContentLength = 0;
     if (options.ContentHash.HasValue()
-        && options.ContentHash.GetValue().Algorithm != HashAlgorithm::Md5)
+        && options.ContentHash.Value().Algorithm != HashAlgorithm::Md5)
     {
       std::abort();
     }
@@ -227,13 +227,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     if (result.Value.Details.LeaseDuration.HasValue())
     {
       ret.Details.LeaseDuration
-          = Models::LeaseDuration(result.Value.Details.LeaseDuration.GetValue().ToString());
+          = Models::LeaseDuration(result.Value.Details.LeaseDuration.Value().ToString());
     }
     ret.Details.LeaseState = result.Value.Details.LeaseState.HasValue()
-        ? FromBlobLeaseState(result.Value.Details.LeaseState.GetValue())
+        ? FromBlobLeaseState(result.Value.Details.LeaseState.Value())
         : ret.Details.LeaseState;
     ret.Details.LeaseStatus = result.Value.Details.LeaseStatus.HasValue()
-        ? FromBlobLeaseStatus(result.Value.Details.LeaseStatus.GetValue())
+        ? FromBlobLeaseStatus(result.Value.Details.LeaseStatus.Value())
         : ret.Details.LeaseStatus;
     ret.Details.Metadata = std::move(result.Value.Details.Metadata);
     ret.Details.CreatedOn = std::move(result.Value.Details.CreatedOn);
@@ -301,13 +301,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     if (result.Value.Details.LeaseDuration.HasValue())
     {
       ret.Details.LeaseDuration
-          = Models::LeaseDuration(result.Value.Details.LeaseDuration.GetValue().ToString());
+          = Models::LeaseDuration(result.Value.Details.LeaseDuration.Value().ToString());
     }
     ret.Details.LeaseState = result.Value.Details.LeaseState.HasValue()
-        ? FromBlobLeaseState(result.Value.Details.LeaseState.GetValue())
+        ? FromBlobLeaseState(result.Value.Details.LeaseState.Value())
         : ret.Details.LeaseState;
     ret.Details.LeaseStatus = result.Value.Details.LeaseStatus.HasValue()
-        ? FromBlobLeaseStatus(result.Value.Details.LeaseStatus.GetValue())
+        ? FromBlobLeaseStatus(result.Value.Details.LeaseStatus.Value())
         : ret.Details.LeaseStatus;
     ret.Details.Metadata = std::move(result.Value.Details.Metadata);
     ret.Details.CreatedOn = std::move(result.Value.Details.CreatedOn);
@@ -343,13 +343,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     if (result.Value.Details.LeaseDuration.HasValue())
     {
       ret.Details.LeaseDuration
-          = Models::LeaseDuration(result.Value.Details.LeaseDuration.GetValue().ToString());
+          = Models::LeaseDuration(result.Value.Details.LeaseDuration.Value().ToString());
     }
     ret.Details.LeaseState = result.Value.Details.LeaseState.HasValue()
-        ? FromBlobLeaseState(result.Value.Details.LeaseState.GetValue())
+        ? FromBlobLeaseState(result.Value.Details.LeaseState.Value())
         : ret.Details.LeaseState;
     ret.Details.LeaseStatus = result.Value.Details.LeaseStatus.HasValue()
-        ? FromBlobLeaseStatus(result.Value.Details.LeaseStatus.GetValue())
+        ? FromBlobLeaseStatus(result.Value.Details.LeaseStatus.Value())
         : ret.Details.LeaseStatus;
     ret.Details.Metadata = std::move(result.Value.Details.Metadata);
     ret.Details.CreatedOn = std::move(result.Value.Details.CreatedOn);
@@ -385,11 +385,11 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     if (options.ExpiresOn.HasValue())
     {
       protocolLayerOptions.ExpiryTime
-          = options.ExpiresOn.GetValue().ToString(Azure::DateTime::DateFormat::Rfc1123);
+          = options.ExpiresOn.Value().ToString(Azure::DateTime::DateFormat::Rfc1123);
     }
     else if (options.TimeToExpire.HasValue())
     {
-      protocolLayerOptions.ExpiryTime = std::to_string(options.TimeToExpire.GetValue().count());
+      protocolLayerOptions.ExpiryTime = std::to_string(options.TimeToExpire.Value().count());
     }
     return Blobs::_detail::BlobRestClient::Blob::ScheduleDeletion(
         *m_pipeline, m_blobClient.m_blobUrl, protocolLayerOptions, context);

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
@@ -350,7 +350,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     std::string destinationFileSystem;
     if (options.DestinationFileSystem.HasValue())
     {
-      destinationFileSystem = options.DestinationFileSystem.GetValue();
+      destinationFileSystem = options.DestinationFileSystem.Value();
     }
     else
     {
@@ -398,7 +398,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     std::string destinationFileSystem;
     if (options.DestinationFileSystem.HasValue())
     {
-      destinationFileSystem = options.DestinationFileSystem.GetValue();
+      destinationFileSystem = options.DestinationFileSystem.Value();
     }
     else
     {

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_path_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_path_client.cpp
@@ -245,7 +245,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         m_pathUrl, *m_pipeline, context, protocolLayerOptions);
     Models::CreatePathResult ret;
     ret.ETag = std::move(result.Value.ETag);
-    ret.LastModified = std::move(result.Value.LastModified.GetValue());
+    ret.LastModified = std::move(result.Value.LastModified.Value());
     ret.FileSize = std::move(result.Value.ContentLength);
     return Azure::Response<Models::CreatePathResult>(std::move(ret), std::move(result.RawResponse));
   }
@@ -330,13 +330,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     ret.Metadata = std::move(result.Value.Metadata);
     if (result.Value.LeaseDuration.HasValue())
     {
-      ret.LeaseDuration = Models::LeaseDuration(result.Value.LeaseDuration.GetValue().ToString());
+      ret.LeaseDuration = Models::LeaseDuration(result.Value.LeaseDuration.Value().ToString());
     }
     ret.LeaseState = result.Value.LeaseState.HasValue()
-        ? FromBlobLeaseState(result.Value.LeaseState.GetValue())
+        ? FromBlobLeaseState(result.Value.LeaseState.Value())
         : ret.LeaseState;
     ret.LeaseStatus = result.Value.LeaseStatus.HasValue()
-        ? FromBlobLeaseStatus(result.Value.LeaseStatus.GetValue())
+        ? FromBlobLeaseStatus(result.Value.LeaseStatus.Value())
         : ret.LeaseStatus;
     ret.HttpHeaders.CacheControl = std::move(result.Value.HttpHeaders.CacheControl);
     ret.HttpHeaders.ContentDisposition = std::move(result.Value.HttpHeaders.ContentDisposition);
@@ -381,7 +381,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     Azure::Nullable<std::vector<Models::Acl>> acl;
     if (result.Value.Acl.HasValue())
     {
-      acl = Models::Acl::DeserializeAcls(result.Value.Acl.GetValue());
+      acl = Models::Acl::DeserializeAcls(result.Value.Acl.Value());
     }
     Models::PathAccessControlList ret;
     if (!acl.HasValue())
@@ -389,18 +389,18 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       throw Azure::Core::RequestFailedException(
           "Got null value returned when getting access control.");
     }
-    ret.Acls = std::move(acl.GetValue());
+    ret.Acls = std::move(acl.Value());
     if (result.Value.Owner.HasValue())
     {
-      ret.Owner = result.Value.Owner.GetValue();
+      ret.Owner = result.Value.Owner.Value();
     }
     if (result.Value.Group.HasValue())
     {
-      ret.Group = result.Value.Group.GetValue();
+      ret.Group = result.Value.Group.Value();
     }
     if (result.Value.Permissions.HasValue())
     {
-      ret.Permissions = result.Value.Permissions.GetValue();
+      ret.Permissions = result.Value.Permissions.Value();
     }
     return Azure::Response<Models::PathAccessControlList>(
         std::move(ret), std::move(result.RawResponse));

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_sas_builder.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_sas_builder.cpp
@@ -124,7 +124,7 @@ namespace Azure { namespace Storage { namespace Sas {
     std::string resource = DataLakeSasResourceToString(Resource);
 
     std::string startsOnStr = StartsOn.HasValue()
-        ? StartsOn.GetValue().ToString(
+        ? StartsOn.Value().ToString(
             Azure::DateTime::DateFormat::Rfc3339, Azure::DateTime::TimeFractionFormat::Truncate)
         : "";
     std::string expiresOnStr = Identifier.empty()
@@ -133,7 +133,7 @@ namespace Azure { namespace Storage { namespace Sas {
         : "";
 
     std::string stringToSign = Permissions + "\n" + startsOnStr + "\n" + expiresOnStr + "\n"
-        + canonicalName + "\n" + Identifier + "\n" + (IPRange.HasValue() ? IPRange.GetValue() : "")
+        + canonicalName + "\n" + Identifier + "\n" + (IPRange.HasValue() ? IPRange.Value() : "")
         + "\n" + protocol + "\n" + _internal::DefaultSasVersion + "\n" + resource + "\n" + "\n"
         + CacheControl + "\n" + ContentDisposition + "\n" + ContentEncoding + "\n" + ContentLanguage
         + "\n" + ContentType;
@@ -156,7 +156,7 @@ namespace Azure { namespace Storage { namespace Sas {
     }
     if (IPRange.HasValue())
     {
-      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.GetValue()));
+      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.Value()));
     }
     if (!Identifier.empty())
     {
@@ -205,7 +205,7 @@ namespace Azure { namespace Storage { namespace Sas {
     std::string resource = DataLakeSasResourceToString(Resource);
 
     std::string startsOnStr = StartsOn.HasValue()
-        ? StartsOn.GetValue().ToString(
+        ? StartsOn.Value().ToString(
             Azure::DateTime::DateFormat::Rfc3339, Azure::DateTime::TimeFractionFormat::Truncate)
         : "";
     std::string expiresOnStr = ExpiresOn.ToString(
@@ -220,7 +220,7 @@ namespace Azure { namespace Storage { namespace Sas {
         + userDelegationKey.SignedTenantId + "\n" + signedStartsOnStr + "\n" + signedExpiresOnStr
         + "\n" + userDelegationKey.SignedService + "\n" + userDelegationKey.SignedVersion + "\n"
         + PreauthorizedAgentObjectId + "\n" + AgentObjectId + "\n" + CorrelationId + "\n"
-        + (IPRange.HasValue() ? IPRange.GetValue() : "") + "\n" + protocol + "\n"
+        + (IPRange.HasValue() ? IPRange.Value() : "") + "\n" + protocol + "\n"
         + _internal::DefaultSasVersion + "\n" + resource + "\n" + "\n" + CacheControl + "\n"
         + ContentDisposition + "\n" + ContentEncoding + "\n" + ContentLanguage + "\n" + ContentType;
 
@@ -240,7 +240,7 @@ namespace Azure { namespace Storage { namespace Sas {
     builder.AppendQueryParameter("sp", Permissions);
     if (IPRange.HasValue())
     {
-      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.GetValue()));
+      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.Value()));
     }
     builder.AppendQueryParameter("spr", _internal::UrlEncodeQueryParameter(protocol));
     builder.AppendQueryParameter(
@@ -269,7 +269,7 @@ namespace Azure { namespace Storage { namespace Sas {
     if (DirectoryDepth.HasValue())
     {
       builder.AppendQueryParameter(
-          "sdd", _internal::UrlEncodeQueryParameter(std::to_string(DirectoryDepth.GetValue())));
+          "sdd", _internal::UrlEncodeQueryParameter(std::to_string(DirectoryDepth.Value())));
     }
     if (!CacheControl.empty())
     {

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_service_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_service_client.cpp
@@ -53,7 +53,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         if (item.Details.LeaseDuration.HasValue())
         {
           fileSystem.Details.LeaseDuration
-              = Models::LeaseDuration((item.Details.LeaseDuration.GetValue().ToString()));
+              = Models::LeaseDuration((item.Details.LeaseDuration.Value().ToString()));
         }
         fileSystem.Details.LeaseState = Models::LeaseState(item.Details.LeaseState.ToString());
         fileSystem.Details.LeaseStatus = Models::LeaseStatus(item.Details.LeaseStatus.ToString());

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_file_client_test.cpp
@@ -272,7 +272,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto downloaded = ReadBodyStream(result.Value.Body);
     EXPECT_EQ(buffer, downloaded);
     EXPECT_EQ(bufferSize, result.Value.FileSize);
-    EXPECT_EQ(bufferSize, result.Value.ContentRange.Length.GetValue());
+    EXPECT_EQ(bufferSize, result.Value.ContentRange.Length.Value());
     EXPECT_EQ(0, result.Value.ContentRange.Offset);
 
     // Read Range
@@ -280,27 +280,27 @@ namespace Azure { namespace Storage { namespace Test {
       auto firstHalf = std::vector<uint8_t>(buffer.begin(), buffer.begin() + (bufferSize / 2));
       Files::DataLake::DownloadFileOptions options;
       options.Range = Azure::Core::Http::HttpRange();
-      options.Range.GetValue().Offset = 0;
-      options.Range.GetValue().Length = bufferSize / 2;
+      options.Range.Value().Offset = 0;
+      options.Range.Value().Length = bufferSize / 2;
       result = newFileClient->Download(options);
       downloaded = ReadBodyStream(result.Value.Body);
       EXPECT_EQ(firstHalf.size(), downloaded.size());
       EXPECT_EQ(firstHalf, downloaded);
       EXPECT_EQ(bufferSize, result.Value.FileSize);
-      EXPECT_EQ(bufferSize / 2, result.Value.ContentRange.Length.GetValue());
+      EXPECT_EQ(bufferSize / 2, result.Value.ContentRange.Length.Value());
       EXPECT_EQ(0, result.Value.ContentRange.Offset);
     }
     {
       auto secondHalf = std::vector<uint8_t>(buffer.begin() + bufferSize / 2, buffer.end());
       Files::DataLake::DownloadFileOptions options;
       options.Range = Azure::Core::Http::HttpRange();
-      options.Range.GetValue().Offset = bufferSize / 2;
-      options.Range.GetValue().Length = bufferSize / 2;
+      options.Range.Value().Offset = bufferSize / 2;
+      options.Range.Value().Length = bufferSize / 2;
       result = newFileClient->Download(options);
       downloaded = ReadBodyStream(result.Value.Body);
       EXPECT_EQ(secondHalf, downloaded);
       EXPECT_EQ(bufferSize, result.Value.FileSize);
-      EXPECT_EQ(bufferSize / 2, result.Value.ContentRange.Length.GetValue());
+      EXPECT_EQ(bufferSize / 2, result.Value.ContentRange.Length.Value());
       EXPECT_EQ(bufferSize / 2, result.Value.ContentRange.Offset);
     }
     {

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_file_system_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_file_system_client_test.cpp
@@ -70,7 +70,7 @@ namespace Azure { namespace Storage { namespace Test {
         result.insert(result.end(), response.Value.Items.begin(), response.Value.Items.end());
         if (response.Value.ContinuationToken.HasValue())
         {
-          continuation = response.Value.ContinuationToken.GetValue();
+          continuation = response.Value.ContinuationToken.Value();
           options.ContinuationToken = continuation;
         }
         else
@@ -88,7 +88,7 @@ namespace Azure { namespace Storage { namespace Test {
         result.insert(result.end(), response.Value.Items.begin(), response.Value.Items.end());
         if (response.Value.ContinuationToken.HasValue())
         {
-          continuation = response.Value.ContinuationToken.GetValue();
+          continuation = response.Value.ContinuationToken.Value();
           options.ContinuationToken = continuation;
         }
         else

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_path_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_path_client_test.cpp
@@ -300,9 +300,9 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(aLease.LeaseId, leaseId1);
 
     auto properties = *m_pathClient->GetProperties();
-    EXPECT_EQ(properties.LeaseState.GetValue(), Files::DataLake::Models::LeaseStateType::Leased);
-    EXPECT_EQ(properties.LeaseStatus.GetValue(), Files::DataLake::Models::LeaseStatusType::Locked);
-    EXPECT_FALSE(properties.LeaseDuration.GetValue().empty());
+    EXPECT_EQ(properties.LeaseState.Value(), Files::DataLake::Models::LeaseStateType::Leased);
+    EXPECT_EQ(properties.LeaseStatus.Value(), Files::DataLake::Models::LeaseStatusType::Locked);
+    EXPECT_FALSE(properties.LeaseDuration.Value().empty());
 
     lastModified = properties.LastModified;
     auto rLease = *m_pathClient->RenewLease(leaseId1);
@@ -326,7 +326,7 @@ namespace Azure { namespace Storage { namespace Test {
     lastModified = m_pathClient->GetProperties().Value.LastModified;
     aLease = *m_pathClient->AcquireLease(CreateUniqueLeaseId(), InfiniteLeaseDuration);
     properties = *m_pathClient->GetProperties();
-    EXPECT_FALSE(properties.LeaseDuration.GetValue().empty());
+    EXPECT_FALSE(properties.LeaseDuration.Value().empty());
     auto brokenLease = *m_pathClient->BreakLease();
     EXPECT_FALSE(brokenLease.ETag.empty());
     EXPECT_FALSE(brokenLease.LastModified > lastModified);

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_service_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_service_client_test.cpp
@@ -69,7 +69,7 @@ namespace Azure { namespace Storage { namespace Test {
       result.insert(result.end(), response.Value.Items.begin(), response.Value.Items.end());
       if (response.Value.ContinuationToken.HasValue())
       {
-        continuation = response.Value.ContinuationToken.GetValue();
+        continuation = response.Value.ContinuationToken.Value();
         options.ContinuationToken = continuation;
       }
     } while (!continuation.empty());

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/protocol/share_rest_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/protocol/share_rest_client.hpp
@@ -1086,7 +1086,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setPropertiesOptions.Timeout.GetValue())));
+                    std::to_string(setPropertiesOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, setPropertiesOptions.ApiVersionParameter);
           return SetPropertiesParseResult(context, pipeline.Send(request, context));
@@ -1112,7 +1112,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(getPropertiesOptions.Timeout.GetValue())));
+                    std::to_string(getPropertiesOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, getPropertiesOptions.ApiVersionParameter);
           return GetPropertiesParseResult(context, pipeline.Send(request, context));
@@ -1140,35 +1140,35 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPrefix,
-                _internal::UrlEncodeQueryParameter(listSharesSinglePageOptions.Prefix.GetValue()));
+                _internal::UrlEncodeQueryParameter(listSharesSinglePageOptions.Prefix.Value()));
           }
           if (listSharesSinglePageOptions.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
                 _internal::UrlEncodeQueryParameter(
-                    listSharesSinglePageOptions.ContinuationToken.GetValue()));
+                    listSharesSinglePageOptions.ContinuationToken.Value()));
           }
           if (listSharesSinglePageOptions.MaxResults.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPageSizeHint,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(listSharesSinglePageOptions.MaxResults.GetValue())));
+                    std::to_string(listSharesSinglePageOptions.MaxResults.Value())));
           }
           if (listSharesSinglePageOptions.IncludeFlags.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryIncludeFlags,
                 _internal::UrlEncodeQueryParameter(ListSharesIncludeFlagsToString(
-                    listSharesSinglePageOptions.IncludeFlags.GetValue())));
+                    listSharesSinglePageOptions.IncludeFlags.Value())));
           }
           if (listSharesSinglePageOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(listSharesSinglePageOptions.Timeout.GetValue())));
+                    std::to_string(listSharesSinglePageOptions.Timeout.Value())));
           }
           request.SetHeader(
               _detail::HeaderVersion, listSharesSinglePageOptions.ApiVersionParameter);
@@ -1209,7 +1209,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             writer.Write(_internal::XmlNode{
                 _internal::XmlNodeType::Text,
                 nullptr,
-                std::to_string(object.Days.GetValue()).data()});
+                std::to_string(object.Days.Value()).data()});
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
           }
         }
@@ -1230,7 +1230,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             writer.Write(_internal::XmlNode{
                 _internal::XmlNodeType::Text,
                 nullptr,
-                object.IncludeApis.GetValue() ? "true" : "false"});
+                object.IncludeApis.Value() ? "true" : "false"});
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
           }
           writer.Write(_internal::XmlNode{_internal::XmlNodeType::StartTag, "RetentionPolicy"});
@@ -1317,7 +1317,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           }
           if (object.Protocol.HasValue())
           {
-            ProtocolSettingsToXml(writer, object.Protocol.GetValue());
+            ProtocolSettingsToXml(writer, object.Protocol.Value());
           }
           writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
         }
@@ -2477,7 +2477,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(createOptions.Timeout.GetValue())));
+                    std::to_string(createOptions.Timeout.Value())));
           }
           for (const auto& pair : createOptions.Metadata)
           {
@@ -2486,12 +2486,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (createOptions.ShareQuota.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderQuota, std::to_string(createOptions.ShareQuota.GetValue()));
+                _detail::HeaderQuota, std::to_string(createOptions.ShareQuota.Value()));
           }
           if (createOptions.XMsAccessTier.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderAccessTier, createOptions.XMsAccessTier.GetValue().ToString());
+                _detail::HeaderAccessTier, createOptions.XMsAccessTier.Value().ToString());
           }
           request.SetHeader(_detail::HeaderVersion, createOptions.ApiVersionParameter);
           return CreateParseResult(context, pipeline.Send(request, context));
@@ -2517,20 +2517,20 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(getPropertiesOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(getPropertiesOptions.ShareSnapshot.Value()));
           }
           if (getPropertiesOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(getPropertiesOptions.Timeout.GetValue())));
+                    std::to_string(getPropertiesOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, getPropertiesOptions.ApiVersionParameter);
           if (getPropertiesOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.Value());
           }
           return GetPropertiesParseResult(context, pipeline.Send(request, context));
         }
@@ -2556,25 +2556,25 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(deleteOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(deleteOptions.ShareSnapshot.Value()));
           }
           if (deleteOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(deleteOptions.Timeout.GetValue())));
+                    std::to_string(deleteOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, deleteOptions.ApiVersionParameter);
           if (deleteOptions.XMsDeleteSnapshots.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderDeleteSnapshots,
-                deleteOptions.XMsDeleteSnapshots.GetValue().ToString());
+                deleteOptions.XMsDeleteSnapshots.Value().ToString());
           }
           if (deleteOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, deleteOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, deleteOptions.LeaseIdOptional.Value());
           }
           return DeleteParseResult(context, pipeline.Send(request, context));
         }
@@ -2604,7 +2604,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(acquireLeaseOptions.Timeout.GetValue())));
+                    std::to_string(acquireLeaseOptions.Timeout.Value())));
           }
           request.SetHeader(
               _detail::HeaderDuration, std::to_string(acquireLeaseOptions.LeaseDuration));
@@ -2612,14 +2612,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.SetHeader(
                 _detail::HeaderProposedLeaseId,
-                acquireLeaseOptions.ProposedLeaseIdOptional.GetValue());
+                acquireLeaseOptions.ProposedLeaseIdOptional.Value());
           }
           request.SetHeader(_detail::HeaderVersion, acquireLeaseOptions.ApiVersionParameter);
           if (acquireLeaseOptions.ShareSnapshot.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(acquireLeaseOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(acquireLeaseOptions.ShareSnapshot.Value()));
           }
           return AcquireLeaseParseResult(context, pipeline.Send(request, context));
         }
@@ -2648,7 +2648,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(releaseLeaseOptions.Timeout.GetValue())));
+                    std::to_string(releaseLeaseOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderLeaseId, releaseLeaseOptions.LeaseIdRequired);
           request.SetHeader(_detail::HeaderVersion, releaseLeaseOptions.ApiVersionParameter);
@@ -2656,7 +2656,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(releaseLeaseOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(releaseLeaseOptions.ShareSnapshot.Value()));
           }
           return ReleaseLeaseParseResult(context, pipeline.Send(request, context));
         }
@@ -2686,21 +2686,21 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(changeLeaseOptions.Timeout.GetValue())));
+                    std::to_string(changeLeaseOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderLeaseId, changeLeaseOptions.LeaseIdRequired);
           if (changeLeaseOptions.ProposedLeaseIdOptional.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderProposedLeaseId,
-                changeLeaseOptions.ProposedLeaseIdOptional.GetValue());
+                changeLeaseOptions.ProposedLeaseIdOptional.Value());
           }
           request.SetHeader(_detail::HeaderVersion, changeLeaseOptions.ApiVersionParameter);
           if (changeLeaseOptions.ShareSnapshot.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(changeLeaseOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(changeLeaseOptions.ShareSnapshot.Value()));
           }
           return ChangeLeaseParseResult(context, pipeline.Send(request, context));
         }
@@ -2729,7 +2729,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(renewLeaseOptions.Timeout.GetValue())));
+                    std::to_string(renewLeaseOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderLeaseId, renewLeaseOptions.LeaseIdRequired);
           request.SetHeader(_detail::HeaderVersion, renewLeaseOptions.ApiVersionParameter);
@@ -2737,7 +2737,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(renewLeaseOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(renewLeaseOptions.ShareSnapshot.Value()));
           }
           return RenewLeaseParseResult(context, pipeline.Send(request, context));
         }
@@ -2767,24 +2767,24 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(breakLeaseOptions.Timeout.GetValue())));
+                    std::to_string(breakLeaseOptions.Timeout.Value())));
           }
           if (breakLeaseOptions.LeaseBreakPeriod.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderBreakPeriod,
-                std::to_string(breakLeaseOptions.LeaseBreakPeriod.GetValue()));
+                std::to_string(breakLeaseOptions.LeaseBreakPeriod.Value()));
           }
           if (breakLeaseOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, breakLeaseOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, breakLeaseOptions.LeaseIdOptional.Value());
           }
           request.SetHeader(_detail::HeaderVersion, breakLeaseOptions.ApiVersionParameter);
           if (breakLeaseOptions.ShareSnapshot.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(breakLeaseOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(breakLeaseOptions.ShareSnapshot.Value()));
           }
           return BreakLeaseParseResult(context, pipeline.Send(request, context));
         }
@@ -2811,7 +2811,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(createSnapshotOptions.Timeout.GetValue())));
+                    std::to_string(createSnapshotOptions.Timeout.Value())));
           }
           for (const auto& pair : createSnapshotOptions.Metadata)
           {
@@ -2852,7 +2852,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(createPermissionOptions.Timeout.GetValue())));
+                    std::to_string(createPermissionOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, createPermissionOptions.ApiVersionParameter);
           return CreatePermissionParseResult(context, pipeline.Send(request, context));
@@ -2881,7 +2881,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(getPermissionOptions.Timeout.GetValue())));
+                    std::to_string(getPermissionOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, getPermissionOptions.ApiVersionParameter);
           return GetPermissionParseResult(context, pipeline.Send(request, context));
@@ -2911,24 +2911,24 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setPropertiesOptions.Timeout.GetValue())));
+                    std::to_string(setPropertiesOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, setPropertiesOptions.ApiVersionParameter);
           if (setPropertiesOptions.ShareQuota.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderQuota, std::to_string(setPropertiesOptions.ShareQuota.GetValue()));
+                _detail::HeaderQuota, std::to_string(setPropertiesOptions.ShareQuota.Value()));
           }
           if (setPropertiesOptions.XMsAccessTier.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderAccessTier,
-                setPropertiesOptions.XMsAccessTier.GetValue().ToString());
+                setPropertiesOptions.XMsAccessTier.Value().ToString());
           }
           if (setPropertiesOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, setPropertiesOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, setPropertiesOptions.LeaseIdOptional.Value());
           }
           return SetPropertiesParseResult(context, pipeline.Send(request, context));
         }
@@ -2956,7 +2956,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setMetadataOptions.Timeout.GetValue())));
+                    std::to_string(setMetadataOptions.Timeout.Value())));
           }
           for (const auto& pair : setMetadataOptions.Metadata)
           {
@@ -2966,7 +2966,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (setMetadataOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, setMetadataOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, setMetadataOptions.LeaseIdOptional.Value());
           }
           return SetMetadataParseResult(context, pipeline.Send(request, context));
         }
@@ -2992,13 +2992,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(getAccessPolicyOptions.Timeout.GetValue())));
+                    std::to_string(getAccessPolicyOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, getAccessPolicyOptions.ApiVersionParameter);
           if (getAccessPolicyOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, getAccessPolicyOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, getAccessPolicyOptions.LeaseIdOptional.Value());
           }
           return GetAccessPolicyParseResult(context, pipeline.Send(request, context));
         }
@@ -3036,13 +3036,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setAccessPolicyOptions.Timeout.GetValue())));
+                    std::to_string(setAccessPolicyOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, setAccessPolicyOptions.ApiVersionParameter);
           if (setAccessPolicyOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, setAccessPolicyOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, setAccessPolicyOptions.LeaseIdOptional.Value());
           }
           return SetAccessPolicyParseResult(context, pipeline.Send(request, context));
         }
@@ -3068,13 +3068,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(getStatisticsOptions.Timeout.GetValue())));
+                    std::to_string(getStatisticsOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, getStatisticsOptions.ApiVersionParameter);
           if (getStatisticsOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, getStatisticsOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, getStatisticsOptions.LeaseIdOptional.Value());
           }
           return GetStatisticsParseResult(context, pipeline.Send(request, context));
         }
@@ -3102,18 +3102,18 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(restoreOptions.Timeout.GetValue())));
+                    std::to_string(restoreOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, restoreOptions.ApiVersionParameter);
           if (restoreOptions.DeletedShareName.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderDeletedShareName, restoreOptions.DeletedShareName.GetValue());
+                _detail::HeaderDeletedShareName, restoreOptions.DeletedShareName.Value());
           }
           if (restoreOptions.DeletedShareVersion.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderDeletedShareVersion, restoreOptions.DeletedShareVersion.GetValue());
+                _detail::HeaderDeletedShareVersion, restoreOptions.DeletedShareVersion.Value());
           }
           return RestoreParseResult(context, pipeline.Send(request, context));
         }
@@ -3943,7 +3943,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(createOptions.Timeout.GetValue())));
+                    std::to_string(createOptions.Timeout.Value())));
           }
           for (const auto& pair : createOptions.Metadata)
           {
@@ -3953,12 +3953,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (createOptions.FilePermission.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermission, createOptions.FilePermission.GetValue());
+                _detail::HeaderFilePermission, createOptions.FilePermission.Value());
           }
           if (createOptions.FilePermissionKey.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermissionKey, createOptions.FilePermissionKey.GetValue());
+                _detail::HeaderFilePermissionKey, createOptions.FilePermissionKey.Value());
           }
           request.SetHeader(_detail::HeaderFileAttributes, createOptions.FileAttributes);
           request.SetHeader(_detail::HeaderFileCreatedOn, createOptions.FileCreationTime);
@@ -3985,14 +3985,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(getPropertiesOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(getPropertiesOptions.ShareSnapshot.Value()));
           }
           if (getPropertiesOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(getPropertiesOptions.Timeout.GetValue())));
+                    std::to_string(getPropertiesOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, getPropertiesOptions.ApiVersionParameter);
           return GetPropertiesParseResult(context, pipeline.Send(request, context));
@@ -4017,7 +4017,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(deleteOptions.Timeout.GetValue())));
+                    std::to_string(deleteOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, deleteOptions.ApiVersionParameter);
           return DeleteParseResult(context, pipeline.Send(request, context));
@@ -4049,19 +4049,19 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setPropertiesOptions.Timeout.GetValue())));
+                    std::to_string(setPropertiesOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, setPropertiesOptions.ApiVersionParameter);
           if (setPropertiesOptions.FilePermission.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermission, setPropertiesOptions.FilePermission.GetValue());
+                _detail::HeaderFilePermission, setPropertiesOptions.FilePermission.Value());
           }
           if (setPropertiesOptions.FilePermissionKey.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderFilePermissionKey,
-                setPropertiesOptions.FilePermissionKey.GetValue());
+                setPropertiesOptions.FilePermissionKey.Value());
           }
           request.SetHeader(_detail::HeaderFileAttributes, setPropertiesOptions.FileAttributes);
           request.SetHeader(_detail::HeaderFileCreatedOn, setPropertiesOptions.FileCreationTime);
@@ -4092,7 +4092,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setMetadataOptions.Timeout.GetValue())));
+                    std::to_string(setMetadataOptions.Timeout.Value())));
           }
           for (const auto& pair : setMetadataOptions.Metadata)
           {
@@ -4128,35 +4128,35 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPrefix,
                 _internal::UrlEncodeQueryParameter(
-                    listFilesAndDirectoriesSinglePageOptions.Prefix.GetValue()));
+                    listFilesAndDirectoriesSinglePageOptions.Prefix.Value()));
           }
           if (listFilesAndDirectoriesSinglePageOptions.ShareSnapshot.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
                 _internal::UrlEncodeQueryParameter(
-                    listFilesAndDirectoriesSinglePageOptions.ShareSnapshot.GetValue()));
+                    listFilesAndDirectoriesSinglePageOptions.ShareSnapshot.Value()));
           }
           if (listFilesAndDirectoriesSinglePageOptions.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
                 _internal::UrlEncodeQueryParameter(
-                    listFilesAndDirectoriesSinglePageOptions.ContinuationToken.GetValue()));
+                    listFilesAndDirectoriesSinglePageOptions.ContinuationToken.Value()));
           }
           if (listFilesAndDirectoriesSinglePageOptions.MaxResults.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPageSizeHint,
                 _internal::UrlEncodeQueryParameter(std::to_string(
-                    listFilesAndDirectoriesSinglePageOptions.MaxResults.GetValue())));
+                    listFilesAndDirectoriesSinglePageOptions.MaxResults.Value())));
           }
           if (listFilesAndDirectoriesSinglePageOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(listFilesAndDirectoriesSinglePageOptions.Timeout.GetValue())));
+                    std::to_string(listFilesAndDirectoriesSinglePageOptions.Timeout.Value())));
           }
           request.SetHeader(
               _detail::HeaderVersion, listFilesAndDirectoriesSinglePageOptions.ApiVersionParameter);
@@ -4187,33 +4187,33 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
                 _internal::UrlEncodeQueryParameter(
-                    listHandlesOptions.ContinuationToken.GetValue()));
+                    listHandlesOptions.ContinuationToken.Value()));
           }
           if (listHandlesOptions.MaxResults.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPageSizeHint,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(listHandlesOptions.MaxResults.GetValue())));
+                    std::to_string(listHandlesOptions.MaxResults.Value())));
           }
           if (listHandlesOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(listHandlesOptions.Timeout.GetValue())));
+                    std::to_string(listHandlesOptions.Timeout.Value())));
           }
           if (listHandlesOptions.ShareSnapshot.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(listHandlesOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(listHandlesOptions.ShareSnapshot.Value()));
           }
           if (listHandlesOptions.Recursive.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderRecursive,
-                (listHandlesOptions.Recursive.GetValue() ? "true" : "false"));
+                (listHandlesOptions.Recursive.Value() ? "true" : "false"));
           }
           request.SetHeader(_detail::HeaderVersion, listHandlesOptions.ApiVersionParameter);
           return ListHandlesParseResult(context, pipeline.Send(request, context));
@@ -4243,28 +4243,28 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(forceCloseHandlesOptions.Timeout.GetValue())));
+                    std::to_string(forceCloseHandlesOptions.Timeout.Value())));
           }
           if (forceCloseHandlesOptions.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
                 _internal::UrlEncodeQueryParameter(
-                    forceCloseHandlesOptions.ContinuationToken.GetValue()));
+                    forceCloseHandlesOptions.ContinuationToken.Value()));
           }
           if (forceCloseHandlesOptions.ShareSnapshot.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
                 _internal::UrlEncodeQueryParameter(
-                    forceCloseHandlesOptions.ShareSnapshot.GetValue()));
+                    forceCloseHandlesOptions.ShareSnapshot.Value()));
           }
           request.SetHeader(_detail::HeaderHandleId, forceCloseHandlesOptions.HandleId);
           if (forceCloseHandlesOptions.Recursive.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderRecursive,
-                (forceCloseHandlesOptions.Recursive.GetValue() ? "true" : "false"));
+                (forceCloseHandlesOptions.Recursive.Value() ? "true" : "false"));
           }
           request.SetHeader(_detail::HeaderVersion, forceCloseHandlesOptions.ApiVersionParameter);
           return ForceCloseHandlesParseResult(context, pipeline.Send(request, context));
@@ -5112,7 +5112,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(createOptions.Timeout.GetValue())));
+                    std::to_string(createOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, createOptions.ApiVersionParameter);
           request.SetHeader(
@@ -5121,34 +5121,34 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (createOptions.FileContentType.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFileContentType, createOptions.FileContentType.GetValue());
+                _detail::HeaderFileContentType, createOptions.FileContentType.Value());
           }
           if (createOptions.FileContentEncoding.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFileContentEncoding, createOptions.FileContentEncoding.GetValue());
+                _detail::HeaderFileContentEncoding, createOptions.FileContentEncoding.Value());
           }
           if (createOptions.FileContentLanguage.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFileContentLanguage, createOptions.FileContentLanguage.GetValue());
+                _detail::HeaderFileContentLanguage, createOptions.FileContentLanguage.Value());
           }
           if (createOptions.FileCacheControl.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFileCacheControl, createOptions.FileCacheControl.GetValue());
+                _detail::HeaderFileCacheControl, createOptions.FileCacheControl.Value());
           }
           if (createOptions.ContentMd5.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderContentHashMd5,
-                _internal::ToBase64String(createOptions.ContentMd5.GetValue()));
+                _internal::ToBase64String(createOptions.ContentMd5.Value()));
           }
           if (createOptions.FileContentDisposition.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderFileContentDisposition,
-                createOptions.FileContentDisposition.GetValue());
+                createOptions.FileContentDisposition.Value());
           }
           for (const auto& pair : createOptions.Metadata)
           {
@@ -5157,19 +5157,19 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (createOptions.FilePermission.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermission, createOptions.FilePermission.GetValue());
+                _detail::HeaderFilePermission, createOptions.FilePermission.Value());
           }
           if (createOptions.FilePermissionKey.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermissionKey, createOptions.FilePermissionKey.GetValue());
+                _detail::HeaderFilePermissionKey, createOptions.FilePermissionKey.Value());
           }
           request.SetHeader(_detail::HeaderFileAttributes, createOptions.FileAttributes);
           request.SetHeader(_detail::HeaderFileCreatedOn, createOptions.FileCreationTime);
           request.SetHeader(_detail::HeaderFileLastWrittenOn, createOptions.FileLastWriteTime);
           if (createOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, createOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, createOptions.LeaseIdOptional.Value());
           }
           return CreateParseResult(context, pipeline.Send(request, context));
         }
@@ -5195,22 +5195,22 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(downloadOptions.Timeout.GetValue())));
+                    std::to_string(downloadOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, downloadOptions.ApiVersionParameter);
           if (downloadOptions.Range.HasValue())
           {
-            request.SetHeader(_detail::HeaderRange, downloadOptions.Range.GetValue());
+            request.SetHeader(_detail::HeaderRange, downloadOptions.Range.Value());
           }
           if (downloadOptions.GetRangeContentMd5.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderRangeGetContentMd5,
-                (downloadOptions.GetRangeContentMd5.GetValue() ? "true" : "false"));
+                (downloadOptions.GetRangeContentMd5.Value() ? "true" : "false"));
           }
           if (downloadOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, downloadOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, downloadOptions.LeaseIdOptional.Value());
           }
           return DownloadParseResult(context, pipeline.Send(request, context));
         }
@@ -5234,20 +5234,20 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(getPropertiesOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(getPropertiesOptions.ShareSnapshot.Value()));
           }
           if (getPropertiesOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(getPropertiesOptions.Timeout.GetValue())));
+                    std::to_string(getPropertiesOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, getPropertiesOptions.ApiVersionParameter);
           if (getPropertiesOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.Value());
           }
           return GetPropertiesParseResult(context, pipeline.Send(request, context));
         }
@@ -5271,12 +5271,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(deleteOptions.Timeout.GetValue())));
+                    std::to_string(deleteOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, deleteOptions.ApiVersionParameter);
           if (deleteOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, deleteOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, deleteOptions.LeaseIdOptional.Value());
           }
           return DeleteParseResult(context, pipeline.Send(request, context));
         }
@@ -5314,59 +5314,59 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setHttpHeadersOptions.Timeout.GetValue())));
+                    std::to_string(setHttpHeadersOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, setHttpHeadersOptions.ApiVersionParameter);
           if (setHttpHeadersOptions.XMsContentLength.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderXMsContentLength,
-                std::to_string(setHttpHeadersOptions.XMsContentLength.GetValue()));
+                std::to_string(setHttpHeadersOptions.XMsContentLength.Value()));
           }
           if (setHttpHeadersOptions.FileContentType.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFileContentType, setHttpHeadersOptions.FileContentType.GetValue());
+                _detail::HeaderFileContentType, setHttpHeadersOptions.FileContentType.Value());
           }
           if (setHttpHeadersOptions.FileContentEncoding.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderFileContentEncoding,
-                setHttpHeadersOptions.FileContentEncoding.GetValue());
+                setHttpHeadersOptions.FileContentEncoding.Value());
           }
           if (setHttpHeadersOptions.FileContentLanguage.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderFileContentLanguage,
-                setHttpHeadersOptions.FileContentLanguage.GetValue());
+                setHttpHeadersOptions.FileContentLanguage.Value());
           }
           if (setHttpHeadersOptions.FileCacheControl.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFileCacheControl, setHttpHeadersOptions.FileCacheControl.GetValue());
+                _detail::HeaderFileCacheControl, setHttpHeadersOptions.FileCacheControl.Value());
           }
           if (setHttpHeadersOptions.ContentMd5.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderContentHashMd5,
-                _internal::ToBase64String(setHttpHeadersOptions.ContentMd5.GetValue()));
+                _internal::ToBase64String(setHttpHeadersOptions.ContentMd5.Value()));
           }
           if (setHttpHeadersOptions.FileContentDisposition.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderFileContentDisposition,
-                setHttpHeadersOptions.FileContentDisposition.GetValue());
+                setHttpHeadersOptions.FileContentDisposition.Value());
           }
           if (setHttpHeadersOptions.FilePermission.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermission, setHttpHeadersOptions.FilePermission.GetValue());
+                _detail::HeaderFilePermission, setHttpHeadersOptions.FilePermission.Value());
           }
           if (setHttpHeadersOptions.FilePermissionKey.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderFilePermissionKey,
-                setHttpHeadersOptions.FilePermissionKey.GetValue());
+                setHttpHeadersOptions.FilePermissionKey.Value());
           }
           request.SetHeader(_detail::HeaderFileAttributes, setHttpHeadersOptions.FileAttributes);
           request.SetHeader(_detail::HeaderFileCreatedOn, setHttpHeadersOptions.FileCreationTime);
@@ -5375,7 +5375,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (setHttpHeadersOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, setHttpHeadersOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, setHttpHeadersOptions.LeaseIdOptional.Value());
           }
           return SetHttpHeadersParseResult(context, pipeline.Send(request, context));
         }
@@ -5402,7 +5402,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(setMetadataOptions.Timeout.GetValue())));
+                    std::to_string(setMetadataOptions.Timeout.Value())));
           }
           for (const auto& pair : setMetadataOptions.Metadata)
           {
@@ -5412,7 +5412,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (setMetadataOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, setMetadataOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, setMetadataOptions.LeaseIdOptional.Value());
           }
           return SetMetadataParseResult(context, pipeline.Send(request, context));
         }
@@ -5440,7 +5440,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(acquireLeaseOptions.Timeout.GetValue())));
+                    std::to_string(acquireLeaseOptions.Timeout.Value())));
           }
           request.SetHeader(
               _detail::HeaderDuration, std::to_string(acquireLeaseOptions.LeaseDuration));
@@ -5448,7 +5448,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.SetHeader(
                 _detail::HeaderProposedLeaseId,
-                acquireLeaseOptions.ProposedLeaseIdOptional.GetValue());
+                acquireLeaseOptions.ProposedLeaseIdOptional.Value());
           }
           request.SetHeader(_detail::HeaderVersion, acquireLeaseOptions.ApiVersionParameter);
           return AcquireLeaseParseResult(context, pipeline.Send(request, context));
@@ -5476,7 +5476,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(releaseLeaseOptions.Timeout.GetValue())));
+                    std::to_string(releaseLeaseOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderLeaseId, releaseLeaseOptions.LeaseIdRequired);
           request.SetHeader(_detail::HeaderVersion, releaseLeaseOptions.ApiVersionParameter);
@@ -5506,14 +5506,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(changeLeaseOptions.Timeout.GetValue())));
+                    std::to_string(changeLeaseOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderLeaseId, changeLeaseOptions.LeaseIdRequired);
           if (changeLeaseOptions.ProposedLeaseIdOptional.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderProposedLeaseId,
-                changeLeaseOptions.ProposedLeaseIdOptional.GetValue());
+                changeLeaseOptions.ProposedLeaseIdOptional.Value());
           }
           request.SetHeader(_detail::HeaderVersion, changeLeaseOptions.ApiVersionParameter);
           return ChangeLeaseParseResult(context, pipeline.Send(request, context));
@@ -5541,11 +5541,11 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(breakLeaseOptions.Timeout.GetValue())));
+                    std::to_string(breakLeaseOptions.Timeout.Value())));
           }
           if (breakLeaseOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, breakLeaseOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, breakLeaseOptions.LeaseIdOptional.Value());
           }
           request.SetHeader(_detail::HeaderVersion, breakLeaseOptions.ApiVersionParameter);
           return BreakLeaseParseResult(context, pipeline.Send(request, context));
@@ -5576,7 +5576,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(uploadRangeOptions.Timeout.GetValue())));
+                    std::to_string(uploadRangeOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderXMsRange, uploadRangeOptions.XMsRange);
           request.SetHeader(
@@ -5587,13 +5587,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.SetHeader(
                 _detail::HeaderContentHashMd5,
-                _internal::ToBase64String(uploadRangeOptions.ContentMd5.GetValue()));
+                _internal::ToBase64String(uploadRangeOptions.ContentMd5.Value()));
           }
           request.SetHeader(_detail::HeaderVersion, uploadRangeOptions.ApiVersionParameter);
           if (uploadRangeOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, uploadRangeOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, uploadRangeOptions.LeaseIdOptional.Value());
           }
           return UploadRangeParseResult(context, pipeline.Send(request, context));
         }
@@ -5627,14 +5627,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(uploadRangeFromUrlOptions.Timeout.GetValue())));
+                    std::to_string(uploadRangeFromUrlOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderRange, uploadRangeFromUrlOptions.TargetRange);
           request.SetHeader(_detail::HeaderCopySource, uploadRangeFromUrlOptions.CopySource);
           if (uploadRangeFromUrlOptions.SourceRange.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderSourceRange, uploadRangeFromUrlOptions.SourceRange.GetValue());
+                _detail::HeaderSourceRange, uploadRangeFromUrlOptions.SourceRange.Value());
           }
           request.SetHeader(
               _detail::HeaderFileRangeWriteFromUrl, uploadRangeFromUrlOptions.XMsWrite.ToString());
@@ -5645,26 +5645,26 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.SetHeader(
                 _detail::HeaderSourceContentHashCrc64,
-                _internal::ToBase64String(uploadRangeFromUrlOptions.SourceContentCrc64.GetValue()));
+                _internal::ToBase64String(uploadRangeFromUrlOptions.SourceContentCrc64.Value()));
           }
           if (uploadRangeFromUrlOptions.SourceIfMatchCrc64.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderSourceIfMatchHashCrc64,
-                _internal::ToBase64String(uploadRangeFromUrlOptions.SourceIfMatchCrc64.GetValue()));
+                _internal::ToBase64String(uploadRangeFromUrlOptions.SourceIfMatchCrc64.Value()));
           }
           if (uploadRangeFromUrlOptions.SourceIfNoneMatchCrc64.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderSourceIfNoneMatchHashCrc64,
                 _internal::ToBase64String(
-                    uploadRangeFromUrlOptions.SourceIfNoneMatchCrc64.GetValue()));
+                    uploadRangeFromUrlOptions.SourceIfNoneMatchCrc64.Value()));
           }
           request.SetHeader(_detail::HeaderVersion, uploadRangeFromUrlOptions.ApiVersionParameter);
           if (uploadRangeFromUrlOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, uploadRangeFromUrlOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, uploadRangeFromUrlOptions.LeaseIdOptional.Value());
           }
           return UploadRangeFromUrlParseResult(context, pipeline.Send(request, context));
         }
@@ -5691,31 +5691,31 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(getRangeListOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(getRangeListOptions.ShareSnapshot.Value()));
           }
           if (getRangeListOptions.PrevShareSnapshot.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPrevShareSnapshot,
                 _internal::UrlEncodeQueryParameter(
-                    getRangeListOptions.PrevShareSnapshot.GetValue()));
+                    getRangeListOptions.PrevShareSnapshot.Value()));
           }
           if (getRangeListOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(getRangeListOptions.Timeout.GetValue())));
+                    std::to_string(getRangeListOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, getRangeListOptions.ApiVersionParameter);
           if (getRangeListOptions.XMsRange.HasValue())
           {
-            request.SetHeader(_detail::HeaderXMsRange, getRangeListOptions.XMsRange.GetValue());
+            request.SetHeader(_detail::HeaderXMsRange, getRangeListOptions.XMsRange.Value());
           }
           if (getRangeListOptions.LeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderLeaseId, getRangeListOptions.LeaseIdOptional.GetValue());
+                _detail::HeaderLeaseId, getRangeListOptions.LeaseIdOptional.Value());
           }
           return GetRangeListParseResult(context, pipeline.Send(request, context));
         }
@@ -5750,7 +5750,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(startCopyOptions.Timeout.GetValue())));
+                    std::to_string(startCopyOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, startCopyOptions.ApiVersionParameter);
           for (const auto& pair : startCopyOptions.Metadata)
@@ -5761,50 +5761,50 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (startCopyOptions.FilePermission.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermission, startCopyOptions.FilePermission.GetValue());
+                _detail::HeaderFilePermission, startCopyOptions.FilePermission.Value());
           }
           if (startCopyOptions.FilePermissionKey.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermissionKey, startCopyOptions.FilePermissionKey.GetValue());
+                _detail::HeaderFilePermissionKey, startCopyOptions.FilePermissionKey.Value());
           }
           if (startCopyOptions.XMsFilePermissionCopyMode.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderFilePermissionCopyMode,
-                startCopyOptions.XMsFilePermissionCopyMode.GetValue().ToString());
+                startCopyOptions.XMsFilePermissionCopyMode.Value().ToString());
           }
           if (startCopyOptions.FileCopyIgnoreReadOnly.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderIgnoreReadOnly,
-                (startCopyOptions.FileCopyIgnoreReadOnly.GetValue() ? "true" : "false"));
+                (startCopyOptions.FileCopyIgnoreReadOnly.Value() ? "true" : "false"));
           }
           if (startCopyOptions.FileCopyFileAttributes.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFileAttributes, startCopyOptions.FileCopyFileAttributes.GetValue());
+                _detail::HeaderFileAttributes, startCopyOptions.FileCopyFileAttributes.Value());
           }
           if (startCopyOptions.FileCopyFileCreationTime.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFileCreatedOn, startCopyOptions.FileCopyFileCreationTime.GetValue());
+                _detail::HeaderFileCreatedOn, startCopyOptions.FileCopyFileCreationTime.Value());
           }
           if (startCopyOptions.FileCopyFileLastWriteTime.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderFileLastWrittenOn,
-                startCopyOptions.FileCopyFileLastWriteTime.GetValue());
+                startCopyOptions.FileCopyFileLastWriteTime.Value());
           }
           if (startCopyOptions.FileCopySetArchiveAttribute.HasValue())
           {
             request.SetHeader(
                 _detail::HeaderSetArchiveAttribute,
-                (startCopyOptions.FileCopySetArchiveAttribute.GetValue() ? "true" : "false"));
+                (startCopyOptions.FileCopySetArchiveAttribute.Value() ? "true" : "false"));
           }
           if (startCopyOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, startCopyOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, startCopyOptions.LeaseIdOptional.Value());
           }
           return StartCopyParseResult(context, pipeline.Send(request, context));
         }
@@ -5833,13 +5833,13 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(abortCopyOptions.Timeout.GetValue())));
+                    std::to_string(abortCopyOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderCopyActionAbortConstant, "abort");
           request.SetHeader(_detail::HeaderVersion, abortCopyOptions.ApiVersionParameter);
           if (abortCopyOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(_detail::HeaderLeaseId, abortCopyOptions.LeaseIdOptional.GetValue());
+            request.SetHeader(_detail::HeaderLeaseId, abortCopyOptions.LeaseIdOptional.Value());
           }
           return AbortCopyParseResult(context, pipeline.Send(request, context));
         }
@@ -5866,27 +5866,27 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
                 _internal::UrlEncodeQueryParameter(
-                    listHandlesOptions.ContinuationToken.GetValue()));
+                    listHandlesOptions.ContinuationToken.Value()));
           }
           if (listHandlesOptions.MaxResults.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPageSizeHint,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(listHandlesOptions.MaxResults.GetValue())));
+                    std::to_string(listHandlesOptions.MaxResults.Value())));
           }
           if (listHandlesOptions.Timeout.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(listHandlesOptions.Timeout.GetValue())));
+                    std::to_string(listHandlesOptions.Timeout.Value())));
           }
           if (listHandlesOptions.ShareSnapshot.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(listHandlesOptions.ShareSnapshot.GetValue()));
+                _internal::UrlEncodeQueryParameter(listHandlesOptions.ShareSnapshot.Value()));
           }
           request.SetHeader(_detail::HeaderVersion, listHandlesOptions.ApiVersionParameter);
           return ListHandlesParseResult(context, pipeline.Send(request, context));
@@ -5915,21 +5915,21 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
                 _internal::UrlEncodeQueryParameter(
-                    std::to_string(forceCloseHandlesOptions.Timeout.GetValue())));
+                    std::to_string(forceCloseHandlesOptions.Timeout.Value())));
           }
           if (forceCloseHandlesOptions.ContinuationToken.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
                 _internal::UrlEncodeQueryParameter(
-                    forceCloseHandlesOptions.ContinuationToken.GetValue()));
+                    forceCloseHandlesOptions.ContinuationToken.Value()));
           }
           if (forceCloseHandlesOptions.ShareSnapshot.HasValue())
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
                 _internal::UrlEncodeQueryParameter(
-                    forceCloseHandlesOptions.ShareSnapshot.GetValue()));
+                    forceCloseHandlesOptions.ShareSnapshot.Value()));
           }
           request.SetHeader(_detail::HeaderHandleId, forceCloseHandlesOptions.HandleId);
           request.SetHeader(_detail::HeaderVersion, forceCloseHandlesOptions.ApiVersionParameter);

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/protocol/share_rest_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/protocol/share_rest_client.hpp
@@ -1207,9 +1207,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::StartTag, "Days"});
             writer.Write(_internal::XmlNode{
-                _internal::XmlNodeType::Text,
-                nullptr,
-                std::to_string(object.Days.Value()).data()});
+                _internal::XmlNodeType::Text, nullptr, std::to_string(object.Days.Value()).data()});
             writer.Write(_internal::XmlNode{_internal::XmlNodeType::EndTag});
           }
         }
@@ -2476,8 +2474,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
-                _internal::UrlEncodeQueryParameter(
-                    std::to_string(createOptions.Timeout.Value())));
+                _internal::UrlEncodeQueryParameter(std::to_string(createOptions.Timeout.Value())));
           }
           for (const auto& pair : createOptions.Metadata)
           {
@@ -2529,8 +2526,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           request.SetHeader(_detail::HeaderVersion, getPropertiesOptions.ApiVersionParameter);
           if (getPropertiesOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.Value());
+            request.SetHeader(_detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.Value());
           }
           return GetPropertiesParseResult(context, pipeline.Send(request, context));
         }
@@ -2562,8 +2558,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
-                _internal::UrlEncodeQueryParameter(
-                    std::to_string(deleteOptions.Timeout.Value())));
+                _internal::UrlEncodeQueryParameter(std::to_string(deleteOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, deleteOptions.ApiVersionParameter);
           if (deleteOptions.XMsDeleteSnapshots.HasValue())
@@ -2692,8 +2687,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (changeLeaseOptions.ProposedLeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderProposedLeaseId,
-                changeLeaseOptions.ProposedLeaseIdOptional.Value());
+                _detail::HeaderProposedLeaseId, changeLeaseOptions.ProposedLeaseIdOptional.Value());
           }
           request.SetHeader(_detail::HeaderVersion, changeLeaseOptions.ApiVersionParameter);
           if (changeLeaseOptions.ShareSnapshot.HasValue())
@@ -2922,13 +2916,11 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (setPropertiesOptions.XMsAccessTier.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderAccessTier,
-                setPropertiesOptions.XMsAccessTier.Value().ToString());
+                _detail::HeaderAccessTier, setPropertiesOptions.XMsAccessTier.Value().ToString());
           }
           if (setPropertiesOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderLeaseId, setPropertiesOptions.LeaseIdOptional.Value());
+            request.SetHeader(_detail::HeaderLeaseId, setPropertiesOptions.LeaseIdOptional.Value());
           }
           return SetPropertiesParseResult(context, pipeline.Send(request, context));
         }
@@ -2965,8 +2957,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           request.SetHeader(_detail::HeaderVersion, setMetadataOptions.ApiVersionParameter);
           if (setMetadataOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderLeaseId, setMetadataOptions.LeaseIdOptional.Value());
+            request.SetHeader(_detail::HeaderLeaseId, setMetadataOptions.LeaseIdOptional.Value());
           }
           return SetMetadataParseResult(context, pipeline.Send(request, context));
         }
@@ -3073,8 +3064,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           request.SetHeader(_detail::HeaderVersion, getStatisticsOptions.ApiVersionParameter);
           if (getStatisticsOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderLeaseId, getStatisticsOptions.LeaseIdOptional.Value());
+            request.SetHeader(_detail::HeaderLeaseId, getStatisticsOptions.LeaseIdOptional.Value());
           }
           return GetStatisticsParseResult(context, pipeline.Send(request, context));
         }
@@ -3101,8 +3091,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
-                _internal::UrlEncodeQueryParameter(
-                    std::to_string(restoreOptions.Timeout.Value())));
+                _internal::UrlEncodeQueryParameter(std::to_string(restoreOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, restoreOptions.ApiVersionParameter);
           if (restoreOptions.DeletedShareName.HasValue())
@@ -3942,8 +3931,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
-                _internal::UrlEncodeQueryParameter(
-                    std::to_string(createOptions.Timeout.Value())));
+                _internal::UrlEncodeQueryParameter(std::to_string(createOptions.Timeout.Value())));
           }
           for (const auto& pair : createOptions.Metadata)
           {
@@ -3952,8 +3940,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           request.SetHeader(_detail::HeaderVersion, createOptions.ApiVersionParameter);
           if (createOptions.FilePermission.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderFilePermission, createOptions.FilePermission.Value());
+            request.SetHeader(_detail::HeaderFilePermission, createOptions.FilePermission.Value());
           }
           if (createOptions.FilePermissionKey.HasValue())
           {
@@ -4016,8 +4003,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
-                _internal::UrlEncodeQueryParameter(
-                    std::to_string(deleteOptions.Timeout.Value())));
+                _internal::UrlEncodeQueryParameter(std::to_string(deleteOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, deleteOptions.ApiVersionParameter);
           return DeleteParseResult(context, pipeline.Send(request, context));
@@ -4060,8 +4046,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (setPropertiesOptions.FilePermissionKey.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermissionKey,
-                setPropertiesOptions.FilePermissionKey.Value());
+                _detail::HeaderFilePermissionKey, setPropertiesOptions.FilePermissionKey.Value());
           }
           request.SetHeader(_detail::HeaderFileAttributes, setPropertiesOptions.FileAttributes);
           request.SetHeader(_detail::HeaderFileCreatedOn, setPropertiesOptions.FileCreationTime);
@@ -4148,8 +4133,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPageSizeHint,
-                _internal::UrlEncodeQueryParameter(std::to_string(
-                    listFilesAndDirectoriesSinglePageOptions.MaxResults.Value())));
+                _internal::UrlEncodeQueryParameter(
+                    std::to_string(listFilesAndDirectoriesSinglePageOptions.MaxResults.Value())));
           }
           if (listFilesAndDirectoriesSinglePageOptions.Timeout.HasValue())
           {
@@ -4186,8 +4171,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
-                _internal::UrlEncodeQueryParameter(
-                    listHandlesOptions.ContinuationToken.Value()));
+                _internal::UrlEncodeQueryParameter(listHandlesOptions.ContinuationToken.Value()));
           }
           if (listHandlesOptions.MaxResults.HasValue())
           {
@@ -4256,8 +4240,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(
-                    forceCloseHandlesOptions.ShareSnapshot.Value()));
+                _internal::UrlEncodeQueryParameter(forceCloseHandlesOptions.ShareSnapshot.Value()));
           }
           request.SetHeader(_detail::HeaderHandleId, forceCloseHandlesOptions.HandleId);
           if (forceCloseHandlesOptions.Recursive.HasValue())
@@ -5111,8 +5094,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
-                _internal::UrlEncodeQueryParameter(
-                    std::to_string(createOptions.Timeout.Value())));
+                _internal::UrlEncodeQueryParameter(std::to_string(createOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, createOptions.ApiVersionParameter);
           request.SetHeader(
@@ -5156,8 +5138,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           }
           if (createOptions.FilePermission.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderFilePermission, createOptions.FilePermission.Value());
+            request.SetHeader(_detail::HeaderFilePermission, createOptions.FilePermission.Value());
           }
           if (createOptions.FilePermissionKey.HasValue())
           {
@@ -5246,8 +5227,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           request.SetHeader(_detail::HeaderVersion, getPropertiesOptions.ApiVersionParameter);
           if (getPropertiesOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.Value());
+            request.SetHeader(_detail::HeaderLeaseId, getPropertiesOptions.LeaseIdOptional.Value());
           }
           return GetPropertiesParseResult(context, pipeline.Send(request, context));
         }
@@ -5270,8 +5250,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryTimeout,
-                _internal::UrlEncodeQueryParameter(
-                    std::to_string(deleteOptions.Timeout.Value())));
+                _internal::UrlEncodeQueryParameter(std::to_string(deleteOptions.Timeout.Value())));
           }
           request.SetHeader(_detail::HeaderVersion, deleteOptions.ApiVersionParameter);
           if (deleteOptions.LeaseIdOptional.HasValue())
@@ -5365,8 +5344,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (setHttpHeadersOptions.FilePermissionKey.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderFilePermissionKey,
-                setHttpHeadersOptions.FilePermissionKey.Value());
+                _detail::HeaderFilePermissionKey, setHttpHeadersOptions.FilePermissionKey.Value());
           }
           request.SetHeader(_detail::HeaderFileAttributes, setHttpHeadersOptions.FileAttributes);
           request.SetHeader(_detail::HeaderFileCreatedOn, setHttpHeadersOptions.FileCreationTime);
@@ -5411,8 +5389,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           request.SetHeader(_detail::HeaderVersion, setMetadataOptions.ApiVersionParameter);
           if (setMetadataOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderLeaseId, setMetadataOptions.LeaseIdOptional.Value());
+            request.SetHeader(_detail::HeaderLeaseId, setMetadataOptions.LeaseIdOptional.Value());
           }
           return SetMetadataParseResult(context, pipeline.Send(request, context));
         }
@@ -5512,8 +5489,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           if (changeLeaseOptions.ProposedLeaseIdOptional.HasValue())
           {
             request.SetHeader(
-                _detail::HeaderProposedLeaseId,
-                changeLeaseOptions.ProposedLeaseIdOptional.Value());
+                _detail::HeaderProposedLeaseId, changeLeaseOptions.ProposedLeaseIdOptional.Value());
           }
           request.SetHeader(_detail::HeaderVersion, changeLeaseOptions.ApiVersionParameter);
           return ChangeLeaseParseResult(context, pipeline.Send(request, context));
@@ -5592,8 +5568,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           request.SetHeader(_detail::HeaderVersion, uploadRangeOptions.ApiVersionParameter);
           if (uploadRangeOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderLeaseId, uploadRangeOptions.LeaseIdOptional.Value());
+            request.SetHeader(_detail::HeaderLeaseId, uploadRangeOptions.LeaseIdOptional.Value());
           }
           return UploadRangeParseResult(context, pipeline.Send(request, context));
         }
@@ -5697,8 +5672,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryPrevShareSnapshot,
-                _internal::UrlEncodeQueryParameter(
-                    getRangeListOptions.PrevShareSnapshot.Value()));
+                _internal::UrlEncodeQueryParameter(getRangeListOptions.PrevShareSnapshot.Value()));
           }
           if (getRangeListOptions.Timeout.HasValue())
           {
@@ -5714,8 +5688,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           }
           if (getRangeListOptions.LeaseIdOptional.HasValue())
           {
-            request.SetHeader(
-                _detail::HeaderLeaseId, getRangeListOptions.LeaseIdOptional.Value());
+            request.SetHeader(_detail::HeaderLeaseId, getRangeListOptions.LeaseIdOptional.Value());
           }
           return GetRangeListParseResult(context, pipeline.Send(request, context));
         }
@@ -5865,8 +5838,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryContinuationToken,
-                _internal::UrlEncodeQueryParameter(
-                    listHandlesOptions.ContinuationToken.Value()));
+                _internal::UrlEncodeQueryParameter(listHandlesOptions.ContinuationToken.Value()));
           }
           if (listHandlesOptions.MaxResults.HasValue())
           {
@@ -5928,8 +5900,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           {
             request.GetUrl().AppendQueryParameter(
                 _detail::QueryShareSnapshot,
-                _internal::UrlEncodeQueryParameter(
-                    forceCloseHandlesOptions.ShareSnapshot.Value()));
+                _internal::UrlEncodeQueryParameter(forceCloseHandlesOptions.ShareSnapshot.Value()));
           }
           request.SetHeader(_detail::HeaderHandleId, forceCloseHandlesOptions.HandleId);
           request.SetHeader(_detail::HeaderVersion, forceCloseHandlesOptions.ApiVersionParameter);

--- a/sdk/storage/azure-storage-files-shares/src/share_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_client.cpp
@@ -139,7 +139,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const Azure::Core::Context& context) const
   {
     auto protocolLayerOptions = _detail::ShareRestClient::Share::DeleteOptions();
-    if (options.DeleteSnapshots.HasValue() && options.DeleteSnapshots.GetValue())
+    if (options.DeleteSnapshots.HasValue() && options.DeleteSnapshots.Value())
     {
       protocolLayerOptions.XMsDeleteSnapshots = Models::DeleteSnapshotsOption::Include;
     }

--- a/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
@@ -133,9 +133,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.SmbProperties.LastWrittenOn.HasValue())
     {
-      protocolLayerOptions.FileLastWriteTime
-          = options.SmbProperties.LastWrittenOn.Value().ToString(
-              Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
+      protocolLayerOptions.FileLastWriteTime = options.SmbProperties.LastWrittenOn.Value().ToString(
+          Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
     {

--- a/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
@@ -124,7 +124,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.SmbProperties.CreatedOn.HasValue())
     {
-      protocolLayerOptions.FileCreationTime = options.SmbProperties.CreatedOn.GetValue().ToString(
+      protocolLayerOptions.FileCreationTime = options.SmbProperties.CreatedOn.Value().ToString(
           Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -134,7 +134,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     if (options.SmbProperties.LastWrittenOn.HasValue())
     {
       protocolLayerOptions.FileLastWriteTime
-          = options.SmbProperties.LastWrittenOn.GetValue().ToString(
+          = options.SmbProperties.LastWrittenOn.Value().ToString(
               Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -143,7 +143,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.DirectoryPermission.HasValue())
     {
-      protocolLayerOptions.FilePermission = options.DirectoryPermission.GetValue();
+      protocolLayerOptions.FilePermission = options.DirectoryPermission.Value();
     }
     else if (options.SmbProperties.PermissionKey.HasValue())
     {
@@ -243,7 +243,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.FileAttributes = smbProperties.Attributes.ToString();
     if (smbProperties.CreatedOn.HasValue())
     {
-      protocolLayerOptions.FileCreationTime = smbProperties.CreatedOn.GetValue().ToString(
+      protocolLayerOptions.FileCreationTime = smbProperties.CreatedOn.Value().ToString(
           Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -252,7 +252,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (smbProperties.LastWrittenOn.HasValue())
     {
-      protocolLayerOptions.FileLastWriteTime = smbProperties.LastWrittenOn.GetValue().ToString(
+      protocolLayerOptions.FileLastWriteTime = smbProperties.LastWrittenOn.Value().ToString(
           Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -261,7 +261,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.FilePermission.HasValue())
     {
-      protocolLayerOptions.FilePermission = options.FilePermission.GetValue();
+      protocolLayerOptions.FilePermission = options.FilePermission.Value();
     }
     else if (smbProperties.PermissionKey.HasValue())
     {

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -123,9 +123,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.SmbProperties.LastWrittenOn.HasValue())
     {
-      protocolLayerOptions.FileLastWriteTime
-          = options.SmbProperties.LastWrittenOn.Value().ToString(
-              Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
+      protocolLayerOptions.FileLastWriteTime = options.SmbProperties.LastWrittenOn.Value().ToString(
+          Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
     {
@@ -230,8 +229,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       {
         protocolLayerOptions.Range = std::string("bytes=")
             + std::to_string(options.Range.Value().Offset) + std::string("-")
-            + std::to_string(options.Range.Value().Offset
-                             + options.Range.Value().Length.Value() - 1);
+            + std::to_string(options.Range.Value().Offset + options.Range.Value().Length.Value()
+                             - 1);
       }
       else
       {
@@ -269,8 +268,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
             = (options.Range.HasValue() ? options.Range.Value().Offset : 0) + retryInfo.Offset;
         if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
         {
-          newOptions.Range.Value().Length
-              = options.Range.Value().Length.Value() - retryInfo.Offset;
+          newOptions.Range.Value().Length = options.Range.Value().Length.Value() - retryInfo.Offset;
         }
 
         auto newResponse = Download(newOptions, context);
@@ -541,8 +539,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       {
         protocolLayerOptions.XMsRange = std::string("bytes=")
             + std::to_string(options.Range.Value().Offset) + std::string("-")
-            + std::to_string(options.Range.Value().Offset
-                             + options.Range.Value().Length.Value() - 1);
+            + std::to_string(options.Range.Value().Offset + options.Range.Value().Length.Value()
+                             - 1);
       }
       else
       {
@@ -568,8 +566,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       {
         protocolLayerOptions.XMsRange = std::string("bytes=")
             + std::to_string(options.Range.Value().Offset) + std::string("-")
-            + std::to_string(options.Range.Value().Offset
-                             + options.Range.Value().Length.Value() - 1);
+            + std::to_string(options.Range.Value().Offset + options.Range.Value().Length.Value()
+                             - 1);
       }
       else
       {
@@ -868,9 +866,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.SmbProperties.LastWrittenOn.HasValue())
     {
-      protocolLayerOptions.FileLastWriteTime
-          = options.SmbProperties.LastWrittenOn.Value().ToString(
-              Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
+      protocolLayerOptions.FileLastWriteTime = options.SmbProperties.LastWrittenOn.Value().ToString(
+          Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
     {
@@ -972,9 +969,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.SmbProperties.LastWrittenOn.HasValue())
     {
-      protocolLayerOptions.FileLastWriteTime
-          = options.SmbProperties.LastWrittenOn.Value().ToString(
-              Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
+      protocolLayerOptions.FileLastWriteTime = options.SmbProperties.LastWrittenOn.Value().ToString(
+          Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
     {
@@ -1081,8 +1077,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     protocolLayerOptions.SourceContentCrc64 = options.TransactionalContentHash;
     if (options.SourceAccessCondition.IfMatchContentHash.HasValue()
-        && options.SourceAccessCondition.IfMatchContentHash.Value().Algorithm
-            == HashAlgorithm::Md5)
+        && options.SourceAccessCondition.IfMatchContentHash.Value().Algorithm == HashAlgorithm::Md5)
     {
       // IfMatchContentHash now only supports Crc64 hash algorithm.
       std::abort();

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -114,7 +114,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.SmbProperties.CreatedOn.HasValue())
     {
-      protocolLayerOptions.FileCreationTime = options.SmbProperties.CreatedOn.GetValue().ToString(
+      protocolLayerOptions.FileCreationTime = options.SmbProperties.CreatedOn.Value().ToString(
           Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -124,7 +124,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     if (options.SmbProperties.LastWrittenOn.HasValue())
     {
       protocolLayerOptions.FileLastWriteTime
-          = options.SmbProperties.LastWrittenOn.GetValue().ToString(
+          = options.SmbProperties.LastWrittenOn.Value().ToString(
               Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -226,22 +226,22 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::ShareRestClient::File::DownloadOptions();
     if (options.Range.HasValue())
     {
-      if (options.Range.GetValue().Length.HasValue())
+      if (options.Range.Value().Length.HasValue())
       {
         protocolLayerOptions.Range = std::string("bytes=")
-            + std::to_string(options.Range.GetValue().Offset) + std::string("-")
-            + std::to_string(options.Range.GetValue().Offset
-                             + options.Range.GetValue().Length.GetValue() - 1);
+            + std::to_string(options.Range.Value().Offset) + std::string("-")
+            + std::to_string(options.Range.Value().Offset
+                             + options.Range.Value().Length.Value() - 1);
       }
       else
       {
         protocolLayerOptions.Range = std::string("bytes=")
-            + std::to_string(options.Range.GetValue().Offset) + std::string("-");
+            + std::to_string(options.Range.Value().Offset) + std::string("-");
       }
     }
     if (options.RangeHashAlgorithm.HasValue())
     {
-      if (options.RangeHashAlgorithm.GetValue() == HashAlgorithm::Md5)
+      if (options.RangeHashAlgorithm.Value() == HashAlgorithm::Md5)
       {
         protocolLayerOptions.GetRangeContentMd5 = true;
       }
@@ -265,12 +265,12 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
               const Azure::Core::Context& context) -> std::unique_ptr<Azure::Core::IO::BodyStream> {
         DownloadFileOptions newOptions = options;
         newOptions.Range = Core::Http::HttpRange();
-        newOptions.Range.GetValue().Offset
-            = (options.Range.HasValue() ? options.Range.GetValue().Offset : 0) + retryInfo.Offset;
-        if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
+        newOptions.Range.Value().Offset
+            = (options.Range.HasValue() ? options.Range.Value().Offset : 0) + retryInfo.Offset;
+        if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
         {
-          newOptions.Range.GetValue().Length
-              = options.Range.GetValue().Length.GetValue() - retryInfo.Offset;
+          newOptions.Range.Value().Length
+              = options.Range.Value().Length.Value() - retryInfo.Offset;
         }
 
         auto newResponse = Download(newOptions, context);
@@ -323,7 +323,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     if (options.SmbProperties.CreatedOn.HasValue())
     {
       protocolLayerOptions.FileCopyFileCreationTime
-          = options.SmbProperties.CreatedOn.GetValue().ToString(
+          = options.SmbProperties.CreatedOn.Value().ToString(
               Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -333,7 +333,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     if (options.SmbProperties.LastWrittenOn.HasValue())
     {
       protocolLayerOptions.FileCopyFileLastWriteTime
-          = options.SmbProperties.LastWrittenOn.GetValue().ToString(
+          = options.SmbProperties.LastWrittenOn.Value().ToString(
               Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -342,8 +342,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.PermissionCopyMode.HasValue())
     {
-      protocolLayerOptions.XMsFilePermissionCopyMode = options.PermissionCopyMode.GetValue();
-      if (options.PermissionCopyMode.GetValue() == Models::PermissionCopyMode::Override)
+      protocolLayerOptions.XMsFilePermissionCopyMode = options.PermissionCopyMode.Value();
+      if (options.PermissionCopyMode.Value() == Models::PermissionCopyMode::Override)
       {
         if (options.Permission.HasValue())
         {
@@ -413,7 +413,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (smbProperties.CreatedOn.HasValue())
     {
-      protocolLayerOptions.FileCreationTime = smbProperties.CreatedOn.GetValue().ToString(
+      protocolLayerOptions.FileCreationTime = smbProperties.CreatedOn.Value().ToString(
           Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -422,7 +422,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (smbProperties.LastWrittenOn.HasValue())
     {
-      protocolLayerOptions.FileLastWriteTime = smbProperties.LastWrittenOn.GetValue().ToString(
+      protocolLayerOptions.FileLastWriteTime = smbProperties.LastWrittenOn.Value().ToString(
           Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -493,7 +493,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.XMsRange = std::string("bytes=") + std::to_string(offset)
         + std::string("-") + std::to_string(offset + content.Length() - 1);
     if (options.TransactionalContentHash.HasValue()
-        && options.TransactionalContentHash.GetValue().Algorithm != HashAlgorithm::Md5)
+        && options.TransactionalContentHash.Value().Algorithm != HashAlgorithm::Md5)
     {
       std::abort();
     }
@@ -537,17 +537,17 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::ShareRestClient::File::GetRangeListOptions();
     if (options.Range.HasValue())
     {
-      if (options.Range.GetValue().Length.HasValue())
+      if (options.Range.Value().Length.HasValue())
       {
         protocolLayerOptions.XMsRange = std::string("bytes=")
-            + std::to_string(options.Range.GetValue().Offset) + std::string("-")
-            + std::to_string(options.Range.GetValue().Offset
-                             + options.Range.GetValue().Length.GetValue() - 1);
+            + std::to_string(options.Range.Value().Offset) + std::string("-")
+            + std::to_string(options.Range.Value().Offset
+                             + options.Range.Value().Length.Value() - 1);
       }
       else
       {
         protocolLayerOptions.XMsRange = std::string("bytes=")
-            + std::to_string(options.Range.GetValue().Offset) + std::string("-");
+            + std::to_string(options.Range.Value().Offset) + std::string("-");
       }
     }
 
@@ -564,17 +564,17 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::ShareRestClient::File::GetRangeListOptions();
     if (options.Range.HasValue())
     {
-      if (options.Range.GetValue().Length.HasValue())
+      if (options.Range.Value().Length.HasValue())
       {
         protocolLayerOptions.XMsRange = std::string("bytes=")
-            + std::to_string(options.Range.GetValue().Offset) + std::string("-")
-            + std::to_string(options.Range.GetValue().Offset
-                             + options.Range.GetValue().Length.GetValue() - 1);
+            + std::to_string(options.Range.Value().Offset) + std::string("-")
+            + std::to_string(options.Range.Value().Offset
+                             + options.Range.Value().Length.Value() - 1);
       }
       else
       {
         protocolLayerOptions.XMsRange = std::string("bytes=")
-            + std::to_string(options.Range.GetValue().Offset) + std::string("-");
+            + std::to_string(options.Range.Value().Offset) + std::string("-");
       }
     }
 
@@ -636,19 +636,19 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     // Just start downloading using an initial chunk. If it's a small file, we'll get the whole
     // thing in one shot. If it's a large file, we'll get its full size in Content-Range and can
     // keep downloading it in chunks.
-    int64_t firstChunkOffset = options.Range.HasValue() ? options.Range.GetValue().Offset : 0;
+    int64_t firstChunkOffset = options.Range.HasValue() ? options.Range.Value().Offset : 0;
     int64_t firstChunkLength = options.TransferOptions.InitialChunkSize;
 
-    if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
+    if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
     {
-      firstChunkLength = std::min(firstChunkLength, options.Range.GetValue().Length.GetValue());
+      firstChunkLength = std::min(firstChunkLength, options.Range.Value().Length.Value());
     }
 
     DownloadFileOptions firstChunkOptions;
     firstChunkOptions.Range = options.Range;
     if (firstChunkOptions.Range.HasValue())
     {
-      firstChunkOptions.Range.GetValue().Length = firstChunkLength;
+      firstChunkOptions.Range.Value().Length = firstChunkLength;
     }
 
     auto firstChunk = Download(firstChunkOptions, context);
@@ -659,9 +659,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       fileSize = firstChunk.Value.FileSize;
       fileRangeSize = fileSize - firstChunkOffset;
-      if (options.Range.GetValue().Length.HasValue())
+      if (options.Range.Value().Length.HasValue())
       {
-        fileRangeSize = std::min(fileRangeSize, options.Range.GetValue().Length.GetValue());
+        fileRangeSize = std::min(fileRangeSize, options.Range.Value().Length.Value());
       }
     }
     else
@@ -699,14 +699,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
             DownloadFileOptions chunkOptions;
             chunkOptions.Range = Core::Http::HttpRange();
-            chunkOptions.Range.GetValue().Offset = offset;
-            chunkOptions.Range.GetValue().Length = length;
+            chunkOptions.Range.Value().Offset = offset;
+            chunkOptions.Range.Value().Length = length;
             auto chunk = Download(chunkOptions, context);
             int64_t bytesRead = chunk.Value.BodyStream->ReadToCount(
                 buffer + (offset - firstChunkOffset),
-                chunkOptions.Range.GetValue().Length.GetValue(),
+                chunkOptions.Range.Value().Length.Value(),
                 context);
-            if (bytesRead != chunkOptions.Range.GetValue().Length.GetValue())
+            if (bytesRead != chunkOptions.Range.Value().Length.Value())
             {
               throw Azure::Core::RequestFailedException("error when reading body stream");
             }
@@ -739,18 +739,18 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     // Just start downloading using an initial chunk. If it's a small file, we'll get the whole
     // thing in one shot. If it's a large file, we'll get its full size in Content-Range and can
     // keep downloading it in chunks.
-    int64_t firstChunkOffset = options.Range.HasValue() ? options.Range.GetValue().Offset : 0;
+    int64_t firstChunkOffset = options.Range.HasValue() ? options.Range.Value().Offset : 0;
     int64_t firstChunkLength = options.TransferOptions.InitialChunkSize;
-    if (options.Range.HasValue() && options.Range.GetValue().Length.HasValue())
+    if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
     {
-      firstChunkLength = std::min(firstChunkLength, options.Range.GetValue().Length.GetValue());
+      firstChunkLength = std::min(firstChunkLength, options.Range.Value().Length.Value());
     }
 
     DownloadFileOptions firstChunkOptions;
     firstChunkOptions.Range = options.Range;
     if (firstChunkOptions.Range.HasValue())
     {
-      firstChunkOptions.Range.GetValue().Length = firstChunkLength;
+      firstChunkOptions.Range.Value().Length = firstChunkLength;
     }
 
     _internal::FileWriter fileWriter(fileName);
@@ -763,9 +763,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       fileSize = firstChunk.Value.FileSize;
       fileRangeSize = fileSize - firstChunkOffset;
-      if (options.Range.GetValue().Length.HasValue())
+      if (options.Range.Value().Length.HasValue())
       {
-        fileRangeSize = std::min(fileRangeSize, options.Range.GetValue().Length.GetValue());
+        fileRangeSize = std::min(fileRangeSize, options.Range.Value().Length.Value());
       }
     }
     else
@@ -814,14 +814,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         = [&](int64_t offset, int64_t length, int64_t chunkId, int64_t numChunks) {
             DownloadFileOptions chunkOptions;
             chunkOptions.Range = Core::Http::HttpRange();
-            chunkOptions.Range.GetValue().Offset = offset;
-            chunkOptions.Range.GetValue().Length = length;
+            chunkOptions.Range.Value().Offset = offset;
+            chunkOptions.Range.Value().Length = length;
             auto chunk = Download(chunkOptions, context);
             bodyStreamToFile(
                 *(chunk.Value.BodyStream),
                 fileWriter,
                 offset - firstChunkOffset,
-                chunkOptions.Range.GetValue().Length.GetValue(),
+                chunkOptions.Range.Value().Length.Value(),
                 context);
 
             if (chunkId == numChunks - 1)
@@ -859,7 +859,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.SmbProperties.CreatedOn.HasValue())
     {
-      protocolLayerOptions.FileCreationTime = options.SmbProperties.CreatedOn.GetValue().ToString(
+      protocolLayerOptions.FileCreationTime = options.SmbProperties.CreatedOn.Value().ToString(
           Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -869,7 +869,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     if (options.SmbProperties.LastWrittenOn.HasValue())
     {
       protocolLayerOptions.FileLastWriteTime
-          = options.SmbProperties.LastWrittenOn.GetValue().ToString(
+          = options.SmbProperties.LastWrittenOn.Value().ToString(
               Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -963,7 +963,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     if (options.SmbProperties.CreatedOn.HasValue())
     {
-      protocolLayerOptions.FileCreationTime = options.SmbProperties.CreatedOn.GetValue().ToString(
+      protocolLayerOptions.FileCreationTime = options.SmbProperties.CreatedOn.Value().ToString(
           Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -973,7 +973,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     if (options.SmbProperties.LastWrittenOn.HasValue())
     {
       protocolLayerOptions.FileLastWriteTime
-          = options.SmbProperties.LastWrittenOn.GetValue().ToString(
+          = options.SmbProperties.LastWrittenOn.Value().ToString(
               Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
     else
@@ -1065,7 +1065,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       // sourceRange must have length to perform this operation.
       std::abort();
     }
-    int64_t rangeLength = sourceRange.Length.GetValue();
+    int64_t rangeLength = sourceRange.Length.Value();
 
     auto protocolLayerOptions = _detail::ShareRestClient::File::UploadRangeFromUrlOptions();
     protocolLayerOptions.TargetRange = std::string("bytes=") + std::to_string(destinationOffset)
@@ -1074,14 +1074,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.CopySource = sourceUri;
     protocolLayerOptions.LeaseIdOptional = options.AccessConditions.LeaseId;
     if (options.TransactionalContentHash.HasValue()
-        && options.TransactionalContentHash.GetValue().Algorithm == HashAlgorithm::Md5)
+        && options.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
     {
       // SourceContentHash now only supports Crc64 hash algorithm.
       std::abort();
     }
     protocolLayerOptions.SourceContentCrc64 = options.TransactionalContentHash;
     if (options.SourceAccessCondition.IfMatchContentHash.HasValue()
-        && options.SourceAccessCondition.IfMatchContentHash.GetValue().Algorithm
+        && options.SourceAccessCondition.IfMatchContentHash.Value().Algorithm
             == HashAlgorithm::Md5)
     {
       // IfMatchContentHash now only supports Crc64 hash algorithm.
@@ -1089,7 +1089,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     protocolLayerOptions.SourceIfMatchCrc64 = options.SourceAccessCondition.IfMatchContentHash;
     if (options.SourceAccessCondition.IfNoneMatchContentHash.HasValue()
-        && options.SourceAccessCondition.IfNoneMatchContentHash.GetValue().Algorithm
+        && options.SourceAccessCondition.IfNoneMatchContentHash.Value().Algorithm
             == HashAlgorithm::Md5)
     {
       // IfNoneMatchContentHash now only supports Crc64 hash algorithm.
@@ -1098,7 +1098,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.SourceIfNoneMatchCrc64
         = options.SourceAccessCondition.IfNoneMatchContentHash;
     protocolLayerOptions.SourceRange = std::string("bytes=") + std::to_string(sourceRange.Offset)
-        + std::string("-") + std::to_string(sourceRange.Offset + sourceRange.Length.GetValue() - 1);
+        + std::string("-") + std::to_string(sourceRange.Offset + sourceRange.Length.Value() - 1);
     protocolLayerOptions.XMsWrite = _detail::FileRangeWriteFromUrlType::Update;
 
     return _detail::ShareRestClient::File::UploadRangeFromUrl(

--- a/sdk/storage/azure-storage-files-shares/src/share_lease_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_lease_client.cpp
@@ -27,8 +27,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       protocolLayerOptions.LeaseDuration = static_cast<int32_t>(duration.count());
 
       auto response = _detail::ShareRestClient::File::AcquireLease(
-          m_fileClient.GetValue().m_shareFileUrl,
-          *(m_fileClient.GetValue().m_pipeline),
+          m_fileClient.Value().m_shareFileUrl,
+          *(m_fileClient.Value().m_pipeline),
           context,
           protocolLayerOptions);
 
@@ -47,8 +47,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       protocolLayerOptions.LeaseDuration = static_cast<int32_t>(duration.count());
 
       auto response = _detail::ShareRestClient::Share::AcquireLease(
-          m_shareClient.GetValue().m_shareUrl,
-          *(m_shareClient.GetValue().m_pipeline),
+          m_shareClient.Value().m_shareUrl,
+          *(m_shareClient.Value().m_pipeline),
           context,
           protocolLayerOptions);
 
@@ -82,8 +82,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       protocolLayerOptions.LeaseIdRequired = m_leaseId;
 
       auto response = _detail::ShareRestClient::Share::RenewLease(
-          m_shareClient.GetValue().m_shareUrl,
-          *(m_shareClient.GetValue().m_pipeline),
+          m_shareClient.Value().m_shareUrl,
+          *(m_shareClient.Value().m_pipeline),
           context,
           protocolLayerOptions);
 
@@ -112,8 +112,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       protocolLayerOptions.LeaseIdRequired = m_leaseId;
 
       auto response = _detail::ShareRestClient::File::ReleaseLease(
-          m_fileClient.GetValue().m_shareFileUrl,
-          *(m_fileClient.GetValue().m_pipeline),
+          m_fileClient.Value().m_shareFileUrl,
+          *(m_fileClient.Value().m_pipeline),
           context,
           protocolLayerOptions);
 
@@ -130,8 +130,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       protocolLayerOptions.LeaseIdRequired = m_leaseId;
 
       auto response = _detail::ShareRestClient::Share::ReleaseLease(
-          m_shareClient.GetValue().m_shareUrl,
-          *(m_shareClient.GetValue().m_pipeline),
+          m_shareClient.Value().m_shareUrl,
+          *(m_shareClient.Value().m_pipeline),
           context,
           protocolLayerOptions);
 
@@ -161,8 +161,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       protocolLayerOptions.ProposedLeaseIdOptional = proposedLeaseId;
 
       auto response = _detail::ShareRestClient::File::ChangeLease(
-          m_fileClient.GetValue().m_shareFileUrl,
-          *(m_fileClient.GetValue().m_pipeline),
+          m_fileClient.Value().m_shareFileUrl,
+          *(m_fileClient.Value().m_pipeline),
           context,
           protocolLayerOptions);
 
@@ -181,8 +181,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       protocolLayerOptions.ProposedLeaseIdOptional = proposedLeaseId;
 
       auto response = _detail::ShareRestClient::Share::ChangeLease(
-          m_shareClient.GetValue().m_shareUrl,
-          *(m_shareClient.GetValue().m_pipeline),
+          m_shareClient.Value().m_shareUrl,
+          *(m_shareClient.Value().m_pipeline),
           context,
           protocolLayerOptions);
 
@@ -210,8 +210,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       _detail::ShareRestClient::File::BreakLeaseOptions protocolLayerOptions;
 
       auto response = _detail::ShareRestClient::File::BreakLease(
-          m_fileClient.GetValue().m_shareFileUrl,
-          *(m_fileClient.GetValue().m_pipeline),
+          m_fileClient.Value().m_shareFileUrl,
+          *(m_fileClient.Value().m_pipeline),
           context,
           protocolLayerOptions);
 
@@ -227,8 +227,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       _detail::ShareRestClient::Share::BreakLeaseOptions protocolLayerOptions;
 
       auto response = _detail::ShareRestClient::Share::BreakLease(
-          m_shareClient.GetValue().m_shareUrl,
-          *(m_shareClient.GetValue().m_pipeline),
+          m_shareClient.Value().m_shareUrl,
+          *(m_shareClient.Value().m_pipeline),
           context,
           protocolLayerOptions);
 

--- a/sdk/storage/azure-storage-files-shares/src/share_responses.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_responses.cpp
@@ -18,11 +18,11 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       m_status = Azure::Core::OperationStatus::Failed;
     }
-    else if (response.Value.CopyStatus.GetValue() == Models::CopyStatus::Pending)
+    else if (response.Value.CopyStatus.Value() == Models::CopyStatus::Pending)
     {
       m_status = Azure::Core::OperationStatus::Running;
     }
-    else if (response.Value.CopyStatus.GetValue() == Models::CopyStatus::Success)
+    else if (response.Value.CopyStatus.Value() == Models::CopyStatus::Success)
     {
       m_status = Azure::Core::OperationStatus::Succeeded;
     }

--- a/sdk/storage/azure-storage-files-shares/src/share_sas_builder.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_sas_builder.cpp
@@ -85,7 +85,7 @@ namespace Azure { namespace Storage { namespace Sas {
     std::string resource = ShareSasResourceToString(Resource);
 
     std::string startsOnStr = StartsOn.HasValue()
-        ? StartsOn.GetValue().ToString(
+        ? StartsOn.Value().ToString(
             Azure::DateTime::DateFormat::Rfc3339, Azure::DateTime::TimeFractionFormat::Truncate)
         : "";
     std::string expiresOnStr = Identifier.empty()
@@ -94,7 +94,7 @@ namespace Azure { namespace Storage { namespace Sas {
         : "";
 
     std::string stringToSign = Permissions + "\n" + startsOnStr + "\n" + expiresOnStr + "\n"
-        + canonicalName + "\n" + Identifier + "\n" + (IPRange.HasValue() ? IPRange.GetValue() : "")
+        + canonicalName + "\n" + Identifier + "\n" + (IPRange.HasValue() ? IPRange.Value() : "")
         + "\n" + protocol + "\n" + _internal::DefaultSasVersion + "\n" + CacheControl + "\n"
         + ContentDisposition + "\n" + ContentEncoding + "\n" + ContentLanguage + "\n" + ContentType;
 
@@ -116,7 +116,7 @@ namespace Azure { namespace Storage { namespace Sas {
     }
     if (IPRange.HasValue())
     {
-      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.GetValue()));
+      builder.AppendQueryParameter("sip", _internal::UrlEncodeQueryParameter(IPRange.Value()));
     }
     if (!Identifier.empty())
     {

--- a/sdk/storage/azure-storage-files-shares/test/share_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_client_test.cpp
@@ -377,8 +377,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(shareClient.Create(options));
       EXPECT_NO_THROW(properties = shareClient.GetProperties().Value);
       EXPECT_EQ(
-          Files::Shares::Models::AccessTier::TransactionOptimized,
-          properties.AccessTier.Value());
+          Files::Shares::Models::AccessTier::TransactionOptimized, properties.AccessTier.Value());
       EXPECT_FALSE(properties.AccessTierTransitionState.HasValue());
       EXPECT_TRUE(IsValidTime(properties.AccessTierChangedOn.Value()));
       shareClients.emplace(std::move(shareName), std::move(shareClient));
@@ -455,8 +454,7 @@ namespace Azure { namespace Storage { namespace Test {
           shareItem.Details.AccessTierChangedOn.HasValue()
               && properties.AccessTierChangedOn.HasValue());
       EXPECT_EQ(
-          shareItem.Details.AccessTierChangedOn.Value(),
-          properties.AccessTierChangedOn.Value());
+          shareItem.Details.AccessTierChangedOn.Value(), properties.AccessTierChangedOn.Value());
       EXPECT_EQ(
           false,
           shareItem.Details.AccessTierTransitionState.HasValue()
@@ -483,8 +481,7 @@ namespace Azure { namespace Storage { namespace Test {
                           .ListSharesSinglePage(listOptions)
                           .Value.Items;
     EXPECT_EQ(1U, shareItems.size());
-    EXPECT_EQ(
-        Files::Shares::Models::AccessTier::Premium, shareItems[0].Details.AccessTier.Value());
+    EXPECT_EQ(Files::Shares::Models::AccessTier::Premium, shareItems[0].Details.AccessTier.Value());
     EXPECT_FALSE(shareItems[0].Details.AccessTierTransitionState.HasValue());
     EXPECT_FALSE(shareItems[0].Details.AccessTierChangedOn.HasValue());
 

--- a/sdk/storage/azure-storage-files-shares/test/share_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_client_test.cpp
@@ -244,10 +244,10 @@ namespace Azure { namespace Storage { namespace Test {
   //  EXPECT_EQ(aLease.LeaseId, leaseId1);
 
   //  auto properties = *m_shareClient->GetProperties();
-  //  EXPECT_EQ(properties.LeaseState.GetValue(), Files::Shares::Models::LeaseStateType::Leased);
-  //  EXPECT_EQ(properties.LeaseStatus.GetValue(), Files::Shares::Models::LeaseStatusType::Locked);
+  //  EXPECT_EQ(properties.LeaseState.Value(), Files::Shares::Models::LeaseStateType::Leased);
+  //  EXPECT_EQ(properties.LeaseStatus.Value(), Files::Shares::Models::LeaseStatusType::Locked);
   //  EXPECT_EQ(Files::Shares::Models::LeaseDurationType::Fixed,
-  //  properties.LeaseDuration.GetValue());
+  //  properties.LeaseDuration.Value());
 
   //  auto rLease = *leaseClient.Renew();
   //  EXPECT_FALSE(rLease.ETag.empty());
@@ -269,7 +269,7 @@ namespace Azure { namespace Storage { namespace Test {
   //  aLease = *leaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration);
   //  properties = *m_shareClient->GetProperties();
   //  EXPECT_EQ(
-  //      Files::Shares::Models::LeaseDurationType::Infinite, properties.LeaseDuration.GetValue());
+  //      Files::Shares::Models::LeaseDurationType::Infinite, properties.LeaseDuration.Value());
   //  auto brokenLease = *leaseClient.Break();
   //  EXPECT_FALSE(brokenLease.ETag.empty());
   //  EXPECT_NE(Azure::DateTime(), brokenLease.LastModified);
@@ -297,10 +297,10 @@ namespace Azure { namespace Storage { namespace Test {
   //  EXPECT_EQ(aLease.LeaseId, leaseId1);
 
   //  auto properties = *shareSnapshot.GetProperties();
-  //  EXPECT_EQ(properties.LeaseState.GetValue(), Files::Shares::Models::LeaseStateType::Leased);
-  //  EXPECT_EQ(properties.LeaseStatus.GetValue(), Files::Shares::Models::LeaseStatusType::Locked);
+  //  EXPECT_EQ(properties.LeaseState.Value(), Files::Shares::Models::LeaseStateType::Leased);
+  //  EXPECT_EQ(properties.LeaseStatus.Value(), Files::Shares::Models::LeaseStatusType::Locked);
   //  EXPECT_EQ(Files::Shares::Models::LeaseDurationType::Fixed,
-  //  properties.LeaseDuration.GetValue());
+  //  properties.LeaseDuration.Value());
 
   //  auto rLease = *shareSnapshotLeaseClient.Renew();
   //  EXPECT_FALSE(rLease.ETag.empty());
@@ -325,7 +325,7 @@ namespace Azure { namespace Storage { namespace Test {
   //      *shareSnapshotLeaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration);
   //  properties = *shareSnapshot.GetProperties();
   //  EXPECT_EQ(
-  //      Files::Shares::Models::LeaseDurationType::Infinite, properties.LeaseDuration.GetValue());
+  //      Files::Shares::Models::LeaseDurationType::Infinite, properties.LeaseDuration.Value());
   //  auto brokenLease = *shareSnapshotLeaseClient.Break();
   //  EXPECT_FALSE(brokenLease.ETag.empty());
   //  EXPECT_NE(Azure::DateTime(), brokenLease.LastModified);
@@ -378,9 +378,9 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(properties = shareClient.GetProperties().Value);
       EXPECT_EQ(
           Files::Shares::Models::AccessTier::TransactionOptimized,
-          properties.AccessTier.GetValue());
+          properties.AccessTier.Value());
       EXPECT_FALSE(properties.AccessTierTransitionState.HasValue());
-      EXPECT_TRUE(IsValidTime(properties.AccessTierChangedOn.GetValue()));
+      EXPECT_TRUE(IsValidTime(properties.AccessTierChangedOn.Value()));
       shareClients.emplace(std::move(shareName), std::move(shareClient));
     }
     {
@@ -391,9 +391,9 @@ namespace Azure { namespace Storage { namespace Test {
       options.AccessTier = Files::Shares::Models::AccessTier::Hot;
       EXPECT_NO_THROW(shareClient.Create(options));
       EXPECT_NO_THROW(properties = shareClient.GetProperties().Value);
-      EXPECT_EQ(Files::Shares::Models::AccessTier::Hot, properties.AccessTier.GetValue());
+      EXPECT_EQ(Files::Shares::Models::AccessTier::Hot, properties.AccessTier.Value());
       EXPECT_FALSE(properties.AccessTierTransitionState.HasValue());
-      EXPECT_EQ(properties.LastModified, properties.AccessTierChangedOn.GetValue());
+      EXPECT_EQ(properties.LastModified, properties.AccessTierChangedOn.Value());
       shareClients.emplace(std::move(shareName), std::move(shareClient));
     }
     {
@@ -404,9 +404,9 @@ namespace Azure { namespace Storage { namespace Test {
       options.AccessTier = Files::Shares::Models::AccessTier::Cool;
       EXPECT_NO_THROW(shareClient.Create(options));
       EXPECT_NO_THROW(properties = shareClient.GetProperties().Value);
-      EXPECT_EQ(Files::Shares::Models::AccessTier::Cool, properties.AccessTier.GetValue());
+      EXPECT_EQ(Files::Shares::Models::AccessTier::Cool, properties.AccessTier.Value());
       EXPECT_FALSE(properties.AccessTierTransitionState.HasValue());
-      EXPECT_EQ(properties.LastModified, properties.AccessTierChangedOn.GetValue());
+      EXPECT_EQ(properties.LastModified, properties.AccessTierChangedOn.Value());
       shareClients.emplace(std::move(shareName), std::move(shareClient));
     }
 
@@ -419,7 +419,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(shareClient.Create(options));
       EXPECT_EQ(
           Files::Shares::Models::AccessTier::Cool,
-          shareClient.GetProperties().Value.AccessTier.GetValue());
+          shareClient.GetProperties().Value.AccessTier.Value());
 
       auto setPropertiesOptions = Files::Shares::SetSharePropertiesOptions();
       setPropertiesOptions.AccessTier = Files::Shares::Models::AccessTier::Hot;
@@ -427,13 +427,13 @@ namespace Azure { namespace Storage { namespace Test {
       properties = shareClient.GetProperties().Value;
       if (properties.AccessTierTransitionState.HasValue())
       {
-        EXPECT_EQ(Files::Shares::Models::AccessTier::Cool, properties.AccessTier.GetValue());
+        EXPECT_EQ(Files::Shares::Models::AccessTier::Cool, properties.AccessTier.Value());
       }
       else
       {
-        EXPECT_EQ(Files::Shares::Models::AccessTier::Hot, properties.AccessTier.GetValue());
+        EXPECT_EQ(Files::Shares::Models::AccessTier::Hot, properties.AccessTier.Value());
       }
-      EXPECT_EQ(properties.LastModified, properties.AccessTierChangedOn.GetValue());
+      EXPECT_EQ(properties.LastModified, properties.AccessTierChangedOn.Value());
     }
 
     // List shares works.
@@ -449,14 +449,14 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(shareClients.find(shareItem.Name) != shareClients.end());
       properties = shareClients.at(shareItem.Name).GetProperties().Value;
       EXPECT_EQ(true, shareItem.Details.AccessTier.HasValue() && properties.AccessTier.HasValue());
-      EXPECT_EQ(shareItem.Details.AccessTier.GetValue(), properties.AccessTier.GetValue());
+      EXPECT_EQ(shareItem.Details.AccessTier.Value(), properties.AccessTier.Value());
       EXPECT_EQ(
           true,
           shareItem.Details.AccessTierChangedOn.HasValue()
               && properties.AccessTierChangedOn.HasValue());
       EXPECT_EQ(
-          shareItem.Details.AccessTierChangedOn.GetValue(),
-          properties.AccessTierChangedOn.GetValue());
+          shareItem.Details.AccessTierChangedOn.Value(),
+          properties.AccessTierChangedOn.Value());
       EXPECT_EQ(
           false,
           shareItem.Details.AccessTierTransitionState.HasValue()
@@ -472,7 +472,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_NO_THROW(shareClient.Create());
     Files::Shares::Models::ShareProperties properties;
     EXPECT_NO_THROW(properties = shareClient.GetProperties().Value);
-    EXPECT_EQ(Files::Shares::Models::AccessTier::Premium, properties.AccessTier.GetValue());
+    EXPECT_EQ(Files::Shares::Models::AccessTier::Premium, properties.AccessTier.Value());
     EXPECT_FALSE(properties.AccessTierTransitionState.HasValue());
     EXPECT_FALSE(properties.AccessTierChangedOn.HasValue());
 
@@ -484,7 +484,7 @@ namespace Azure { namespace Storage { namespace Test {
                           .Value.Items;
     EXPECT_EQ(1U, shareItems.size());
     EXPECT_EQ(
-        Files::Shares::Models::AccessTier::Premium, shareItems[0].Details.AccessTier.GetValue());
+        Files::Shares::Models::AccessTier::Premium, shareItems[0].Details.AccessTier.Value());
     EXPECT_FALSE(shareItems[0].Details.AccessTierTransitionState.HasValue());
     EXPECT_FALSE(shareItems[0].Details.AccessTierChangedOn.HasValue());
 
@@ -497,7 +497,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_THROW(shareClient.SetProperties(setPropertiesOptions), StorageException);
     setPropertiesOptions.AccessTier = Files::Shares::Models::AccessTier::Premium;
     EXPECT_NO_THROW(shareClient.SetProperties(setPropertiesOptions));
-    EXPECT_EQ(Files::Shares::Models::AccessTier::Premium, properties.AccessTier.GetValue());
+    EXPECT_EQ(Files::Shares::Models::AccessTier::Premium, properties.AccessTier.Value());
     EXPECT_FALSE(properties.AccessTierTransitionState.HasValue());
     EXPECT_FALSE(properties.AccessTierChangedOn.HasValue());
   }

--- a/sdk/storage/azure-storage-files-shares/test/share_directory_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_directory_client_test.cpp
@@ -212,7 +212,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(client2.Create(options2));
       auto result1 = client1.GetProperties().Value.SmbProperties.PermissionKey;
       auto result2 = client2.GetProperties().Value.SmbProperties.PermissionKey;
-      EXPECT_EQ(result1.GetValue(), result2.GetValue());
+      EXPECT_EQ(result1.Value(), result2.Value());
 
       auto client3
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
@@ -220,7 +220,7 @@ namespace Azure { namespace Storage { namespace Test {
       options3.SmbProperties.PermissionKey = result1;
       EXPECT_NO_THROW(client3.Create(options3));
       auto result3 = client3.GetProperties().Value.SmbProperties.PermissionKey;
-      EXPECT_EQ(result1.GetValue(), result3.GetValue());
+      EXPECT_EQ(result1.Value(), result3.Value());
     }
 
     {
@@ -246,7 +246,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(client2.SetProperties(properties, options2));
       auto result1 = client1.GetProperties().Value.SmbProperties.PermissionKey;
       auto result2 = client2.GetProperties().Value.SmbProperties.PermissionKey;
-      EXPECT_EQ(result1.GetValue(), result2.GetValue());
+      EXPECT_EQ(result1.Value(), result2.Value());
 
       auto client3
           = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(LowercaseRandomString());
@@ -254,8 +254,8 @@ namespace Azure { namespace Storage { namespace Test {
       options3.SmbProperties.PermissionKey = result1;
       std::string permissionKey;
       EXPECT_NO_THROW(
-          permissionKey = client3.Create(options3).Value.SmbProperties.PermissionKey.GetValue());
-      auto result3 = client3.GetProperties().Value.SmbProperties.PermissionKey.GetValue();
+          permissionKey = client3.Create(options3).Value.SmbProperties.PermissionKey.Value());
+      auto result3 = client3.GetProperties().Value.SmbProperties.PermissionKey.Value();
       EXPECT_EQ(permissionKey, result3);
     }
   }
@@ -285,11 +285,11 @@ namespace Azure { namespace Storage { namespace Test {
       auto directoryProperties1 = client1.GetProperties();
       auto directoryProperties2 = client2.GetProperties();
       EXPECT_EQ(
-          directoryProperties2.Value.SmbProperties.CreatedOn.GetValue(),
-          directoryProperties1.Value.SmbProperties.CreatedOn.GetValue());
+          directoryProperties2.Value.SmbProperties.CreatedOn.Value(),
+          directoryProperties1.Value.SmbProperties.CreatedOn.Value());
       EXPECT_EQ(
-          directoryProperties2.Value.SmbProperties.LastWrittenOn.GetValue(),
-          directoryProperties1.Value.SmbProperties.LastWrittenOn.GetValue());
+          directoryProperties2.Value.SmbProperties.LastWrittenOn.Value(),
+          directoryProperties1.Value.SmbProperties.LastWrittenOn.Value());
       EXPECT_EQ(
           directoryProperties2.Value.SmbProperties.Attributes,
           directoryProperties1.Value.SmbProperties.Attributes);
@@ -309,11 +309,11 @@ namespace Azure { namespace Storage { namespace Test {
       auto directoryProperties1 = client1.GetProperties();
       auto directoryProperties2 = client2.GetProperties();
       EXPECT_EQ(
-          directoryProperties2.Value.SmbProperties.CreatedOn.GetValue(),
-          directoryProperties1.Value.SmbProperties.CreatedOn.GetValue());
+          directoryProperties2.Value.SmbProperties.CreatedOn.Value(),
+          directoryProperties1.Value.SmbProperties.CreatedOn.Value());
       EXPECT_EQ(
-          directoryProperties2.Value.SmbProperties.LastWrittenOn.GetValue(),
-          directoryProperties1.Value.SmbProperties.LastWrittenOn.GetValue());
+          directoryProperties2.Value.SmbProperties.LastWrittenOn.Value(),
+          directoryProperties1.Value.SmbProperties.LastWrittenOn.Value());
       EXPECT_EQ(
           directoryProperties2.Value.SmbProperties.Attributes,
           directoryProperties1.Value.SmbProperties.Attributes);

--- a/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
@@ -155,7 +155,7 @@ namespace Azure { namespace Storage { namespace Test {
       auto result2 = client2.GetProperties().Value.SmbProperties.PermissionKey;
       EXPECT_TRUE(result1.HasValue());
       EXPECT_TRUE(result2.HasValue());
-      EXPECT_EQ(result1.GetValue(), result2.GetValue());
+      EXPECT_EQ(result1.Value(), result2.Value());
 
       auto client3 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
       Files::Shares::CreateFileOptions options3;
@@ -163,7 +163,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(client3.Create(1024, options3));
       auto result3 = client3.GetProperties().Value.SmbProperties.PermissionKey;
       EXPECT_TRUE(result3.HasValue());
-      EXPECT_EQ(result1.GetValue(), result3.GetValue());
+      EXPECT_EQ(result1.Value(), result3.Value());
     }
 
     {
@@ -189,7 +189,7 @@ namespace Azure { namespace Storage { namespace Test {
       auto result2 = client1.GetProperties().Value.SmbProperties.PermissionKey;
       EXPECT_TRUE(result1.HasValue());
       EXPECT_TRUE(result2.HasValue());
-      EXPECT_EQ(result1.GetValue(), result2.GetValue());
+      EXPECT_EQ(result1.Value(), result2.Value());
 
       auto client3 = m_fileShareDirectoryClient->GetFileClient(LowercaseRandomString());
       Files::Shares::CreateFileOptions options3;
@@ -197,10 +197,10 @@ namespace Azure { namespace Storage { namespace Test {
       std::string permissionKey;
       EXPECT_NO_THROW(
           permissionKey
-          = client3.Create(1024, options3).Value.SmbProperties.PermissionKey.GetValue());
+          = client3.Create(1024, options3).Value.SmbProperties.PermissionKey.Value());
       auto result3 = client3.GetProperties().Value.SmbProperties.PermissionKey;
       EXPECT_TRUE(result3.HasValue());
-      EXPECT_EQ(permissionKey, result3.GetValue());
+      EXPECT_EQ(permissionKey, result3.Value());
     }
   }
 
@@ -226,11 +226,11 @@ namespace Azure { namespace Storage { namespace Test {
       auto directoryProperties1 = client1.GetProperties();
       auto directoryProperties2 = client2.GetProperties();
       EXPECT_EQ(
-          directoryProperties2.Value.SmbProperties.CreatedOn.GetValue(),
-          directoryProperties1.Value.SmbProperties.CreatedOn.GetValue());
+          directoryProperties2.Value.SmbProperties.CreatedOn.Value(),
+          directoryProperties1.Value.SmbProperties.CreatedOn.Value());
       EXPECT_EQ(
-          directoryProperties2.Value.SmbProperties.LastWrittenOn.GetValue(),
-          directoryProperties1.Value.SmbProperties.LastWrittenOn.GetValue());
+          directoryProperties2.Value.SmbProperties.LastWrittenOn.Value(),
+          directoryProperties1.Value.SmbProperties.LastWrittenOn.Value());
       EXPECT_EQ(
           directoryProperties2.Value.SmbProperties.Attributes,
           directoryProperties1.Value.SmbProperties.Attributes);
@@ -248,11 +248,11 @@ namespace Azure { namespace Storage { namespace Test {
       auto directoryProperties1 = client1.GetProperties();
       auto directoryProperties2 = client2.GetProperties();
       EXPECT_EQ(
-          directoryProperties2.Value.SmbProperties.CreatedOn.GetValue(),
-          directoryProperties1.Value.SmbProperties.CreatedOn.GetValue());
+          directoryProperties2.Value.SmbProperties.CreatedOn.Value(),
+          directoryProperties1.Value.SmbProperties.CreatedOn.Value());
       EXPECT_EQ(
-          directoryProperties2.Value.SmbProperties.LastWrittenOn.GetValue(),
-          directoryProperties1.Value.SmbProperties.LastWrittenOn.GetValue());
+          directoryProperties2.Value.SmbProperties.LastWrittenOn.Value(),
+          directoryProperties1.Value.SmbProperties.LastWrittenOn.Value());
       EXPECT_EQ(
           directoryProperties2.Value.SmbProperties.Attributes,
           directoryProperties1.Value.SmbProperties.Attributes);
@@ -283,8 +283,8 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(aLease.LeaseId, leaseId1);
 
     auto properties = m_fileClient->GetProperties().Value;
-    EXPECT_EQ(properties.LeaseState.GetValue(), Files::Shares::Models::LeaseState::Leased);
-    EXPECT_EQ(properties.LeaseStatus.GetValue(), Files::Shares::Models::LeaseStatus::Locked);
+    EXPECT_EQ(properties.LeaseState.Value(), Files::Shares::Models::LeaseState::Leased);
+    EXPECT_EQ(properties.LeaseStatus.Value(), Files::Shares::Models::LeaseStatus::Locked);
 
     std::string leaseId2 = Files::Shares::ShareLeaseClient::CreateUniqueLeaseId();
     EXPECT_NE(leaseId1, leaseId2);
@@ -399,13 +399,13 @@ namespace Azure { namespace Storage { namespace Test {
       int64_t actualDownloadSize = std::min(downloadSize, fileSize);
       if (offset.HasValue() && length.HasValue())
       {
-        actualDownloadSize = std::min(length.GetValue(), fileSize - offset.GetValue());
+        actualDownloadSize = std::min(length.Value(), fileSize - offset.Value());
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
-              m_fileContent.begin() + static_cast<std::ptrdiff_t>(offset.GetValue()),
+              m_fileContent.begin() + static_cast<std::ptrdiff_t>(offset.Value()),
               m_fileContent.begin()
-                  + static_cast<std::ptrdiff_t>(offset.GetValue() + actualDownloadSize));
+                  + static_cast<std::ptrdiff_t>(offset.Value() + actualDownloadSize));
         }
         else
         {
@@ -414,11 +414,11 @@ namespace Azure { namespace Storage { namespace Test {
       }
       else if (offset.HasValue())
       {
-        actualDownloadSize = fileSize - offset.GetValue();
+        actualDownloadSize = fileSize - offset.Value();
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
-              m_fileContent.begin() + static_cast<std::ptrdiff_t>(offset.GetValue()),
+              m_fileContent.begin() + static_cast<std::ptrdiff_t>(offset.Value()),
               m_fileContent.end());
         }
         else
@@ -432,23 +432,23 @@ namespace Azure { namespace Storage { namespace Test {
       if (offset.HasValue())
       {
         options.Range = Core::Http::HttpRange();
-        options.Range.GetValue().Offset = offset.GetValue();
-        options.Range.GetValue().Length = length;
+        options.Range.Value().Offset = offset.Value();
+        options.Range.Value().Length = length;
       }
 
       if (initialChunkSize.HasValue())
       {
-        options.TransferOptions.InitialChunkSize = initialChunkSize.GetValue();
+        options.TransferOptions.InitialChunkSize = initialChunkSize.Value();
       }
       if (chunkSize.HasValue())
       {
-        options.TransferOptions.ChunkSize = chunkSize.GetValue();
+        options.TransferOptions.ChunkSize = chunkSize.Value();
       }
       if (actualDownloadSize > 0)
       {
         auto res = m_fileClient->DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options);
-        EXPECT_EQ(res.Value.ContentRange.Length.GetValue(), actualDownloadSize);
-        downloadBuffer.resize(static_cast<std::size_t>(res.Value.ContentRange.Length.GetValue()));
+        EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
+        downloadBuffer.resize(static_cast<std::size_t>(res.Value.ContentRange.Length.Value()));
         EXPECT_EQ(downloadBuffer, expectedData);
       }
       else
@@ -470,13 +470,13 @@ namespace Azure { namespace Storage { namespace Test {
       int64_t actualDownloadSize = std::min(downloadSize, fileSize);
       if (offset.HasValue() && length.HasValue())
       {
-        actualDownloadSize = std::min(length.GetValue(), fileSize - offset.GetValue());
+        actualDownloadSize = std::min(length.Value(), fileSize - offset.Value());
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
-              m_fileContent.begin() + static_cast<std::ptrdiff_t>(offset.GetValue()),
+              m_fileContent.begin() + static_cast<std::ptrdiff_t>(offset.Value()),
               m_fileContent.begin()
-                  + static_cast<std::ptrdiff_t>(offset.GetValue() + actualDownloadSize));
+                  + static_cast<std::ptrdiff_t>(offset.Value() + actualDownloadSize));
         }
         else
         {
@@ -485,11 +485,11 @@ namespace Azure { namespace Storage { namespace Test {
       }
       else if (offset.HasValue())
       {
-        actualDownloadSize = fileSize - offset.GetValue();
+        actualDownloadSize = fileSize - offset.Value();
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
-              m_fileContent.begin() + static_cast<std::ptrdiff_t>(offset.GetValue()),
+              m_fileContent.begin() + static_cast<std::ptrdiff_t>(offset.Value()),
               m_fileContent.end());
         }
         else
@@ -502,21 +502,21 @@ namespace Azure { namespace Storage { namespace Test {
       if (offset.HasValue())
       {
         options.Range = Core::Http::HttpRange();
-        options.Range.GetValue().Offset = offset.GetValue();
-        options.Range.GetValue().Length = length;
+        options.Range.Value().Offset = offset.Value();
+        options.Range.Value().Length = length;
       }
       if (initialChunkSize.HasValue())
       {
-        options.TransferOptions.InitialChunkSize = initialChunkSize.GetValue();
+        options.TransferOptions.InitialChunkSize = initialChunkSize.Value();
       }
       if (chunkSize.HasValue())
       {
-        options.TransferOptions.ChunkSize = chunkSize.GetValue();
+        options.TransferOptions.ChunkSize = chunkSize.Value();
       }
       if (actualDownloadSize > 0)
       {
         auto res = m_fileClient->DownloadTo(tempFilename, options);
-        EXPECT_EQ(res.Value.ContentRange.Length.GetValue(), actualDownloadSize);
+        EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
         EXPECT_EQ(ReadFile(tempFilename), expectedData);
       }
       else
@@ -585,12 +585,12 @@ namespace Azure { namespace Storage { namespace Test {
       Files::Shares::DownloadFileToOptions options;
       options.TransferOptions.Concurrency = c;
       options.Range = Core::Http::HttpRange();
-      options.Range.GetValue().Offset = 1;
+      options.Range.Value().Offset = 1;
       for (int64_t length : {1ULL, 2ULL, 4_KB, 5_KB, 8_KB, 11_KB, 20_KB})
       {
         std::vector<uint8_t> downloadBuffer;
         downloadBuffer.resize(static_cast<std::size_t>(length - 1));
-        options.Range.GetValue().Length = length;
+        options.Range.Value().Length = length;
         EXPECT_THROW(
             m_fileClient->DownloadTo(
                 downloadBuffer.data(), static_cast<std::size_t>(length - 1), options),
@@ -630,16 +630,16 @@ namespace Azure { namespace Storage { namespace Test {
       {
         Files::Shares::DownloadFileOptions downloadOptions;
         downloadOptions.Range = Core::Http::HttpRange();
-        downloadOptions.Range.GetValue().Offset = static_cast<int64_t>(rangeSize) * i;
-        downloadOptions.Range.GetValue().Length = rangeSize;
+        downloadOptions.Range.Value().Offset = static_cast<int64_t>(rangeSize) * i;
+        downloadOptions.Range.Value().Length = rangeSize;
         Files::Shares::Models::DownloadFileResult result;
         EXPECT_NO_THROW(result = fileClient.Download(downloadOptions).Value);
         auto resultBuffer = result.BodyStream->ReadToEnd(Core::Context());
         EXPECT_EQ(rangeContent, resultBuffer);
         EXPECT_EQ(
-            downloadOptions.Range.GetValue().Length.GetValue(),
-            result.ContentRange.Length.GetValue());
-        EXPECT_EQ(downloadOptions.Range.GetValue().Offset, result.ContentRange.Offset);
+            downloadOptions.Range.Value().Length.Value(),
+            result.ContentRange.Length.Value());
+        EXPECT_EQ(downloadOptions.Range.Value().Offset, result.ContentRange.Offset);
         EXPECT_EQ(static_cast<int64_t>(numOfChunks) * rangeSize, result.FileSize);
       }
     }
@@ -684,7 +684,7 @@ namespace Azure { namespace Storage { namespace Test {
           copyOperation.GetRawResponse().GetStatusCode(),
           Azure::Core::Http::HttpStatusCode::Accepted);
       auto fileProperties = copyOperation.PollUntilDone(std::chrono::milliseconds(1000)).Value;
-      EXPECT_EQ(fileProperties.CopyStatus.GetValue(), Files::Shares::Models::CopyStatus::Success);
+      EXPECT_EQ(fileProperties.CopyStatus.Value(), Files::Shares::Models::CopyStatus::Success);
     }
 
     {
@@ -722,10 +722,10 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(2U, result.Ranges.size());
     EXPECT_EQ(0, result.Ranges[0].Offset);
     EXPECT_TRUE(result.Ranges[0].Length.HasValue());
-    EXPECT_EQ(512, result.Ranges[0].Length.GetValue());
+    EXPECT_EQ(512, result.Ranges[0].Length.Value());
     EXPECT_EQ(1024, result.Ranges[1].Offset);
     EXPECT_TRUE(result.Ranges[1].Length.HasValue());
-    EXPECT_EQ(static_cast<int32_t>(fileSize / 2) - 1024, result.Ranges[1].Length.GetValue());
+    EXPECT_EQ(static_cast<int32_t>(fileSize / 2) - 1024, result.Ranges[1].Length.Value());
   }
 
   TEST_F(FileShareFileClientTest, PreviousRangeWithSnapshot)
@@ -755,34 +755,34 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(2U, result.Ranges.size());
     EXPECT_EQ(0, result.Ranges[0].Offset);
     EXPECT_TRUE(result.Ranges[0].Length.HasValue());
-    EXPECT_EQ(512, result.Ranges[0].Length.GetValue());
+    EXPECT_EQ(512, result.Ranges[0].Length.Value());
     EXPECT_EQ(2048, result.Ranges[1].Offset);
     EXPECT_TRUE(result.Ranges[1].Length.HasValue());
-    EXPECT_EQ(512, result.Ranges[1].Length.GetValue());
+    EXPECT_EQ(512, result.Ranges[1].Length.Value());
     EXPECT_NO_THROW(fileClient.ClearRange(3096, 2048));
     auto snapshot3 = m_shareClient->CreateSnapshot().Value.Snapshot;
     EXPECT_NO_THROW(result = fileClient.GetRangeListDiff(snapshot1, options).Value);
     EXPECT_EQ(4U, result.Ranges.size());
     EXPECT_EQ(0, result.Ranges[0].Offset);
     EXPECT_TRUE(result.Ranges[0].Length.HasValue());
-    EXPECT_EQ(512, result.Ranges[0].Length.GetValue());
+    EXPECT_EQ(512, result.Ranges[0].Length.Value());
     EXPECT_EQ(2048, result.Ranges[1].Offset);
     EXPECT_TRUE(result.Ranges[1].Length.HasValue());
-    EXPECT_EQ(512, result.Ranges[1].Length.GetValue());
+    EXPECT_EQ(512, result.Ranges[1].Length.Value());
     EXPECT_EQ(3072, result.Ranges[2].Offset);
     EXPECT_TRUE(result.Ranges[2].Length.HasValue());
-    EXPECT_EQ(512, result.Ranges[2].Length.GetValue());
+    EXPECT_EQ(512, result.Ranges[2].Length.Value());
     EXPECT_EQ(5120, result.Ranges[3].Offset);
     EXPECT_TRUE(result.Ranges[3].Length.HasValue());
-    EXPECT_EQ(512, result.Ranges[3].Length.GetValue());
+    EXPECT_EQ(512, result.Ranges[3].Length.Value());
 
     EXPECT_EQ(2U, result.ClearRanges.size());
     EXPECT_EQ(512, result.ClearRanges[0].Offset);
     EXPECT_TRUE(result.ClearRanges[0].Length.HasValue());
-    EXPECT_EQ(1536, result.ClearRanges[0].Length.GetValue());
+    EXPECT_EQ(1536, result.ClearRanges[0].Length.Value());
     EXPECT_EQ(3584, result.ClearRanges[1].Offset);
     EXPECT_TRUE(result.ClearRanges[1].Length.HasValue());
-    EXPECT_EQ(1536, result.ClearRanges[1].Length.GetValue());
+    EXPECT_EQ(1536, result.ClearRanges[1].Length.Value());
   }
 
   TEST_F(FileShareFileClientTest, StorageExceptionAdditionalInfo)
@@ -875,7 +875,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(1U, getRangeResult.Ranges.size());
     EXPECT_EQ(static_cast<int64_t>(fileSize), getRangeResult.Ranges[0].Offset);
     EXPECT_TRUE(getRangeResult.Ranges[0].Length.HasValue());
-    EXPECT_EQ(static_cast<int64_t>(fileSize), getRangeResult.Ranges[0].Length.GetValue());
+    EXPECT_EQ(static_cast<int64_t>(fileSize), getRangeResult.Ranges[0].Length.Value());
 
     // source access condition works.
     std::vector<uint8_t> invalidCrc64(
@@ -896,7 +896,7 @@ namespace Azure { namespace Storage { namespace Test {
                              .Value,
           StorageException);
       // Below code seems to be triggering a server bug. Uncomment when server resolves the issue.
-      // uploadRangeOptions.SourceAccessCondition.IfNoneMatchContentHash.GetValue().Value
+      // uploadRangeOptions.SourceAccessCondition.IfNoneMatchContentHash.Value().Value
       //    = invalidCrc64;
       // EXPECT_NO_THROW(
       //    uploadResult = *destFileClient.UploadRangeFromUri(
@@ -916,7 +916,7 @@ namespace Azure { namespace Storage { namespace Test {
                              .Value);
       // Below code seems to be triggering a server high latency. Uncomment when server resolves the
       // issue.
-      // uploadRangeOptions.SourceAccessCondition.IfMatchContentHash.GetValue().Value =
+      // uploadRangeOptions.SourceAccessCondition.IfMatchContentHash.Value().Value =
       // invalidCrc64;
       // EXPECT_THROW(
       //    uploadResult = *destFileClient.UploadRangeFromUri(
@@ -936,7 +936,7 @@ namespace Azure { namespace Storage { namespace Test {
                              .Value);
       // Below code seems to be triggering a server high latency. Uncomment when server resolves the
       // issue.
-      // uploadRangeOptions.SourceContentHash.GetValue().Value = invalidCrc64;
+      // uploadRangeOptions.SourceContentHash.Value().Value = invalidCrc64;
       // EXPECT_THROW(
       //    uploadResult = *destFileClient.UploadRangeFromUri(
       //        sourceFileClient.GetUrl() + sourceSas, sourceRange, destRange, uploadRangeOptions),

--- a/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
@@ -196,8 +196,7 @@ namespace Azure { namespace Storage { namespace Test {
       options3.SmbProperties.PermissionKey = result1;
       std::string permissionKey;
       EXPECT_NO_THROW(
-          permissionKey
-          = client3.Create(1024, options3).Value.SmbProperties.PermissionKey.Value());
+          permissionKey = client3.Create(1024, options3).Value.SmbProperties.PermissionKey.Value());
       auto result3 = client3.GetProperties().Value.SmbProperties.PermissionKey;
       EXPECT_TRUE(result3.HasValue());
       EXPECT_EQ(permissionKey, result3.Value());
@@ -636,9 +635,7 @@ namespace Azure { namespace Storage { namespace Test {
         EXPECT_NO_THROW(result = fileClient.Download(downloadOptions).Value);
         auto resultBuffer = result.BodyStream->ReadToEnd(Core::Context());
         EXPECT_EQ(rangeContent, resultBuffer);
-        EXPECT_EQ(
-            downloadOptions.Range.Value().Length.Value(),
-            result.ContentRange.Length.Value());
+        EXPECT_EQ(downloadOptions.Range.Value().Length.Value(), result.ContentRange.Length.Value());
         EXPECT_EQ(downloadOptions.Range.Value().Offset, result.ContentRange.Offset);
         EXPECT_EQ(static_cast<int64_t>(numOfChunks) * rangeSize, result.FileSize);
       }

--- a/sdk/storage/azure-storage-files-shares/test/share_service_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_service_client_test.cpp
@@ -11,7 +11,7 @@ namespace Azure { namespace Storage { namespace Test {
   namespace {
     bool NullableEquals(const Azure::Nullable<bool>& lhs, const Azure::Nullable<bool>& rhs)
     {
-      return (lhs.HasValue() && rhs.HasValue() && (lhs.GetValue() == rhs.GetValue()))
+      return (lhs.HasValue() && rhs.HasValue() && (lhs.Value() == rhs.Value()))
           || (!lhs.HasValue() && !rhs.HasValue());
     }
   } // namespace
@@ -200,8 +200,8 @@ namespace Azure { namespace Storage { namespace Test {
     if (properties.HourMetrics.RetentionPolicy.Days.HasValue())
     {
       EXPECT_EQ(
-          downloadedProperties.HourMetrics.RetentionPolicy.Days.GetValue(),
-          properties.HourMetrics.RetentionPolicy.Days.GetValue());
+          downloadedProperties.HourMetrics.RetentionPolicy.Days.Value(),
+          properties.HourMetrics.RetentionPolicy.Days.Value());
     }
 
     EXPECT_EQ(downloadedProperties.MinuteMetrics.Version, properties.MinuteMetrics.Version);
@@ -217,8 +217,8 @@ namespace Azure { namespace Storage { namespace Test {
     if (properties.MinuteMetrics.RetentionPolicy.Days.HasValue())
     {
       EXPECT_EQ(
-          downloadedProperties.MinuteMetrics.RetentionPolicy.Days.GetValue(),
-          properties.MinuteMetrics.RetentionPolicy.Days.GetValue());
+          downloadedProperties.MinuteMetrics.RetentionPolicy.Days.Value(),
+          properties.MinuteMetrics.RetentionPolicy.Days.Value());
     }
 
     EXPECT_EQ(downloadedProperties.Cors.size(), properties.Cors.size());
@@ -296,8 +296,8 @@ namespace Azure { namespace Storage { namespace Test {
     if (properties.HourMetrics.RetentionPolicy.Days.HasValue())
     {
       EXPECT_EQ(
-          downloadedProperties.HourMetrics.RetentionPolicy.Days.GetValue(),
-          properties.HourMetrics.RetentionPolicy.Days.GetValue());
+          downloadedProperties.HourMetrics.RetentionPolicy.Days.Value(),
+          properties.HourMetrics.RetentionPolicy.Days.Value());
     }
 
     EXPECT_EQ(downloadedProperties.MinuteMetrics.Version, properties.MinuteMetrics.Version);
@@ -313,8 +313,8 @@ namespace Azure { namespace Storage { namespace Test {
     if (properties.MinuteMetrics.RetentionPolicy.Days.HasValue())
     {
       EXPECT_EQ(
-          downloadedProperties.MinuteMetrics.RetentionPolicy.Days.GetValue(),
-          properties.MinuteMetrics.RetentionPolicy.Days.GetValue());
+          downloadedProperties.MinuteMetrics.RetentionPolicy.Days.Value(),
+          properties.MinuteMetrics.RetentionPolicy.Days.Value());
     }
 
     EXPECT_EQ(downloadedProperties.Cors.size(), properties.Cors.size());
@@ -333,7 +333,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NE(properties.Cors.end(), iter);
     }
 
-    EXPECT_EQ(true, properties.Protocol.GetValue().Settings.Multichannel.Enabled);
+    EXPECT_EQ(true, properties.Protocol.Value().Settings.Multichannel.Enabled);
 
     premiumFileShareServiceClient->SetProperties(originalProperties);
   }


### PR DESCRIPTION
This rename makes `Nullable<T>` consistent with other Core types like `Operation<T>` and the C++ `Optional<T>`

https://en.cppreference.com/w/cpp/utility/optional/value
https://github.com/Azure/azure-sdk-for-cpp/blob/a7fdea42e65435c354e64c862f8490e410aef0e2/sdk/core/azure-core/inc/azure/core/operation.hpp#L82