### PR TITLE
Incorrect use of hashing Final/Append APIs now have an assert failure.

### DIFF
--- a/sdk/storage/azure-storage-common/test/crypt_functions_test.cpp
+++ b/sdk/storage/azure-storage-common/test/crypt_functions_test.cpp
@@ -127,8 +127,8 @@ namespace Azure { namespace Storage { namespace Test {
     const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data.data());
     Crc64Hash instance;
 
-    EXPECT_THROW(instance.Final(nullptr, 1), std::invalid_argument);
-    EXPECT_THROW(instance.Append(nullptr, 1), std::invalid_argument);
+    ASSERT_DEATH(instance.Final(nullptr, 1), "");
+    ASSERT_DEATH(instance.Append(nullptr, 1), "");
 
     EXPECT_EQ(
         Azure::Core::Convert::Base64Encode(instance.Final(ptr, data.length())), "AAAAAAAAAAA=");

--- a/sdk/storage/azure-storage-common/test/crypt_functions_test.cpp
+++ b/sdk/storage/azure-storage-common/test/crypt_functions_test.cpp
@@ -132,9 +132,17 @@ namespace Azure { namespace Storage { namespace Test {
 
     EXPECT_EQ(
         Azure::Core::Convert::Base64Encode(instance.Final(ptr, data.length())), "AAAAAAAAAAA=");
-    EXPECT_THROW(instance.Final(), std::runtime_error);
-    EXPECT_THROW(instance.Final(ptr, data.length()), std::runtime_error);
-    EXPECT_THROW(instance.Append(ptr, data.length()), std::runtime_error);
+
+#if defined(NDEBUG)
+    // Release build won't provide assert msg
+    ASSERT_DEATH(instance.Final(), "");
+    ASSERT_DEATH(instance.Final(ptr, data.length()), "");
+    ASSERT_DEATH(instance.Append(ptr, data.length()), "");
+#else
+    ASSERT_DEATH(instance.Final(), "Cannot call Final");
+    ASSERT_DEATH(instance.Final(ptr, data.length()), "Cannot call Final");
+    ASSERT_DEATH(instance.Append(ptr, data.length()), "Cannot call Append after calling Final");
+#endif
   }
 
   TEST(CryptFunctionsTest, Crc64Hash_CtorDtor)


### PR DESCRIPTION
Follow up from https://github.com/Azure/azure-sdk-for-cpp/pull/2189