### PR TITLE
Experiment to see trade-offs of special casing MemoryBodyStream to avoid extra data copies.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/io/body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/io/body_stream.hpp
@@ -116,13 +116,14 @@ namespace Azure { namespace Core { namespace IO {
    */
   class MemoryBodyStream final : public BodyStream {
   private:
-    const uint8_t* m_data;
     int64_t m_length;
     int64_t m_offset = 0;
 
     int64_t OnRead(uint8_t* buffer, int64_t count, Azure::Core::Context const& context) override;
 
   public:
+    const uint8_t* m_data;
+
     // Forbid constructor for rval so we don't end up storing dangling ptr
     MemoryBodyStream(std::vector<uint8_t> const&&) = delete;
 


### PR DESCRIPTION
Though it introduces tighter coupling, and hence shouldn't be done lightly, I have observed this type of special casing in places like the .NET framework to emphasize and enable better performance for perf sensitive workloads.

I want to experiment with and get your thoughts on minimizing unnecessary data copies as much as possible. It might very well be that the network I/O continues to be the bulk of the cost, in which case, such a change would not be worth it.