### PR TITLE
Return false when Context::TryGetValue has a type mismatch, rather than aborting.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -174,13 +174,10 @@ namespace Azure { namespace Core {
     {
       for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)
       {
-        if (ptr->Key == key)
+        // Only return true if we find a key-type pair that matches.
+        // Otherwise, keep looping through the context graph.
+        if (ptr->Key == key && typeid(T) != ptr->ValueType)
         {
-          if (typeid(T) != ptr->ValueType)
-          {
-            // type mismatch
-            return false;
-          }
           outputValue = *reinterpret_cast<const T*>(ptr->Value.get());
           return true;
         }

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -165,7 +165,8 @@ namespace Azure { namespace Core {
      * within the context tree.
      *
      * @return If found, returns `true`, with \p outputValue set to the value associated with the
-     * key found; otherwise returns `false`.
+     * key found; otherwise returns `false`, including when the key found is not of the expected
+     * type.
      *
      * @remark The \p outputValue is left unmodified it the \p key is not found.
      */
@@ -178,7 +179,7 @@ namespace Azure { namespace Core {
           if (typeid(T) != ptr->ValueType)
           {
             // type mismatch
-            std::abort();
+            return false;
           }
           outputValue = *reinterpret_cast<const T*>(ptr->Value.get());
           return true;

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -176,7 +176,7 @@ namespace Azure { namespace Core {
       {
         // Only return true if we find a key-type pair that matches.
         // Otherwise, keep looping through the context graph.
-        if (ptr->Key == key && typeid(T) != ptr->ValueType)
+        if (ptr->Key == key && typeid(T) == ptr->ValueType)
         {
           outputValue = *reinterpret_cast<const T*>(ptr->Value.get());
           return true;

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -88,6 +88,36 @@ TEST(Context, BasicChar)
   EXPECT_TRUE(value == str);
 }
 
+TEST(Context, KeyTypePair)
+{
+  Context context;
+  Context::Key const key;
+  Context::Key const keyNotFound;
+
+  std::string s("Test String");
+
+  // New context from previous
+  auto c2 = context.WithValue(key, 123);
+  auto c3 = c2.WithValue(key, s);
+
+  int intValue = -1;
+  std::string strValue = "previous value";
+
+  EXPECT_FALSE(c2.TryGetValue<std::string>(keyNotFound, strValue));
+  EXPECT_FALSE(c2.TryGetValue<int>(keyNotFound, intValue));
+
+  EXPECT_FALSE(c2.TryGetValue<std::string>(key, strValue));
+  EXPECT_TRUE(strValue == "previous value");
+  EXPECT_TRUE(c2.TryGetValue<int>(key, intValue));
+  EXPECT_TRUE(intValue == 123);
+
+  EXPECT_TRUE(c3.TryGetValue<int>(key, intValue));
+  EXPECT_TRUE(intValue == 123);
+
+  EXPECT_TRUE(c3.TryGetValue<std::string>(key, strValue));
+  EXPECT_TRUE(strValue == s);
+}
+
 TEST(Context, IsCancelled)
 {
   auto duration = std::chrono::milliseconds(250);


### PR DESCRIPTION
~Todo: Add unit tests~