### PR TITLE
Update FileWriter buffer size in storage from int64_t to size_t.

### DIFF
--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -378,7 +378,7 @@ namespace Azure { namespace Storage { namespace Blobs {
       while (length > 0)
       {
         int64_t readSize = std::min(static_cast<int64_t>(bufferSize), length);
-        int64_t bytesRead = stream.ReadToCount(buffer.data(), readSize, context);
+        size_t bytesRead = stream.ReadToCount(buffer.data(), readSize, context);
         if (bytesRead != readSize)
         {
           throw Azure::Core::RequestFailedException("error when reading body stream");

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/file_io.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/file_io.hpp
@@ -39,7 +39,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
     FileHandle GetHandle() const { return m_handle; }
 
-    void Write(const uint8_t* buffer, int64_t length, int64_t offset);
+    void Write(const uint8_t* buffer, size_t length, int64_t offset);
 
   private:
     FileHandle m_handle;

--- a/sdk/storage/azure-storage-common/src/file_io.cpp
+++ b/sdk/storage/azure-storage-common/src/file_io.cpp
@@ -101,7 +101,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   FileWriter::~FileWriter() { CloseHandle(static_cast<HANDLE>(m_handle)); }
 
-  void FileWriter::Write(const uint8_t* buffer, int64_t length, int64_t offset)
+  void FileWriter::Write(const uint8_t* buffer, size_t length, int64_t offset)
   {
     if (length > std::numeric_limits<DWORD>::max())
     {
@@ -155,15 +155,13 @@ namespace Azure { namespace Storage { namespace _internal {
 
   FileWriter::~FileWriter() { close(m_handle); }
 
-  void FileWriter::Write(const uint8_t* buffer, int64_t length, int64_t offset)
+  void FileWriter::Write(const uint8_t* buffer, size_t length, int64_t offset)
   {
-    if (static_cast<uint64_t>(length) > std::numeric_limits<size_t>::max()
-        || offset > static_cast<int64_t>(std::numeric_limits<off_t>::max()))
+    if (offset > static_cast<int64_t>(std::numeric_limits<off_t>::max()))
     {
       throw std::runtime_error("failed to write file");
     }
-    ssize_t bytesWritten
-        = pwrite(m_handle, buffer, static_cast<size_t>(length), static_cast<off_t>(offset));
+    ssize_t bytesWritten = pwrite(m_handle, buffer, length, static_cast<off_t>(offset));
     if (bytesWritten != length)
     {
       throw std::runtime_error("failed to write file");

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -802,7 +802,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       while (length > 0)
       {
         int64_t readSize = std::min(static_cast<int64_t>(bufferSize), length);
-        int64_t bytesRead = stream.ReadToCount(buffer.data(), readSize, context);
+        size_t bytesRead = stream.ReadToCount(buffer.data(), readSize, context);
         if (bytesRead != readSize)
         {
           throw Azure::Core::RequestFailedException("error when reading body stream");


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/2226

Mainly modifies FileWriter and call sites.

Todo: Changelog

cc @Jinming-Hu 