### PR TITLE
Remove exposing windows.h header from our public headers within storage.

### DIFF
--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/file_io.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/file_io.hpp
@@ -5,16 +5,6 @@
 
 #include <azure/core/platform.hpp>
 
-#if defined(AZ_PLATFORM_WINDOWS)
-#if !defined(WIN32_LEAN_AND_MEAN)
-#define WIN32_LEAN_AND_MEAN
-#endif
-#if !defined(NOMINMAX)
-#define NOMINMAX
-#endif
-#include <windows.h>
-#endif
-
 #include <cstdint>
 #include <string>
 

--- a/sdk/storage/azure-storage-common/src/file_io.cpp
+++ b/sdk/storage/azure-storage-common/src/file_io.cpp
@@ -12,6 +12,16 @@
 #include <unistd.h>
 #endif
 
+#if defined(AZ_PLATFORM_WINDOWS)
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
 #include <codecvt>
 #include <limits>
 #include <locale>

--- a/sdk/storage/azure-storage-common/src/file_io.cpp
+++ b/sdk/storage/azure-storage-common/src/file_io.cpp
@@ -12,16 +12,6 @@
 #include <unistd.h>
 #endif
 
-#if defined(AZ_PLATFORM_WINDOWS)
-#if !defined(WIN32_LEAN_AND_MEAN)
-#define WIN32_LEAN_AND_MEAN
-#endif
-#if !defined(NOMINMAX)
-#define NOMINMAX
-#endif
-#include <windows.h>
-#endif
-
 #include <codecvt>
 #include <limits>
 #include <locale>


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-cpp/pull/2188, fixes https://github.com/Azure/azure-sdk-for-cpp/issues/2182