### PR TITLE
Removed `Azure::Core::Context::HasKey()` and add `TryGetValue()` instead

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -15,6 +15,7 @@
   - `GetMajorVersion`.
   - `GetMinorVersion`.
 - Removed from `Azure::Core::Http::Policies` namespace: `HttpPolicyOrder`, `TransportPolicy`, `RetryPolicy`, `RequestIdPolicy`, `TelemetryPolicy`, `BearerTokenAuthenticationPolicy`, `LogPolicy`.
+- Removed `Azure::Core::Context::HasKey()`.
 - Renamed `Azure::Core::Http::RawResponse::GetBodyStream()` to `ExtractBodyStream()`.
 
 ## 1.0.0-beta.7 (2021-03-11)

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -20,7 +20,7 @@
   - `GetMinorVersion`.
 - Renamed `Azure::Nullable<T>::GetValue()` to `Value()`.
 - Changes to `Azure::Core::Context`:
-  - Removed `Get()` and `HasKey()`.
+  - Removed `Get()` and `HasKey()` in favor of a new method `TryGetValue()`.
   - Changed input parameter type of `WithDeadline()` to `Azure::DateTime`.
 - Removed `Azure::Core::PackageVersion`.
 - Removed from `Azure::Core::Http::Policies` namespace: `HttpPolicyOrder`, `TransportPolicy`, `RetryPolicy`, `RequestIdPolicy`, `TelemetryPolicy`, `BearerTokenAuthenticationPolicy`, `LogPolicy`.

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -20,11 +20,10 @@
   - `GetMinorVersion`.
 - Renamed `Azure::Nullable<T>::GetValue()` to `Value()`.
 - Changes to `Azure::Core::Context`:
-  - Renamed `Get()` to `GetValue()`.
+  - Removed `Get()` and `HasKey()`.
   - Changed input parameter type of `WithDeadline()` to `Azure::DateTime`.
 - Removed `Azure::Core::PackageVersion`.
 - Removed from `Azure::Core::Http::Policies` namespace: `HttpPolicyOrder`, `TransportPolicy`, `RetryPolicy`, `RequestIdPolicy`, `TelemetryPolicy`, `BearerTokenAuthenticationPolicy`, `LogPolicy`.
-- Removed `Azure::Core::Context::HasKey()`.
 - Renamed `Azure::Core::Http::RawResponse::GetBodyStream()` to `ExtractBodyStream()`.
 - Changed the `Azure::Core::Http::HttpMethod` regular enum into an extensible enum class and removed the `HttpMethodToString()` helper method.
 - Introduced `Azure::Core::Context::Key` class which takes place of `std::string` used for `Azure::Core::Context` keys previously.

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.8 (Unreleased)
 
+### New Features
+
+- Added `Azure::Core::Context::TryGetValue()`.
+
 ### Breaking Changes
 
 - Simplified the `Response<T>` API surface to expose two public fields with direct access: `T Value` and a `unique_ptr` to an `Azure::Core::Http::RawResponse`.

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Removed from `Azure::Core::Http::Policies` namespace: `HttpPolicyOrder`, `TransportPolicy`, `RetryPolicy`, `RequestIdPolicy`, `TelemetryPolicy`, `BearerTokenAuthenticationPolicy`, `LogPolicy`.
 - Removed `Azure::Core::Context::HasKey()`.
 - Renamed `Azure::Core::Http::RawResponse::GetBodyStream()` to `ExtractBodyStream()`.
-- Changed the `Azure::Core::Http::HttpMethod` regular enum into an extensible enum class and removed the `HttpMethodToString` helper method.
+- Changed the `Azure::Core::Http::HttpMethod` regular enum into an extensible enum class and removed the `HttpMethodToString()` helper method.
 - Introduced `Azure::Core::Context::Key` class which takes place of `std::string` used for `Azure::Core::Context` keys previously.
 
 ## 1.0.0-beta.7 (2021-03-11)

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -142,13 +142,13 @@ namespace Azure { namespace Core {
      * branch of contexts this context belongs to.
      *
      * @param key A key associated with a context to find.
-     * @param outputValue A reference to the value corresponding to the key to be set, if found
+     * @param outputValue A pointer to the value corresponding to the key to be set, if found
      * within the context tree.
      *
      * @return If found, returns true, with outputValue set to the value associated with the context
      * found; otherwise returns false.
      */
-    template <class T> bool TryGetValue(const std::string& key, T& outputValue) const
+    template <class T> bool TryGetValue(const std::string& key, T* outputValue) const
     {
       // if (!outputValue)
       //{
@@ -166,7 +166,7 @@ namespace Azure { namespace Core {
               // type mismatch
               std::abort();
             }
-            outputValue = *reinterpret_cast<const T*>(ptr->Value.get());
+            outputValue = reinterpret_cast<T*>(ptr->Value.get());
             return true;
           }
         }

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -142,13 +142,13 @@ namespace Azure { namespace Core {
      * branch of contexts this context belongs to.
      *
      * @param key A key associated with a context to find.
-     * @param outputValue A pointer to the value corresponding to the key to be set, if found
+     * @param outputValue A reference to the value corresponding to the key to be set, if found
      * within the context tree.
      *
      * @return If found, returns true, with outputValue set to the value associated with the context
      * found; otherwise returns false.
      */
-    template <class T> bool TryGetValue(const std::string& key, T* outputValue) const
+    template <class T> bool TryGetValue(const std::string& key, T& outputValue) const
     {
       // if (!outputValue)
       //{
@@ -166,7 +166,7 @@ namespace Azure { namespace Core {
               // type mismatch
               std::abort();
             }
-            outputValue = reinterpret_cast<T*>(ptr->Value.get());
+            outputValue = *reinterpret_cast<const T*>(ptr->Value.get());
             return true;
           }
         }

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -161,11 +161,13 @@ namespace Azure { namespace Core {
      * branch of contexts this context belongs to.
      *
      * @param key A key associated with a context to find.
-     * @param outputValue A reference to the value corresponding to the key to be set, if found
+     * @param outputValue A reference to the value corresponding to the \p key to be set, if found
      * within the context tree.
      *
-     * @return If found, returns true, with outputValue set to the value associated with the context
-     * found; otherwise returns false.
+     * @return If found, returns `true`, with \p outputValue set to the value associated with the
+     * key found; otherwise returns `false`.
+     *
+     * @remark The \p outputValue is left unmodified it the \p key is not found.
      */
     template <class T> bool TryGetValue(Key const& key, T& outputValue) const
     {
@@ -183,34 +185,6 @@ namespace Azure { namespace Core {
         }
       }
       return false;
-    }
-
-    /**
-     * @brief Get a value associated with a \p key parameter within this context or the branch of
-     * contexts this context belongs to.
-     *
-     * @param key A key associated with a context to find.
-     *
-     * @return A value associated with the context found; an empty value if a specific value can't
-     * be found.
-     */
-    template <class T> const T& GetValue(Key const& key) const
-    {
-      for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)
-      {
-        if (ptr->Key == key)
-        {
-          if (typeid(T) != ptr->ValueType)
-          {
-            // type mismatch
-            std::abort();
-          }
-          return *reinterpret_cast<const T*>(ptr->Value.get());
-        }
-      }
-      std::abort();
-      // It should be expected that keys may not exist
-      //  That implies we return T* and NOT a T&
     }
 
     /**

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -169,30 +169,6 @@ namespace Azure { namespace Core {
     }
 
     /**
-     * @brief Check whether the context has a key matching \p key parameter in it itself, or in the
-     * branch the context belongs to.
-     *
-     * @param key A key associated with a context to find.
-     *
-     * @return `true` if this context, or the tree branch this context belongs to has a \p key
-     * associated with it. `false` otherwise.
-     */
-    bool HasKey(const std::string& key) const
-    {
-      if (!key.empty())
-      {
-        for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)
-        {
-          if (ptr->Key == key)
-          {
-            return true;
-          }
-        }
-      }
-      return false;
-    }
-
-    /**
      * @brief Cancels the context.
      */
     void Cancel()

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -138,6 +138,43 @@ namespace Azure { namespace Core {
     }
 
     /**
+     * @brief Try to get a value associated with a \p key parameter within this context or the
+     * branch of contexts this context belongs to.
+     *
+     * @param key A key associated with a context to find.
+     * @param outputValue A reference to the value corresponding to the key to be set, if found
+     * within the context tree.
+     *
+     * @return If found, returns true, with outputValue set to the value associated with the context
+     * found; otherwise returns false.
+     */
+    template <class T> bool TryGetValue(const std::string& key, T& outputValue) const
+    {
+      // if (!outputValue)
+      //{
+      //  // null pointer
+      //  std::abort();
+      //}
+      if (!key.empty())
+      {
+        for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)
+        {
+          if (ptr->Key == key)
+          {
+            if (typeid(T) != ptr->ValueType)
+            {
+              // type mismatch
+              std::abort();
+            }
+            outputValue = *reinterpret_cast<const T*>(ptr->Value.get());
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    /**
      * @brief Get a value associated with a \p key parameter within this context or the branch of
      * contexts this context belongs to.
      *

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -150,11 +150,6 @@ namespace Azure { namespace Core {
      */
     template <class T> bool TryGetValue(const std::string& key, T& outputValue) const
     {
-      // if (!outputValue)
-      //{
-      //  // null pointer
-      //  std::abort();
-      //}
       if (!key.empty())
       {
         for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -164,7 +164,7 @@ Context inline CreateRetryContext(Context const& parent)
 int RetryPolicy::GetRetryNumber(Context const& context)
 {
   int number = -1;
-  if (!context.TryGetValue<int>(RetryKey, &number))
+  if (!context.TryGetValue<int>(RetryKey, number))
   {
     // Context with no data abut sending request with retry policy = -1
     // First try = 0

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -94,16 +94,17 @@ Context::Key const RetryKey;
 int32_t RetryPolicy::GetRetryCount(Context const& context)
 {
   int32_t number = -1;
-  if (!context.TryGetValue<int32_t>(RetryKey, number))
+  int32_t* ptr = &number;
+  if (!context.TryGetValue<int32_t*>(RetryKey, ptr))
   {
     // Context with no data abut sending request with retry policy = -1
     // First try = 0
     // Second try = 1
     // third try = 2
     // ...
-    number = -1;
+    *ptr = -1;
   }
-  return number;
+  return *ptr;
 }
 
 std::unique_ptr<RawResponse> RetryPolicy::Send(

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -103,7 +103,7 @@ int32_t RetryPolicy::GetRetryCount(Context const& context)
     // ...
     number = -1;
   }
-  return *context.GetValue<int32_t*>(RetryKey);
+  return number;
 }
 
 std::unique_ptr<RawResponse> RetryPolicy::Send(

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -94,16 +94,15 @@ Context::Key const RetryKey;
 int32_t RetryPolicy::GetRetryCount(Context const& context)
 {
   int32_t number = -1;
+
+  // Context with no data abut sending request with retry policy = -1
+  // First try = 0
+  // Second try = 1
+  // third try = 2
+  // ...
   int32_t* ptr = &number;
-  if (!context.TryGetValue<int32_t*>(RetryKey, ptr))
-  {
-    // Context with no data abut sending request with retry policy = -1
-    // First try = 0
-    // Second try = 1
-    // third try = 2
-    // ...
-    *ptr = -1;
-  }
+  context.TryGetValue<int32_t*>(RetryKey, ptr);
+
   return *ptr;
 }
 

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -93,8 +93,8 @@ Context::Key const RetryKey;
 
 int32_t RetryPolicy::GetRetryCount(Context const& context)
 {
-  int number = -1;
-  if (!context.TryGetValue<int>(RetryKey, number))
+  int32_t number = -1;
+  if (!context.TryGetValue<int32_t>(RetryKey, number))
   {
     // Context with no data abut sending request with retry policy = -1
     // First try = 0

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -156,27 +156,24 @@ static constexpr char RetryKey[] = "AzureSdkRetryPolicyCounter";
 Context inline CreateRetryContext(Context const& parent)
 {
   // First try as default
-  int retryCount = 0;
-  if (parent.HasKey(RetryKey))
-  {
-    retryCount = parent.Get<int>(RetryKey) + 1;
-  }
+  int retryCount = parent.Get<int>(RetryKey) + 1;
   return parent.WithValue(RetryKey, retryCount);
 }
 } // namespace
 
 int RetryPolicy::GetRetryNumber(Context const& context)
 {
-  if (!context.HasKey(RetryKey))
+  int number = -1;
+  if (!context.TryGetValue<int>(RetryKey, number))
   {
     // Context with no data abut sending request with retry policy = -1
     // First try = 0
     // Second try = 1
     // third try = 2
     // ...
-    return -1;
+    number = -1;
   }
-  return context.Get<int>(RetryKey);
+  return number;
 }
 
 std::unique_ptr<RawResponse> RetryPolicy::Send(

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -164,7 +164,7 @@ Context inline CreateRetryContext(Context const& parent)
 int RetryPolicy::GetRetryNumber(Context const& context)
 {
   int number = -1;
-  if (!context.TryGetValue<int>(RetryKey, number))
+  if (!context.TryGetValue<int>(RetryKey, &number))
   {
     // Context with no data abut sending request with retry policy = -1
     // First try = 0

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -82,7 +82,8 @@ TEST(Context, NestedIsCancelled)
   auto deadline = std::chrono::system_clock::now() + duration;
 
   Context context;
-  auto c2 = context.WithValue("Key", "Value");
+  std::string actualValue = "Value";
+  auto c2 = context.WithValue("Key", actualValue);
   EXPECT_FALSE(c2.IsCancelled());
   std::string value = "a";
   EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
@@ -110,7 +111,8 @@ TEST(Context, NestedIsCancelled)
 TEST(Context, CancelWithValue)
 {
   Context context;
-  auto c2 = context.WithValue("Key", "Value");
+  std::string actualValue = "Value";
+  auto c2 = context.WithValue("Key", actualValue);
   EXPECT_FALSE(context.IsCancelled());
   EXPECT_FALSE(c2.IsCancelled());
   std::string value = "a";
@@ -210,7 +212,7 @@ TEST(Context, HeapLinkIntegrity)
     Context root;
     auto firstGeneration = root.WithValue("a", std::string("a"));
     EXPECT_TRUE(firstGeneration.TryGetValue<std::string>("a", value));
-    EXPECT_EQ(value, "z");
+    EXPECT_EQ(value, "a");
 
     auto secondGeneration = firstGeneration.WithValue("b", std::string("b"));
     EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -16,8 +16,10 @@ using namespace Azure::Core;
 TEST(Context, Basic)
 {
   Context context;
-  EXPECT_FALSE(context.HasKey(""));
-  EXPECT_FALSE(context.HasKey("key"));
+
+  int placeholder;
+  EXPECT_FALSE(context.TryGetValue<int>("", placeholder));
+  EXPECT_FALSE(context.TryGetValue<int>("key", placeholder));
 }
 
 TEST(Context, BasicBool)
@@ -82,8 +84,11 @@ TEST(Context, NestedIsCancelled)
   Context context;
   auto c2 = context.WithValue("Key", "Value");
   EXPECT_FALSE(c2.IsCancelled());
-  EXPECT_TRUE(c2.HasKey("Key"));
-  EXPECT_FALSE(context.HasKey("Key"));
+  std::string value = "a";
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
+  EXPECT_EQ(value, "Value");
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
+  EXPECT_EQ(value, "Value");
 
   auto c3 = context.WithDeadline(deadline);
   EXPECT_FALSE(context.IsCancelled());
@@ -95,9 +100,11 @@ TEST(Context, NestedIsCancelled)
   EXPECT_FALSE(c2.IsCancelled());
   EXPECT_TRUE(c3.IsCancelled());
 
-  EXPECT_TRUE(c2.HasKey("Key"));
-  EXPECT_FALSE(context.HasKey("Key"));
-  EXPECT_FALSE(c3.HasKey("Key"));
+  value = "b";
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
+  EXPECT_EQ(value, "Value");
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
+  EXPECT_FALSE(c3.TryGetValue<std::string>("Key", value));
 }
 
 TEST(Context, CancelWithValue)
@@ -106,15 +113,18 @@ TEST(Context, CancelWithValue)
   auto c2 = context.WithValue("Key", "Value");
   EXPECT_FALSE(context.IsCancelled());
   EXPECT_FALSE(c2.IsCancelled());
-  EXPECT_TRUE(c2.HasKey("Key"));
-  EXPECT_FALSE(context.HasKey("Key"));
+  std::string value = "a";
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
+  EXPECT_EQ(value, "Value");
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
 
   c2.Cancel();
   EXPECT_TRUE(c2.IsCancelled());
   EXPECT_FALSE(context.IsCancelled());
 
-  EXPECT_TRUE(c2.HasKey("Key"));
-  EXPECT_FALSE(context.HasKey("Key"));
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
+  EXPECT_EQ(value, "Value");
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
 }
 
 TEST(Context, ThrowIfCancelled)
@@ -194,38 +204,49 @@ TEST(Context, UniquePtr)
 
 TEST(Context, HeapLinkIntegrity)
 {
+  std::string value = "z";
   Context thirdGeneration; // To be used at the end
   {
     Context root;
     auto firstGeneration = root.WithValue("a", std::string("a"));
-    EXPECT_TRUE(firstGeneration.HasKey("a"));
+    EXPECT_TRUE(firstGeneration.TryGetValue<std::string>("a", value));
+    EXPECT_EQ(value, "z");
 
     auto secondGeneration = firstGeneration.WithValue("b", std::string("b"));
-    EXPECT_TRUE(secondGeneration.HasKey("a"));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));
+    EXPECT_EQ(value, "a");
     EXPECT_EQ("a", secondGeneration.Get<std::string>("a"));
-    EXPECT_TRUE(secondGeneration.HasKey("b"));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", value));
+    EXPECT_EQ(value, "b");
     EXPECT_EQ("b", secondGeneration.Get<std::string>("b"));
 
     // Now overide the generation
     secondGeneration = secondGeneration.WithValue("c", std::string("c"));
-    EXPECT_TRUE(
-        secondGeneration.HasKey("a")); // Still know about first gen - The link is still in heap
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));
+    EXPECT_EQ(value, "a"); // Still know about first gen - The link is still in heap
     EXPECT_EQ("a", secondGeneration.Get<std::string>("a"));
-    EXPECT_TRUE(secondGeneration.HasKey(
-        "b")); // Still knows about the initial second gen, as a shared_ptr, it is still on heap
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", value));
+    EXPECT_EQ(
+        value,
+        "b"); // Still knows about the initial second gen, as a shared_ptr, it is still on heap
     EXPECT_EQ("b", secondGeneration.Get<std::string>("b"));
-    EXPECT_TRUE(secondGeneration.HasKey("c")); // Check new value
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", value));
+    EXPECT_EQ(value, "c"); // Check new value
     EXPECT_EQ("c", secondGeneration.Get<std::string>("c"));
 
     // One more override
     secondGeneration = secondGeneration.WithValue("d", std::string("d"));
-    EXPECT_TRUE(secondGeneration.HasKey("a"));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));
+    EXPECT_EQ(value, "a");
     EXPECT_EQ("a", secondGeneration.Get<std::string>("a"));
-    EXPECT_TRUE(secondGeneration.HasKey("b"));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", value));
+    EXPECT_EQ(value, "b");
     EXPECT_EQ("b", secondGeneration.Get<std::string>("b"));
-    EXPECT_TRUE(secondGeneration.HasKey("c"));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", value));
+    EXPECT_EQ(value, "c");
     EXPECT_EQ("c", secondGeneration.Get<std::string>("c"));
-    EXPECT_TRUE(secondGeneration.HasKey("d"));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("d", value));
+    EXPECT_EQ(value, "d");
     EXPECT_EQ("d", secondGeneration.Get<std::string>("d"));
 
     // New Gen
@@ -233,14 +254,19 @@ TEST(Context, HeapLinkIntegrity)
   }
   // Went out of scope, root and secondGeneration are destroyed. but should remain in heap for the
   // third-generation since the previous geneations are still alive inside his heart <3.
-  EXPECT_TRUE(thirdGeneration.HasKey("a"));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("a", value));
+  EXPECT_EQ(value, "a");
   EXPECT_EQ("a", thirdGeneration.Get<std::string>("a"));
-  EXPECT_TRUE(thirdGeneration.HasKey("b"));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("b", value));
+  EXPECT_EQ(value, "b");
   EXPECT_EQ("b", thirdGeneration.Get<std::string>("b"));
-  EXPECT_TRUE(thirdGeneration.HasKey("c"));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("c", value));
+  EXPECT_EQ(value, "c");
   EXPECT_EQ("c", thirdGeneration.Get<std::string>("c"));
-  EXPECT_TRUE(thirdGeneration.HasKey("d"));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("d", value));
+  EXPECT_EQ(value, "d");
   EXPECT_EQ("d", thirdGeneration.Get<std::string>("d"));
-  EXPECT_TRUE(thirdGeneration.HasKey("e"));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("e", value));
+  EXPECT_EQ(value, "e");
   EXPECT_EQ("e", thirdGeneration.Get<std::string>("e"));
 }

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -18,8 +18,8 @@ TEST(Context, Basic)
   Context context;
 
   int placeholder;
-  EXPECT_FALSE(context.TryGetValue<int>("", &placeholder));
-  EXPECT_FALSE(context.TryGetValue<int>("key", &placeholder));
+  EXPECT_FALSE(context.TryGetValue<int>("", placeholder));
+  EXPECT_FALSE(context.TryGetValue<int>("key", placeholder));
 }
 
 TEST(Context, BasicBool)
@@ -84,11 +84,10 @@ TEST(Context, NestedIsCancelled)
   Context context;
   auto c2 = context.WithValue("Key", "Value");
   EXPECT_FALSE(c2.IsCancelled());
-  EXPECT_EQ(c2.Get<const char*>("Key"), "Value");
-  const char* value = "a";
-  EXPECT_TRUE(c2.TryGetValue<char*>("Key", &value1));
+  std::string value = "a";
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
   EXPECT_EQ(value, "Value");
-  EXPECT_FALSE(context.TryGetValue<const char*>("Key", &value));
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
   EXPECT_EQ(value, "Value");
 
   auto c3 = context.WithDeadline(deadline);
@@ -102,10 +101,10 @@ TEST(Context, NestedIsCancelled)
   EXPECT_TRUE(c3.IsCancelled());
 
   value = "b";
-  EXPECT_TRUE(c2.TryGetValue<const char*>("Key", &value));
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
   EXPECT_EQ(value, "Value");
-  EXPECT_FALSE(context.TryGetValue<const char*>("Key", &value));
-  EXPECT_FALSE(c3.TryGetValue<const char*>("Key", &value));
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
+  EXPECT_FALSE(c3.TryGetValue<std::string>("Key", value));
 }
 
 TEST(Context, CancelWithValue)
@@ -115,17 +114,17 @@ TEST(Context, CancelWithValue)
   EXPECT_FALSE(context.IsCancelled());
   EXPECT_FALSE(c2.IsCancelled());
   std::string value = "a";
-  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", &value));
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
   EXPECT_EQ(value, "Value");
-  EXPECT_FALSE(context.TryGetValue<std::string>("Key", &value));
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
 
   c2.Cancel();
   EXPECT_TRUE(c2.IsCancelled());
   EXPECT_FALSE(context.IsCancelled());
 
-  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", &value));
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
   EXPECT_EQ(value, "Value");
-  EXPECT_FALSE(context.TryGetValue<std::string>("Key", &value));
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
 }
 
 TEST(Context, ThrowIfCancelled)
@@ -210,43 +209,43 @@ TEST(Context, HeapLinkIntegrity)
   {
     Context root;
     auto firstGeneration = root.WithValue("a", std::string("a"));
-    EXPECT_TRUE(firstGeneration.TryGetValue<std::string>("a", &value));
+    EXPECT_TRUE(firstGeneration.TryGetValue<std::string>("a", value));
     EXPECT_EQ(value, "z");
 
     auto secondGeneration = firstGeneration.WithValue("b", std::string("b"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", &value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));
     EXPECT_EQ(value, "a");
     EXPECT_EQ("a", secondGeneration.Get<std::string>("a"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", &value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", value));
     EXPECT_EQ(value, "b");
     EXPECT_EQ("b", secondGeneration.Get<std::string>("b"));
 
     // Now overide the generation
     secondGeneration = secondGeneration.WithValue("c", std::string("c"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", &value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));
     EXPECT_EQ(value, "a"); // Still know about first gen - The link is still in heap
     EXPECT_EQ("a", secondGeneration.Get<std::string>("a"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", &value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", value));
     EXPECT_EQ(
         value,
         "b"); // Still knows about the initial second gen, as a shared_ptr, it is still on heap
     EXPECT_EQ("b", secondGeneration.Get<std::string>("b"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", &value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", value));
     EXPECT_EQ(value, "c"); // Check new value
     EXPECT_EQ("c", secondGeneration.Get<std::string>("c"));
 
     // One more override
     secondGeneration = secondGeneration.WithValue("d", std::string("d"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", &value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));
     EXPECT_EQ(value, "a");
     EXPECT_EQ("a", secondGeneration.Get<std::string>("a"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", &value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", value));
     EXPECT_EQ(value, "b");
     EXPECT_EQ("b", secondGeneration.Get<std::string>("b"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", &value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", value));
     EXPECT_EQ(value, "c");
     EXPECT_EQ("c", secondGeneration.Get<std::string>("c"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("d", &value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("d", value));
     EXPECT_EQ(value, "d");
     EXPECT_EQ("d", secondGeneration.Get<std::string>("d"));
 
@@ -255,19 +254,19 @@ TEST(Context, HeapLinkIntegrity)
   }
   // Went out of scope, root and secondGeneration are destroyed. but should remain in heap for the
   // third-generation since the previous geneations are still alive inside his heart <3.
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("a", &value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("a", value));
   EXPECT_EQ(value, "a");
   EXPECT_EQ("a", thirdGeneration.Get<std::string>("a"));
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("b", &value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("b", value));
   EXPECT_EQ(value, "b");
   EXPECT_EQ("b", thirdGeneration.Get<std::string>("b"));
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("c", &value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("c", value));
   EXPECT_EQ(value, "c");
   EXPECT_EQ("c", thirdGeneration.Get<std::string>("c"));
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("d", &value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("d", value));
   EXPECT_EQ(value, "d");
   EXPECT_EQ("d", thirdGeneration.Get<std::string>("d"));
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("e", &value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("e", value));
   EXPECT_EQ(value, "e");
   EXPECT_EQ("e", thirdGeneration.Get<std::string>("e"));
 }

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -18,8 +18,8 @@ TEST(Context, Basic)
   Context context;
 
   int placeholder;
-  EXPECT_FALSE(context.TryGetValue<int>("", placeholder));
-  EXPECT_FALSE(context.TryGetValue<int>("key", placeholder));
+  EXPECT_FALSE(context.TryGetValue<int>("", &placeholder));
+  EXPECT_FALSE(context.TryGetValue<int>("key", &placeholder));
 }
 
 TEST(Context, BasicBool)
@@ -84,10 +84,11 @@ TEST(Context, NestedIsCancelled)
   Context context;
   auto c2 = context.WithValue("Key", "Value");
   EXPECT_FALSE(c2.IsCancelled());
-  std::string value = "a";
-  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
+  EXPECT_EQ(c2.Get<const char*>("Key"), "Value");
+  const char* value = "a";
+  EXPECT_TRUE(c2.TryGetValue<char*>("Key", &value1));
   EXPECT_EQ(value, "Value");
-  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
+  EXPECT_FALSE(context.TryGetValue<const char*>("Key", &value));
   EXPECT_EQ(value, "Value");
 
   auto c3 = context.WithDeadline(deadline);
@@ -101,10 +102,10 @@ TEST(Context, NestedIsCancelled)
   EXPECT_TRUE(c3.IsCancelled());
 
   value = "b";
-  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
+  EXPECT_TRUE(c2.TryGetValue<const char*>("Key", &value));
   EXPECT_EQ(value, "Value");
-  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
-  EXPECT_FALSE(c3.TryGetValue<std::string>("Key", value));
+  EXPECT_FALSE(context.TryGetValue<const char*>("Key", &value));
+  EXPECT_FALSE(c3.TryGetValue<const char*>("Key", &value));
 }
 
 TEST(Context, CancelWithValue)
@@ -114,17 +115,17 @@ TEST(Context, CancelWithValue)
   EXPECT_FALSE(context.IsCancelled());
   EXPECT_FALSE(c2.IsCancelled());
   std::string value = "a";
-  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", &value));
   EXPECT_EQ(value, "Value");
-  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", &value));
 
   c2.Cancel();
   EXPECT_TRUE(c2.IsCancelled());
   EXPECT_FALSE(context.IsCancelled());
 
-  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", value));
+  EXPECT_TRUE(c2.TryGetValue<std::string>("Key", &value));
   EXPECT_EQ(value, "Value");
-  EXPECT_FALSE(context.TryGetValue<std::string>("Key", value));
+  EXPECT_FALSE(context.TryGetValue<std::string>("Key", &value));
 }
 
 TEST(Context, ThrowIfCancelled)
@@ -209,43 +210,43 @@ TEST(Context, HeapLinkIntegrity)
   {
     Context root;
     auto firstGeneration = root.WithValue("a", std::string("a"));
-    EXPECT_TRUE(firstGeneration.TryGetValue<std::string>("a", value));
+    EXPECT_TRUE(firstGeneration.TryGetValue<std::string>("a", &value));
     EXPECT_EQ(value, "z");
 
     auto secondGeneration = firstGeneration.WithValue("b", std::string("b"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", &value));
     EXPECT_EQ(value, "a");
     EXPECT_EQ("a", secondGeneration.Get<std::string>("a"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", &value));
     EXPECT_EQ(value, "b");
     EXPECT_EQ("b", secondGeneration.Get<std::string>("b"));
 
     // Now overide the generation
     secondGeneration = secondGeneration.WithValue("c", std::string("c"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", &value));
     EXPECT_EQ(value, "a"); // Still know about first gen - The link is still in heap
     EXPECT_EQ("a", secondGeneration.Get<std::string>("a"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", &value));
     EXPECT_EQ(
         value,
         "b"); // Still knows about the initial second gen, as a shared_ptr, it is still on heap
     EXPECT_EQ("b", secondGeneration.Get<std::string>("b"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", &value));
     EXPECT_EQ(value, "c"); // Check new value
     EXPECT_EQ("c", secondGeneration.Get<std::string>("c"));
 
     // One more override
     secondGeneration = secondGeneration.WithValue("d", std::string("d"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("a", &value));
     EXPECT_EQ(value, "a");
     EXPECT_EQ("a", secondGeneration.Get<std::string>("a"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("b", &value));
     EXPECT_EQ(value, "b");
     EXPECT_EQ("b", secondGeneration.Get<std::string>("b"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("c", &value));
     EXPECT_EQ(value, "c");
     EXPECT_EQ("c", secondGeneration.Get<std::string>("c"));
-    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("d", value));
+    EXPECT_TRUE(secondGeneration.TryGetValue<std::string>("d", &value));
     EXPECT_EQ(value, "d");
     EXPECT_EQ("d", secondGeneration.Get<std::string>("d"));
 
@@ -254,19 +255,19 @@ TEST(Context, HeapLinkIntegrity)
   }
   // Went out of scope, root and secondGeneration are destroyed. but should remain in heap for the
   // third-generation since the previous geneations are still alive inside his heart <3.
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("a", value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("a", &value));
   EXPECT_EQ(value, "a");
   EXPECT_EQ("a", thirdGeneration.Get<std::string>("a"));
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("b", value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("b", &value));
   EXPECT_EQ(value, "b");
   EXPECT_EQ("b", thirdGeneration.Get<std::string>("b"));
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("c", value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("c", &value));
   EXPECT_EQ(value, "c");
   EXPECT_EQ("c", thirdGeneration.Get<std::string>("c"));
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("d", value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("d", &value));
   EXPECT_EQ(value, "d");
   EXPECT_EQ("d", thirdGeneration.Get<std::string>("d"));
-  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("e", value));
+  EXPECT_TRUE(thirdGeneration.TryGetValue<std::string>("e", &value));
   EXPECT_EQ(value, "e");
   EXPECT_EQ("e", thirdGeneration.Get<std::string>("e"));
 }

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -250,8 +250,7 @@ TEST(Context, Ptr)
 {
   Context::Key const key;
   SomeStructForContext value;
-  auto contextP
-      = Context::GetApplicationContext().WithValue(key, &value);
+  auto contextP = Context::GetApplicationContext().WithValue(key, &value);
 
   SomeStructForContext* contextValueRef;
   EXPECT_TRUE(contextP.TryGetValue<SomeStructForContext*>(key, contextValueRef));
@@ -274,7 +273,7 @@ TEST(Context, NestedClassPtr)
   {
     auto sharedPtr = std::make_shared<TestClass>(&instanceCount);
     EXPECT_EQ(sharedPtr.use_count(), 1);
-   
+
     Context::Key const key;
 
     auto context = Context::GetApplicationContext().WithValue(key, sharedPtr);

--- a/sdk/core/azure-core/test/ut/global_context.cpp
+++ b/sdk/core/azure-core/test/ut/global_context.cpp
@@ -15,7 +15,6 @@
 #include <azure/core/context.hpp>
 
 #include <chrono>
-#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -25,9 +24,9 @@ TEST(Context, ApplicationContext)
 {
   Context appContext = Context::GetApplicationContext();
 
-  int value;
+  int value = 42;
   EXPECT_FALSE(appContext.TryGetValue(Context::Key(), value));
-  // EXPECT_THROW(appContext.GetValue<int>(Context::Key()), std::logic_error);
+  EXPECT_EQ(value, 42);
 
   auto duration = std::chrono::milliseconds(250);
   EXPECT_FALSE(appContext.IsCancelled());

--- a/sdk/core/azure-core/test/ut/global_context.cpp
+++ b/sdk/core/azure-core/test/ut/global_context.cpp
@@ -25,7 +25,9 @@ TEST(Context, ApplicationContext)
 {
   Context appContext = Context::GetApplicationContext();
 
-  EXPECT_FALSE(appContext.HasKey(Context::Key()));
+  int value;
+  EXPECT_FALSE(appContext.TryGetValue(Context::Key(), value));
+  //EXPECT_THROW(appContext.GetValue<int>(Context::Key()), std::logic_error);
 
   auto duration = std::chrono::milliseconds(250);
   EXPECT_FALSE(appContext.IsCancelled());

--- a/sdk/core/azure-core/test/ut/global_context.cpp
+++ b/sdk/core/azure-core/test/ut/global_context.cpp
@@ -27,7 +27,7 @@ TEST(Context, ApplicationContext)
 
   int value;
   EXPECT_FALSE(appContext.TryGetValue(Context::Key(), value));
-  //EXPECT_THROW(appContext.GetValue<int>(Context::Key()), std::logic_error);
+  // EXPECT_THROW(appContext.GetValue<int>(Context::Key()), std::logic_error);
 
   auto duration = std::chrono::milliseconds(250);
   EXPECT_FALSE(appContext.IsCancelled());

--- a/sdk/core/azure-core/test/ut/global_context.cpp
+++ b/sdk/core/azure-core/test/ut/global_context.cpp
@@ -15,6 +15,7 @@
 #include <azure/core/context.hpp>
 
 #include <chrono>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -24,12 +25,12 @@ TEST(Context, ApplicationContext)
 {
   Context appContext = Context::GetApplicationContext();
 
-  EXPECT_FALSE(appContext.HasKey("Key"));
-  EXPECT_FALSE(appContext.HasKey("key"));
-  EXPECT_FALSE(appContext.HasKey("Value"));
-  EXPECT_FALSE(appContext.HasKey("value"));
-  EXPECT_FALSE(appContext.HasKey("1"));
-  EXPECT_FALSE(appContext.HasKey(""));
+  EXPECT_THROW(appContext.Get<int>("Key"), std::logic_error);
+  EXPECT_THROW(appContext.Get<int>("key"), std::logic_error);
+  EXPECT_THROW(appContext.Get<int>("Value"), std::logic_error);
+  EXPECT_THROW(appContext.Get<int>("value"), std::logic_error);
+  EXPECT_THROW(appContext.Get<int>("1"), std::logic_error);
+  EXPECT_THROW(appContext.Get<int>(""), std::logic_error);
 
   auto duration = std::chrono::milliseconds(250);
   EXPECT_FALSE(appContext.IsCancelled());

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -59,12 +59,8 @@ struct TestContextTreeIntegrity : public Azure::Core::Http::Policies::HttpPolicy
       Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
       Azure::Core::Context const& ctx) const override
   {
-    EXPECT_TRUE(ctx.HasKey("TheKey"));
-    if (ctx.HasKey("TheKey"))
-    {
-      auto value = ctx.Get<std::string>("TheKey");
-      EXPECT_EQ("TheValue", value);
-    }
+    auto value = ctx.Get<std::string>("TheKey");
+    EXPECT_EQ("TheValue", value);
     return nextHttpPolicy.Send(request, ctx);
   }
 };

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -60,7 +60,7 @@ struct TestContextTreeIntegrity : public Azure::Core::Http::Policies::HttpPolicy
       Azure::Core::Context const& ctx) const override
   {
     std::string valueHolder;
-    EXPECT_TRUE(ctx.TryGetValue(TheKey, valueHolder));
+    EXPECT_TRUE(ctx.TryGetValue<std::string>(TheKey, valueHolder));
     auto value = ctx.GetValue<std::string>(TheKey);
     EXPECT_EQ("TheValue", value);
     return nextHttpPolicy.Send(request, ctx);

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -61,8 +61,7 @@ struct TestContextTreeIntegrity : public Azure::Core::Http::Policies::HttpPolicy
   {
     std::string valueHolder;
     EXPECT_TRUE(ctx.TryGetValue<std::string>(TheKey, valueHolder));
-    auto value = ctx.GetValue<std::string>(TheKey);
-    EXPECT_EQ("TheValue", value);
+    EXPECT_EQ("TheValue", valueHolder);
     return nextHttpPolicy.Send(request, ctx);
   }
 };

--- a/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
@@ -13,7 +13,7 @@ namespace Azure { namespace Storage { namespace _internal {
       const Azure::Core::Context& ctx) const
   {
     std::shared_ptr<bool> replicaStatus;
-    ctx.TryGetValue(SecondaryHostReplicaStatusKey, replicaStatus);
+    ctx.TryGetValue<std::shared_ptr<bool>>(SecondaryHostReplicaStatusKey, replicaStatus);
 
     bool considerSecondary = (request.GetMethod() == Azure::Core::Http::HttpMethod::Get
                               || request.GetMethod() == Azure::Core::Http::HttpMethod::Head)

--- a/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
@@ -11,7 +11,7 @@ namespace Azure { namespace Storage { namespace _internal {
       const Azure::Core::Context& ctx) const
   {
     std::shared_ptr<bool> replicaStatus;
-    ctx.TryGetValue<std::shared_ptr<bool>>(SecondaryHostReplicaStatusKey, &replicaStatus);
+    ctx.TryGetValue<std::shared_ptr<bool>>(SecondaryHostReplicaStatusKey, replicaStatus);
 
     bool considerSecondary = (request.GetMethod() == Azure::Core::Http::HttpMethod::Get
                               || request.GetMethod() == Azure::Core::Http::HttpMethod::Head)

--- a/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
@@ -11,7 +11,7 @@ namespace Azure { namespace Storage { namespace _internal {
       const Azure::Core::Context& ctx) const
   {
     std::shared_ptr<bool> replicaStatus;
-    ctx.TryGetValue<std::shared_ptr<bool>>(SecondaryHostReplicaStatusKey, replicaStatus);
+    ctx.TryGetValue<std::shared_ptr<bool>>(SecondaryHostReplicaStatusKey, &replicaStatus);
 
     bool considerSecondary = (request.GetMethod() == Azure::Core::Http::HttpMethod::Get
                               || request.GetMethod() == Azure::Core::Http::HttpMethod::Head)

--- a/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
@@ -13,7 +13,7 @@ namespace Azure { namespace Storage { namespace _internal {
       const Azure::Core::Context& ctx) const
   {
     std::shared_ptr<bool> replicaStatus;
-    ctx.TryGetValue<std::shared_ptr<bool>>(SecondaryHostReplicaStatusKey, replicaStatus);
+    ctx.TryGetValue(SecondaryHostReplicaStatusKey, replicaStatus);
 
     bool considerSecondary = (request.GetMethod() == Azure::Core::Http::HttpMethod::Get
                               || request.GetMethod() == Azure::Core::Http::HttpMethod::Head)

--- a/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_switch_to_secondary_policy.cpp
@@ -11,10 +11,7 @@ namespace Azure { namespace Storage { namespace _internal {
       const Azure::Core::Context& ctx) const
   {
     std::shared_ptr<bool> replicaStatus;
-    if (ctx.HasKey(SecondaryHostReplicaStatusKey))
-    {
-      replicaStatus = ctx.Get<std::shared_ptr<bool>>(SecondaryHostReplicaStatusKey);
-    }
+    ctx.TryGetValue<std::shared_ptr<bool>>(SecondaryHostReplicaStatusKey, replicaStatus);
 
     bool considerSecondary = (request.GetMethod() == Azure::Core::Http::HttpMethod::Get
                               || request.GetMethod() == Azure::Core::Http::HttpMethod::Head)


### PR DESCRIPTION
~@vhvb1989 This change is blocked until after the retry policy implementation has been updated. Let me know once you have that PR available.~

Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/2036