### PR TITLE
Add ValueOr API to context

### DIFF
--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -361,3 +361,17 @@ TEST(Context, Deadline)
     EXPECT_EQ(childCtx.GetDeadline(), Azure::DateTime::min());
   }
 }
+
+TEST(Context, ValueOr)
+{
+  const char* str = "Test String";
+  std::string s(str);
+
+  Context context;
+  Context::Key const key;
+
+  auto value = context.ValueOr<std::string>(key, str);
+
+  EXPECT_TRUE(value == s);
+  EXPECT_TRUE(value == str);
+}

--- a/sdk/core/azure-core/test/ut/nullable.cpp
+++ b/sdk/core/azure-core/test/ut/nullable.cpp
@@ -171,3 +171,21 @@ TEST(Nullable, ValueOr)
   // Ensure val2 is still disengaged after call to ValueOr
   EXPECT_FALSE(val2);
 }
+
+TEST(Nullable, ValueOrString)
+{
+  std::string s("Test");
+  Nullable<std::string> val1(s);
+  Nullable<std::string> val2;
+
+  EXPECT_TRUE(val1);
+  EXPECT_TRUE(val1.ValueOr(s) == s);
+  // Ensure the value was unmodified in ValueOr
+  EXPECT_TRUE(val1.GetValue() == s);
+
+  EXPECT_FALSE(val2);
+  EXPECT_TRUE(val2.ValueOr(s) == s);
+  // Ensure val2 is still disengaged after call to ValueOr
+  EXPECT_FALSE(val2);
+}
+


### PR DESCRIPTION
Adding a proposal for the ValurOr method.  This would be the preferred way to retrieve context values in 1.0.  