### PR TITLE
VcPkg manifest tweaks

### DIFF
--- a/sdk/core/azure-core/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core/vcpkg/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_check_features(
         winhttp BUILD_TRANSPORT_WINHTTP
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/sdk/core/azure-core/
     PREFER_NINJA
     OPTIONS
@@ -23,8 +23,8 @@ vcpkg_configure_cmake(
         -DWARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()

--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -12,6 +12,14 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "openssl",
       "platform": "!windows & !uwp"
     }

--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -9,6 +9,7 @@
     "This library provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C++."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/core/azure-core",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "openssl",
@@ -20,17 +21,32 @@
   ],
   "features": {
     "curl": {
-      "description": "Build an HTTP transport implementation with LibCURL",
+      "description": "LibCURL HTTP transport implementation",
       "dependencies": [
         {
           "name": "azure-core-cpp",
           "default-features": false
         },
-        "curl"
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": [
+            "ssl"
+          ]
+        }
+      ]
+    },
+    "winhttp": {
+      "description": "WinHTTP HTTP transport implementation",
+      "dependencies": [
+        {
+          "name": "azure-core-cpp",
+          "default-features": false
+        }
       ]
     },
     "http": {
-      "description": "Build all HTTP transport implementations, depending on the platform",
+      "description": "All HTTP transport implementations available on the platform",
       "dependencies": [
         {
           "name": "azure-core-cpp",
@@ -47,15 +63,6 @@
             "winhttp"
           ],
           "platform": "windows & !uwp"
-        }
-      ]
-    },
-    "winhttp": {
-      "description": "Build an HTTP transport implementation with WinHTTP",
-      "dependencies": [
-        {
-          "name": "azure-core-cpp",
-          "default-features": false
         }
       ]
     }

--- a/sdk/identity/azure-identity/vcpkg/portfile.cmake
+++ b/sdk/identity/azure-identity/vcpkg/portfile.cmake
@@ -8,15 +8,15 @@ vcpkg_from_github(
     SHA512 1
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/sdk/identity/azure-identity/
     PREFER_NINJA
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()

--- a/sdk/identity/azure-identity/vcpkg/vcpkg.json
+++ b/sdk/identity/azure-identity/vcpkg/vcpkg.json
@@ -9,7 +9,11 @@
     "This library provides common authentication-related abstractions for Azure SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/identity/azure-identity",
+  "license": "MIT",
   "dependencies": [
-    "azure-core-cpp"
+    {
+      "name": "azure-core-cpp",
+      "default-features": false
+    }
   ]
 }

--- a/sdk/identity/azure-identity/vcpkg/vcpkg.json
+++ b/sdk/identity/azure-identity/vcpkg/vcpkg.json
@@ -12,6 +12,14 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "azure-core-cpp",
       "default-features": false
     }

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/portfile.cmake
@@ -8,15 +8,15 @@ vcpkg_from_github(
     SHA512 1
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-common/
     PREFER_NINJA
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
@@ -9,7 +9,11 @@
     "This library provides common Azure KeyVault-related abstractions for Azure SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/keyvault/azure-security-keyvault-common",
+  "license": "MIT",
   "dependencies": [
-    "azure-core-cpp"
+    {
+      "name": "azure-core-cpp",
+      "default-features": false
+    }
   ]
 }

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
@@ -12,6 +12,14 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "azure-core-cpp",
       "default-features": false
     }

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
@@ -8,15 +8,15 @@ vcpkg_from_github(
     SHA512 1
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys/
     PREFER_NINJA
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
@@ -12,6 +12,14 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "azure-security-keyvault-common-cpp",
       "default-features": false
     }

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
@@ -9,7 +9,11 @@
     "This library provides Azure Key Vault Keys SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/keyvault/azure-security-keyvault-keys",
+  "license": "MIT",
   "dependencies": [
-    "azure-security-keyvault-common-cpp"
+    {
+      "name": "azure-security-keyvault-common-cpp",
+      "default-features": false
+    }
   ]
 }

--- a/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
@@ -8,15 +8,15 @@ vcpkg_from_github(
     SHA512 1
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/sdk/storage/azure-storage-blobs/
     PREFER_NINJA
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()

--- a/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
@@ -12,6 +12,14 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "azure-storage-common-cpp",
       "default-features": false
     }

--- a/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
@@ -9,7 +9,11 @@
     "This library provides Azure Storage Blobs SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/storage/azure-storage-blobs",
+  "license": "MIT",
   "dependencies": [
-    "azure-storage-common-cpp"
+    {
+      "name": "azure-storage-common-cpp",
+      "default-features": false
+    }
   ]
 }

--- a/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
@@ -8,15 +8,15 @@ vcpkg_from_github(
     SHA512 1
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/sdk/storage/azure-storage-common/
     PREFER_NINJA
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()

--- a/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
@@ -9,8 +9,12 @@
     "This library provides common Azure Storage-related abstractions for Azure SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/storage/azure-storage-common",
+  "license": "MIT",
   "dependencies": [
-    "azure-core-cpp",
+    {
+      "name": "azure-core-cpp",
+      "default-features": false
+    },
     "libxml2",
     {
       "name": "openssl",

--- a/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
@@ -12,6 +12,14 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "azure-core-cpp",
       "default-features": false
     },

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
@@ -8,15 +8,15 @@ vcpkg_from_github(
     SHA512 1
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/sdk/storage/azure-storage-files-datalake/
     PREFER_NINJA
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
@@ -12,6 +12,14 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "azure-storage-blobs-cpp",
       "default-features": false
     }

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
@@ -9,7 +9,11 @@
     "This library provides Azure Storage Files Data Lake SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/storage/azure-storage-files-datalake",
+  "license": "MIT",
   "dependencies": [
-    "azure-storage-blobs-cpp"
+    {
+      "name": "azure-storage-blobs-cpp",
+      "default-features": false
+    }
   ]
 }

--- a/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
@@ -8,15 +8,15 @@ vcpkg_from_github(
     SHA512 1
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/sdk/storage/azure-storage-files-shares/
     PREFER_NINJA
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()

--- a/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
@@ -12,6 +12,14 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "azure-storage-common-cpp",
       "default-features": false
     }

--- a/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
@@ -9,7 +9,11 @@
     "This library provides Azure Storage Files Shares SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/storage/azure-storage-files-shares",
+  "license": "MIT",
   "dependencies": [
-    "azure-storage-common-cpp"
+    {
+      "name": "azure-storage-common-cpp",
+      "default-features": false
+    }
   ]
 }

--- a/sdk/template/azure-template/vcpkg/portfile.cmake
+++ b/sdk/template/azure-template/vcpkg/portfile.cmake
@@ -8,15 +8,15 @@ vcpkg_from_github(
     SHA512 1
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/sdk/template/azure-template/
     PREFER_NINJA
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()

--- a/sdk/template/azure-template/vcpkg/vcpkg.json
+++ b/sdk/template/azure-template/vcpkg/vcpkg.json
@@ -10,7 +10,11 @@
     "It is not meant to be published to vcpkg."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/master/sdk/template/azure-template",
+  "license": "MIT",
   "dependencies": [
-    "azure-core-cpp"
+    {
+      "name": "azure-core-cpp",
+      "default-features": false
+    }
   ]
 }

--- a/sdk/template/azure-template/vcpkg/vcpkg.json
+++ b/sdk/template/azure-template/vcpkg/vcpkg.json
@@ -13,6 +13,14 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
       "name": "azure-core-cpp",
       "default-features": false
     }


### PR DESCRIPTION
Closes #1583 (lighter dependencies).
Closes #2107 (upgrade functions that were deprecated)

Closes #1689 : by default, if you `vcpkg install azure-storage-blobs-cpp`, you get both Curl and WinHTTP transport implementations (all available on the platform) for Windows (WinHTTP is used by default and not Curl, but Curl is also available).
On Linux and Mac, you only get Curl implementation (expected).
However, if you want only WinHTTP to be installed, you should install as `vcpkg install azure-core-cpp[core,winhttp] azure-identity-cpp` *, and it won't build Curl transport and won't bring curl dependency. 
And the last thing, if you install only Curl on Winodws, it will be the default transport (as expected).

`*` - you could be thinking, why not `vcpkg install azure-core-cpp[winhttp] azure-identity-cpp`, i.e. why do we have to also put `core` (i.e. `azure-core-cpp[core,winhttp]`)? That is how VcPkg works. If you don't put `core`, that means "install default features + winhttp".