### PR TITLE
VcPkg: format json manifest files

### DIFF
--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -12,16 +12,16 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "openssl",
+      "platform": "!windows & !uwp"
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "openssl",
-      "platform": "!windows & !uwp"
     }
   ],
   "default-features": [
@@ -44,15 +44,6 @@
         }
       ]
     },
-    "winhttp": {
-      "description": "WinHTTP HTTP transport implementation",
-      "dependencies": [
-        {
-          "name": "azure-core-cpp",
-          "default-features": false
-        }
-      ]
-    },
     "http": {
       "description": "All HTTP transport implementations available on the platform",
       "dependencies": [
@@ -71,6 +62,15 @@
             "winhttp"
           ],
           "platform": "windows & !uwp"
+        }
+      ]
+    },
+    "winhttp": {
+      "description": "WinHTTP HTTP transport implementation",
+      "dependencies": [
+        {
+          "name": "azure-core-cpp",
+          "default-features": false
         }
       ]
     }

--- a/sdk/identity/azure-identity/vcpkg/vcpkg.json
+++ b/sdk/identity/azure-identity/vcpkg/vcpkg.json
@@ -12,16 +12,16 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "azure-core-cpp",
+      "default-features": false
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "azure-core-cpp",
-      "default-features": false
     }
   ]
 }

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
@@ -12,16 +12,16 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "azure-core-cpp",
+      "default-features": false
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "azure-core-cpp",
-      "default-features": false
     }
   ]
 }

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
@@ -12,16 +12,16 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "azure-security-keyvault-common-cpp",
+      "default-features": false
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "azure-security-keyvault-common-cpp",
-      "default-features": false
     }
   ]
 }

--- a/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
@@ -12,16 +12,16 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "azure-storage-common-cpp",
+      "default-features": false
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "azure-storage-common-cpp",
-      "default-features": false
     }
   ]
 }

--- a/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
@@ -12,14 +12,6 @@
   "license": "MIT",
   "dependencies": [
     {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    },
-    {
       "name": "azure-core-cpp",
       "default-features": false
     },
@@ -27,6 +19,14 @@
     {
       "name": "openssl",
       "platform": "!windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
@@ -12,16 +12,16 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "azure-storage-common-cpp",
+      "default-features": false
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "azure-storage-blobs-cpp",
-      "default-features": false
     }
   ]
 }

--- a/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
@@ -12,16 +12,16 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "azure-storage-common-cpp",
+      "default-features": false
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "azure-storage-common-cpp",
-      "default-features": false
     }
   ]
 }

--- a/sdk/template/azure-template/vcpkg/vcpkg.json
+++ b/sdk/template/azure-template/vcpkg/vcpkg.json
@@ -13,16 +13,16 @@
   "license": "MIT",
   "dependencies": [
     {
+      "name": "azure-core-cpp",
+      "default-features": false
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "azure-core-cpp",
-      "default-features": false
     }
   ]
 }


### PR DESCRIPTION
VcPkg's CI does not like if vcpkg.json is not formatted (ordered) as `vcpkg format-manifest` would produce it (https://github.com/microsoft/vcpkg/pull/17447).