### PR TITLE
Fix minor nit to storage common change log by specifying full namespace

### DIFF
--- a/sdk/storage/azure-storage-blobs/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blobs/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Replaced all paginated collection functions that have the SinglePage suffix with pageable functions returning a `PagedResponse<T>`-derived type. The options are also renamed accordingly.
   - `BlobServiceClient::ListBlobContainers()`.
   - `BlobServiceClient::FindBlobsByTags()`.
-  - `BlobContainerClinet::ListBlobs()`.
+  - `BlobContainerClient::ListBlobs()`.
   - `BlobContainerClient::ListBlobsByHierarchy()`.
   - `PageBlobClient::GetPageRanges()`.
   - `PageBlobClient::GetPageRangesDiff()`.

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New Features
 
 - Added server timeout support.
-- Added `PagedResponse<T>` for returning paginated collections.
+- Added `Azure::PagedResponse<T>` for returning paginated collections.
 
 ### Breaking Changes
 


### PR DESCRIPTION
We don't have to block the beta.10 release for this change, it can be merged and fixed up after the release.

That is, this can be merged **after** https://dev.azure.com/azure-sdk/internal/_build/results?buildId=846565&view=results is successful.