### PR TITLE
Use consistent pascal casing and rename HKEYHolder to HkeyHolder.

### DIFF
--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -57,7 +57,7 @@ set(
     inc/azure/core/internal/client_options.hpp
     inc/azure/core/internal/contract.hpp
     inc/azure/core/internal/diagnostics/log.hpp
-    inc/azure/core/internal/hkeyholder.hpp
+    inc/azure/core/internal/hkey_holder.hpp
     inc/azure/core/internal/http/pipeline.hpp
     inc/azure/core/internal/io/null_body_stream.hpp
     inc/azure/core/internal/json/json_serializable.hpp

--- a/sdk/core/azure-core/inc/azure/core/internal/hkey_holder.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/hkey_holder.hpp
@@ -26,16 +26,16 @@
 namespace Azure { namespace Core { namespace _internal {
 
   /**
-   * @brief HKeyHolder ensures native handle resource is released.
+   * @brief HkeyHolder ensures native handle resource is released.
    */
-  class HKeyHolder {
+  class HkeyHolder {
   private:
     HKEY m_value = nullptr;
 
   public:
-    explicit HKeyHolder() noexcept : m_value(nullptr){};
+    explicit HkeyHolder() noexcept : m_value(nullptr){};
 
-    ~HKeyHolder() noexcept
+    ~HkeyHolder() noexcept
     {
       if (m_value != nullptr)
       {

--- a/sdk/core/azure-core/inc/azure/core/internal/hkeyholder.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/hkeyholder.hpp
@@ -26,16 +26,16 @@
 namespace Azure { namespace Core { namespace _internal {
 
   /**
-   * @brief HKEYHolder ensures native handle resource is released.
+   * @brief HKeyHolder ensures native handle resource is released.
    */
-  class HKEYHolder {
+  class HKeyHolder {
   private:
     HKEY m_value = nullptr;
 
   public:
-    explicit HKEYHolder() noexcept : m_value(nullptr){};
+    explicit HKeyHolder() noexcept : m_value(nullptr){};
 
-    ~HKEYHolder() noexcept
+    ~HKeyHolder() noexcept
     {
       if (m_value != nullptr)
       {

--- a/sdk/core/azure-core/src/http/telemetry_policy.cpp
+++ b/sdk/core/azure-core/src/http/telemetry_policy.cpp
@@ -17,7 +17,7 @@
 
 #include <windows.h>
 
-#include "azure/core/internal/hkeyholder.hpp"
+#include "azure/core/internal/hkey_holder.hpp"
 
 #elif defined(AZ_PLATFORM_POSIX)
 #include <sys/utsname.h>
@@ -32,7 +32,7 @@ std::string GetOSVersion()
 #if !defined(WINAPI_PARTITION_DESKTOP) \
     || WINAPI_PARTITION_DESKTOP // See azure/core/platform.hpp for explanation.
   {
-    Azure::Core::_internal::HKEYHolder regKey;
+    Azure::Core::_internal::HkeyHolder regKey;
     if (RegOpenKeyExA(
             HKEY_LOCAL_MACHINE,
             "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-cpp/issues/1877 and https://github.com/Azure/azure-sdk-for-cpp/pull/2066 to apply consistent naming pattern across the SDK.

Since it is in the internal header, a CL is not needed.