### PR TITLE
Explore removing use of `int` within header files to align with guidelines.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -28,7 +28,7 @@ namespace Azure { namespace Core {
   class Uuid final {
 
   private:
-    static constexpr int UuidSize = 16;
+    static constexpr int32_t UuidSize = 16;
 
     uint8_t m_uuid[UuidSize];
     // The UUID reserved variants.
@@ -86,13 +86,13 @@ namespace Azure { namespace Core {
 #if defined(AZ_PLATFORM_WINDOWS)
       std::random_device rd;
 
-      for (int i = 0; i < UuidSize; i += 4)
+      for (size_t i = 0; i < UuidSize; i += 4)
       {
         const uint32_t x = rd();
         std::memcpy(uuid + i, &x, 4);
       }
 #elif defined(AZ_PLATFORM_POSIX)
-      int ret = RAND_bytes(uuid, UuidSize);
+      size_t ret = RAND_bytes(uuid, UuidSize);
       if (ret <= 0)
       {
         abort();

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -92,7 +92,7 @@ namespace Azure { namespace Core {
         std::memcpy(uuid + i, &x, 4);
       }
 #elif defined(AZ_PLATFORM_POSIX)
-      size_t ret = RAND_bytes(uuid, UuidSize);
+      int ret = RAND_bytes(uuid, UuidSize);
       if (ret <= 0)
       {
         abort();

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -28,7 +28,7 @@ namespace Azure { namespace Core {
   class Uuid final {
 
   private:
-    static constexpr int32_t UuidSize = 16;
+    static constexpr size_t UuidSize = 16;
 
     uint8_t m_uuid[UuidSize];
     // The UUID reserved variants.
@@ -92,7 +92,8 @@ namespace Azure { namespace Core {
         std::memcpy(uuid + i, &x, 4);
       }
 #elif defined(AZ_PLATFORM_POSIX)
-      int ret = RAND_bytes(uuid, UuidSize);
+      // This static cast is safe since we know Uuid size, which is a const, will always fit an int.
+      int ret = RAND_bytes(uuid, static_cast<int>(UuidSize));
       if (ret <= 0)
       {
         abort();

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -105,7 +105,7 @@ constexpr int8_t const MaxDaysPerMonth[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30
 constexpr int16_t DayOfYear(int16_t year, int8_t month, int8_t day)
 {
   int16_t daysInPrevMonths = 0;
-  for (size_t i = 1; i < month; ++i)
+  for (int i = 1; i < month; ++i)
   {
     daysInPrevMonths += MaxDaysPerMonth[i - 1];
   }

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -105,7 +105,7 @@ constexpr int8_t const MaxDaysPerMonth[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30
 constexpr int16_t DayOfYear(int16_t year, int8_t month, int8_t day)
 {
   int16_t daysInPrevMonths = 0;
-  for (int i = 1; i < month; ++i)
+  for (size_t i = 1; i < month; ++i)
   {
     daysInPrevMonths += MaxDaysPerMonth[i - 1];
   }

--- a/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
@@ -25,14 +25,14 @@ namespace Azure { namespace Core { namespace Http {
     // Run time error template
     constexpr static const char* DefaultFailedToGetNewConnectionTemplate
         = "Fail to get a new connection for: ";
-    constexpr static int DefaultMaxOpenNewConnectionIntentsAllowed = 10;
+    constexpr static int32_t DefaultMaxOpenNewConnectionIntentsAllowed = 10;
     // After 3 connections are received from the pool and failed to send a request, the next
     // connections would ask the pool to be clean and spawn new connection.
-    constexpr static int RequestPoolResetAfterConnectionFailed = 3;
+    constexpr static int32_t RequestPoolResetAfterConnectionFailed = 3;
     // 90 sec -> cleaner wait time before next clean routine
-    constexpr static int DefaultCleanerIntervalMilliseconds = 1000 * 90;
+    constexpr static int32_t DefaultCleanerIntervalMilliseconds = 1000 * 90;
     // 60 sec -> expired connection is when it waits for 60 sec or more and it's not re-used
-    constexpr static int DefaultConnectionExpiredMilliseconds = 1000 * 60;
+    constexpr static int32_t DefaultConnectionExpiredMilliseconds = 1000 * 60;
     // Define the maximun allowed connections per host-index in the pool. If this number is reached
     // for the host-index, next connections trying to be added to the pool will be ignored.
     constexpr static size_t MaxConnectionsPerIndex = 1024;

--- a/sdk/core/azure-core/src/private/curl_connection.hpp
+++ b/sdk/core/azure-core/src/private/curl_connection.hpp
@@ -25,14 +25,14 @@ namespace Azure { namespace Core { namespace Http {
     // Run time error template
     constexpr static const char* DefaultFailedToGetNewConnectionTemplate
         = "Fail to get a new connection for: ";
-    constexpr static int DefaultMaxOpenNewConnectionIntentsAllowed = 10;
+    constexpr static int32_t DefaultMaxOpenNewConnectionIntentsAllowed = 10;
     // After 3 connections are received from the pool and failed to send a request, the next
     // connections would ask the pool to be clean and spawn new connection.
-    constexpr static int RequestPoolResetAfterConnectionFailed = 3;
+    constexpr static int32_t RequestPoolResetAfterConnectionFailed = 3;
     // 90 sec -> cleaner wait time before next clean routine
-    constexpr static int DefaultCleanerIntervalMilliseconds = 1000 * 90;
+    constexpr static int32_t DefaultCleanerIntervalMilliseconds = 1000 * 90;
     // 60 sec -> expired connection is when it waits for 60 sec or more and it's not re-used
-    constexpr static int DefaultConnectionExpiredMilliseconds = 1000 * 60;
+    constexpr static int32_t DefaultConnectionExpiredMilliseconds = 1000 * 60;
     // Define the maximun allowed connections per host-index in the pool. If this number is reached
     // for the host-index, next connections trying to be added to the pool will be ignored.
     constexpr static size_t MaxConnectionsPerIndex = 1024;

--- a/sdk/core/azure-core/src/private/package_version.hpp
+++ b/sdk/core/azure-core/src/private/package_version.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #define AZURE_CORE_VERSION_MAJOR 1
 #define AZURE_CORE_VERSION_MINOR 0
 #define AZURE_CORE_VERSION_PATCH 0
@@ -24,13 +26,13 @@ namespace Azure { namespace Core { namespace _detail {
   class PackageVersion final {
   public:
     /// Major numeric identifier.
-    static constexpr int Major = AZURE_CORE_VERSION_MAJOR;
+    static constexpr int32_t Major = AZURE_CORE_VERSION_MAJOR;
 
     /// Minor numeric identifier.
-    static constexpr int Minor = AZURE_CORE_VERSION_MINOR;
+    static constexpr int32_t Minor = AZURE_CORE_VERSION_MINOR;
 
     /// Patch numeric identifier.
-    static constexpr int Patch = AZURE_CORE_VERSION_PATCH;
+    static constexpr int32_t Patch = AZURE_CORE_VERSION_PATCH;
 
     /// Indicates whether the SDK is in a pre-release state.
     static constexpr bool IsPreRelease = sizeof(AZURE_CORE_VERSION_PRERELEASE) != sizeof("");

--- a/sdk/core/azure-core/test/ut/operation_test.hpp
+++ b/sdk/core/azure-core/test/ut/operation_test.hpp
@@ -21,7 +21,7 @@ namespace Azure { namespace Core { namespace Test {
   private:
     std::string m_operationToken;
     std::string m_value;
-    int m_count = 0;
+    int32_t m_count = 0;
 
   private:
     std::unique_ptr<Http::RawResponse> PollInternal(Context const&) override

--- a/sdk/identity/azure-identity/src/private/package_version.hpp
+++ b/sdk/identity/azure-identity/src/private/package_version.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #define AZURE_IDENTITY_VERSION_MAJOR 1
 #define AZURE_IDENTITY_VERSION_MINOR 0
 #define AZURE_IDENTITY_VERSION_PATCH 0
@@ -24,13 +26,13 @@ namespace Azure { namespace Identity { namespace _detail {
   class PackageVersion final {
   public:
     /// Major numeric identifier.
-    static constexpr int Major = AZURE_IDENTITY_VERSION_MAJOR;
+    static constexpr int32_t Major = AZURE_IDENTITY_VERSION_MAJOR;
 
     /// Minor numeric identifier.
-    static constexpr int Minor = AZURE_IDENTITY_VERSION_MINOR;
+    static constexpr int32_t Minor = AZURE_IDENTITY_VERSION_MINOR;
 
     /// Patch numeric identifier.
-    static constexpr int Patch = AZURE_IDENTITY_VERSION_PATCH;
+    static constexpr int32_t Patch = AZURE_IDENTITY_VERSION_PATCH;
 
     /// Indicates whether the SDK is in a pre-release state.
     static constexpr bool IsPreRelease = sizeof(AZURE_IDENTITY_VERSION_PRERELEASE) != sizeof("");

--- a/sdk/keyvault/azure-security-keyvault-common/src/private/package_version.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/src/private/package_version.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #define AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MAJOR 4
 #define AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MINOR 0
 #define AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PATCH 0
@@ -25,13 +27,13 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Common { n
   class PackageVersion final {
   public:
     /// Major numeric identifier.
-    static constexpr int Major = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MAJOR;
+    static constexpr int32_t Major = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MAJOR;
 
     /// Minor numeric identifier.
-    static constexpr int Minor = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MINOR;
+    static constexpr int32_t Minor = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MINOR;
 
     /// Patch numeric identifier.
-    static constexpr int Patch = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PATCH;
+    static constexpr int32_t Patch = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PATCH;
 
     /// Indicates whether the SDK is in a pre-release state.
     static constexpr bool IsPreRelease

--- a/sdk/keyvault/azure-security-keyvault-keys/src/private/package_version.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/private/package_version.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #define AZURE_SECURITY_KEYVAULT_KEYS_VERSION_MAJOR 4
 #define AZURE_SECURITY_KEYVAULT_KEYS_VERSION_MINOR 0
 #define AZURE_SECURITY_KEYVAULT_KEYS_VERSION_PATCH 0
@@ -25,13 +27,13 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
   class PackageVersion final {
   public:
     /// Major numeric identifier.
-    static constexpr int Major = AZURE_SECURITY_KEYVAULT_KEYS_VERSION_MAJOR;
+    static constexpr int32_t Major = AZURE_SECURITY_KEYVAULT_KEYS_VERSION_MAJOR;
 
     /// Minor numeric identifier.
-    static constexpr int Minor = AZURE_SECURITY_KEYVAULT_KEYS_VERSION_MINOR;
+    static constexpr int32_t Minor = AZURE_SECURITY_KEYVAULT_KEYS_VERSION_MINOR;
 
     /// Patch numeric identifier.
-    static constexpr int Patch = AZURE_SECURITY_KEYVAULT_KEYS_VERSION_PATCH;
+    static constexpr int32_t Patch = AZURE_SECURITY_KEYVAULT_KEYS_VERSION_PATCH;
 
     /// Indicates whether the SDK is in a pre-release state.
     static constexpr bool IsPreRelease


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/2226

Trying to focus mainly on headers, depending on the conclusion, we'd want to make cpp file changes as well, but that can be done later.

Assuming this is the guideline we want:
https://azure.github.io/azure-sdk/cpp_implementation.html#integer-sizes

![image](https://user-images.githubusercontent.com/6527137/118341184-00d52580-b4d3-11eb-8e96-937cb5899c92.png)

Some places that we still use `int` is for things like unix file desriptor or where APIs like BIO_read from OpenSSL returns an int. Are those exceptions OK?
https://github.com/Azure/azure-sdk-for-cpp/blob/0b64ab3845d6850bc1666337f21640899e732ef5/sdk/core/azure-core/inc/azure/core/io/body_stream.hpp#L166
https://github.com/Azure/azure-sdk-for-cpp/blob/308e5363adaa00ace2f06ff0f1a31747a0a28062/sdk/core/azure-core/src/base64.cpp#L87