### PR TITLE
`BlobServiceClient::UndeleteBlobContainer` doesn't support restoring a deleted container under a different name anymore.

### DIFF
--- a/sdk/storage/azure-storage-blobs/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blobs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `BlobLeaseClient::Change()` updates internal lease id.
 - Removed `ContentType` from `GetBlockListResult`.
 - Moved `GetPageRangesResult` to detail namespace.
+- `BlobServiceClient::UndeleteBlobContainer` doesn't support restoring a deleted container under a different name anymore.
 
 ## 12.0.0-beta.10 (2021-04-16)
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
@@ -293,11 +293,6 @@ namespace Azure { namespace Storage { namespace Blobs {
    */
   struct UndeleteBlobContainerOptions final
   {
-    /**
-     * @brief Use this parameter if you would like to restore the container under a
-     * different name.
-     */
-    Azure::Nullable<std::string> DestinationBlobContainerName;
   };
 
   /**

--- a/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
@@ -252,10 +252,9 @@ namespace Azure { namespace Storage { namespace Blobs {
       const UndeleteBlobContainerOptions& options,
       const Azure::Core::Context& context) const
   {
-    std::string destinationBlobContainerName = options.DestinationBlobContainerName.HasValue()
-        ? options.DestinationBlobContainerName.Value()
-        : deletedBlobContainerName;
-    auto blobContainerClient = GetBlobContainerClient(destinationBlobContainerName);
+    (void)options;
+
+    auto blobContainerClient = GetBlobContainerClient(deletedBlobContainerName);
 
     _detail::BlobRestClient::BlobContainer::UndeleteBlobContainerOptions protocolLayerOptions;
     protocolLayerOptions.DeletedBlobContainerName = deletedBlobContainerName;

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
@@ -353,7 +353,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_THROW(containerClient.Value.GetProperties(), StorageException);
   }
 
-  TEST_F(BlobServiceClientTest, DISABLED_UndeleteBlobContainer)
+  TEST_F(BlobServiceClientTest, UndeleteBlobContainer)
   {
     std::string containerName = LowercaseRandomString();
     auto containerClient = m_blobServiceClient.GetBlobContainerClient(containerName);
@@ -387,15 +387,12 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_TRUE(deletedContainerItem.Details.RemainingRetentionDays.HasValue());
     EXPECT_GE(deletedContainerItem.Details.RemainingRetentionDays.Value(), 0);
 
-    std::string containerName2 = LowercaseRandomString();
     for (int i = 0; i < 60; ++i)
     {
       try
       {
-        Azure::Storage::Blobs::UndeleteBlobContainerOptions options;
-        options.DestinationBlobContainerName = containerName2;
         m_blobServiceClient.UndeleteBlobContainer(
-            deletedContainerItem.Name, deletedContainerItem.VersionId.Value(), options);
+            deletedContainerItem.Name, deletedContainerItem.VersionId.Value());
         break;
       }
       catch (StorageException& e)
@@ -411,8 +408,7 @@ namespace Azure { namespace Storage { namespace Test {
         }
       }
     }
-    auto containerClient2 = m_blobServiceClient.GetBlobContainerClient(containerName2);
-    EXPECT_NO_THROW(containerClient2.GetProperties());
+    EXPECT_NO_THROW(containerClient.GetProperties());
   }
 
   TEST_F(BlobServiceClientTest, UserDelegationKey)


### PR DESCRIPTION
fixed https://github.com/Azure/azure-sdk-for-cpp/issues/2252

Hi @JeffreyRichter , storage service team decided to take back the feature of restoring a deleted container under a different name. This introduces a breaking change in client side.