### PR TITLE
Narrow $packagePattern to exclude vcpkg.json files which are now part of the publishing process

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -1,7 +1,7 @@
 $Language = "cpp"
 $LanguageDisplayName = "C++"
 $PackageRepository = "CPP"
-$packagePattern = "*.json"
+$packagePattern = "package-info.json"
 $MetadataUri = "https://raw.githubusercontent.com/Azure/azure-sdk/master/_data/releases/latest/cpp-packages.csv"
 $BlobStorageUrl = "https://azuresdkdocs.blob.core.windows.net/%24web?restype=container&comp=list&prefix=cpp%2F&delimiter=%2F"
 


### PR DESCRIPTION
Fixes #2325 

The issue happens because we have 2 .json files for a given package now -

* `package-info.json` -- This contains metadata about the package that we use during release processes
* `vcpkg.json` -- This file is included as part of the publishing artifacts. It is new to this version of the release

When `RetrievePackages` runs it uses the pattern `*.json` and matches both `.json` files (where `package-info.json` was the only one matched before). The tagging process then loops through the list of `.json` files and tries to generate tags for them. Since these are JSON files entries like `name` show up in both `package-info.json` and `vcpkg.json` and happen to be the name of the package. 

Filtering to `package-info.json` fixes this problem as that is the only metadata file we care about. 

This could've been caught if we had exercised releasing the `template` project. 

This PR fixes the issue as only one tag was created on a test template release: 

![image](https://user-images.githubusercontent.com/2158838/118889336-d360f100-b8b1-11eb-96f4-e7cea81092ad.png)

That release will be deleted shortly. 

This is the build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=903734&view=results