### PR TITLE
Add final specifier

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/base64.hpp
+++ b/sdk/core/azure-core/inc/azure/core/base64.hpp
@@ -18,7 +18,7 @@ namespace Azure { namespace Core {
    *@brief Used to convert one form of data  into another, for example encoding binary data into
    *base 64 text.
    */
-  class Convert {
+  class Convert final {
   private:
     // This type currently only contains static methods and hence disallowing instance creation.
     Convert() = default;

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -25,7 +25,7 @@ namespace Azure { namespace Core {
    * @brief An exception that gets thrown when some operation is cancelled.
    *
    */
-  class OperationCancelledException : public std::runtime_error {
+  class OperationCancelledException final : public std::runtime_error {
   public:
     /**
      * @brief Construct with message string as description.
@@ -40,7 +40,7 @@ namespace Azure { namespace Core {
   /**
    * @brief A context is a node within a tree that represents deadlines and key/value pairs.
    */
-  class Context {
+  class Context final {
   public:
     /**
      * @brief A context key.
@@ -60,7 +60,7 @@ namespace Azure { namespace Core {
     };
 
   private:
-    struct ContextSharedState
+    struct ContextSharedState final
     {
       std::shared_ptr<ContextSharedState> Parent;
       std::atomic<DateTime::rep> Deadline;

--- a/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
+++ b/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
@@ -23,7 +23,7 @@ namespace Azure { namespace Core { namespace Credentials {
   /**
    * @brief Represents an access token.
    */
-  struct AccessToken
+  struct AccessToken final
   {
     /**
      * @brief Token string.
@@ -39,7 +39,7 @@ namespace Azure { namespace Core { namespace Credentials {
   /**
    * @brief Defines context for getting token.
    */
-  struct TokenRequestContext
+  struct TokenRequestContext final
   {
     /**
      * @brief Authentication scopes.
@@ -77,7 +77,7 @@ namespace Azure { namespace Core { namespace Credentials {
   /**
    * @brief An exception that gets thrown when authentication error occurs.
    */
-  class AuthenticationException : public std::exception {
+  class AuthenticationException final : public std::exception {
     std::string m_message;
 
   public:
@@ -93,6 +93,6 @@ namespace Azure { namespace Core { namespace Credentials {
      *
      * @return C string with explanatory information.
      */
-    char const* what() const noexcept override { return m_message.c_str(); }
+    char const* what() const noexcept final { return m_message.c_str(); }
   };
 }}} // namespace Azure::Core::Credentials

--- a/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
+++ b/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
@@ -93,6 +93,6 @@ namespace Azure { namespace Core { namespace Credentials {
      *
      * @return C string with explanatory information.
      */
-    char const* what() const noexcept final { return m_message.c_str(); }
+    char const* what() const noexcept override { return m_message.c_str(); }
   };
 }}} // namespace Azure::Core::Credentials

--- a/sdk/core/azure-core/inc/azure/core/cryptography/hash.hpp
+++ b/sdk/core/azure-core/inc/azure/core/cryptography/hash.hpp
@@ -122,7 +122,7 @@ namespace Azure { namespace Core { namespace Cryptography {
    * @brief Represents the class for the MD5 hash function which maps binary data of an arbitrary
    * length to small binary data of a fixed length.
    */
-  class Md5Hash : public Hash {
+  class Md5Hash final : public Hash {
 
   public:
     /**

--- a/sdk/core/azure-core/inc/azure/core/datetime.hpp
+++ b/sdk/core/azure-core/inc/azure/core/datetime.hpp
@@ -17,7 +17,7 @@
 namespace Azure {
 
 namespace _detail {
-  class Clock {
+  class Clock final {
   public:
     using rep = int64_t;
     using period = std::ratio<1, 10000000>;
@@ -51,7 +51,7 @@ namespace _detail {
  * for the date range and precision.
  * @remark This class is supposed to be able to handle a DateTime that comes over the wire.
  */
-class DateTime : public _detail::Clock::time_point {
+class DateTime final : public _detail::Clock::time_point {
 
 private:
   AZ_CORE_DLLEXPORT static DateTime const SystemClockEpoch;

--- a/sdk/core/azure-core/inc/azure/core/diagnostics/logger.hpp
+++ b/sdk/core/azure-core/inc/azure/core/diagnostics/logger.hpp
@@ -16,7 +16,7 @@ namespace Azure { namespace Core { namespace Diagnostics {
   /**
    * @brief Log message handler.
    */
-  class Logger {
+  class Logger final {
   public:
     /**
      * @brief Log message level.

--- a/sdk/core/azure-core/inc/azure/core/etag.hpp
+++ b/sdk/core/azure-core/inc/azure/core/etag.hpp
@@ -18,7 +18,7 @@ namespace Azure {
 /**
  * @brief Represents an HTTP validator.
  */
-class ETag {
+class ETag final {
   // ETag is a validator based on https://tools.ietf.org/html/rfc7232#section-2.3.2
 private:
   Azure::Nullable<std::string> m_value;

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -21,7 +21,7 @@ namespace Azure { namespace Core { namespace Http {
    * https://curl.haxx.se/libcurl/c/CURLOPT_SSL_OPTIONS.html
    *
    */
-  struct CurlTransportSslOptions
+  struct CurlTransportSslOptions final
   {
     /**
      * @brief This option can enable the revocation list check.
@@ -38,7 +38,7 @@ namespace Azure { namespace Core { namespace Http {
    * @brief Set the curl connection options like a proxy and CA path.
    *
    */
-  struct CurlTransportOptions
+  struct CurlTransportOptions final
   {
     /**
      * @brief The string for the proxy is passed directly to the libcurl handle without any parsing
@@ -95,7 +95,7 @@ namespace Azure { namespace Core { namespace Http {
    * @brief Concrete implementation of an HTTP Transport that uses libcurl.
    *
    */
-  class CurlTransport : public HttpTransport {
+  class CurlTransport final : public HttpTransport {
   private:
     CurlTransportOptions m_options;
 

--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -53,7 +53,7 @@ namespace Azure { namespace Core { namespace Http {
   /**
    * @brief HTTP transport layer error.
    */
-  class TransportException : public Azure::Core::RequestFailedException {
+  class TransportException final : public Azure::Core::RequestFailedException {
   public:
     /**
      * @brief An error while sending the HTTP request with the transport adapter.
@@ -74,7 +74,7 @@ namespace Azure { namespace Core { namespace Http {
    * `Offset + Length - 1` inclusively.
    *
    */
-  struct HttpRange
+  struct HttpRange final
   {
     /**
      * @brief The starting point of the HTTP Range.
@@ -92,7 +92,7 @@ namespace Azure { namespace Core { namespace Http {
   /**
    * HTTP request method.
    */
-  class HttpMethod {
+  class HttpMethod final {
   public:
     HttpMethod() = delete;
     explicit HttpMethod(std::string value) : m_value(std::move(value)) {}
@@ -118,7 +118,7 @@ namespace Azure { namespace Core { namespace Http {
   /**
    * @brief HTTP request.
    */
-  class Request {
+  class Request final {
     friend class Azure::Core::Http::Policies::_internal::RetryPolicy;
 #if defined(TESTING_BUILD)
     // make tests classes friends to validate set Retry
@@ -258,7 +258,7 @@ namespace Azure { namespace Core { namespace Http {
   };
 
   namespace _detail {
-    struct RawResponseHelpers
+    struct RawResponseHelpers final
     {
       /**
        * @brief Insert a header into \p headers checking that \p headerName does not contain invalid
@@ -308,7 +308,7 @@ namespace Azure { namespace Core { namespace Http {
 
   namespace _internal {
 
-    struct HttpShared
+    struct HttpShared final
     {
       AZ_CORE_DLLEXPORT static char const ContentType[];
       AZ_CORE_DLLEXPORT static char const ApplicationJson[];

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -37,7 +37,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
    * @brief Telemetry options.
    *
    */
-  struct TelemetryOptions
+  struct TelemetryOptions final
   {
     /**
      * @brief The Application ID is the last part of the user agent for telemetry.
@@ -52,7 +52,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
   /**
    * @brief Retry options.
    */
-  struct RetryOptions
+  struct RetryOptions final
   {
     /**
      * @brief Maximum number of attempts to retry.
@@ -84,7 +84,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
   /**
    * @brief Log options.
    */
-  struct LogOptions
+  struct LogOptions final
   {
     /**
      * @brief HTTP query parameters that are allowed to be logged.
@@ -101,7 +101,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
    * @brief Transport options.
    *
    */
-  struct TransportOptions
+  struct TransportOptions final
   {
     /**
      * @brief Set the #Azure::Core::Http::HttpTransport that the transport policy will use to send
@@ -165,7 +165,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
    * @brief Represents the next HTTP policy in the stack sequence of policies.
    *
    */
-  class NextHttpPolicy {
+  class NextHttpPolicy final {
     const std::size_t m_index;
     const std::vector<std::unique_ptr<HttpPolicy>>& m_policies;
 
@@ -203,7 +203,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * @brief Applying this policy sends an HTTP request over the wire.
      * @remark This policy must be the bottom policy in the stack of the HTTP policy stack.
      */
-    class TransportPolicy : public HttpPolicy {
+    class TransportPolicy final : public HttpPolicy {
     private:
       TransportOptions m_options;
 
@@ -232,7 +232,11 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     /**
      * @brief HTTP retry policy.
      */
-    class RetryPolicy : public HttpPolicy {
+    class RetryPolicy
+#if !defined(TESTING_BUILD)
+        final
+#endif
+        : public HttpPolicy {
     private:
       RetryOptions m_retryOptions;
 
@@ -252,7 +256,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
       std::unique_ptr<RawResponse> Send(
           Request& request,
           NextHttpPolicy nextHttpPolicy,
-          Context const& ctx) const override;
+          Context const& ctx) const final;
 
       /**
        * @brief Get the Retry Count from the context.
@@ -288,7 +292,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * @details Applies an HTTP header with a unique ID to each HTTP request, so that each
      * individual request can be traced for troubleshooting.
      */
-    class RequestIdPolicy : public HttpPolicy {
+    class RequestIdPolicy final : public HttpPolicy {
     private:
       constexpr static const char* RequestIdHeader = "x-ms-client-request-id";
 
@@ -322,7 +326,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * includes Azure SDK version information, and operating system information.
      * @remark See https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy.
      */
-    class TelemetryPolicy : public HttpPolicy {
+    class TelemetryPolicy final : public HttpPolicy {
     private:
       std::string const m_telemetryId;
 
@@ -361,7 +365,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     /**
      * @brief Bearer Token authentication policy.
      */
-    class BearerTokenAuthenticationPolicy : public HttpPolicy {
+    class BearerTokenAuthenticationPolicy final : public HttpPolicy {
     private:
       std::shared_ptr<Credentials::TokenCredential const> const m_credential;
       Credentials::TokenRequestContext m_tokenRequestContext;
@@ -405,7 +409,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * @details Logs every HTTP request and response.
      * @remark See Azure::Core::Diagnostics::Logger.
      */
-    class LogPolicy : public HttpPolicy {
+    class LogPolicy final : public HttpPolicy {
       LogOptions m_options;
 
     public:

--- a/sdk/core/azure-core/inc/azure/core/http/raw_response.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/raw_response.hpp
@@ -20,7 +20,7 @@ namespace Azure { namespace Core { namespace Http {
   /**
    * @brief Raw HTTP response.
    */
-  class RawResponse {
+  class RawResponse final {
 
   private:
     int32_t m_majorVersion;

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -35,7 +35,7 @@ namespace Azure { namespace Core { namespace Http {
     constexpr static int64_t DefaultUploadChunkSize = 1024 * 64;
     constexpr static int64_t MaximumUploadChunkSize = 1024 * 1024;
 
-    struct HandleManager
+    struct HandleManager final
     {
       Context const& m_context;
       Request& m_request;
@@ -75,7 +75,7 @@ namespace Azure { namespace Core { namespace Http {
       }
     };
 
-    class WinHttpStream : public Azure::Core::IO::BodyStream {
+    class WinHttpStream final : public Azure::Core::IO::BodyStream {
     private:
       std::unique_ptr<HandleManager> m_handleManager;
       bool m_isEOF;
@@ -127,7 +127,7 @@ namespace Azure { namespace Core { namespace Http {
    * transport.
    *
    */
-  struct WinHttpTransportOptions
+  struct WinHttpTransportOptions final
   {
     // Empty struct reserved for future options.
   };
@@ -137,7 +137,7 @@ namespace Azure { namespace Core { namespace Http {
    * receiving requests and responses over the wire.
    *
    */
-  class WinHttpTransport : public HttpTransport {
+  class WinHttpTransport final : public HttpTransport {
   private:
     WinHttpTransportOptions m_options;
 

--- a/sdk/core/azure-core/inc/azure/core/internal/client_options.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/client_options.hpp
@@ -24,6 +24,7 @@ namespace Azure { namespace Core { namespace _internal {
    */
   struct ClientOptions
   {
+    virtual ~ClientOptions() = default;
 
     /**
      * @brief Define policies to be called one time for every Http request from an sdk client.

--- a/sdk/core/azure-core/inc/azure/core/internal/diagnostics/log.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/diagnostics/log.hpp
@@ -10,7 +10,7 @@
 #include <type_traits>
 
 namespace Azure { namespace Core { namespace Diagnostics { namespace _internal {
-  class Log {
+  class Log final {
     using LogLevelInt = std::underlying_type<Logger::Level>::type;
 
     static_assert(

--- a/sdk/core/azure-core/inc/azure/core/internal/http/pipeline.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/http/pipeline.hpp
@@ -29,7 +29,7 @@ namespace Azure { namespace Core { namespace Http { namespace _internal {
    *
    * @remark See #policy.hpp
    */
-  class HttpPipeline {
+  class HttpPipeline final {
   protected:
     std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> m_policies;
 

--- a/sdk/core/azure-core/inc/azure/core/internal/io/null_body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/io/null_body_stream.hpp
@@ -16,7 +16,7 @@ namespace Azure { namespace Core { namespace IO { namespace _internal {
    * @brief Empty #Azure::Core::IO::BodyStream.
    * @remark Used for requests with no body.
    */
-  class NullBodyStream : public BodyStream {
+  class NullBodyStream final : public BodyStream {
   private:
     int64_t OnRead(uint8_t* buffer, int64_t count, Azure::Core::Context const& context) override
     {

--- a/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
@@ -21,7 +21,7 @@ namespace Azure { namespace Core { namespace Json { namespace _internal {
    * @brief Define a wrapper for working with Json containing optional fields.
    *
    */
-  struct JsonOptional
+  struct JsonOptional final
   {
     /**
      * @brief If the optional key \p key is present in the json node \p jsonKey set the value of \p

--- a/sdk/core/azure-core/inc/azure/core/internal/strings.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/strings.hpp
@@ -18,9 +18,9 @@ namespace Azure { namespace Core { namespace _internal {
    * operations.
    *
    */
-  struct StringExtensions
+  struct StringExtensions final
   {
-    struct CaseInsensitiveComparator
+    struct CaseInsensitiveComparator final
     {
       bool operator()(const std::string& lhs, const std::string& rhs) const
       {

--- a/sdk/core/azure-core/inc/azure/core/io/body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/io/body_stream.hpp
@@ -114,7 +114,7 @@ namespace Azure { namespace Core { namespace IO {
   /**
    * @brief #Azure::Core::IO::BodyStream providing data from an initialized memory buffer.
    */
-  class MemoryBodyStream : public BodyStream {
+  class MemoryBodyStream final : public BodyStream {
   private:
     const uint8_t* m_data;
     int64_t m_length;
@@ -157,7 +157,7 @@ namespace Azure { namespace Core { namespace IO {
      * @brief A concrete implementation of  #Azure::Core::IO::BodyStream used for reading data from
      * a file from any offset and length within it.
      */
-    class RandomAccessFileBodyStream : public BodyStream {
+    class RandomAccessFileBodyStream final : public BodyStream {
     private:
       // immutable
 #if defined(AZ_PLATFORM_POSIX)
@@ -234,7 +234,7 @@ namespace Azure { namespace Core { namespace IO {
    * @brief A concrete implementation of #Azure::Core::IO::BodyStream used for reading data from a
    * file.
    */
-  class FileBodyStream : public BodyStream {
+  class FileBodyStream final : public BodyStream {
   private:
     // immutable
 #if defined(AZ_PLATFORM_WINDOWS)

--- a/sdk/core/azure-core/inc/azure/core/match_conditions.hpp
+++ b/sdk/core/azure-core/inc/azure/core/match_conditions.hpp
@@ -19,6 +19,8 @@ namespace Azure {
  */
 struct MatchConditions
 {
+  virtual ~MatchConditions() = default;
+
   /**
    * @brief Optionally limit requests to resources that match the value specified.
    */

--- a/sdk/core/azure-core/inc/azure/core/modified_conditions.hpp
+++ b/sdk/core/azure-core/inc/azure/core/modified_conditions.hpp
@@ -20,6 +20,8 @@ namespace Azure {
  */
 struct ModifiedConditions
 {
+  virtual ~ModifiedConditions() = default;
+
   /**
    * @brief Optionally limit requests to resources that have only been modified since this point
    * in time.

--- a/sdk/core/azure-core/inc/azure/core/nullable.hpp
+++ b/sdk/core/azure-core/inc/azure/core/nullable.hpp
@@ -16,7 +16,7 @@
 
 namespace Azure {
 namespace _detail {
-  struct NontrivialEmptyType
+  struct NontrivialEmptyType final
   {
     constexpr NontrivialEmptyType() noexcept {}
   };
@@ -27,7 +27,7 @@ namespace _detail {
  *
  * @tparam T A type to represent contained values.
  */
-template <class T> class Nullable {
+template <class T> class Nullable final {
   union
   {
     _detail::NontrivialEmptyType m_disengaged; // due to constexpr rules for the default constructor

--- a/sdk/core/azure-core/inc/azure/core/operation_status.hpp
+++ b/sdk/core/azure-core/inc/azure/core/operation_status.hpp
@@ -21,7 +21,7 @@ namespace Azure { namespace Core {
   /**
    * @brief Long-running operation states.
    */
-  class OperationStatus {
+  class OperationStatus final {
     std::string m_value;
 
   public:

--- a/sdk/core/azure-core/inc/azure/core/paged_response.hpp
+++ b/sdk/core/azure-core/inc/azure/core/paged_response.hpp
@@ -40,6 +40,8 @@ namespace Azure { namespace Core {
     PagedResponse& operator=(PagedResponse&&) = default;
 
   public:
+    virtual ~PagedResponse() = default;
+
     /**
      * @brief Defines the token used to fetch the current page.
      *

--- a/sdk/core/azure-core/inc/azure/core/response.hpp
+++ b/sdk/core/azure-core/inc/azure/core/response.hpp
@@ -22,7 +22,7 @@ namespace Azure {
  *
  * @tparam T A specific type of value to get from the raw HTTP response.
  */
-template <class T> class Response {
+template <class T> class Response final {
 
 public:
   /// The value returned by the service.

--- a/sdk/core/azure-core/inc/azure/core/url.hpp
+++ b/sdk/core/azure-core/inc/azure/core/url.hpp
@@ -43,7 +43,7 @@ namespace Azure { namespace Core {
    * It can be parsed and initialized from a string that contains all URL components (scheme, host,
    * path, etc.). Authority is not currently supported.
    */
-  class Url {
+  class Url final {
   private:
     std::string m_scheme;
     std::string m_host;

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -24,7 +24,7 @@ namespace Azure { namespace Core {
   /**
    * @brief Universally unique identifier.
    */
-  class Uuid {
+  class Uuid final {
 
   private:
     static constexpr int UuidSize = 16;

--- a/sdk/core/azure-core/src/cryptography/md5.cpp
+++ b/sdk/core/azure-core/src/cryptography/md5.cpp
@@ -20,7 +20,7 @@ namespace {
 
 #if defined(AZ_PLATFORM_WINDOWS)
 
-class Md5AlgorithmProvider {
+class Md5AlgorithmProvider final {
 private:
   // Make sure the initial state of status is non-successful
   NTSTATUS m_status = 0;
@@ -86,7 +86,7 @@ Md5AlgorithmProvider const& GetMD5AlgorithmProvider()
   return instance;
 }
 
-class Md5BCrypt : public Azure::Core::Cryptography::Hash {
+class Md5BCrypt final : public Azure::Core::Cryptography::Hash {
 private:
   // Make sure the initial state of status is non-successful
   NTSTATUS m_status = 0;
@@ -159,7 +159,7 @@ Azure::Core::Cryptography::Md5Hash::Md5Hash() : m_implementation(std::make_uniqu
 
 #elif defined(AZ_PLATFORM_POSIX)
 
-class Md5OpenSSL : public Azure::Core::Cryptography::Hash {
+class Md5OpenSSL final : public Azure::Core::Cryptography::Hash {
 private:
   std::unique_ptr<MD5_CTX> m_context;
 

--- a/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
@@ -40,7 +40,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
    * This pool offers static methods and it is allocated statically. There can be only one
    * connection pool per application.
    */
-  class CurlConnectionPool {
+  class CurlConnectionPool final {
 #if defined(TESTING_BUILD)
     // Give access to private to this tests class
     friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;

--- a/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
@@ -106,7 +106,7 @@ namespace Azure { namespace Core { namespace Http {
   /**
    * @brief CURL HTTP connection.
    */
-  class CurlConnection : public CurlNetworkConnection {
+  class CurlConnection final : public CurlNetworkConnection {
   private:
     CURL* m_handle;
     curl_socket_t m_curlSocket;

--- a/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
@@ -39,7 +39,7 @@ namespace Azure { namespace Core { namespace Http {
    * @remarks This component is expected to be used by an HTTP Transporter to ensure that
    * transporter to be reusable in multiple pipelines while every call to network is unique.
    */
-  class CurlSession : public Azure::Core::IO::BodyStream {
+  class CurlSession final : public Azure::Core::IO::BodyStream {
 #ifdef TESTING_BUILD
     // Give access to private to this tests class
     friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
@@ -98,7 +98,7 @@ namespace Azure { namespace Core { namespace Http {
      * component. A libcurl session will use this component to build and return the HTTP
      * RawResponse with a body stream to the pipeline.
      */
-    class ResponseBufferParser {
+    class ResponseBufferParser final {
     private:
       /**
        * @brief Controls what the parser is expecting during the reading process

--- a/sdk/core/azure-core/src/http/telemetry_policy.cpp
+++ b/sdk/core/azure-core/src/http/telemetry_policy.cpp
@@ -25,7 +25,7 @@ namespace Azure { namespace Core { namespace _internal {
   /**
    * @brief HkeyHolder ensures native handle resource is released.
    */
-  class HkeyHolder {
+  class HkeyHolder final {
   private:
     HKEY m_value = nullptr;
 

--- a/sdk/core/azure-core/src/private/curl_connection.hpp
+++ b/sdk/core/azure-core/src/private/curl_connection.hpp
@@ -106,7 +106,7 @@ namespace Azure { namespace Core { namespace Http {
   /**
    * @brief CURL HTTP connection.
    */
-  class CurlConnection : public CurlNetworkConnection {
+  class CurlConnection final : public CurlNetworkConnection {
   private:
     CURL* m_handle;
     curl_socket_t m_curlSocket;

--- a/sdk/core/azure-core/src/private/curl_connection_pool.hpp
+++ b/sdk/core/azure-core/src/private/curl_connection_pool.hpp
@@ -40,7 +40,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
    * This pool offers static methods and it is allocated statically. There can be only one
    * connection pool per application.
    */
-  class CurlConnectionPool {
+  class CurlConnectionPool final {
 #if defined(TESTING_BUILD)
     // Give access to private to this tests class
     friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;

--- a/sdk/core/azure-core/src/private/curl_session.hpp
+++ b/sdk/core/azure-core/src/private/curl_session.hpp
@@ -39,7 +39,7 @@ namespace Azure { namespace Core { namespace Http {
    * @remarks This component is expected to be used by an HTTP Transporter to ensure that
    * transporter to be reusable in multiple pipelines while every call to network is unique.
    */
-  class CurlSession : public Azure::Core::IO::BodyStream {
+  class CurlSession final : public Azure::Core::IO::BodyStream {
 #ifdef TESTING_BUILD
     // Give access to private to this tests class
     friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
@@ -98,7 +98,7 @@ namespace Azure { namespace Core { namespace Http {
      * component. A libcurl session will use this component to build and return the HTTP
      * RawResponse with a body stream to the pipeline.
      */
-    class ResponseBufferParser {
+    class ResponseBufferParser final {
     private:
       /**
        * @brief Controls what the parser is expecting during the reading process

--- a/sdk/core/azure-core/src/private/environment_log_level_listener.hpp
+++ b/sdk/core/azure-core/src/private/environment_log_level_listener.hpp
@@ -19,7 +19,7 @@
 
 namespace Azure { namespace Core { namespace Diagnostics { namespace _detail {
 
-  class EnvironmentLogLevelListener {
+  class EnvironmentLogLevelListener final {
     EnvironmentLogLevelListener() = delete;
     ~EnvironmentLogLevelListener() = delete;
 

--- a/sdk/core/azure-core/src/private/package_version.hpp
+++ b/sdk/core/azure-core/src/private/package_version.hpp
@@ -20,7 +20,7 @@ namespace Azure { namespace Core { namespace _detail {
   /**
    * @brief Provides version information.
    */
-  class PackageVersion {
+  class PackageVersion final {
   public:
     /// Major numeric identifier.
     static constexpr int Major = AZURE_CORE_VERSION_MAJOR;

--- a/sdk/core/azure-core/test/ut/bearer_token_authentication_policy.cpp
+++ b/sdk/core/azure-core/test/ut/bearer_token_authentication_policy.cpp
@@ -7,7 +7,7 @@
 #include <gtest/gtest.h>
 
 namespace {
-class TestTokenCredential : public Azure::Core::Credentials::TokenCredential {
+class TestTokenCredential final : public Azure::Core::Credentials::TokenCredential {
 private:
   std::shared_ptr<Azure::Core::Credentials::AccessToken const> m_accessToken;
 
@@ -26,7 +26,7 @@ public:
   }
 };
 
-class TestTransportPolicy : public Azure::Core::Http::Policies::HttpPolicy {
+class TestTransportPolicy final : public Azure::Core::Http::Policies::HttpPolicy {
 public:
   std::unique_ptr<Azure::Core::Http::RawResponse> Send(
       Azure::Core::Http::Request&,

--- a/sdk/core/azure-core/test/ut/bodystream.cpp
+++ b/sdk/core/azure-core/test/ut/bodystream.cpp
@@ -25,7 +25,7 @@ using namespace Azure::Core::IO;
 using namespace Azure::Core;
 
 // Used to test virtual, default behavior of BodyStream.
-class TestBodyStream : public BodyStream {
+class TestBodyStream final : public BodyStream {
   int64_t OnRead(uint8_t*, int64_t, Context const&) override { return 0; }
   int64_t Length() const override { return 0; }
 };

--- a/sdk/core/azure-core/test/ut/client_options.cpp
+++ b/sdk/core/azure-core/test/ut/client_options.cpp
@@ -16,7 +16,7 @@ using namespace Azure::Core::_internal;
 using namespace Azure::Core::Http;
 using namespace Azure::Core::Http::Policies;
 
-struct FakeTransport : public HttpTransport
+struct FakeTransport final : public HttpTransport
 {
   std::unique_ptr<RawResponse> Send(Request& request, Context const& context) override
   {
@@ -26,7 +26,7 @@ struct FakeTransport : public HttpTransport
   }
 };
 
-struct PerCallPolicy : public HttpPolicy
+struct PerCallPolicy final : public HttpPolicy
 {
   std::unique_ptr<RawResponse> Send(Request& request, NextHttpPolicy policy, Context const& context)
       const override
@@ -43,7 +43,7 @@ struct PerCallPolicy : public HttpPolicy
   }
 };
 
-struct PerRetryPolicy : public HttpPolicy
+struct PerRetryPolicy final : public HttpPolicy
 {
   std::unique_ptr<RawResponse> Send(Request& request, NextHttpPolicy policy, Context const& context)
       const override
@@ -124,7 +124,7 @@ TEST(ClientOptions, copyWithConstructor)
 
 TEST(ClientOptions, copyDerivedClassConstructor)
 {
-  struct ServiceClientOptions : ClientOptions
+  struct ServiceClientOptions final : ClientOptions
   {
     std::string ApiVersion;
   };
@@ -162,7 +162,7 @@ TEST(ClientOptions, copyDerivedClassConstructor)
 
 TEST(ClientOptions, copyDerivedClassOperator)
 {
-  struct ServiceClientOptions : ClientOptions
+  struct ServiceClientOptions final : ClientOptions
   {
     std::string ApiVersion;
   };
@@ -200,7 +200,7 @@ TEST(ClientOptions, copyDerivedClassOperator)
 
 TEST(ClientOptions, moveConstruct)
 {
-  struct ServiceClientOptions : ClientOptions
+  struct ServiceClientOptions final : ClientOptions
   {
     std::string ApiVersion;
   };

--- a/sdk/core/azure-core/test/ut/context.cpp
+++ b/sdk/core/azure-core/test/ut/context.cpp
@@ -232,7 +232,7 @@ TEST(Context, MatchingKeys)
   EXPECT_TRUE(valueT3 == 456);
 }
 
-struct SomeStructForContext
+struct SomeStructForContext final
 {
   int someField = 12345;
 };
@@ -260,7 +260,7 @@ TEST(Context, Ptr)
 
 TEST(Context, NestedClassPtr)
 {
-  class TestClass {
+  class TestClass final {
   private:
     int* m_instanceCount;
 

--- a/sdk/core/azure-core/test/ut/curl_session.hpp
+++ b/sdk/core/azure-core/test/ut/curl_session.hpp
@@ -35,7 +35,7 @@ namespace Azure { namespace Core { namespace Test {
    * @brief mock the network connection
    *
    */
-  class MockCurlNetworkConnection : public Azure::Core::Http::CurlNetworkConnection {
+  class MockCurlNetworkConnection final : public Azure::Core::Http::CurlNetworkConnection {
   public:
     MOCK_METHOD(std::string const&, GetConnectionKey, (), (const, override));
     MOCK_METHOD(void, UpdateLastUsageTime, (), (override));

--- a/sdk/core/azure-core/test/ut/http.hpp
+++ b/sdk/core/azure-core/test/ut/http.hpp
@@ -13,7 +13,7 @@
 
 namespace Azure { namespace Core { namespace Test {
 
-  class TestHttp final : public ::testing::Test {
+  class TestHttp : public ::testing::Test {
   };
 
 }}} // namespace Azure::Core::Test

--- a/sdk/core/azure-core/test/ut/http.hpp
+++ b/sdk/core/azure-core/test/ut/http.hpp
@@ -13,7 +13,7 @@
 
 namespace Azure { namespace Core { namespace Test {
 
-  class TestHttp : public ::testing::Test {
+  class TestHttp final : public ::testing::Test {
   };
 
 }}} // namespace Azure::Core::Test

--- a/sdk/core/azure-core/test/ut/log_policy.cpp
+++ b/sdk/core/azure-core/test/ut/log_policy.cpp
@@ -20,7 +20,7 @@ void SendRequest(LogOptions const& logOptions)
   using namespace Azure::Core::Http::Policies;
   using namespace Azure::Core::Http::Policies::_internal;
 
-  class TestTransportPolicy : public HttpPolicy {
+  class TestTransportPolicy final : public HttpPolicy {
   public:
     std::unique_ptr<HttpPolicy> Clone() const override
     {
@@ -71,7 +71,7 @@ void SendRequest(LogOptions const& logOptions)
   }
 }
 
-class TestLogger {
+class TestLogger final {
 private:
   static void Deinitialize()
   {
@@ -83,7 +83,7 @@ private:
   void operator=(TestLogger const&) = delete;
 
 public:
-  struct LogMessage
+  struct LogMessage final
   {
     Logger::Level Level;
     std::string Message;

--- a/sdk/core/azure-core/test/ut/operation_test.hpp
+++ b/sdk/core/azure-core/test/ut/operation_test.hpp
@@ -16,7 +16,7 @@ namespace Azure { namespace Core { namespace Test {
 
   class StringClient;
 
-  class StringOperation : public Operation<std::string> {
+  class StringOperation final : public Operation<std::string> {
 
   private:
     std::string m_operationToken;
@@ -97,7 +97,7 @@ namespace Azure { namespace Core { namespace Test {
     }
   };
 
-  class StringClient {
+  class StringClient final {
   public:
     StringOperation StartStringUpdate()
     {

--- a/sdk/core/azure-core/test/ut/policy.cpp
+++ b/sdk/core/azure-core/test/ut/policy.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 namespace {
-class NoOpPolicy : public Azure::Core::Http::Policies::HttpPolicy {
+class NoOpPolicy final : public Azure::Core::Http::Policies::HttpPolicy {
 public:
   std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override
   {
@@ -26,7 +26,7 @@ public:
 
 // A policy to test retry state
 static int retryCounterState = 0;
-struct TestRetryPolicySharedState : public Azure::Core::Http::Policies::HttpPolicy
+struct TestRetryPolicySharedState final : public Azure::Core::Http::Policies::HttpPolicy
 {
   std::unique_ptr<HttpPolicy> Clone() const override
   {
@@ -47,7 +47,7 @@ struct TestRetryPolicySharedState : public Azure::Core::Http::Policies::HttpPoli
 
 Azure::Core::Context::Key const TheKey;
 
-struct TestContextTreeIntegrity : public Azure::Core::Http::Policies::HttpPolicy
+struct TestContextTreeIntegrity final : public Azure::Core::Http::Policies::HttpPolicy
 {
   std::unique_ptr<HttpPolicy> Clone() const override
   {
@@ -66,7 +66,7 @@ struct TestContextTreeIntegrity : public Azure::Core::Http::Policies::HttpPolicy
   }
 };
 
-class SuccessAfter : public Azure::Core::Http::Policies::HttpPolicy {
+class SuccessAfter final : public Azure::Core::Http::Policies::HttpPolicy {
 private:
   int m_successAfter; // Always success
 

--- a/sdk/core/azure-core/test/ut/request_id_policy.cpp
+++ b/sdk/core/azure-core/test/ut/request_id_policy.cpp
@@ -12,7 +12,7 @@ using namespace Azure::Core::Http::Policies;
 using namespace Azure::Core::Http::Policies::_internal;
 
 namespace {
-class NoOpPolicy : public HttpPolicy {
+class NoOpPolicy final : public HttpPolicy {
 public:
   std::unique_ptr<HttpPolicy> Clone() const override { return std::make_unique<NoOpPolicy>(*this); }
 

--- a/sdk/core/azure-core/test/ut/retry_policy.cpp
+++ b/sdk/core/azure-core/test/ut/retry_policy.cpp
@@ -13,7 +13,7 @@ using namespace Azure::Core::Http::Policies;
 using namespace Azure::Core::Http::Policies::_internal;
 
 namespace {
-class TestTransportPolicy : public HttpPolicy {
+class TestTransportPolicy final : public HttpPolicy {
 private:
   std::function<std::unique_ptr<RawResponse>()> m_send;
 
@@ -34,7 +34,7 @@ public:
   };
 };
 
-class RetryPolicyTest : public RetryPolicy {
+class RetryPolicyTest final : public RetryPolicy {
 private:
   std::function<bool(RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
       m_shouldRetryOnTransportFailure;
@@ -319,7 +319,7 @@ TEST(RetryPolicy, ShouldRetryOnTransportFailure)
 }
 
 namespace {
-class RetryLogic : private RetryPolicy {
+class RetryLogic final : private RetryPolicy {
   RetryLogic() : RetryPolicy(RetryOptions()){};
   ~RetryLogic(){};
 

--- a/sdk/core/azure-core/test/ut/simplified_header.cpp
+++ b/sdk/core/azure-core/test/ut/simplified_header.cpp
@@ -22,7 +22,7 @@
 
 #include <vector>
 
-class DllExportTest {
+class DllExportTest final {
   AZ_CORE_DLLEXPORT static const bool DllExportHIncluded;
 };
 

--- a/sdk/core/azure-core/test/ut/telemetry_policy.cpp
+++ b/sdk/core/azure-core/test/ut/telemetry_policy.cpp
@@ -13,7 +13,7 @@ using namespace Azure::Core::Http::Policies::_internal;
 
 namespace {
 
-class NoOpPolicy : public HttpPolicy {
+class NoOpPolicy final : public HttpPolicy {
 private:
   std::unique_ptr<RawResponse> Send(Request& request, NextHttpPolicy policy, Context const& context)
       const override

--- a/sdk/core/azure-core/test/ut/transport_adapter_base.hpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base.hpp
@@ -24,7 +24,7 @@ namespace Azure { namespace Core { namespace Test {
     constexpr static const char AzureSdkHttpbinServer[] = "azuresdkforcpp.azurewebsites.net";
   } // namespace _detail
 
-  struct AzureSdkHttpbinServer
+  struct AzureSdkHttpbinServer final
   {
     inline static std::string Get()
     {
@@ -55,7 +55,7 @@ namespace Azure { namespace Core { namespace Test {
     inline static std::string Schema() { return std::string(_detail::AzureSdkHttpbinServerSchema); }
   };
 
-  struct TransportAdaptersTestParameter
+  struct TransportAdaptersTestParameter final
   {
     std::string Suffix;
     Azure::Core::Http::Policies::TransportOptions TransportAdapter;

--- a/sdk/core/azure-core/test/ut/url.cpp
+++ b/sdk/core/azure-core/test/ut/url.cpp
@@ -7,7 +7,7 @@
 
 namespace Azure { namespace Core { namespace Test {
 
-  class TestURL final : public ::testing::Test {
+  class TestURL : public ::testing::Test {
   };
 
 }}} // namespace Azure::Core::Test

--- a/sdk/core/azure-core/test/ut/url.cpp
+++ b/sdk/core/azure-core/test/ut/url.cpp
@@ -7,7 +7,7 @@
 
 namespace Azure { namespace Core { namespace Test {
 
-  class TestURL : public ::testing::Test {
+  class TestURL final : public ::testing::Test {
   };
 
 }}} // namespace Azure::Core::Test

--- a/sdk/identity/azure-identity/CMakeLists.txt
+++ b/sdk/identity/azure-identity/CMakeLists.txt
@@ -26,11 +26,6 @@ if(NOT AZ_ALL_LIBRARIES)
   endif()
 endif()
 
-if(BUILD_TESTING)
-  # define a symbol that enables some test hooks in code
-  add_compile_definitions(TESTING_BUILD)
-endif()
-
 set(
   AZURE_IDENTITY_HEADER
     inc/azure/identity/client_secret_credential.hpp

--- a/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
@@ -25,7 +25,8 @@ namespace Azure { namespace Identity {
   /**
    * @brief Defines options for token authentication.
    */
-  struct ClientSecretCredentialOptions final : public Azure::Core::Credentials::TokenCredentialOptions
+  struct ClientSecretCredentialOptions final
+      : public Azure::Core::Credentials::TokenCredentialOptions
   {
   public:
     /**

--- a/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
@@ -25,7 +25,7 @@ namespace Azure { namespace Identity {
   /**
    * @brief Defines options for token authentication.
    */
-  struct ClientSecretCredentialOptions : public Azure::Core::Credentials::TokenCredentialOptions
+  struct ClientSecretCredentialOptions final : public Azure::Core::Credentials::TokenCredentialOptions
   {
   public:
     /**
@@ -44,7 +44,7 @@ namespace Azure { namespace Identity {
    * @brief This class is used by Azure SDK clients to authenticate with the Azure service using a
    * tenant ID, client ID and client secret.
    */
-  class ClientSecretCredential : public Core::Credentials::TokenCredential {
+  class ClientSecretCredential final : public Core::Credentials::TokenCredential {
   private:
     std::string m_tenantId;
     std::string m_clientId;

--- a/sdk/identity/azure-identity/inc/azure/identity/environment_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/environment_credential.hpp
@@ -17,7 +17,7 @@ namespace Azure { namespace Identity {
   /**
    * @brief An environment credential.
    */
-  class EnvironmentCredential : public Core::Credentials::TokenCredential {
+  class EnvironmentCredential final : public Core::Credentials::TokenCredential {
     std::unique_ptr<TokenCredential> m_credentialImpl;
 
   public:

--- a/sdk/identity/azure-identity/src/private/package_version.hpp
+++ b/sdk/identity/azure-identity/src/private/package_version.hpp
@@ -20,7 +20,7 @@ namespace Azure { namespace Identity { namespace _detail {
   /**
    * @brief Provides version information.
    */
-  class PackageVersion {
+  class PackageVersion final {
   public:
     /// Major numeric identifier.
     static constexpr int Major = AZURE_IDENTITY_VERSION_MAJOR;

--- a/sdk/identity/azure-identity/test/ut/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/test/ut/client_secret_credential.cpp
@@ -13,9 +13,9 @@ using namespace Azure::Identity;
 
 namespace {
 
-struct CredentialResult
+struct CredentialResult final
 {
-  struct RequestInfo
+  struct RequestInfo final
   {
     std::string AbsoluteUrl;
     Azure::Core::CaseInsensitiveMap Headers;

--- a/sdk/identity/azure-identity/test/ut/environment_credential.cpp
+++ b/sdk/identity/azure-identity/test/ut/environment_credential.cpp
@@ -28,8 +28,8 @@
 using namespace Azure::Identity;
 
 namespace {
-class EnvironmentOverride {
-  class Environment {
+class EnvironmentOverride final {
+  class Environment final {
     static void SetVariable(std::string const& name, std::string const& value)
     {
 #if defined(_MSC_VER)
@@ -112,7 +112,7 @@ public:
   }
 };
 
-struct CredentialResult
+struct CredentialResult final
 {
   struct
   {

--- a/sdk/identity/azure-identity/test/ut/simplified_header.cpp
+++ b/sdk/identity/azure-identity/test/ut/simplified_header.cpp
@@ -11,7 +11,7 @@
 #include <azure/identity.hpp>
 #include <gtest/gtest.h>
 
-class DllExportTest {
+class DllExportTest final {
   AZ_IDENTITY_DLLEXPORT static const bool DllExportHIncluded;
 };
 

--- a/sdk/identity/azure-identity/test/ut/test_transport.hpp
+++ b/sdk/identity/azure-identity/test/ut/test_transport.hpp
@@ -7,7 +7,7 @@
 
 #include <azure/core/http/transport.hpp>
 
-class TestTransport : public Azure::Core::Http::HttpTransport {
+class TestTransport final : public Azure::Core::Http::HttpTransport {
 public:
   typedef std::function<std::unique_ptr<Azure::Core::Http::RawResponse>(
       Azure::Core::Http::Request& request,

--- a/sdk/keyvault/CMakeLists.txt
+++ b/sdk/keyvault/CMakeLists.txt
@@ -7,5 +7,10 @@ project (azure-security-keyvault LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(BUILD_TESTING)
+  # define a symbol that enables some test hooks in code
+  add_compile_definitions(TESTING_BUILD)
+endif()
+
 add_subdirectory(azure-security-keyvault-common)
 add_subdirectory(azure-security-keyvault-keys)

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/base64url.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/base64url.hpp
@@ -18,7 +18,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace _internal 
   /**
    * @brief Provides conversion methods for base64url.
    */
-  struct Base64Url
+  struct Base64Url final
   {
     static inline std::string Base64UrlEncode(const std::vector<uint8_t>& data)
     {

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/keyvault_pipeline.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/keyvault_pipeline.hpp
@@ -26,7 +26,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace _internal 
   /**
    * @brief The HTTP pipeline used by KeyVault clients.
    */
-  class KeyVaultPipeline {
+  class KeyVaultPipeline final {
     Azure::Core::Url m_vaultUrl;
     Azure::Core::Http::_internal::HttpPipeline m_pipeline;
     std::string m_apiVersion;

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/single_page.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/single_page.hpp
@@ -15,6 +15,7 @@
 namespace Azure { namespace Security { namespace KeyVault { namespace _internal {
   struct GetPageResultOptions
   {
+    virtual ~GetPageResultOptions() = default;
     Azure::Nullable<std::string> NextPageToken;
     Azure::Nullable<uint32_t> MaxPageResults;
   };

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/unix_time_helper.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/unix_time_helper.hpp
@@ -17,7 +17,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace _internal 
   /**
    * @brief Provides convertion methods for unix time to Azure Core Datetime.
    */
-  class UnixTimeConverter {
+  class UnixTimeConverter final {
   public:
     /**
      * @brief Converts unix time to a #Azure::Core::Datetime.

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/keyvault_exception.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/keyvault_exception.hpp
@@ -20,7 +20,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace _detail {
    * @brief Container for static methods to parse keyvault payloads to Azure Core Exception.
    *
    */
-  struct KeyVaultException
+  struct KeyVaultException final
   {
     /**
      * @brief Parsed the http payload into an #Azure::Core::RequestFailedException

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/sha.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/sha.hpp
@@ -21,7 +21,7 @@ namespace Azure { namespace Security { namespace KeyVault {
    * @brief Defines #SHA256.
    *
    */
-  class SHA256 : public Azure::Core::Cryptography::Hash {
+  class SHA256 final : public Azure::Core::Cryptography::Hash {
   public:
     /**
      * @brief Construct a default instance of #SHA256.
@@ -71,7 +71,7 @@ namespace Azure { namespace Security { namespace KeyVault {
    * @brief Defines #SHA384.
    *
    */
-  class SHA384 : public Azure::Core::Cryptography::Hash {
+  class SHA384 final : public Azure::Core::Cryptography::Hash {
   public:
     /**
      * @brief Construct a default instance of #SHA384.
@@ -121,7 +121,7 @@ namespace Azure { namespace Security { namespace KeyVault {
    * @brief Defines #SHA512.
    *
    */
-  class SHA512 : public Azure::Core::Cryptography::Hash {
+  class SHA512 final : public Azure::Core::Cryptography::Hash {
   public:
     /**
      * @brief Construct a default instance of #SHA512.

--- a/sdk/keyvault/azure-security-keyvault-common/src/private/package_version.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/src/private/package_version.hpp
@@ -21,7 +21,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Common { n
   /**
    * @brief Provides version information.
    */
-  class PackageVersion {
+  class PackageVersion final {
   public:
     /// Major numeric identifier.
     static constexpr int Major = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MAJOR;

--- a/sdk/keyvault/azure-security-keyvault-common/src/sha.cpp
+++ b/sdk/keyvault/azure-security-keyvault-common/src/sha.cpp
@@ -32,7 +32,7 @@ enum class SHASize
 };
 
 /*************************** SHA256 *******************/
-class SHAWithOpenSSL : public Azure::Core::Cryptography::Hash {
+class SHAWithOpenSSL final : public Azure::Core::Cryptography::Hash {
 private:
   EVP_MD_CTX* m_context;
 
@@ -116,7 +116,7 @@ Azure::Security::KeyVault::SHA512::SHA512()
 
 #if defined(AZ_PLATFORM_WINDOWS)
 namespace {
-struct AlgorithmProviderInstance
+struct AlgorithmProviderInstance final
 {
   BCRYPT_ALG_HANDLE Handle;
   std::size_t ContextSize;
@@ -161,7 +161,7 @@ struct AlgorithmProviderInstance
   ~AlgorithmProviderInstance() { BCryptCloseAlgorithmProvider(Handle, 0); }
 };
 
-class SHAWithBCrypt : public Azure::Core::Cryptography::Hash {
+class SHAWithBCrypt final : public Azure::Core::Cryptography::Hash {
 private:
   std::string m_buffer;
   BCRYPT_HASH_HANDLE m_hashHandle = nullptr;

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_client.hpp
@@ -34,7 +34,7 @@ namespace Azure {
    * @brief A client used to perform cryptographic operations with Azure Key Vault keys.
    *
    */
-  class CryptographyClient {
+  class CryptographyClient final {
   private:
     std::shared_ptr<Azure::Security::KeyVault::_internal::KeyVaultPipeline> m_pipeline;
     std::string m_keyId;

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_client_options.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_client_options.hpp
@@ -24,7 +24,7 @@ namespace Azure {
    * @brief Represent the Key Vault Keys Service Version.
    *
    */
-  class ServiceVersion {
+  class ServiceVersion final {
   private:
     std::string m_version;
 
@@ -73,7 +73,7 @@ namespace Azure {
    * operations on Key Vault.
    *
    */
-  struct CryptographyClientOptions : public Azure::Core::_internal::ClientOptions
+  struct CryptographyClientOptions final : public Azure::Core::_internal::ClientOptions
   {
     /**
      * @brief Gets the #ServiceVersion of the service API used when making requests. For more

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_serializers.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_serializers.hpp
@@ -35,41 +35,41 @@ namespace Azure {
   namespace _detail {
 
     /***************** Encrypt Result *****************/
-    struct EncryptResultSerializer
+    struct EncryptResultSerializer final
     {
       static EncryptResult EncryptResultDeserialize(
           Azure::Core::Http::RawResponse const& rawResponse);
     };
 
     /***************** Encrypt Parameters *****************/
-    struct EncryptParametersSerializer
+    struct EncryptParametersSerializer final
     {
       static std::string EncryptParametersSerialize(
           Azure::Security::KeyVault::Keys::Cryptography::EncryptParameters const& parameters);
     };
 
     /***************** Decrypt Result *****************/
-    struct DecryptResultSerializer
+    struct DecryptResultSerializer final
     {
       static DecryptResult DecryptResultDeserialize(
           Azure::Core::Http::RawResponse const& rawResponse);
     };
 
     /***************** Encrypt Parameters *****************/
-    struct DecryptParametersSerializer
+    struct DecryptParametersSerializer final
     {
       static std::string DecryptParametersSerialize(
           Azure::Security::KeyVault::Keys::Cryptography::DecryptParameters const& parameters);
     };
 
     /***************** WrapKey Result *****************/
-    struct WrapResultSerializer
+    struct WrapResultSerializer final
     {
       static WrapResult WrapResultDeserialize(Azure::Core::Http::RawResponse const& rawResponse);
     };
 
     /***************** WrapKey Parameters *****************/
-    struct KeyWrapParametersSerializer
+    struct KeyWrapParametersSerializer final
     {
       static std::string KeyWrapParametersSerialize(
           Azure::Security::KeyVault::Keys::Cryptography::_detail::KeyWrapParameters const&
@@ -77,20 +77,20 @@ namespace Azure {
     };
 
     /***************** UnwrapKey Result *****************/
-    struct UnwrapResultSerializer
+    struct UnwrapResultSerializer final
     {
       static UnwrapResult UnwrapResultDeserialize(
           Azure::Core::Http::RawResponse const& rawResponse);
     };
 
     /***************** Sign Result *****************/
-    struct SignResultSerializer
+    struct SignResultSerializer final
     {
       static SignResult SignResultDeserialize(Azure::Core::Http::RawResponse const& rawResponse);
     };
 
     /***************** Key sign Parameters *****************/
-    struct KeySignParametersSerializer
+    struct KeySignParametersSerializer final
     {
       static std::string KeySignParametersSerialize(
           Azure::Security::KeyVault::Keys::Cryptography::_detail::KeySignParameters const&
@@ -98,14 +98,14 @@ namespace Azure {
     };
 
     /***************** Verify Result *****************/
-    struct VerifyResultSerializer
+    struct VerifyResultSerializer final
     {
       static VerifyResult VerifyResultDeserialize(
           Azure::Core::Http::RawResponse const& rawResponse);
     };
 
     /***************** Key Verify Parameters *****************/
-    struct KeyVerifyParametersSerializer
+    struct KeyVerifyParametersSerializer final
     {
       static std::string KeyVerifyParametersSerialize(
           Azure::Security::KeyVault::Keys::Cryptography::_detail::KeyVerifyParameters const&

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/decrypt_parameters.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/decrypt_parameters.hpp
@@ -24,7 +24,7 @@ namespace Azure {
    * @brief Parameters for decrypting ciphertext.
    *
    */
-  struct DecryptParameters
+  struct DecryptParameters final
   {
     /**
      * @brief Construct a new Decrypt Parameters object.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/decrypt_result.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/decrypt_result.hpp
@@ -23,7 +23,7 @@ namespace Azure {
    * @brief Represents information about an encryption operation.
    *
    */
-  struct DecryptResult
+  struct DecryptResult final
   {
     /**
      * @brief Gets the key identifier of the #KeyVaultKey used to encrypt. This must be stored

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/encrypt_parameters.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/encrypt_parameters.hpp
@@ -24,7 +24,7 @@ namespace Azure {
    * @brief Parameters for encrypting plaintext.
    *
    */
-  struct EncryptParameters
+  struct EncryptParameters final
   {
     /**
      * @brief Construct a new Encrypt Parameters object.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/encrypt_result.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/encrypt_result.hpp
@@ -23,7 +23,7 @@ namespace Azure {
    * @brief Represents information about an encryption operation.
    *
    */
-  struct EncryptResult
+  struct EncryptResult final
   {
     /**
      * @brief Gets the key identifier of the #KeyVaultKey used to encrypt. This must be stored

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/encryption_algorithm.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/encryption_algorithm.hpp
@@ -24,7 +24,7 @@ namespace Azure {
    * @brief An algorithm used for encryption and decryption.
    *
    */
-  class EncryptionAlgorithm {
+  class EncryptionAlgorithm final {
   private:
     std::string m_value;
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/key_sign_parameters.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/key_sign_parameters.hpp
@@ -23,7 +23,7 @@ namespace Azure {
      * @brief Parameters for sign a key.
      *
      */
-    struct KeySignParameters
+    struct KeySignParameters final
     {
       std::string Algorithm;
       std::vector<uint8_t> Digest;

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/key_verify_parameters.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/key_verify_parameters.hpp
@@ -23,7 +23,7 @@ namespace Azure {
      * @brief Parameters for verify a key.
      *
      */
-    struct KeyVerifyParameters
+    struct KeyVerifyParameters final
     {
       std::string Algorithm;
       std::vector<uint8_t> Digest;

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/key_wrap_algorithm.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/key_wrap_algorithm.hpp
@@ -24,7 +24,7 @@ namespace Azure {
    * @brief An algorithm used for key wrap and unwrap.
    *
    */
-  class KeyWrapAlgorithm {
+  class KeyWrapAlgorithm final {
   private:
     std::string m_value;
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/key_wrap_parameters.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/key_wrap_parameters.hpp
@@ -23,7 +23,7 @@ namespace Azure {
      * @brief Parameters for wrap a key.
      *
      */
-    struct KeyWrapParameters
+    struct KeyWrapParameters final
     {
       std::string Algorithm;
       std::vector<uint8_t> Key;

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/local_cryptography_provider_factory.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/local_cryptography_provider_factory.hpp
@@ -23,7 +23,7 @@ namespace Azure {
         namespace Cryptography {
   namespace _detail {
 
-    struct LocalCryptographyProviderFactory
+    struct LocalCryptographyProviderFactory final
     {
       LocalCryptographyProviderFactory() = delete;
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/remote_cryptography_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/remote_cryptography_client.hpp
@@ -30,7 +30,7 @@ namespace Azure {
         namespace Cryptography {
   namespace _detail {
 
-    struct RemoteCryptographyClient
+    struct RemoteCryptographyClient final
         : public Azure::Security::KeyVault::Keys::Cryptography::_detail::CryptographyProvider
     {
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/rsa_cryptography_provider.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/rsa_cryptography_provider.hpp
@@ -21,7 +21,7 @@ namespace Azure {
         namespace Cryptography {
   namespace _detail {
 
-    struct RsaCryptographyProvider : public LocalCryptographyProvider
+    struct RsaCryptographyProvider final : public LocalCryptographyProvider
     {
       RsaCryptographyProvider(
           Azure::Security::KeyVault::Keys::JsonWebKey const& keyMaterial,

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/sign_result.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/sign_result.hpp
@@ -24,7 +24,7 @@ namespace Azure {
    * @brief Represents information about a sign operation.
    *
    */
-  struct SignResult
+  struct SignResult final
   {
     /**
      * @brief Gets the key identifier of the #KeyVaultKey used to sign. This must be stored

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/signature_algorithm.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/signature_algorithm.hpp
@@ -27,7 +27,7 @@ namespace Azure {
    * @brief An algorithm used for signing and verification.
    *
    */
-  class SignatureAlgorithm {
+  class SignatureAlgorithm final {
   private:
     std::string m_value;
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/unwrap_result.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/unwrap_result.hpp
@@ -24,7 +24,7 @@ namespace Azure {
    * @brief Represents information about an unwrap operation.
    *
    */
-  struct UnwrapResult
+  struct UnwrapResult final
   {
     /**
      * @brief Gets the key identifier of the #Key used to uwrap.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/verify_result.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/verify_result.hpp
@@ -24,7 +24,7 @@ namespace Azure {
    * @brief Represents information about a verify operation.
    *
    */
-  struct VerifyResult
+  struct VerifyResult final
   {
     /**
      * @brief Gets the key identifier of the #KeyVaultKey used to verify.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/wrap_result.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/wrap_result.hpp
@@ -23,7 +23,7 @@ namespace Azure {
    * @brief Represents information about a wrap operation.
    *
    */
-  struct WrapResult
+  struct WrapResult final
   {
     /**
      * @brief Gets the key identifier of the #KeyVaultKey used to encrypt. This must be stored

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
@@ -29,7 +29,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief A long running operation to delete a key.
    *
    */
-  class DeleteKeyOperation
+  class DeleteKeyOperation final
       : public Azure::Core::Operation<Azure::Security::KeyVault::Keys::DeletedKey> {
   private:
     /* DeleteKeyOperation can be constructed only by friends classes (internal creation). The

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/deleted_key.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/deleted_key.hpp
@@ -20,7 +20,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * needed.
    *
    */
-  struct DeletedKey : public KeyVaultKey
+  struct DeletedKey final : public KeyVaultKey
   {
     /**
      * @brief A recovery url that can be used to recover it.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/details/key_backup.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/details/key_backup.hpp
@@ -17,7 +17,7 @@
 
 namespace Azure { namespace Security { namespace KeyVault { namespace Keys { namespace _detail {
 
-  struct KeyBackup : public Azure::Core::Json::_internal::JsonSerializable
+  struct KeyBackup final : public Azure::Core::Json::_internal::JsonSerializable
   {
 
     std::vector<uint8_t> Value;

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/details/key_request_parameters.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/details/key_request_parameters.hpp
@@ -25,7 +25,7 @@
 
 namespace Azure { namespace Security { namespace KeyVault { namespace Keys { namespace _detail {
 
-  class KeyRequestParameters : public Azure::Core::Json::_internal::JsonSerializable {
+  class KeyRequestParameters final : public Azure::Core::Json::_internal::JsonSerializable {
   private:
     Azure::Nullable<KeyVaultKeyType> m_keyType;
     CreateKeyOptions m_options;

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/details/key_serializers.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/details/key_serializers.hpp
@@ -20,7 +20,7 @@
 
 namespace Azure { namespace Security { namespace KeyVault { namespace Keys { namespace _detail {
   /***************** KeyVault Key *****************/
-  struct KeyVaultKeySerializer
+  struct KeyVaultKeySerializer final
   {
     // Creates a new key based on a name and an http raw response.
     static KeyVaultKey KeyVaultKeyDeserialize(
@@ -83,7 +83,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
   };
 
   /**************** Deleted Key *******************/
-  struct DeletedKeySerializer
+  struct DeletedKeySerializer final
   {
     static DeletedKey DeletedKeyDeserialize(
         std::string const& name,
@@ -91,13 +91,13 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
   };
 
   /**************** Import Key Options ***********/
-  struct ImportKeyOptionsSerializer
+  struct ImportKeyOptionsSerializer final
   {
     static std::string ImportKeyOptionsSerialize(ImportKeyOptions const& importKeyOptions);
   };
 
   /**************** Key Properties ************/
-  struct KeyPropertiesPageResultSerializer
+  struct KeyPropertiesPageResultSerializer final
   {
     static KeyPropertiesPageResult KeyPropertiesPageResultDeserialize(
         Azure::Core::Http::RawResponse const& rawResponse);
@@ -106,7 +106,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
   };
 
   /**************** JWK  ************/
-  struct JsonWebKeySerializer
+  struct JsonWebKeySerializer final
   {
     static void JsonWebKeySerialize(
         JsonWebKey const& jwk,

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/import_key_options.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/import_key_options.hpp
@@ -25,7 +25,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief A key resource and its properties.
    *
    */
-  struct ImportKeyOptions
+  struct ImportKeyOptions final
   {
     /**
      * @brief The cryptographic key, the key type, and the operations you can perform using the key.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/json_web_key.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/json_web_key.hpp
@@ -25,7 +25,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief Represents a JSON Web Key as defined in http://tools.ietf.org/html/rfc7517.
    *
    */
-  class JsonWebKey {
+  class JsonWebKey final {
   public:
     /**
      * @brief The Identifier of the key. This is not limited to a Url.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
@@ -30,7 +30,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief Define a model for a purged key.
    *
    */
-  struct PurgedKey
+  struct PurgedKey final
   {
   };
 
@@ -38,7 +38,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief Optional parameters for KeyVaultClient::GetKey
    *
    */
-  struct GetKeyOptions
+  struct GetKeyOptions final
   {
     /**
      * @brief Specify the key version to get.
@@ -51,12 +51,18 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * Vault. The client supports creating, retrieving, updating, deleting, purging, backing up,
    * restoring, and listing the KeyVaultKey.
    */
-  class KeyClient {
+  class KeyClient
+#if !defined(TESTING_BUILD)
+      final
+#endif
+  {
   protected:
     // Using a shared pipeline for a client to share it with LRO (like delete key)
     std::shared_ptr<Azure::Security::KeyVault::_internal::KeyVaultPipeline> m_pipeline;
 
   public:
+    virtual ~KeyClient() = default;
+
     /**
      * @brief Construct a new Key Client object
      *

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client_options.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client_options.hpp
@@ -16,7 +16,7 @@
 
 namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
 
-  class ServiceVersion {
+  class ServiceVersion final {
   private:
     std::string m_version;
 
@@ -64,7 +64,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief Define the options to create an SDK Keys client.
    *
    */
-  struct KeyClientOptions : public Azure::Core::_internal::ClientOptions
+  struct KeyClientOptions final : public Azure::Core::_internal::ClientOptions
   {
     ServiceVersion Version;
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_create_options.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_create_options.hpp
@@ -29,6 +29,8 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    */
   struct CreateKeyOptions
   {
+    virtual ~CreateKeyOptions() = default;
+
     /**
      * @brief Define the supported operations for the key.
      *
@@ -64,7 +66,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief The properties needed to create an Elliptic Curve key.
    *
    */
-  class CreateEcKeyOptions : public CreateKeyOptions {
+  class CreateEcKeyOptions final : public CreateKeyOptions {
   private:
     std::string m_name;
     bool m_hardwareProtected;
@@ -130,7 +132,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief The properties needed to create an RSA key.
    *
    */
-  class CreateRsaKeyOptions : public CreateKeyOptions {
+  class CreateRsaKeyOptions final : public CreateKeyOptions {
   private:
     std::string m_name;
     bool m_hardwareProtected;
@@ -202,7 +204,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief The properties needed to create an AES key.
    *
    */
-  class CreateOctKeyOptions : public CreateKeyOptions {
+  class CreateOctKeyOptions final : public CreateKeyOptions {
   private:
     std::string m_name;
     bool m_hardwareProtected;

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_curve_name.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_curve_name.hpp
@@ -20,7 +20,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief Elliptic Curve Cryptography (ECC) curve names.
    *
    */
-  class KeyCurveName {
+  class KeyCurveName final {
   private:
     std::string m_value;
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_operation.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_operation.hpp
@@ -19,7 +19,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief An operation that can be performed with the key.
    *
    */
-  class KeyOperation {
+  class KeyOperation final {
   private:
     std::string m_operation;
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_properties.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_properties.hpp
@@ -22,7 +22,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * properties.
    *
    */
-  struct KeyProperties
+  struct KeyProperties final
   {
     /**
      * @brief The name of the key.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_type.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_type.hpp
@@ -19,7 +19,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief The JsonWebKey types.
    *
    */
-  class KeyVaultKeyType {
+  class KeyVaultKeyType final {
   private:
     std::string m_value;
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_vault_key.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_vault_key.hpp
@@ -25,6 +25,8 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    */
   struct KeyVaultKey
   {
+    virtual ~KeyVaultKey() = default;
+
     /**
      * @brief The cryptographic key, the key type, and the operations you can perform using the key.
      *

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/list_keys_single_page_result.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/list_keys_single_page_result.hpp
@@ -28,7 +28,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief Define a single page to list the keys from the Key Vault.
    *
    */
-  class KeyPropertiesPageResult : public Azure::Core::PagedResponse<KeyPropertiesPageResult> {
+  class KeyPropertiesPageResult final : public Azure::Core::PagedResponse<KeyPropertiesPageResult> {
   private:
     friend class KeyClient;
     friend class Azure::Core::PagedResponse<KeyPropertiesPageResult>;
@@ -77,7 +77,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief Define a single page containing the deleted keys from the Key Vault.
    *
    */
-  class DeletedKeyPageResult : public Azure::Core::PagedResponse<DeletedKeyPageResult> {
+  class DeletedKeyPageResult final : public Azure::Core::PagedResponse<DeletedKeyPageResult> {
   private:
     friend class KeyClient;
     friend class Azure::Core::PagedResponse<DeletedKeyPageResult>;
@@ -124,7 +124,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief The options for calling an operation #GetPropertiesOfKeys.
    *
    */
-  struct GetPropertiesOfKeysOptions
+  struct GetPropertiesOfKeysOptions final
       : public Azure::Security::KeyVault::_internal::GetPageResultOptions
   {
   };
@@ -133,7 +133,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief The options for calling an operation #GetPropertiesOfKeyVersions.
    *
    */
-  struct GetPropertiesOfKeyVersionsOptions
+  struct GetPropertiesOfKeyVersionsOptions final
       : public Azure::Security::KeyVault::_internal::GetPageResultOptions
   {
   };
@@ -142,7 +142,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief The options for calling an operation #GetDeletedKeys.
    *
    */
-  struct GetDeletedKeysOptions : public Azure::Security::KeyVault::_internal::GetPageResultOptions
+  struct GetDeletedKeysOptions final : public Azure::Security::KeyVault::_internal::GetPageResultOptions
   {
   };
 }}}} // namespace Azure::Security::KeyVault::Keys

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/list_keys_single_page_result.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/list_keys_single_page_result.hpp
@@ -142,7 +142,8 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief The options for calling an operation #GetDeletedKeys.
    *
    */
-  struct GetDeletedKeysOptions final : public Azure::Security::KeyVault::_internal::GetPageResultOptions
+  struct GetDeletedKeysOptions final
+      : public Azure::Security::KeyVault::_internal::GetPageResultOptions
   {
   };
 }}}} // namespace Azure::Security::KeyVault::Keys

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/recover_deleted_key_operation.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/recover_deleted_key_operation.hpp
@@ -29,7 +29,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * @brief A long running operation to recover a key.
    *
    */
-  class RecoverDeletedKeyOperation : public Azure::Core::Operation<KeyVaultKey> {
+  class RecoverDeletedKeyOperation final : public Azure::Core::Operation<KeyVaultKey> {
   private:
     /* RecoverDeletedKeyOperation can be constructed only by friends classes (internal creation).
      * The constructor is private and requires internal components.*/

--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -23,7 +23,7 @@ using namespace Azure::Core::Http::Policies;
 using namespace Azure::Core::Http::Policies::_internal;
 
 namespace {
-struct RequestWithContinuationToken
+struct RequestWithContinuationToken final
 {
   std::vector<std::string> Path;
   std::unique_ptr<std::map<std::string, std::string>> Query;

--- a/sdk/keyvault/azure-security-keyvault-keys/src/private/package_version.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/private/package_version.hpp
@@ -21,7 +21,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
   /**
    * @brief Provides version information.
    */
-  class PackageVersion {
+  class PackageVersion final {
   public:
     /// Major numeric identifier.
     static constexpr int Major = AZURE_SECURITY_KEYVAULT_KEYS_VERSION_MAJOR;

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/mocked_transport_adapter_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/mocked_transport_adapter_test.hpp
@@ -54,7 +54,8 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
   }; // namespace Test
 
   // A derived class with no credential and authentication
-  class KeyClientWithNoAuthenticationPolicy final : public Azure::Security::KeyVault::Keys::KeyClient {
+  class KeyClientWithNoAuthenticationPolicy final
+      : public Azure::Security::KeyVault::Keys::KeyClient {
   public:
     explicit KeyClientWithNoAuthenticationPolicy(
         std::string const& vaultUrl,

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/mocked_transport_adapter_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/mocked_transport_adapter_test.hpp
@@ -32,7 +32,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
   } // namespace _detail
 
   // A transport adapter which only echo a request headers back as a response.
-  class MockedTransportAdapter : public Azure::Core::Http::HttpTransport {
+  class MockedTransportAdapter final : public Azure::Core::Http::HttpTransport {
     std::unique_ptr<Azure::Core::Http::RawResponse> Send(
         Azure::Core::Http::Request& request,
         Azure::Core::Context const& context) override
@@ -54,7 +54,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
   }; // namespace Test
 
   // A derived class with no credential and authentication
-  class KeyClientWithNoAuthenticationPolicy : public Azure::Security::KeyVault::Keys::KeyClient {
+  class KeyClientWithNoAuthenticationPolicy final : public Azure::Security::KeyVault::Keys::KeyClient {
   public:
     explicit KeyClientWithNoAuthenticationPolicy(
         std::string const& vaultUrl,

--- a/sdk/template/azure-template/inc/azure/template/template_client.hpp
+++ b/sdk/template/azure-template/inc/azure/template/template_client.hpp
@@ -7,7 +7,7 @@
 
 namespace Azure { namespace Template {
 
-  class TemplateClient {
+  class TemplateClient final {
   public:
     std::string ClientVersion() const;
   };

--- a/sdk/template/azure-template/src/private/package_version.hpp
+++ b/sdk/template/azure-template/src/private/package_version.hpp
@@ -20,7 +20,7 @@ namespace Azure { namespace Template { namespace _detail {
   /**
    * @brief Provides version information.
    */
-  class PackageVersion {
+  class PackageVersion final {
   public:
     /// Major numeric identifier.
     static constexpr int Major = AZURE_TEMPLATE_VERSION_MAJOR;


### PR DESCRIPTION
Closes #2030.

First, I went and added `final` to everything (excluding Storage[can be a separate PR for that], Nlohmann JSON, non-uinit tests), then I removed everything that did not compile.

I know we discussed to add only the `final` qualifier, but I added a `virtual ~ClassName() = default` in the classes and structs that do not have it, and are inherited. It would be irresponsible to see it and walk past. There are just a couple of instances, and I don't see it creating any problem (other than fixing a memory leak).
To better understand the memory leak problem, see this comment: https://github.com/Azure/azure-sdk-for-cpp/pull/2238#discussion_r628743792

In two instances, `final` specifier is dropped for tests. That preprocessor variable has to be defined when building the library source, not only when building the tests, or otherwise it is not guaranteed, whether the overridden methods defined in tests will get called. Practiacally this means, that when you consume via VcPkg, all the finals are exactly where we want them to be. When you are developing the SDK, two of them are inactive, so you would be able to write a library code that inherits from a final class. But the first nightly vcpkg will fail, and it will be discovered.