### PR TITLE
Rename IsBufferedDownload to ShouldBufferResponse to avoid using a storage specific verb in general purpose Request object.

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Breaking Changes
 
 - Removed `Context::GetApplicationContext()` in favor of a new static data member `Context::ApplicationContext`.
-- Renamed `Request::IsDownloadViaStream()` to `IsBufferedDownload()`.
+- Renamed `Request::IsDownloadViaStream()` to `ShouldBufferResponse()`.
 
 ### Bug Fixes
 

--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -131,7 +131,7 @@ namespace Azure { namespace Core { namespace Http {
 
     // flag to know where to insert header
     bool m_retryModeEnabled{false};
-    bool m_isBufferedDownload{true};
+    bool m_shouldBufferResponse{true};
 
     // Expected to be called by a Retry policy to reset all headers set after this function was
     // previously called
@@ -144,16 +144,16 @@ namespace Azure { namespace Core { namespace Http {
      * @param httpMethod HTTP method.
      * @param url URL.
      * @param bodyStream #Azure::Core::IO::BodyStream.
-     * @param bufferedDownload A boolean value indicating whether download should use a buffer
-     * for the response or return a body stream instead.
+     * @param shouldBufferResponse A boolean value indicating whether the returned response should
+     * be buffered or returned as a body stream instead.
      */
     explicit Request(
         HttpMethod httpMethod,
         Url url,
         Azure::Core::IO::BodyStream* bodyStream,
-        bool bufferedDownload)
+        bool shouldBufferResponse)
         : m_method(std::move(httpMethod)), m_url(std::move(url)), m_bodyStream(bodyStream),
-          m_retryModeEnabled(false), m_isBufferedDownload(bufferedDownload)
+          m_retryModeEnabled(false), m_shouldBufferResponse(shouldBufferResponse)
     {
     }
 
@@ -174,10 +174,10 @@ namespace Azure { namespace Core { namespace Http {
      *
      * @param httpMethod HTTP method.
      * @param url URL.
-     * @param bufferedDownload A boolean value indicating whether download should use a buffer
-     * for the response or return a body stream instead.
+     * @param shouldBufferResponse A boolean value indicating whether the returned response should
+     * be buffered or returned as a body stream instead.
      */
-    explicit Request(HttpMethod httpMethod, Url url, bool bufferedDownload);
+    explicit Request(HttpMethod httpMethod, Url url, bool shouldBufferResponse);
 
     /**
      * @brief Construct an #Azure::Core::Http::Request.
@@ -224,10 +224,10 @@ namespace Azure { namespace Core { namespace Http {
     Azure::Core::IO::BodyStream* GetBodyStream() { return this->m_bodyStream; }
 
     /**
-     * @brief A value indicating whether download will return the raw response within a memory
-     * buffer or if it will provide a body stream instead.
+     * @brief A value indicating whether the returned raw response for this request will be buffered
+     * within a memory buffer or if it will be returned as a body stream instead.
      */
-    bool IsBufferedDownload() { return this->m_isBufferedDownload; }
+    bool ShouldBufferResponse() { return this->m_shouldBufferResponse; }
 
     /**
      * @brief Get URL.

--- a/sdk/core/azure-core/src/http/http.cpp
+++ b/sdk/core/azure-core/src/http/http.cpp
@@ -176,8 +176,8 @@ void Azure::Core::Http::_detail::RawResponseHelpers::InsertHeaderWithValidation(
   headers[headerName] = headerValue;
 }
 
-Request::Request(HttpMethod httpMethod, Url url, bool bufferedDownload)
-    : Request(httpMethod, std::move(url), NullBodyStream::GetNullBodyStream(), bufferedDownload)
+Request::Request(HttpMethod httpMethod, Url url, bool shouldBufferResponse)
+    : Request(httpMethod, std::move(url), NullBodyStream::GetNullBodyStream(), shouldBufferResponse)
 {
 }
 

--- a/sdk/core/azure-core/src/http/transport_policy.cpp
+++ b/sdk/core/azure-core/src/http/transport_policy.cpp
@@ -51,8 +51,8 @@ std::unique_ptr<RawResponse> TransportPolicy::Send(
    * - If ReadToEnd() fails while downloading all the response, the retry policy will make sure to
    * re-send the request to re-start the download.
    *
-   * - If the request returns error (statusCode >= 300), even if `request.IsBufferedDownload()`, the
-   * response will be download to the response's buffer.
+   * - If the request returns error (statusCode >= 300), even if `request.ShouldBufferResponse()`,
+   *the response will be download to the response's buffer.
    *
    ***********************************************************************************
    *
@@ -63,13 +63,13 @@ std::unique_ptr<RawResponse> TransportPolicy::Send(
 
   // special case to return a response with BodyStream to read directly from socket
   // Return only if response did not fail.
-  if (!request.IsBufferedDownload() && statusCode < 300)
+  if (!request.ShouldBufferResponse() && statusCode < 300)
   {
     return response;
   }
 
-  // At this point, either the request is `bufferedDownload` or it return with an error code. The
-  // entire payload needs must be downloaded to the response's buffer.
+  // At this point, either the request is `shouldBufferResponse` or it return with an error code.
+  // The entire payload needs must be downloaded to the response's buffer.
   auto bodyStream = response->ExtractBodyStream();
   response->SetBody(bodyStream->ReadToEnd(ctx));
 


### PR DESCRIPTION
Follow-up to https://github.com/Azure/azure-sdk-for-cpp/pull/2196#discussion_r627003594

"Download" is just one particular use case of buffering a raw response rather than streaming it, and it's specific to storage. The API name within core should be agnostic of how it just happens to be used today.