### PR TITLE
pageable for ListBlobs

### DIFF
--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
@@ -213,6 +213,10 @@ namespace Azure { namespace Storage { namespace Blobs {
         const ListBlobsSinglePageOptions& options = ListBlobsSinglePageOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
+    Pageable<ListBlobsPageResult> ListBlobs(
+        const ListBlobsOptions& options = ListBlobsOptions(),
+        const Azure::Core::Context& context = Azure::Core::Context()) const;
+
     /**
      * @brief Returns a single segment of blobs in this container, starting from the
      * specified Marker, Use an empty Marker to start enumeration from the beginning and the
@@ -308,6 +312,7 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     friend class BlobServiceClient;
     friend class BlobLeaseClient;
+    friend class ListBlobsPageResult;
   };
 
 }}} // namespace Azure::Storage::Blobs

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
@@ -357,6 +357,39 @@ namespace Azure { namespace Storage { namespace Blobs {
   };
 
   /**
+   * @brief Optional parameters for BlobContainerClient::ListBlobs and
+   * BlobContainerClient::ListBlobsByHierarchy.
+   */
+  struct ListBlobsOptions
+  {
+    /**
+     * @brief Specifies a string that filters the results to return only blobs whose
+     * name begins with the specified prefix.
+     */
+    Azure::Nullable<std::string> Prefix;
+
+    /**
+     * @brief A string value that identifies the portion of the list of blobs to be
+     * returned with the next listing operation. The operation returns a non-empty
+     * BlobsFlatSegment.ContinuationToken value if the listing operation did not return all blobs
+     * remaining to be listed with the current segment. The ContinuationToken value can be used as
+     * the value for the ContinuationToken parameter in a subsequent call to request the next
+     * segment of list items.
+     */
+    Azure::Nullable<std::string> ContinuationToken;
+
+    /**
+     * @brief Specifies the maximum number of blobs to return.
+     */
+    Azure::Nullable<int32_t> PageSizeHint;
+
+    /**
+     * @brief Specifies one or more datasets to include in the response.
+     */
+    Models::ListBlobsIncludeFlags Include = Models::ListBlobsIncludeFlags::None;
+  };
+
+  /**
    * @brief Optional parameters for BlobContainerClient::GetAccessPolicy.
    */
   struct GetBlobContainerAccessPolicyOptions

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
@@ -9,11 +9,14 @@
 #include <vector>
 
 #include <azure/core/operation.hpp>
+#include <azure/storage/common/paged_response.hpp>
 
+#include "azure/storage/blobs/blob_options.hpp"
 #include "azure/storage/blobs/protocol/blob_rest_client.hpp"
 
 namespace Azure { namespace Storage { namespace Blobs {
 
+  class BlobContainerClient;
   class BlobClient;
   class PageBlobClient;
 
@@ -106,5 +109,22 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     friend class Blobs::BlobClient;
     friend class Blobs::PageBlobClient;
+  };
+
+  class ListBlobsPageResult : public _internal::PageResult<ListBlobsPageResult> {
+  public:
+    std::string ServiceEndpoint;
+    std::string BlobContainerName;
+    std::string Prefix;
+    std::vector<Models::BlobItem> Items;
+
+  private:
+    std::shared_ptr<BlobContainerClient> m_blobContainerClient;
+    ListBlobsOptions m_operationOptions;
+
+    void OnNextPage(const Azure::Core::Context& context);
+
+    friend class Blobs::BlobContainerClient;
+    friend _internal::PageResult<ListBlobsPageResult>;
   };
 }}} // namespace Azure::Storage::Blobs

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
@@ -121,6 +121,7 @@ namespace Azure { namespace Storage { namespace Blobs {
   private:
     std::shared_ptr<BlobContainerClient> m_blobContainerClient;
     ListBlobsOptions m_operationOptions;
+    Azure::Core::Context m_context;
 
     void OnNextPage(const Azure::Core::Context& context);
 

--- a/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
@@ -261,6 +261,22 @@ namespace Azure { namespace Storage { namespace Blobs {
     return response;
   }
 
+  Pageable<ListBlobsPageResult> BlobContainerClient::ListBlobs(
+      const ListBlobsOptions& options,
+      const Azure::Core::Context& context) const
+  {
+    ListBlobsPageResult pageResult;
+    pageResult.NextPageToken = options.ContinuationToken.ValueOr(std::string());
+    pageResult.m_blobContainerClient = std::make_shared<BlobContainerClient>(*this);
+    pageResult.m_operationOptions = options;
+    pageResult.m_context = _internal::WithReplicaStatus(context);
+
+    // Populate the first page
+    pageResult.OnNextPage(pageResult.m_context);
+
+    return Pageable<ListBlobsPageResult>(std::move(pageResult));
+  }
+
   Azure::Response<Models::ListBlobsByHierarchySinglePageResult>
   BlobContainerClient::ListBlobsByHierarchySinglePage(
       const std::string& delimiter,

--- a/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
@@ -61,6 +61,13 @@ namespace Azure { namespace Storage { namespace Blobs {
 
   void ListBlobsPageResult::OnNextPage(const Azure::Core::Context& context)
   {
+    auto contextRef = std::cref(context);
+    if (&context == &Azure::Core::Context::GetApplicationContext())
+    {
+      // Called via iterator increment, use the same context as the last call.
+      contextRef = std::cref(m_context);
+    }
+
     _detail::BlobRestClient::BlobContainer::ListBlobsSinglePageOptions protocolLayerOptions;
     protocolLayerOptions.Prefix = m_operationOptions.Prefix;
     protocolLayerOptions.ContinuationToken = NextPageToken;
@@ -70,7 +77,7 @@ namespace Azure { namespace Storage { namespace Blobs {
         *m_blobContainerClient->m_pipeline,
         m_blobContainerClient->m_blobContainerUrl,
         protocolLayerOptions,
-        context);
+        contextRef.get());
     for (auto& i : response.Value.Items)
     {
       if (i.Details.AccessTier.HasValue() && !i.Details.IsAccessTierInferred.HasValue())

--- a/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
@@ -4,6 +4,7 @@
 #include "azure/storage/blobs/blob_responses.hpp"
 
 #include "azure/storage/blobs/blob_client.hpp"
+#include "azure/storage/blobs/blob_container_client.hpp"
 
 namespace Azure { namespace Storage { namespace Blobs {
 
@@ -56,6 +57,43 @@ namespace Azure { namespace Storage { namespace Blobs {
 
       std::this_thread::sleep_for(period);
     };
+  }
+
+  void ListBlobsPageResult::OnNextPage(const Azure::Core::Context& context)
+  {
+    _detail::BlobRestClient::BlobContainer::ListBlobsSinglePageOptions protocolLayerOptions;
+    protocolLayerOptions.Prefix = m_operationOptions.Prefix;
+    protocolLayerOptions.ContinuationToken = NextPageToken;
+    protocolLayerOptions.MaxResults = m_operationOptions.PageSizeHint;
+    protocolLayerOptions.Include = m_operationOptions.Include;
+    auto response = _detail::BlobRestClient::BlobContainer::ListBlobsSinglePage(
+        *m_blobContainerClient->m_pipeline,
+        m_blobContainerClient->m_blobContainerUrl,
+        protocolLayerOptions,
+        context);
+    for (auto& i : response.Value.Items)
+    {
+      if (i.Details.AccessTier.HasValue() && !i.Details.IsAccessTierInferred.HasValue())
+      {
+        i.Details.IsAccessTierInferred = false;
+      }
+      if (i.VersionId.HasValue() && !i.IsCurrentVersion.HasValue())
+      {
+        i.IsCurrentVersion = false;
+      }
+      if (i.BlobType == Models::BlobType::AppendBlob && !i.Details.IsSealed)
+      {
+        i.Details.IsSealed = false;
+      }
+    }
+
+    ServiceEndpoint = std::move(response.Value.ServiceEndpoint);
+    BlobContainerName = std::move(response.Value.BlobContainerName);
+    Prefix = std::move(response.Value.Prefix);
+    Items = std::move(response.Value.Items);
+
+    NextPageToken = response.Value.ContinuationToken.ValueOr(std::string());
+    RawResponse = std::move(response.RawResponse);
   }
 
 }}} // namespace Azure::Storage::Blobs

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
@@ -263,19 +263,15 @@ namespace Azure { namespace Storage { namespace Test {
       std::set<std::string> listBlobs;
       Azure::Storage::Blobs::ListBlobsOptions options;
       options.PageSizeHint = 3;
-      for (auto& pageResult : m_blobContainerClient->ListBlobs(options))
+      auto firstPageResult = std::move(*m_blobContainerClient->ListBlobs(options).begin());
+
+      for (auto& b : firstPageResult.Items)
       {
-        for (auto& b : pageResult.Items)
-        {
-          listBlobs.emplace(b.Name);
-        }
-        ASSERT_TRUE(pageResult.HasMore());
-        if (pageResult.HasMore())
-        {
-          options.ContinuationToken = pageResult.NextPageToken;
-          break;
-        }
+        listBlobs.emplace(b.Name);
       }
+      ASSERT_TRUE(firstPageResult.HasMore());
+      options.ContinuationToken = firstPageResult.NextPageToken;
+
       for (auto& pageResult : m_blobContainerClient->ListBlobs(options))
       {
         for (auto& b : pageResult.Items)

--- a/sdk/storage/azure-storage-common/CMakeLists.txt
+++ b/sdk/storage/azure-storage-common/CMakeLists.txt
@@ -38,6 +38,7 @@ set(
     inc/azure/storage/common/crypt.hpp
     inc/azure/storage/common/dll_import_export.hpp
     inc/azure/storage/common/file_io.hpp
+    inc/azure/storage/common/paged_response.hpp
     inc/azure/storage/common/reliable_stream.hpp
     inc/azure/storage/common/shared_key_policy.hpp
     inc/azure/storage/common/storage_common.hpp

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
@@ -21,7 +21,7 @@ namespace Azure { namespace Storage {
 
       bool HasMore() const { return !NextPageToken.empty(); }
 
-      void NextPage()
+      void NextPage(const Azure::Core::Context& context)
       {
         if (!HasMore())
         {
@@ -34,15 +34,13 @@ namespace Azure { namespace Storage {
             "The template argument \"Derived\" should derive from PageResult<Derived>.");
 
         CurrentPageToken = NextPageToken;
-        static_cast<Derived*>(this)->OnNextPage(m_context);
+        static_cast<Derived*>(this)->OnNextPage(context);
       }
 
     protected:
       PageResult() = default;
       PageResult(PageResult&&) = default;
       PageResult& operator=(PageResult&&) = default;
-
-      Azure::Core::Context m_context;
     };
 
   } // namespace _internal
@@ -73,7 +71,7 @@ namespace Azure { namespace Storage {
       {
         if (m_ptr->HasMore())
         {
-          m_ptr->NextPage();
+          m_ptr->NextPage(Azure::Core::Context::GetApplicationContext());
         }
         else
         {

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
@@ -64,12 +64,7 @@ namespace Azure { namespace Storage {
       using reference = value_type&;
 
       explicit Iterator(pointer ptr) : m_ptr(ptr) {}
-      Iterator(const Iterator&) = default;
-      Iterator(Iterator&&) = default;
-      ~Iterator() = default;
 
-      Iterator& operator=(const Iterator& other) = default;
-      Iterator& operator=(Iterator&& other) = default;
       bool operator==(const Iterator& other) const { return m_ptr == other.m_ptr; }
       bool operator!=(const Iterator& other) const { return !(*this == other); }
 

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
@@ -39,7 +39,6 @@ namespace Azure { namespace Storage {
 
     protected:
       PageResult() = default;
-      ~PageResult() = default;
       PageResult(PageResult&&) = default;
       PageResult& operator=(PageResult&&) = default;
 

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include <azure/core/context.hpp>
+#include <azure/core/http/raw_response.hpp>
+
+namespace Azure { namespace Storage {
+
+  namespace _internal {
+    template <class Derived> class PageResult {
+    public:
+      std::unique_ptr<Azure::Core::Http::RawResponse> RawResponse;
+      std::string NextPageToken;
+
+      bool HasMore() const { return !NextPageToken.empty(); }
+
+      void NextPage()
+      {
+        if (!HasMore())
+        {
+          // NextPage() should NEVER be called if HasMore() is false
+          std::abort(); // or throw std::out_of_range
+        }
+        static_cast<Derived*>(this)->OnNextPage(m_context);
+      }
+
+    protected:
+      PageResult()
+      {
+        static_assert(
+            std::is_base_of<PageResult, Derived>::value,
+            "The template argument \"Derived\" should derive from PageResult<Derived>.");
+      }
+      ~PageResult() = default;
+      PageResult(PageResult&&) = default;
+      PageResult& operator=(PageResult&&) = default;
+
+      Azure::Core::Context m_context;
+    };
+
+  } // namespace _internal
+
+  template <class T> class Pageable {
+  public:
+    explicit Pageable(T value) : m_value(std::move(value)) {}
+
+    class Iterator {
+    public:
+      using iterator_category = std::input_iterator_tag;
+      using difference_type = std::ptrdiff_t;
+      using value_type = T;
+      using pointer = value_type*;
+      using reference = value_type&;
+
+      explicit Iterator(pointer ptr) : m_ptr(ptr) {}
+      Iterator(const Iterator&) = default;
+      Iterator(Iterator&&) = default;
+      ~Iterator() = default;
+
+      Iterator& operator=(const Iterator& other) = default;
+      Iterator& operator=(Iterator&& other) = default;
+      bool operator==(const Iterator& other) const { return m_ptr == other.m_ptr; }
+      bool operator!=(const Iterator& other) const { return !(*this == other); }
+
+      Iterator& operator++()
+      {
+        if (m_ptr->HasMore())
+        {
+          m_ptr->NextPage();
+        }
+        else
+        {
+          m_ptr = nullptr;
+        }
+        return *this;
+      }
+
+      Iterator operator++(int)
+      {
+        Iterator ret = *this;
+        ++(*this);
+        return ret;
+      }
+
+      reference operator*() const { return *m_ptr; }
+      pointer operator->() const { return m_ptr; }
+
+    private:
+      pointer m_ptr;
+    };
+
+    Iterator begin() { return Iterator(&m_value); }
+    Iterator end() { return Iterator(nullptr); }
+
+  private:
+    T m_value;
+  };
+
+}} // namespace Azure::Storage

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
@@ -17,6 +17,7 @@ namespace Azure { namespace Storage {
     public:
       std::unique_ptr<Azure::Core::Http::RawResponse> RawResponse;
       std::string NextPageToken;
+      std::string CurrentPageToken;
 
       bool HasMore() const { return !NextPageToken.empty(); }
 
@@ -32,6 +33,7 @@ namespace Azure { namespace Storage {
             std::is_base_of<PageResult, Derived>::value,
             "The template argument \"Derived\" should derive from PageResult<Derived>.");
 
+        CurrentPageToken = NextPageToken;
         static_cast<Derived*>(this)->OnNextPage(m_context);
       }
 

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/paged_response.hpp
@@ -27,16 +27,16 @@ namespace Azure { namespace Storage {
           // NextPage() should NEVER be called if HasMore() is false
           std::abort(); // or throw std::out_of_range
         }
+
+        static_assert(
+            std::is_base_of<PageResult, Derived>::value,
+            "The template argument \"Derived\" should derive from PageResult<Derived>.");
+
         static_cast<Derived*>(this)->OnNextPage(m_context);
       }
 
     protected:
-      PageResult()
-      {
-        static_assert(
-            std::is_base_of<PageResult, Derived>::value,
-            "The template argument \"Derived\" should derive from PageResult<Derived>.");
-      }
+      PageResult() = default;
       ~PageResult() = default;
       PageResult(PageResult&&) = default;
       PageResult& operator=(PageResult&&) = default;
@@ -48,7 +48,12 @@ namespace Azure { namespace Storage {
 
   template <class T> class Pageable {
   public:
-    explicit Pageable(T value) : m_value(std::move(value)) {}
+    explicit Pageable(T value) : m_value(std::move(value))
+    {
+      static_assert(
+          std::is_base_of<_internal::PageResult<T>, T>::value,
+          "The template argument should derive from PageResult");
+    }
 
     class Iterator {
     public:


### PR DESCRIPTION
I only added Listblobs while didn't remove other APIs. I want this proposal get approved first before starting making other changes.

The example API in this PR is

```C++
Pageable<ListBlobsPageResult> ListBlobs(
        const ListBlobsOptions& options = ListBlobsOptions(),
        const Azure::Core::Context& context = Azure::Core::Context()) const
```

usage examples are:


```C++
// use the same context for all HTTP requests
for (auto& pageResult : client.ListBlobs())
{
    for (auto& blob : pageResult.Items)
    {
        std::cout << blob.name << std::endl;
    }
    // access continuation token
    // pageResult.NextPageToken

    // access raw response
    // pageResult.RawResponse

    // if there was another colletion
    // for (auto& blobPrefix : pageResult.Prefixes) {}
}
```

```C++
// list from a continuation token we got from other place
ListBlobOptions options;
options.ContinuationToken = token_from_other_place;
for (auto& pageResult : client.ListBlobs(options))
{
    for (auto& blob : pageResult.Items) {}
}
```

```C++
// use different context for each requests:
for (auto& pageResult = *client.ListBlobs(options, context).begin(); pageResult.HasMore(); pageResult.NextPage(context))
{
    for (auto& blob : pageResult.Items) {}
}
```