### PR TITLE
Add transport layer unit tests with non-ascii host strings as input.

### DIFF
--- a/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
@@ -415,7 +415,7 @@ namespace Azure { namespace Core { namespace Test {
 
       auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
       EXPECT_THROW(
-          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          m_pipeline->Send(request, Azure::Core::Context::ApplicationContext),
           Azure::Core::Http::TransportException);
     }
     {
@@ -423,7 +423,7 @@ namespace Azure { namespace Core { namespace Test {
 
       auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
       EXPECT_THROW(
-          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          m_pipeline->Send(request, Azure::Core::Context::ApplicationContext),
           Azure::Core::Http::TransportException);
     }
     {
@@ -431,7 +431,7 @@ namespace Azure { namespace Core { namespace Test {
 
       auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
       EXPECT_THROW(
-          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          m_pipeline->Send(request, Azure::Core::Context::ApplicationContext),
           Azure::Core::Http::TransportException);
     }
     {
@@ -439,7 +439,7 @@ namespace Azure { namespace Core { namespace Test {
 
       auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
       EXPECT_THROW(
-          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          m_pipeline->Send(request, Azure::Core::Context::ApplicationContext),
           Azure::Core::Http::TransportException);
     }
   }
@@ -451,7 +451,7 @@ namespace Azure { namespace Core { namespace Test {
 
       auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
       EXPECT_THROW(
-          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          m_pipeline->Send(request, Azure::Core::Context::ApplicationContext),
           Azure::Core::Http::TransportException);
     }
     {
@@ -459,15 +459,15 @@ namespace Azure { namespace Core { namespace Test {
 
       auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
       EXPECT_THROW(
-          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          m_pipeline->Send(request, Azure::Core::Context::ApplicationContext),
           Azure::Core::Http::TransportException);
     }
     {
-      Azure::Core::Url host(u8"http://\xD800\x0100/get");
+      Azure::Core::Url host("http://\xD8\x00\x01\x00/get");
 
       auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
       EXPECT_THROW(
-          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          m_pipeline->Send(request, Azure::Core::Context::ApplicationContext),
           Azure::Core::Http::TransportException);
     }
   }

--- a/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base.cpp
@@ -408,6 +408,70 @@ namespace Azure { namespace Core { namespace Test {
         Azure::Core::RequestFailedException);
   }
 
+  TEST_P(TransportAdapter, validNonAsciiHost)
+  {
+    {
+      Azure::Core::Url host(u8"http://unresolvedHost\u6F22\u5B57.org/get");
+
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      EXPECT_THROW(
+          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          Azure::Core::Http::TransportException);
+    }
+    {
+      Azure::Core::Url host("http://unresolvedHost\xE9\x87\x91.org/get");
+
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      EXPECT_THROW(
+          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          Azure::Core::Http::TransportException);
+    }
+    {
+      Azure::Core::Url host(u8"http://unresolvedHost\uC328.org/get");
+
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      EXPECT_THROW(
+          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          Azure::Core::Http::TransportException);
+    }
+    {
+      Azure::Core::Url host("http://\0/get");
+
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      EXPECT_THROW(
+          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          Azure::Core::Http::TransportException);
+    }
+  }
+
+  TEST_P(TransportAdapter, invalidNonAsciiHost)
+  {
+    {
+      Azure::Core::Url host("http://unresolvedHost\xC0\x41\x42\xFE\xFE\xFF\xFF.org/get");
+
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      EXPECT_THROW(
+          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          Azure::Core::Http::TransportException);
+    }
+    {
+      Azure::Core::Url host("http://\xC0\x76\x77/get");
+
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      EXPECT_THROW(
+          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          Azure::Core::Http::TransportException);
+    }
+    {
+      Azure::Core::Url host(u8"http://\xD800\x0100/get");
+
+      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, host);
+      EXPECT_THROW(
+          m_pipeline->Send(request, Azure::Core::Context::GetApplicationContext()),
+          Azure::Core::Http::TransportException);
+    }
+  }
+
   TEST_P(TransportAdapter, dynamicCast)
   {
     Azure::Core::Url host("http://unresolvedHost.org/get");


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/1120