### PR TITLE
Correct options assignment for TokenCredentialOptions

### DIFF
--- a/sdk/identity/azure-identity/src/environment_credential.cpp
+++ b/sdk/identity/azure-identity/src/environment_credential.cpp
@@ -55,7 +55,10 @@ EnvironmentCredential::EnvironmentCredential(
       if (authority != nullptr)
       {
         ClientSecretCredentialOptions clientSecretCredentialOptions;
-        static_cast<Core::_internal::ClientOptions&>(clientSecretCredentialOptions) = options;
+        static_cast<Azure::Core::Credentials::TokenCredentialOptions&>(
+            clientSecretCredentialOptions)
+            = options;
+
         clientSecretCredentialOptions.AuthorityHost = authority;
 
         m_credentialImpl.reset(new ClientSecretCredential(


### PR DESCRIPTION
Currently, `TokenCredentialOptions` is empty, so assignment of `ClientOptions` part works just as good as if `static_cast<TokenCredentialOptions&>` was used, but the correct way is to use `TokenCredentialOptions&` that was the intent when the code was written.
Thanks to @ahsonkhan for finding this in the PR a long time ago, and I never go to correct this.