### PR TITLE
Context::GetApplicationContext() => Context::ApplicationContext

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `Azure::PagedResponse<T>`.
 
+### Breaking Changes
+
+- Removed `Context::GetApplicationContext()` in favor of a new static data member `Context::ApplicationContext`.
+
 ### Bug Fixes
 
 - Do not re-use a libcurl connection to same host but different port.

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -9,11 +9,11 @@
 #pragma once
 
 #include "azure/core/datetime.hpp"
+#include "azure/core/dll_import_export.hpp"
 
 #include <atomic>
 #include <chrono>
 #include <memory>
-#include <new> //For the non-allocating placement new
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -214,8 +214,8 @@ namespace Azure { namespace Core {
     }
 
     /**
-     * @brief Get the application context (root).
+     * @brief The application context (root).
      */
-    static Context& GetApplicationContext();
+    static AZ_CORE_DLLEXPORT Context ApplicationContext;
   };
 }} // namespace Azure::Core

--- a/sdk/core/azure-core/inc/azure/core/operation.hpp
+++ b/sdk/core/azure-core/inc/azure/core/operation.hpp
@@ -27,7 +27,7 @@ namespace Azure { namespace Core {
   template <class T> class Operation {
   private:
     // These are pure virtual b/c the derived class must provide an implementation
-    virtual std::unique_ptr<Http::RawResponse> PollInternal(Context& context) = 0;
+    virtual std::unique_ptr<Http::RawResponse> PollInternal(Context const& context) = 0;
     virtual Response<T> PollUntilDoneInternal(std::chrono::milliseconds period, Context& context)
         = 0;
     virtual Azure::Core::Http::RawResponse const& GetRawResponseInternal() const = 0;
@@ -137,7 +137,7 @@ namespace Azure { namespace Core {
     {
       // In the cases where the customer doesn't want to use a context we new one up and pass it
       // through
-      return Poll(Context::GetApplicationContext());
+      return Poll(Context::ApplicationContext);
     }
 
     /**
@@ -147,7 +147,7 @@ namespace Azure { namespace Core {
      *
      * @return An HTTP #Azure::Core::Http::RawResponse returned from the service.
      */
-    Http::RawResponse const& Poll(Context& context)
+    Http::RawResponse const& Poll(Context const& context)
     {
       context.ThrowIfCancelled();
       m_rawResponse = PollInternal(context);
@@ -165,7 +165,7 @@ namespace Azure { namespace Core {
     {
       // In the cases where the customer doesn't want to use a context we new one up and pass it
       // through
-      return PollUntilDone(period, Context::GetApplicationContext());
+      return PollUntilDone(period, Context::ApplicationContext);
     }
 
     /**

--- a/sdk/core/azure-core/src/context.cpp
+++ b/sdk/core/azure-core/src/context.cpp
@@ -5,11 +5,7 @@
 
 using namespace Azure::Core;
 
-Context& Azure::Core::Context::GetApplicationContext()
-{
-  static Context context;
-  return context;
-}
+Context Context::ApplicationContext;
 
 Azure::DateTime Azure::Core::Context::GetDeadline() const
 {

--- a/sdk/core/azure-core/test/perf/src/main.cpp
+++ b/sdk/core/azure-core/test/perf/src/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char** argv)
   // Create the test list
   std::vector<Azure::Perf::TestMetadata> tests{Azure::Core::Test::NullableTest::GetTestMetadata()};
 
-  Azure::Perf::Program::Run(Azure::Core::Context::GetApplicationContext(), tests, argc, argv);
+  Azure::Perf::Program::Run(Azure::Core::Context::ApplicationContext, tests, argc, argv);
 
   return 0;
 }

--- a/sdk/core/azure-core/test/ut/azure_libcurl_core_main.cpp
+++ b/sdk/core/azure-core/test/ut/azure_libcurl_core_main.cpp
@@ -45,9 +45,9 @@ namespace Azure { namespace Core { namespace Test {
 
       auto session = std::make_unique<Azure::Core::Http::CurlSession>(
           req, std::move(connection), options.HttpKeepAlive);
-      session->Perform(Azure::Core::Context::GetApplicationContext());
+      session->Perform(Azure::Core::Context::ApplicationContext);
       // Reading all the response
-      session->ReadToEnd(Azure::Core::Context::GetApplicationContext());
+      session->ReadToEnd(Azure::Core::Context::ApplicationContext);
     }
     // Check that after the connection is gone, it is moved back to the pool
     EXPECT_EQ(

--- a/sdk/core/azure-core/test/ut/bodystream.cpp
+++ b/sdk/core/azure-core/test/ut/bodystream.cpp
@@ -69,7 +69,7 @@ TEST(FileBodyStream, Length)
   Azure::Core::IO::FileBodyStream stream(testDataPath);
   EXPECT_EQ(stream.Length(), FileSize);
 
-  auto readResult = stream.ReadToEnd(Azure::Core::Context::GetApplicationContext());
+  auto readResult = stream.ReadToEnd(Azure::Core::Context::ApplicationContext);
   EXPECT_EQ(readResult.size(), FileSize);
 
   stream.Rewind();
@@ -89,7 +89,7 @@ TEST(FileBodyStream, Read)
 
   stream.Rewind();
 
-  readResult = stream.ReadToEnd(Azure::Core::Context::GetApplicationContext());
+  readResult = stream.ReadToEnd(Azure::Core::Context::ApplicationContext);
   EXPECT_EQ(readResult.size(), FileSize);
 
   stream.Rewind();
@@ -103,7 +103,7 @@ TEST(FileBodyStream, Read)
 
   stream.Rewind();
 
-  readSize = stream.ReadToCount(buffer.data(), 10, Azure::Core::Context::GetApplicationContext());
+  readSize = stream.ReadToCount(buffer.data(), 10, Azure::Core::Context::ApplicationContext);
   EXPECT_EQ(readSize, 10);
   EXPECT_EQ(buffer[10], 0);
 
@@ -116,8 +116,7 @@ TEST(FileBodyStream, Read)
 
   stream.Rewind();
 
-  readSize
-      = stream.Read(buffer.data(), buffer.size(), Azure::Core::Context::GetApplicationContext());
+  readSize = stream.Read(buffer.data(), buffer.size(), Azure::Core::Context::ApplicationContext);
   EXPECT_EQ(readSize, FileSize);
   EXPECT_EQ(buffer[FileSize], 0);
 }

--- a/sdk/core/azure-core/test/ut/client_options.cpp
+++ b/sdk/core/azure-core/test/ut/client_options.cpp
@@ -77,17 +77,17 @@ TEST(ClientOptions, copyWithOperator)
   EXPECT_EQ(1, copyOptions.Retry.MaxRetries);
   EXPECT_EQ(std::string("pleaseCopyMe"), copyOptions.Telemetry.ApplicationId);
   Request r(HttpMethod::Get, Url(""));
-  auto result = copyOptions.Transport.Transport->Send(r, Context::GetApplicationContext());
+  auto result = copyOptions.Transport.Transport->Send(r, Context::ApplicationContext);
   EXPECT_EQ(nullptr, result);
 
   EXPECT_EQ(1, copyOptions.PerOperationPolicies.size());
   result = copyOptions.PerOperationPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerCallPolicy"), result->GetReasonPhrase());
 
   EXPECT_EQ(1, copyOptions.PerRetryPolicies.size());
   result = copyOptions.PerRetryPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerRetryPolicy"), result->GetReasonPhrase());
 }
 
@@ -108,17 +108,17 @@ TEST(ClientOptions, copyWithConstructor)
   EXPECT_EQ(1, copyOptions.Retry.MaxRetries);
   EXPECT_EQ(std::string("pleaseCopyMe"), copyOptions.Telemetry.ApplicationId);
   Request r(HttpMethod::Get, Url(""));
-  auto result = copyOptions.Transport.Transport->Send(r, Context::GetApplicationContext());
+  auto result = copyOptions.Transport.Transport->Send(r, Context::ApplicationContext);
   EXPECT_EQ(nullptr, result);
 
   EXPECT_EQ(1, copyOptions.PerOperationPolicies.size());
   result = copyOptions.PerOperationPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerCallPolicy"), result->GetReasonPhrase());
 
   EXPECT_EQ(1, copyOptions.PerRetryPolicies.size());
   result = copyOptions.PerRetryPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerRetryPolicy"), result->GetReasonPhrase());
 }
 
@@ -146,17 +146,17 @@ TEST(ClientOptions, copyDerivedClassConstructor)
   EXPECT_EQ(1, copyOptions.Retry.MaxRetries);
   EXPECT_EQ(std::string("pleaseCopyMe"), copyOptions.Telemetry.ApplicationId);
   Request r(HttpMethod::Get, Url(""));
-  auto result = copyOptions.Transport.Transport->Send(r, Context::GetApplicationContext());
+  auto result = copyOptions.Transport.Transport->Send(r, Context::ApplicationContext);
   EXPECT_EQ(nullptr, result);
 
   EXPECT_EQ(1, copyOptions.PerOperationPolicies.size());
   result = copyOptions.PerOperationPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerCallPolicy"), result->GetReasonPhrase());
 
   EXPECT_EQ(1, copyOptions.PerRetryPolicies.size());
   result = copyOptions.PerRetryPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerRetryPolicy"), result->GetReasonPhrase());
 }
 
@@ -184,17 +184,17 @@ TEST(ClientOptions, copyDerivedClassOperator)
   EXPECT_EQ(1, copyOptions.Retry.MaxRetries);
   EXPECT_EQ(std::string("pleaseCopyMe"), copyOptions.Telemetry.ApplicationId);
   Request r(HttpMethod::Get, Url(""));
-  auto result = copyOptions.Transport.Transport->Send(r, Context::GetApplicationContext());
+  auto result = copyOptions.Transport.Transport->Send(r, Context::ApplicationContext);
   EXPECT_EQ(nullptr, result);
 
   EXPECT_EQ(1, copyOptions.PerOperationPolicies.size());
   result = copyOptions.PerOperationPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerCallPolicy"), result->GetReasonPhrase());
 
   EXPECT_EQ(1, copyOptions.PerRetryPolicies.size());
   result = copyOptions.PerRetryPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerRetryPolicy"), result->GetReasonPhrase());
 }
 
@@ -222,16 +222,16 @@ TEST(ClientOptions, moveConstruct)
   EXPECT_EQ(1, copyOptions.Retry.MaxRetries);
   EXPECT_EQ(std::string("pleaseCopyMe"), copyOptions.Telemetry.ApplicationId);
   Request r(HttpMethod::Get, Url(""));
-  auto result = copyOptions.Transport.Transport->Send(r, Context::GetApplicationContext());
+  auto result = copyOptions.Transport.Transport->Send(r, Context::ApplicationContext);
   EXPECT_EQ(nullptr, result);
 
   EXPECT_EQ(1, copyOptions.PerOperationPolicies.size());
   result = copyOptions.PerOperationPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerCallPolicy"), result->GetReasonPhrase());
 
   EXPECT_EQ(1, copyOptions.PerRetryPolicies.size());
   result = copyOptions.PerRetryPolicies[0]->Send(
-      r, NextHttpPolicy(0, {}), Context::GetApplicationContext());
+      r, NextHttpPolicy(0, {}), Context::ApplicationContext);
   EXPECT_EQ(std::string("IamAPerRetryPolicy"), result->GetReasonPhrase());
 }

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -240,7 +240,7 @@ struct SomeStructForContext
 TEST(Context, InstanceValue)
 {
   Context::Key const key;
-  auto contextP = Context::GetApplicationContext().WithValue(key, SomeStructForContext());
+  auto contextP = Context::ApplicationContext.WithValue(key, SomeStructForContext());
   SomeStructForContext contextValueRef;
   EXPECT_TRUE(contextP.TryGetValue<SomeStructForContext>(key, contextValueRef));
   EXPECT_EQ(contextValueRef.someField, 12345);
@@ -250,7 +250,7 @@ TEST(Context, Ptr)
 {
   Context::Key const key;
   SomeStructForContext value;
-  auto contextP = Context::GetApplicationContext().WithValue(key, &value);
+  auto contextP = Context::ApplicationContext.WithValue(key, &value);
 
   SomeStructForContext* contextValueRef;
   EXPECT_TRUE(contextP.TryGetValue<SomeStructForContext*>(key, contextValueRef));
@@ -276,7 +276,7 @@ TEST(Context, NestedClassPtr)
 
     Context::Key const key;
 
-    auto context = Context::GetApplicationContext().WithValue(key, sharedPtr);
+    auto context = Context::ApplicationContext.WithValue(key, sharedPtr);
     EXPECT_EQ(sharedPtr.use_count(), 2);
 
     std::shared_ptr<TestClass> foundPtr;

--- a/sdk/core/azure-core/test/ut/curl_connection_pool.cpp
+++ b/sdk/core/azure-core/test/ut/curl_connection_pool.cpp
@@ -266,8 +266,8 @@ namespace Azure { namespace Core { namespace Test {
         // Now check the pool until the clean thread until finishes removing the connections or
         // fail after 5 minutes (indicates a problem with the clean routine)
 
-        auto timeOut = Context::GetApplicationContext().WithDeadline(
-            std::chrono::system_clock::now() + 5min);
+        auto timeOut
+            = Context::ApplicationContext.WithDeadline(std::chrono::system_clock::now() + 5min);
         bool poolIsEmpty = false;
         while (!poolIsEmpty && !timeOut.IsCancelled())
         {
@@ -328,13 +328,13 @@ namespace Azure { namespace Core { namespace Test {
       //                             .ConnectionPoolIndex[hostKey]
       //                             .begin();
       //     EXPECT_EQ(
-      //         connectionIt->get()->ReadFromSocket(nullptr, 0, Context::GetApplicationContext()),
+      //         connectionIt->get()->ReadFromSocket(nullptr, 0, Context::ApplicationContext),
       //         2000 - 1); // starting from zero
       //     connectionIt = --(Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool
       //                           .ConnectionPoolIndex[hostKey]
       //                           .end());
       //     EXPECT_EQ(
-      //         connectionIt->get()->ReadFromSocket(nullptr, 0, Context::GetApplicationContext()),
+      //         connectionIt->get()->ReadFromSocket(nullptr, 0, Context::ApplicationContext),
       //         2000 - 1024);
 
       //     // Check the pool will take other host-key
@@ -550,7 +550,7 @@ namespace Azure { namespace Core { namespace Test {
         // Check that CURLE_SEND_ERROR is produced when trying to use the connection.
         auto session = std::make_unique<Azure::Core::Http::CurlSession>(
             req, std::move(connection), options.HttpKeepAlive);
-        auto r = session->Perform(Azure::Core::Context::GetApplicationContext());
+        auto r = session->Perform(Azure::Core::Context::ApplicationContext);
         EXPECT_EQ(CURLE_SEND_ERROR, r);
       }
     }

--- a/sdk/core/azure-core/test/ut/curl_options.cpp
+++ b/sdk/core/azure-core/test/ut/curl_options.cpp
@@ -47,8 +47,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(
-        response = pipeline.Send(request, Azure::Core::Context::GetApplicationContext()));
+    EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
     auto responseCode = response->GetStatusCode();
     int expectedCode = 200;
     EXPECT_PRED2(
@@ -78,8 +77,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(
-        response = pipeline.Send(request, Azure::Core::Context::GetApplicationContext()));
+    EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
     auto responseCode = response->GetStatusCode();
     int expectedCode = 200;
     EXPECT_PRED2(
@@ -113,7 +111,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(response = pipeline.Send(Azure::Core::Context::GetApplicationContext(),
+    EXPECT_NO_THROW(response = pipeline.Send(Azure::Core::Context::ApplicationContext,
   request)); auto responseCode = response->GetStatusCode(); int expectedCode = 200; EXPECT_PRED2(
         [](int expected, int code) { return expected == code; },
         expectedCode,
@@ -139,7 +137,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(response = pipeline.Send(Azure::Core::Context::GetApplicationContext(),
+    EXPECT_NO_THROW(response = pipeline.Send(Azure::Core::Context::ApplicationContext,
   request)); auto responseCode = response->GetStatusCode(); int expectedCode = 200; EXPECT_PRED2(
         [](int expected, int code) { return expected == code; },
         expectedCode,
@@ -165,7 +163,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(response = pipeline.Send(Azure::Core::Context::GetApplicationContext(),
+    EXPECT_NO_THROW(response = pipeline.Send(Azure::Core::Context::ApplicationContext,
   request)); auto responseCode = response->GetStatusCode(); int expectedCode = 200; EXPECT_PRED2(
         [](int expected, int code) { return expected == code; },
         expectedCode,
@@ -197,8 +195,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(
-        response = pipeline.Send(request, Azure::Core::Context::GetApplicationContext()));
+    EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
     auto responseCode = response->GetStatusCode();
     int expectedCode = 200;
     EXPECT_PRED2(
@@ -230,8 +227,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(
-        response = pipeline.Send(request, Azure::Core::Context::GetApplicationContext()));
+    EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
     auto responseCode = response->GetStatusCode();
     int expectedCode = 200;
     EXPECT_PRED2(
@@ -268,8 +264,7 @@ namespace Azure { namespace Core { namespace Test {
       Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
       std::unique_ptr<Azure::Core::Http::RawResponse> response;
-      EXPECT_NO_THROW(
-          response = pipeline.Send(request, Azure::Core::Context::GetApplicationContext()));
+      EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
       auto responseCode = response->GetStatusCode();
       int expectedCode = 200;
       EXPECT_PRED2(

--- a/sdk/core/azure-core/test/ut/curl_session_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_session_test.cpp
@@ -43,7 +43,7 @@ namespace Azure { namespace Core { namespace Test {
     auto session = std::make_unique<Azure::Core::Http::CurlSession>(
         request, std::move(uniqueCurlMock), true);
 
-    EXPECT_NO_THROW(session->Perform(Azure::Core::Context::GetApplicationContext()));
+    EXPECT_NO_THROW(session->Perform(Azure::Core::Context::ApplicationContext));
   }
 
   TEST_F(CurlSession, chunkResponseSizeZero)
@@ -76,7 +76,7 @@ namespace Azure { namespace Core { namespace Test {
       auto session = std::make_unique<Azure::Core::Http::CurlSession>(
           request, std::move(uniqueCurlMock), true);
 
-      EXPECT_NO_THROW(session->Perform(Azure::Core::Context::GetApplicationContext()));
+      EXPECT_NO_THROW(session->Perform(Azure::Core::Context::ApplicationContext));
     }
     // Clear the connections from the pool to invoke clean routine
     Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool.ConnectionPoolIndex
@@ -117,14 +117,14 @@ namespace Azure { namespace Core { namespace Test {
       auto session = std::make_unique<Azure::Core::Http::CurlSession>(
           request, std::move(uniqueCurlMock), true);
 
-      EXPECT_NO_THROW(session->Perform(Azure::Core::Context::GetApplicationContext()));
+      EXPECT_NO_THROW(session->Perform(Azure::Core::Context::ApplicationContext));
       auto r = session->ExtractResponse();
       r->SetBodyStream(std::move(session));
       auto bodyS = r->ExtractBodyStream();
 
       // Read the bodyStream to get all chunks
       EXPECT_THROW(
-          bodyS->ReadToEnd(Azure::Core::Context::GetApplicationContext()),
+          bodyS->ReadToEnd(Azure::Core::Context::ApplicationContext),
           Azure::Core::Http::TransportException);
     }
     // Clear the connections from the pool to invoke clean routine
@@ -195,13 +195,13 @@ namespace Azure { namespace Core { namespace Test {
       auto session = std::make_unique<Azure::Core::Http::CurlSession>(
           request, std::move(uniqueCurlMock), true);
 
-      EXPECT_NO_THROW(session->Perform(Azure::Core::Context::GetApplicationContext()));
+      EXPECT_NO_THROW(session->Perform(Azure::Core::Context::ApplicationContext));
       auto response = session->ExtractResponse();
       response->SetBodyStream(std::move(session));
       auto bodyS = response->ExtractBodyStream();
 
       // Read the bodyStream to get all chunks
-      EXPECT_NO_THROW(bodyS->ReadToEnd(Azure::Core::Context::GetApplicationContext()));
+      EXPECT_NO_THROW(bodyS->ReadToEnd(Azure::Core::Context::ApplicationContext));
     }
     // Clear the connections from the pool to invoke clean routine
     Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool.ConnectionPoolIndex
@@ -231,7 +231,7 @@ namespace Azure { namespace Core { namespace Test {
       auto session = std::make_unique<Azure::Core::Http::CurlSession>(
           request, std::move(uniqueCurlMock), true);
 
-      auto returnCode = session->Perform(Azure::Core::Context::GetApplicationContext());
+      auto returnCode = session->Perform(Azure::Core::Context::ApplicationContext);
       EXPECT_EQ(CURLE_SEND_ERROR, returnCode);
     }
     // Check connection pool is empty (connection was not moved to the pool)

--- a/sdk/core/azure-core/test/ut/global_context.cpp
+++ b/sdk/core/azure-core/test/ut/global_context.cpp
@@ -22,7 +22,7 @@ using namespace Azure::Core;
 
 TEST(Context, ApplicationContext)
 {
-  Context appContext = Context::GetApplicationContext();
+  Context appContext = Context::ApplicationContext;
 
   int value = 42;
   EXPECT_FALSE(appContext.TryGetValue(Context::Key(), value));
@@ -38,6 +38,6 @@ TEST(Context, ApplicationContext)
 
   // AppContext2 is the same context as AppContext
   //  The context should be cancelled
-  Context appContext2 = Context::GetApplicationContext();
+  Context appContext2 = Context::ApplicationContext;
   EXPECT_TRUE(appContext2.IsCancelled());
 }

--- a/sdk/core/azure-core/test/ut/http.cpp
+++ b/sdk/core/azure-core/test/ut/http.cpp
@@ -185,7 +185,7 @@ namespace Azure { namespace Core { namespace Test {
 
       // Change the offset of the stream to be non-zero by reading a byte.
       std::vector<uint8_t> temp(2);
-      EXPECT_EQ(stream.ReadToCount(temp.data(), 1, Context::GetApplicationContext()), 1);
+      EXPECT_EQ(stream.ReadToCount(temp.data(), 1, Context::ApplicationContext), 1);
 
       EXPECT_EQ(temp[0], 1);
       EXPECT_EQ(temp[1], 0);
@@ -203,7 +203,7 @@ namespace Azure { namespace Core { namespace Test {
 
       // Verify that StartTry rewound the stream back.
       auto getStream = req.GetBodyStream();
-      EXPECT_EQ(getStream->ReadToCount(temp.data(), 2, Context::GetApplicationContext()), 2);
+      EXPECT_EQ(getStream->ReadToCount(temp.data(), 2, Context::ApplicationContext), 2);
 
       EXPECT_EQ(temp[0], 1);
       EXPECT_EQ(temp[1], 2);

--- a/sdk/core/azure-core/test/ut/operation_test.hpp
+++ b/sdk/core/azure-core/test/ut/operation_test.hpp
@@ -26,7 +26,7 @@ namespace Azure { namespace Core { namespace Test {
     int m_count = 0;
 
   private:
-    std::unique_ptr<Http::RawResponse> PollInternal(Context&) override
+    std::unique_ptr<Http::RawResponse> PollInternal(Context const&) override
     {
       // Artificial delay to require 2 polls
       if (++m_count == 2)

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -116,7 +116,7 @@ TEST(Policy, throwWhenNoTransportPolicy)
   Azure::Core::Url url("");
   Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
   EXPECT_THROW(
-      pipeline.Send(request, Azure::Core::Context::GetApplicationContext()), std::invalid_argument);
+      pipeline.Send(request, Azure::Core::Context::ApplicationContext), std::invalid_argument);
 }
 
 TEST(Policy, throwWhenNoTransportPolicyMessage)
@@ -138,7 +138,7 @@ TEST(Policy, throwWhenNoTransportPolicyMessage)
 
   try
   {
-    pipeline.Send(request, Azure::Core::Context::GetApplicationContext());
+    pipeline.Send(request, Azure::Core::Context::ApplicationContext);
   }
   catch (const std::invalid_argument& ex)
   {
@@ -157,7 +157,7 @@ TEST(Policy, RetryPolicyCounter)
   retryCounterState = 0;
 
   // Check when there's no info about retry on the context
-  auto initialContext = Context::GetApplicationContext();
+  auto initialContext = Context::ApplicationContext;
   EXPECT_EQ(-1, RetryPolicy::GetRetryCount(initialContext));
 
   // Pipeline with retry test
@@ -194,7 +194,7 @@ TEST(Policy, RetryPolicyRetryCycle)
 
   HttpPipeline pipeline(policies);
   Request request(HttpMethod::Get, Url("url"));
-  pipeline.Send(request, Context::GetApplicationContext());
+  pipeline.Send(request, Context::ApplicationContext);
 }
 
 // Makes sure that the context tree is not corrupted/broken by some policy
@@ -219,7 +219,6 @@ TEST(Policy, RetryPolicyKeepContext)
 
   HttpPipeline pipeline(policies);
   Request request(HttpMethod::Get, Url("url"));
-  auto withValueContext
-      = Context::GetApplicationContext().WithValue(TheKey, std::string("TheValue"));
+  auto withValueContext = Context::ApplicationContext.WithValue(TheKey, std::string("TheValue"));
   pipeline.Send(request, withValueContext);
 }

--- a/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
@@ -29,7 +29,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Url host(AzureSdkHttpbinServer::Get());
 
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
     CheckBodyFromBuffer(*response, expectedResponseBodySize);
@@ -38,7 +38,7 @@ namespace Azure { namespace Core { namespace Test {
     request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
     // Add a header and send again. RawResponse should return that header in the body
     request.SetHeader("123", "456");
-    response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
     // header length is 6 (data) + 13 (formating) -> `    "123": "456"\r\n,`
     CheckBodyFromBuffer(*response, expectedResponseBodySize + 6 + 13);
@@ -49,7 +49,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Url host("http://mt3.google.com/generate_204");
 
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::NoContent);
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
     CheckBodyFromBuffer(*response, expectedResponseBodySize);
@@ -64,7 +64,7 @@ namespace Azure { namespace Core { namespace Test {
     // loop sending request
     for (auto i = 0; i < 50; i++)
     {
-      auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+      auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
       auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
       checkResponseCode(response->GetStatusCode());
       CheckBodyFromBuffer(*response, expectedResponseBodySize);
@@ -77,7 +77,7 @@ namespace Azure { namespace Core { namespace Test {
     auto expectedResponseBodySize = 0;
 
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Head, host);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
     CheckBodyFromBuffer(*response, expectedResponseBodySize);
 
@@ -95,7 +95,7 @@ namespace Azure { namespace Core { namespace Test {
     auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
 
@@ -111,7 +111,7 @@ namespace Azure { namespace Core { namespace Test {
     auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Delete, host, &bodyRequest);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
 
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
@@ -127,7 +127,7 @@ namespace Azure { namespace Core { namespace Test {
     auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Patch, host, &bodyRequest);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
 
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
@@ -146,7 +146,7 @@ namespace Azure { namespace Core { namespace Test {
         "sent to a client.</h5></body></html>");
 
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
 
     checkResponseCode(response->GetStatusCode());
     CheckBodyFromBuffer(*response, expectedResponseBodySize, expectedChunkResponse);
@@ -165,7 +165,7 @@ namespace Azure { namespace Core { namespace Test {
       auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
       auto request
           = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest);
-      auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+      auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     }
   }
 
@@ -178,7 +178,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Url host(AzureSdkHttpbinServer::Get());
 
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host, true);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
     CheckBodyFromStream(*response, expectedResponseBodySize);
@@ -186,7 +186,7 @@ namespace Azure { namespace Core { namespace Test {
     request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host, true);
     // Add a header and send again. Response should return that header in the body
     request.SetHeader("123", "456");
-    response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
     // header length is 6 (data) + 13 (formating) -> `    "123": "456"\r\n,`
     CheckBodyFromStream(*response, expectedResponseBodySize + 6 + 13);
@@ -201,7 +201,7 @@ namespace Azure { namespace Core { namespace Test {
     // loop sending request
     for (auto i = 0; i < 50; i++)
     {
-      auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+      auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
       auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
       checkResponseCode(response->GetStatusCode());
       CheckBodyFromStream(*response, expectedResponseBodySize);
@@ -214,7 +214,7 @@ namespace Azure { namespace Core { namespace Test {
     auto expectedResponseBodySize = 0;
 
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Head, host, true);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
     CheckBodyFromStream(*response, expectedResponseBodySize);
 
@@ -232,7 +232,7 @@ namespace Azure { namespace Core { namespace Test {
     auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest, true);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
 
@@ -248,7 +248,7 @@ namespace Azure { namespace Core { namespace Test {
     auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Delete, host, &bodyRequest, true);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
 
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
@@ -264,7 +264,7 @@ namespace Azure { namespace Core { namespace Test {
     auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Patch, host, &bodyRequest, true);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(response->GetStatusCode());
 
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
@@ -283,7 +283,7 @@ namespace Azure { namespace Core { namespace Test {
         "sent to a client.</h5></body></html>");
 
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host, true);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
 
     checkResponseCode(response->GetStatusCode());
     CheckBodyFromStream(*response, expectedResponseBodySize, expectedChunkResponse);
@@ -295,7 +295,7 @@ namespace Azure { namespace Core { namespace Test {
     std::string expectedType("This is the Response Type");
 
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host, false);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
 
     Azure::Response<std::string> responseT(expectedType, std::move(response));
     auto& r = responseT.RawResponse;
@@ -325,7 +325,7 @@ namespace Azure { namespace Core { namespace Test {
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest);
     // Make transport adapter to read all stream content for uploading instead of chunks
     {
-      auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+      auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
       checkResponseCode(response->GetStatusCode());
       auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
       CheckBodyFromBuffer(*response, expectedResponseBodySize);
@@ -342,7 +342,7 @@ namespace Azure { namespace Core { namespace Test {
     auto bodyRequest = Azure::Core::IO::MemoryBodyStream(requestBodyVector);
     auto request
         = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Put, host, &bodyRequest, true);
-    auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+    auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     checkResponseCode(
         response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::MethodNotAllowed);
     auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
@@ -404,7 +404,7 @@ namespace Azure { namespace Core { namespace Test {
 
     auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
     EXPECT_THROW(
-        m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+        m_pipeline->Send(request, Azure::Core::Context::ApplicationContext),
         Azure::Core::RequestFailedException);
   }
 
@@ -416,7 +416,7 @@ namespace Azure { namespace Core { namespace Test {
     // test dynamic cast
     try
     {
-      auto result = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+      auto result = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     }
     catch (Azure::Core::RequestFailedException& err)
     {
@@ -444,7 +444,7 @@ namespace Azure { namespace Core { namespace Test {
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Put, host, &requestBodyStream, true);
     {
-      auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+      auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
       checkResponseCode(response->GetStatusCode());
       auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
 
@@ -470,7 +470,7 @@ namespace Azure { namespace Core { namespace Test {
         Azure::Core::Http::HttpMethod::Put, host, &requestBodyStream, true);
     // Make transport adapter to read default chunk size
     {
-      auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+      auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
       checkResponseCode(response->GetStatusCode());
       auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
 
@@ -495,7 +495,7 @@ namespace Azure { namespace Core { namespace Test {
     auto request = Azure::Core::Http::Request(
         Azure::Core::Http::HttpMethod::Put, host, &requestBodyStream, true);
     {
-      auto response = m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext());
+      auto response = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
       checkResponseCode(response->GetStatusCode());
       auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
 
@@ -546,8 +546,7 @@ namespace Azure { namespace Core { namespace Test {
     auto body = response.ExtractBodyStream();
     EXPECT_NE(body, nullptr);
 
-    std::vector<uint8_t> bodyVector
-        = body->ReadToEnd(Azure::Core::Context::GetApplicationContext());
+    std::vector<uint8_t> bodyVector = body->ReadToEnd(Azure::Core::Context::ApplicationContext);
     int64_t bodySize = body->Length();
     EXPECT_EQ(bodySize, size);
     bodySize = bodyVector.size();

--- a/sdk/core/perf/README.md
+++ b/sdk/core/perf/README.md
@@ -152,7 +152,7 @@ int main(int argc, char** argv)
            }}};
 
   // Call the `Run` method with a context, the tests and the application arguments to launch the program.
-  Azure::Perf::Program::Run(Azure::Core::Context::GetApplicationContext(), tests, argc, argv);
+  Azure::Perf::Program::Run(Azure::Core::Context::ApplicationContext, tests, argc, argv);
 
   return 0;
 }

--- a/sdk/core/perf/test/src/main.cpp
+++ b/sdk/core/perf/test/src/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
   tests.emplace_back(Azure::Perf::Test::WinHttpClientGetTest::GetTestMetadata());
 #endif
 
-  Azure::Perf::Program::Run(Azure::Core::Context::GetApplicationContext(), tests, argc, argv);
+  Azure::Perf::Program::Run(Azure::Core::Context::ApplicationContext, tests, argc, argv);
 
   return 0;
 }

--- a/sdk/identity/azure-identity/test/live/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/test/live/client_secret_credential.cpp
@@ -15,7 +15,7 @@ TEST(ClientSecretCredential, Basic)
       GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
 
   auto const token = credential.GetToken(
-      {{"https://vault.azure.net/.default"}}, Azure::Core::Context::GetApplicationContext());
+      {{"https://vault.azure.net/.default"}}, Azure::Core::Context::ApplicationContext);
 
   EXPECT_FALSE(token.Token.empty());
   EXPECT_GE(token.ExpiresOn, std::chrono::system_clock::now());

--- a/sdk/identity/azure-identity/test/live/environment_credential.cpp
+++ b/sdk/identity/azure-identity/test/live/environment_credential.cpp
@@ -20,7 +20,7 @@ TEST(EnvironmentCredential, ClientSecret)
   Azure::Identity::EnvironmentCredential const credential;
 
   auto const token = credential.GetToken(
-      {{"https://vault.azure.net/.default"}}, Azure::Core::Context::GetApplicationContext());
+      {{"https://vault.azure.net/.default"}}, Azure::Core::Context::ApplicationContext);
 
   EXPECT_FALSE(token.Token.empty());
   EXPECT_GE(token.ExpiresOn, std::chrono::system_clock::now());

--- a/sdk/identity/azure-identity/test/perf/src/main.cpp
+++ b/sdk/identity/azure-identity/test/perf/src/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
   std::vector<Azure::Perf::TestMetadata> tests{
       Azure::Identity::Test::SecretCredentialTest::GetTestMetadata()};
 
-  Azure::Perf::Program::Run(Azure::Core::Context::GetApplicationContext(), tests, argc, argv);
+  Azure::Perf::Program::Run(Azure::Core::Context::ApplicationContext, tests, argc, argv);
 
   return 0;
 }

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
@@ -43,7 +43,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * deleted if querying /deletedkeys/keyName returns 200 from server. Or whenever soft-delete is
      * disabled.*/
     std::unique_ptr<Azure::Core::Http::RawResponse> PollInternal(
-        Azure::Core::Context& context) override;
+        Azure::Core::Context const& context) override;
 
     Azure::Response<Azure::Security::KeyVault::Keys::DeletedKey> PollUntilDoneInternal(
         std::chrono::milliseconds period,

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/recover_deleted_key_operation.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/recover_deleted_key_operation.hpp
@@ -40,7 +40,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
     std::string m_continuationToken;
 
     std::unique_ptr<Azure::Core::Http::RawResponse> PollInternal(
-        Azure::Core::Context& context) override;
+        Azure::Core::Context const& context) override;
 
     Azure::Response<Azure::Security::KeyVault::Keys::KeyVaultKey> PollUntilDoneInternal(
         std::chrono::milliseconds period,

--- a/sdk/keyvault/azure-security-keyvault-keys/src/delete_key_operation.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/delete_key_operation.cpp
@@ -13,7 +13,8 @@ using namespace Azure::Security::KeyVault::Keys;
 using namespace Azure::Security::KeyVault;
 
 std::unique_ptr<Azure::Core::Http::RawResponse>
-Azure::Security::KeyVault::Keys::DeleteKeyOperation::PollInternal(Azure::Core::Context& context)
+Azure::Security::KeyVault::Keys::DeleteKeyOperation::PollInternal(
+    Azure::Core::Context const& context)
 {
   std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse;
   if (!IsDone())

--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -220,9 +220,7 @@ Azure::Security::KeyVault::Keys::DeleteKeyOperation KeyClient::ResumeDeleteKey(
     Azure::Core::Context const& context) const
 {
   Azure::Security::KeyVault::Keys::DeleteKeyOperation operation(m_pipeline, resumeToken);
-  // Need to fix this to use context directly. See:
-  // https://github.com/Azure/azure-sdk-for-cpp/issues/2091
-  operation.Poll(context.GetApplicationContext());
+  operation.Poll(context);
   return operation;
 }
 
@@ -231,9 +229,7 @@ Azure::Security::KeyVault::Keys::RecoverDeletedKeyOperation KeyClient::ResumeRec
     Azure::Core::Context const& context) const
 {
   Azure::Security::KeyVault::Keys::RecoverDeletedKeyOperation operation(m_pipeline, resumeToken);
-  // Need to fix this to use context directly. See:
-  // https://github.com/Azure/azure-sdk-for-cpp/issues/2091
-  operation.Poll(context.GetApplicationContext());
+  operation.Poll(const_cast<Core::Context&>(context));
   return operation;
 }
 

--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -229,7 +229,7 @@ Azure::Security::KeyVault::Keys::RecoverDeletedKeyOperation KeyClient::ResumeRec
     Azure::Core::Context const& context) const
 {
   Azure::Security::KeyVault::Keys::RecoverDeletedKeyOperation operation(m_pipeline, resumeToken);
-  operation.Poll(const_cast<Core::Context&>(context));
+  operation.Poll(context);
   return operation;
 }
 

--- a/sdk/keyvault/azure-security-keyvault-keys/src/recover_deleted_key_operation.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/recover_deleted_key_operation.cpp
@@ -12,7 +12,7 @@ using namespace Azure::Security::KeyVault;
 
 std::unique_ptr<Azure::Core::Http::RawResponse>
 Azure::Security::KeyVault::Keys::RecoverDeletedKeyOperation::PollInternal(
-    Azure::Core::Context& context)
+    Azure::Core::Context const& context)
 {
   std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse;
   if (!IsDone())

--- a/sdk/keyvault/azure-security-keyvault-keys/test/perf/src/main.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/perf/src/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
   std::vector<Azure::Perf::TestMetadata> tests{
       Azure::Security::KeyVault::Keys::Test::GetKey::GetTestMetadata()};
 
-  Azure::Perf::Program::Run(Azure::Core::Context::GetApplicationContext(), tests, argc, argv);
+  Azure::Perf::Program::Run(Azure::Core::Context::ApplicationContext, tests, argc, argv);
 
   return 0;
 }

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_delete_test_live.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_delete_test_live.cpp
@@ -59,7 +59,7 @@ TEST_F(KeyVaultClientTest, DeleteKey)
     // Setting 3 min as timeout just because I like number 3. We just want to prevent test running
     // for so long if something happens and no exception is thrown (paranoid scenario)
     auto duration = std::chrono::system_clock::now() + std::chrono::minutes(3);
-    auto cancelToken = Azure::Core::Context::GetApplicationContext().WithDeadline(duration);
+    auto cancelToken = Azure::Core::Context::ApplicationContext.WithDeadline(duration);
 
     auto keyResponseLRO = keyClient.StartDeleteKey(keyName);
     auto expectedStatusToken = keyName;
@@ -146,7 +146,7 @@ TEST_F(KeyVaultClientTest, DoubleDelete)
   }
   {
     auto duration = std::chrono::system_clock::now() + std::chrono::minutes(3);
-    auto cancelToken = Azure::Core::Context::GetApplicationContext().WithDeadline(duration);
+    auto cancelToken = Azure::Core::Context::ApplicationContext.WithDeadline(duration);
     auto keyResponseLRO = keyClient.StartDeleteKey(keyName);
     auto keyResponse = keyResponseLRO.PollUntilDone(std::chrono::milliseconds(1000), cancelToken);
   }
@@ -220,7 +220,7 @@ TEST_F(KeyVaultClientTest, CreateDeletedKey)
   }
   {
     auto duration = std::chrono::system_clock::now() + std::chrono::minutes(3);
-    auto cancelToken = Azure::Core::Context::GetApplicationContext().WithDeadline(duration);
+    auto cancelToken = Azure::Core::Context::ApplicationContext.WithDeadline(duration);
     auto keyResponseLRO = keyClient.StartDeleteKey(keyName);
     auto keyResponse = keyResponseLRO.PollUntilDone(std::chrono::milliseconds(1000), cancelToken);
   }
@@ -301,7 +301,7 @@ TEST_F(KeyVaultClientTest, GetDeletedKey)
   {
     // Wait until key is deleted
     auto duration = std::chrono::system_clock::now() + std::chrono::minutes(3);
-    auto cancelToken = Azure::Core::Context::GetApplicationContext().WithDeadline(duration);
+    auto cancelToken = Azure::Core::Context::ApplicationContext.WithDeadline(duration);
 
     auto keyResponseLRO = keyClient.StartDeleteKey(keyName);
     auto expectedStatusToken = m_keyVaultUrl

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
@@ -194,7 +194,7 @@ namespace Azure { namespace Storage {
       }
 
       std::unique_ptr<Azure::Core::Http::RawResponse> PollInternal(
-          Azure::Core::Context& context) override;
+          Azure::Core::Context const& context) override;
 
       Azure::Response<Models::BlobProperties> PollUntilDoneInternal(
           std::chrono::milliseconds period,

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_responses.hpp
@@ -194,7 +194,7 @@ namespace Azure { namespace Storage {
       }
 
       std::unique_ptr<Azure::Core::Http::RawResponse> PollInternal(
-          Azure::Core::Context const& context) override;
+          const Azure::Core::Context& context) override;
 
       Azure::Response<Models::BlobProperties> PollUntilDoneInternal(
           std::chrono::milliseconds period,

--- a/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
@@ -11,7 +11,7 @@
 namespace Azure { namespace Storage { namespace Blobs {
 
   std::unique_ptr<Azure::Core::Http::RawResponse> StartBlobCopyOperation::PollInternal(
-      Azure::Core::Context&)
+      Azure::Core::Context const&)
   {
 
     auto response = m_blobClient->GetProperties();

--- a/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_responses.cpp
@@ -11,7 +11,7 @@
 namespace Azure { namespace Storage { namespace Blobs {
 
   std::unique_ptr<Azure::Core::Http::RawResponse> StartBlobCopyOperation::PollInternal(
-      Azure::Core::Context const&)
+      const Azure::Core::Context&)
   {
 
     auto response = m_blobClient->GetProperties();

--- a/sdk/storage/azure-storage-blobs/test/perf/src/main.cpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/src/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
   std::vector<Azure::Perf::TestMetadata> tests{
       Azure::Storage::Blobs::Test::DownloadBlob::GetTestMetadata()};
 
-  Azure::Perf::Program::Run(Azure::Core::Context::GetApplicationContext(), tests, argc, argv);
+  Azure::Perf::Program::Run(Azure::Core::Context::ApplicationContext, tests, argc, argv);
 
   return 0;
 }

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -170,7 +170,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
 
     std::unique_ptr<Azure::Core::Http::RawResponse> PollInternal(
-        Azure::Core::Context& context) override;
+        Azure::Core::Context const& context) override;
 
     Azure::Response<Models::FileProperties> PollUntilDoneInternal(
         std::chrono::milliseconds period,

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_responses.hpp
@@ -170,7 +170,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
 
     std::unique_ptr<Azure::Core::Http::RawResponse> PollInternal(
-        Azure::Core::Context const& context) override;
+        const Azure::Core::Context& context) override;
 
     Azure::Response<Models::FileProperties> PollUntilDoneInternal(
         std::chrono::milliseconds period,

--- a/sdk/storage/azure-storage-files-shares/src/share_responses.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_responses.cpp
@@ -11,7 +11,7 @@
 namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
   std::unique_ptr<Azure::Core::Http::RawResponse> StartFileCopyOperation::PollInternal(
-      Azure::Core::Context const&)
+      const Azure::Core::Context&)
   {
 
     auto response = m_fileClient->GetProperties();

--- a/sdk/storage/azure-storage-files-shares/src/share_responses.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_responses.cpp
@@ -11,7 +11,7 @@
 namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
   std::unique_ptr<Azure::Core::Http::RawResponse> StartFileCopyOperation::PollInternal(
-      Azure::Core::Context&)
+      Azure::Core::Context const&)
   {
 
     auto response = m_fileClient->GetProperties();


### PR DESCRIPTION
Closes #1881

Closes #2091 (an easy fix, and I touch the line which, if I update, generates warning that is treated as error, so given the fix is simple, it is easier to for me to fix it all together, rather than take measures to avoid the warning).

The main question is for @CaseyCarter and @BillyONeal : is it reasonably safe to use static data members in this manner?
It is probably tricky if the customer ever needs to initialize their static with our static, which may not get initialized before theirs.
But then if we absolutely avoid public static data members everywhere, our "extensible enum" patterns need to be changed as well - example (there are many others): https://github.com/Azure/azure-sdk-for-cpp/blob/63b2d21bc65a4348cad5fd69cecbe353f74b7120/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/protocol/datalake_rest_client.hpp#L109-L125

I think, we are reasonably fine. We should doc that customers should not use our SDK from global statics initialization, before main()? I do not think many would want to.