### PR TITLE
Add explicit assignment and desctructor for RawResponse and RequestFailedException

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -107,13 +107,9 @@ namespace Azure { namespace Core {
     {
     }
 
-    /**
-     * @brief Constructs a new `RequestFailedException`.
-     * @note Transfers ownership of the #Azure::Core::Http::RawResponse to the new
-     * `RequestFailedException`.
-     *
-     * @param other An rvalue reference for moving the `RequestFailedException`.
-     */
     RequestFailedException(RequestFailedException&& other) = default;
+    RequestFailedException& operator=(const RequestFailedException&) = delete;
+    RequestFailedException& operator=(RequestFailedException&&) = delete;
+    ~RequestFailedException() = default;
   };
 }} // namespace Azure::Core

--- a/sdk/core/azure-core/inc/azure/core/http/raw_response.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/raw_response.hpp
@@ -81,13 +81,10 @@ namespace Azure { namespace Core { namespace Http {
       m_body = response.GetBody();
     }
 
-    /**
-     * @brief Constructs a new `RawResponse`.
-     * @note Transfers ownership of the `RawResponse` to the new `RawResponse`.
-     *
-     * @param response An rvalue reference for moving the raw response.
-     */
     RawResponse(RawResponse&& response) = default;
+    RawResponse& operator=(RawResponse const&) = delete;
+    RawResponse& operator=(RawResponse&&) = delete;
+    ~RawResponse() = default;
 
     // ===== Methods used to build HTTP response =====
 


### PR DESCRIPTION
This is to follow up on the unaddressed comments in https://github.com/Azure/azure-sdk-for-cpp/pull/2291