### PR TITLE
Using Doxygen ALIASES to re-use and sync a common phrase from docs like context

### DIFF
--- a/cmake-modules/AzureDoxygen.cmake
+++ b/cmake-modules/AzureDoxygen.cmake
@@ -38,6 +38,10 @@ function(generate_documentation PROJECT_NAME PROJECT_VERSION)
         # Use MathJax instead of latex to render formulas
         set(DOXYGEN_USE_MATHJAX YES)
 
+        #####  Doxygen Aliases. Define general docs for consistency and re-usability
+        # @param context ...
+        set(DOXYGEN_ALIASES "contextParameter=@param context A #Azure::Core::Context controlling the request lifetime.")
+
         doxygen_add_docs(${PROJECT_NAME}-docs
             ALL
             COMMENT "Generate documentation for ${PROJECT_NAME}")

--- a/cmake-modules/AzureGlobalCompileOptions.cmake
+++ b/cmake-modules/AzureGlobalCompileOptions.cmake
@@ -23,8 +23,9 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if(WARNINGS_AS_ERRORS)
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")
   endif()
-
-  add_compile_options(-fno-operator-names -Wold-style-cast -Xclang -Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -Wcast-qual)
+  # using `Wno-documentation-unknown-command` to support doxygen aliases.
+  # All other checks from -Wdocumentation will still work.
+  add_compile_options(-fno-operator-names -Wold-style-cast -Xclang -Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -Wcast-qual -Wno-documentation-unknown-command)
 else()
   if(WARNINGS_AS_ERRORS)
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")

--- a/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
+++ b/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
@@ -63,7 +63,7 @@ namespace Azure { namespace Core { namespace Credentials {
      *
      * @param tokenRequestContext #Azure::Core::Credentials::TokenRequestContext to get the token
      * in.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @throw Azure::Core::Credentials::AuthenticationException Authentication error occurred.
      */

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -113,7 +113,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Implements interface to send an HTTP Request and produce an HTTP RawResponse
      *
      * @param request an HTTP Request to be send.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return unique ptr to an HTTP RawResponse.
      */

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -161,7 +161,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      *
      * @param request An HTTP request being sent.
      * @param nextPolicy The next HTTP to invoke after this policy has been applied.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return An HTTP response after this policy, and all subsequent HTTP policies in the stack
      * sequence of policies have been applied.
@@ -218,7 +218,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * @brief Applies this HTTP policy.
      *
      * @param request An HTTP request being sent.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return An HTTP response after this policy, and all subsequent HTTP policies in the stack
      * sequence of policies have been applied.
@@ -296,7 +296,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
        * a request by the #RetryPolicy. Any subsequent retry will be referenced with a number
        * greater than 0.
        *
-       * @param context The context used to call send request.
+       * @contextParameter
        * @return A positive number indicating the current intent to send the request.
        */
       static int32_t GetRetryCount(Context const& context);

--- a/sdk/core/azure-core/inc/azure/core/http/transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/transport.hpp
@@ -27,7 +27,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Send an HTTP request over the wire.
      *
      * @param request An #Azure::Core::Http::Request to send.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      */
     // TODO - Should this be const
     virtual std::unique_ptr<RawResponse> Send(Request& request, Context const& context) = 0;

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -99,7 +99,7 @@ namespace Azure { namespace Core { namespace Http {
        * @brief Implement #Azure::Core::IO::BodyStream::OnRead(). Calling this function pulls data
        * from the wire.
        *
-       * @param context #Azure::Core::Context so that operation can be cancelled.
+       * @contextParameter
        * @param buffer Buffer where data from wire is written to.
        * @param count The number of bytes to read from the network.
        * @return The actual number of bytes read from the network.
@@ -170,7 +170,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Implements the HTTP transport interface to send an HTTP Request and produce an HTTP
      * RawResponse.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      * @param request an HTTP request to be send.
      * @return A unique pointer to an HTTP RawResponse.
      */

--- a/sdk/core/azure-core/inc/azure/core/internal/http/pipeline.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/http/pipeline.hpp
@@ -172,7 +172,7 @@ namespace Azure { namespace Core { namespace Http { namespace _internal {
      * @brief Start the HTTP pipeline.
      *
      * @param request The HTTP request to be processed.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return HTTP response after the request has been processed.
      */

--- a/sdk/core/azure-core/inc/azure/core/io/body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/io/body_stream.hpp
@@ -38,7 +38,7 @@ namespace Azure { namespace Core { namespace IO {
      *
      * @param buffer Pointer to a byte buffer to read the data into.
      * @param count Size of the buffer to read the data into.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return Number of bytes read.
      */
@@ -74,7 +74,7 @@ namespace Azure { namespace Core { namespace IO {
      *
      * @param buffer Pointer to a first byte of the byte buffer to read the data into.
      * @param count Size of the buffer to read the data into.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return Number of bytes read.
      */
@@ -95,7 +95,7 @@ namespace Azure { namespace Core { namespace IO {
      *
      * @param buffer Pointer to a first byte of the byte buffer to read the data into.
      * @param count Size of the buffer to read the data into.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return Number of bytes read.
      */
@@ -108,7 +108,7 @@ namespace Azure { namespace Core { namespace IO {
      * @brief Read #Azure::Core::IO::BodyStream until the stream is read to end, allocating memory
      * for the entirety of contents.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return A vector of bytes containing the entirety of data read from the \p body.
      */

--- a/sdk/core/azure-core/inc/azure/core/operation.hpp
+++ b/sdk/core/azure-core/inc/azure/core/operation.hpp
@@ -149,7 +149,7 @@ namespace Azure { namespace Core {
     /**
      * @brief Gets updated status of the long-running operation.
      *
-     * @param context #Azure::Core::Context allows canceling of the long-running operation.
+     * @contextParameter
      *
      * @return An HTTP #Azure::Core::Http::RawResponse returned from the service.
      */
@@ -175,10 +175,10 @@ namespace Azure { namespace Core {
     }
 
     /**
-     * @brief Periodically polls till the long-running operation completes;
+     * @brief Periodically polls till the long-running operation completes.
      *
      * @param period Time in milliseconds to wait between polls.
-     * @param context #Azure::Core::Context allows canceling of the long-running operation.
+     * @contextParameter
      *
      * @return Response<T> the final result of the long-running operation.
      */

--- a/sdk/core/azure-core/inc/azure/core/paged_response.hpp
+++ b/sdk/core/azure-core/inc/azure/core/paged_response.hpp
@@ -83,7 +83,7 @@ namespace Azure { namespace Core {
      *
      * @note Calling this method on the last page will set #HasPage() to `false`.
      *
-     * @param context An #Azure::Core::Context which can be used to cancel the operation.
+     * @contextParameter
      */
     void MoveToNextPage(const Azure::Core::Context& context = Azure::Core::Context())
     {

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -61,7 +61,7 @@ enum class PollSocketDirection
  * @param socketFileDescriptor socket descriptor.
  * @param direction poll events for read or write socket.
  * @param timeout  return if polling for more than \p timeout
- * @param context The context while polling that can be use to cancel waiting for socket.
+ * @contextParameter
  *
  * @return int with negative 1 upon any error, 0 on timeout or greater than zero if events were
  * detected (socket ready to be written/read)

--- a/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
@@ -178,7 +178,7 @@ namespace Azure { namespace Core { namespace Http {
        * Function will try to keep pulling data from socket until the buffer is all written or until
        * there is no more data to get from the socket.
        *
-       * @param context #Azure::Core::Context so that operation can be cancelled.
+       * @contextParameter
        * @param buffer ptr to buffer where to copy bytes from socket.
        * @param bufferSize size of the buffer and the requested bytes to be pulled from wire.
        * @return return the numbers of bytes pulled from socket. It can be less than what it was
@@ -191,7 +191,7 @@ namespace Azure { namespace Core { namespace Http {
        *
        * @remarks Hardcoded timeout is used in case a socket stop responding.
        *
-       * @param context #Azure::Core::Context so that operation can be cancelled.
+       * @contextParameter
        * @param buffer ptr to the data to be sent to wire.
        * @param bufferSize size of the buffer to send.
        * @return CURL_OK when response is sent successfully.

--- a/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
@@ -284,7 +284,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Function used when working with Streams to manually write from the HTTP Request to
      * the wire.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return CURL_OK when response is sent successfully.
      */
@@ -293,7 +293,7 @@ namespace Azure { namespace Core { namespace Http {
     /**
      * @brief Upload body.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return Curl code.
      */
@@ -303,7 +303,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief This function is used after sending an HTTP request to the server to read the HTTP
      * RawResponse from wire until the end of headers only.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      * @param reuseInternalBuffer Indicates whether the internal buffer should be reused.
      */
     void ReadStatusLineAndHeadersFromRawResponse(
@@ -314,7 +314,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Reads from inner buffer or from Wire until chunkSize is parsed and converted to
      * unsigned long long
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      */
     void ParseChunkSize(Context const& context);
 
@@ -357,7 +357,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Implement #Azure::Core::IO::BodyStream::OnRead(). Calling this function pulls data
      * from the wire.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      * @param buffer Buffer where data from wire is written to.
      * @param count The number of bytes to read from the network.
      * @return The actual number of bytes read from the network.
@@ -394,7 +394,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Function will use the HTTP request received in constructor to perform a network call
      * based on the HTTP request configuration.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      * @return CURLE_OK when the network call is completed successfully.
      */
     CURLcode Perform(Context const& context);

--- a/sdk/core/azure-core/src/private/curl_connection.hpp
+++ b/sdk/core/azure-core/src/private/curl_connection.hpp
@@ -178,7 +178,7 @@ namespace Azure { namespace Core { namespace Http {
        * Function will try to keep pulling data from socket until the buffer is all written or until
        * there is no more data to get from the socket.
        *
-       * @param context #Azure::Core::Context so that operation can be cancelled.
+       * @contextParameter
        * @param buffer ptr to buffer where to copy bytes from socket.
        * @param bufferSize size of the buffer and the requested bytes to be pulled from wire.
        * @return return the numbers of bytes pulled from socket. It can be less than what it was
@@ -191,7 +191,7 @@ namespace Azure { namespace Core { namespace Http {
        *
        * @remarks Hardcoded timeout is used in case a socket stop responding.
        *
-       * @param context #Azure::Core::Context so that operation can be cancelled.
+       * @contextParameter
        * @param buffer ptr to the data to be sent to wire.
        * @param bufferSize size of the buffer to send.
        * @return CURL_OK when response is sent successfully.

--- a/sdk/core/azure-core/src/private/curl_session.hpp
+++ b/sdk/core/azure-core/src/private/curl_session.hpp
@@ -284,7 +284,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Function used when working with Streams to manually write from the HTTP Request to
      * the wire.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return CURL_OK when response is sent successfully.
      */
@@ -293,7 +293,7 @@ namespace Azure { namespace Core { namespace Http {
     /**
      * @brief Upload body.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @return Curl code.
      */
@@ -303,7 +303,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief This function is used after sending an HTTP request to the server to read the HTTP
      * RawResponse from wire until the end of headers only.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      * @param reuseInternalBuffer Indicates whether the internal buffer should be reused.
      */
     void ReadStatusLineAndHeadersFromRawResponse(
@@ -314,7 +314,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Reads from inner buffer or from Wire until chunkSize is parsed and converted to
      * unsigned long long
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      */
     void ParseChunkSize(Context const& context);
 
@@ -357,7 +357,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Implement #Azure::Core::IO::BodyStream::OnRead(). Calling this function pulls data
      * from the wire.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      * @param buffer Buffer where data from wire is written to.
      * @param count The number of bytes to read from the network.
      * @return The actual number of bytes read from the network.
@@ -394,7 +394,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Function will use the HTTP request received in constructor to perform a network call
      * based on the HTTP request configuration.
      *
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      * @return CURLE_OK when the network call is completed successfully.
      */
     CURLcode Perform(Context const& context);

--- a/sdk/core/perf/inc/azure/perf/program.hpp
+++ b/sdk/core/perf/inc/azure/perf/program.hpp
@@ -35,7 +35,7 @@ namespace Azure { namespace Perf {
     /**
      * @brief Start the performance application.
      *
-     * @param context The strategy for cancelling the test execution.
+     * @contextParameter
      * @param tests The list of tests that the application can run.
      * @param argc The number of command line arguments.
      * @param argv The reference to the first null terminated command line argument.

--- a/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
@@ -96,7 +96,7 @@ namespace Azure { namespace Identity {
      *
      * @param tokenRequestContext #Azure::Core::Credentials::TokenRequestContext to get the token
      * in.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @throw Azure::Core::Credentials::AuthenticationException Authentication error occurred.
      */

--- a/sdk/identity/azure-identity/inc/azure/identity/environment_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/environment_credential.hpp
@@ -43,7 +43,7 @@ namespace Azure { namespace Identity {
      *
      * @param tokenRequestContext #Azure::Core::Credentials::TokenRequestContext to get the token
      * in.
-     * @param context #Azure::Core::Context so that operation can be cancelled.
+     * @contextParameter
      *
      * @throw Azure::Core::Credentials::AuthenticationException Authentication error occurred.
      */

--- a/sdk/identity/azure-identity/test/perf/inc/azure/identity/test/secret_credential.hpp
+++ b/sdk/identity/azure-identity/test/perf/inc/azure/identity/test/secret_credential.hpp
@@ -56,7 +56,7 @@ namespace Azure { namespace Identity { namespace Test {
     /**
      * @brief Define the test
      *
-     * @param context The cancellation token.
+     * @contextParameter
      */
     void Run(Azure::Core::Context const& context) override
     {

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/keyvault_pipeline.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/keyvault_pipeline.hpp
@@ -59,7 +59,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace _internal 
     /**
      * @brief Start the HTTP transfer based on the \p request.
      *
-     * @param context The context for per-operation options or cancellation.
+     * @contextParameter
      * @param request The HTTP request to be sent.
      * @return The raw response from the network.
      */
@@ -87,7 +87,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace _internal 
      * @brief Create and send the HTTP request. Uses the \p factoryFn function to create
      * the response type.
      *
-     * @param context The context for per-operation options or cancellation.
+     * @contextParameter
      * @param method The method for the request.
      * @param factoryFn The function to deserialize and produce T from the raw response.
      * @param path A path for the request represented as a vector of strings.
@@ -121,7 +121,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace _internal 
      * @brief Create and send the HTTP request with payload content. Uses the \p factoryFn function
      * to create the response type.
      *
-     * @param context The context for per-operation options or cancellation.
+     * @contextParameter
      * @param method The method for the request.
      * @param content The HTTP payload.
      * @param factoryFn The function to deserialize and produce T from the raw response.
@@ -172,7 +172,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace _internal 
      * @brief Create a key vault request and send it using the Azure Core pipeline directly to avoid
      * checking the respone code.
      *
-     * @param context A context for cancellation.
+     * @contextParameter
      * @param method The HTTP method for the request.
      * @param path The path for the request.
      * @return A unique ptr to an HTTP raw response.

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_client.hpp
@@ -94,7 +94,7 @@ namespace Azure {
      *
      * @param parameters An #EncryptParameters containing the data to encrypt and other parameters
      * for algorithm-dependent encryption.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return An #EncryptResult containing the encrypted data along with all other information
      * needed to decrypt it. This information should be stored with the encrypted data.
      */
@@ -107,7 +107,7 @@ namespace Azure {
      *
      * @param algorithm The #EncryptionAlgorithm to use.
      * @param plaintext The data to encrypt.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return An #EncryptResult containing the encrypted data along with all other information
      * needed to decrypt it. This information should be stored with the encrypted data.
      */
@@ -124,7 +124,7 @@ namespace Azure {
      *
      * @param parameters A #DecryptParameters containing the data to decrypt and other parameters
      * for algorithm-dependent Decryption.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return An #DecryptResult containing the decrypted data along with all other information
      * needed to decrypt it. This information should be stored with the Decrypted data.
      */
@@ -137,7 +137,7 @@ namespace Azure {
      *
      * @param algorithm The #EncryptionAlgorithm to use.
      * @param ciphertext The encrypted data to decrypt..
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return An #DecryptResult containing the Decrypted data along with all other information
      * needed to decrypt it. This information should be stored with the Decrypted data.
      */
@@ -154,7 +154,7 @@ namespace Azure {
      *
      * @param algorithm The #KeyWrapAlgorithm to use.
      * @param key The key to encrypt.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return The result of the wrap operation. The returned #WrapResult contains the wrapped key
      * along with all other information needed to unwrap it. This information should be stored with
      * the wrapped key.
@@ -169,7 +169,7 @@ namespace Azure {
      *
      * @param algorithm The #KeyWrapAlgorithm to use.
      * @param encryptedKey The encrypted key.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return The result of the unwrap operation. The returned #UnwrapResult contains the key along
      * with information regarding the algorithm and key used to unwrap it.
      */
@@ -184,7 +184,7 @@ namespace Azure {
      * @param algorithm The #SignatureAlgorithm to use.
      * @param digest The pre-hashed digest to sign. The hash algorithm used to compute the digest
      * must be compatable with the specified algorithm.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return The result of the sign operation. The returned #SignResult contains the signature
      * along with all other information needed to verify it. This information should be stored with
      * the signature.
@@ -199,7 +199,7 @@ namespace Azure {
      *
      * @param algorithm The #SignatureAlgorithm to use.
      * @param data The data to sign.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return The result of the sign operation. The returned #SignResult contains the signature
      * along with all other information needed to verify it. This information should be stored with
      * the signature.
@@ -214,7 +214,7 @@ namespace Azure {
      *
      * @param algorithm The #SignatureAlgorithm to use.
      * @param data The data to sign.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return The result of the sign operation. The returned #SignResult contains the signature
      * along with all other information needed to verify it. This information should be stored with
      * the signature.
@@ -232,7 +232,7 @@ namespace Azure {
      * @param digest The pre-hashed digest corresponding to the signature. The hash algorithm used
      * to compute the digest must be compatable with the specified algorithm.
      * @param signature The signature to verify.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return The result of the verify operation. If the signature is valid the
      * #VerifyResult.IsValid property of the returned #VerifyResult will be set to true.
      */
@@ -249,7 +249,7 @@ namespace Azure {
      * the data.
      * @param data The data corresponding to the signature.
      * @param signature The signature to verify.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return The result of the verify operation. If the signature is valid the
      * #VerifyResult.IsValid property of the returned #VerifyResult will be set to true.
      */
@@ -266,7 +266,7 @@ namespace Azure {
      * the data.
      * @param data The data corresponding to the signature.
      * @param signature The signature to verify.
-     * @param context A #Azure::Core::Context to cancel the operation.
+     * @contextParameter
      * @return The result of the verify operation. If the signature is valid the
      * #VerifyResult.IsValid property of the returned #VerifyResult will be set to true.
      */

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/delete_key_operation.hpp
@@ -119,7 +119,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      *
      * @param resumeToken A previously generated token used to resume the polling of the operation.
      * @param client A #KeyClient that is used for getting status updates.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return DeleteKeyOperation
      */
     static DeleteKeyOperation CreateFromResumeToken(

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
@@ -96,7 +96,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      *
      * @param name The name of the key.
      * @param options Optional parameters for this operation.
-     * @param context The context for the operation can be used for request cancellation.
+     * @contextParameter
      * @return The Key wrapped in the Response.
      */
     Azure::Response<KeyVaultKey> GetKey(
@@ -114,7 +114,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * #Azure::Security::KeyVault::Keys::KeyVaultKeyType.
      * @param options Optional parameters for this operation. See
      * #Azure::Security::KeyVault::Keys::CreateKeyOptions.
-     * @param context The context for the operation can be used for request cancellation.
+     * @contextParameter
      * @return The Key wrapped in the Response.
      */
     Azure::Response<KeyVaultKey> CreateKey(
@@ -132,7 +132,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      *
      * @param ecKeyOptions The key options object containing information about the Elliptic Curve
      * key being created.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return The Key wrapped in the Response.
      */
     Azure::Response<KeyVaultKey> CreateEcKey(
@@ -148,7 +148,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      *
      * @param rsaKeyOptions The key options object containing information about the RSA key being
      * created.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return The Key wrapped in the Response.
      */
     Azure::Response<KeyVaultKey> CreateRsaKey(
@@ -164,7 +164,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      *
      * @param octKeyOptions The key options object containing information about the AES key being
      * created.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return The Key wrapped in the Response.
      */
     Azure::Response<KeyVaultKey> CreateOctKey(
@@ -187,7 +187,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      *
      * @param options The #GetPropertiesOfKeysOptions object to for setting the operation
      * up.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      */
     KeyPropertiesPageResult GetPropertiesOfKeys(
         GetPropertiesOfKeysOptions const& options = GetPropertiesOfKeysOptions(),
@@ -209,7 +209,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * @param name The name of the key.
      * @param options The #GetPropertiesOfKeyVersionsOptions object to for setting the
      * operation up.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      */
     KeyPropertiesPageResult GetPropertiesOfKeyVersions(
         std::string const& name,
@@ -225,7 +225,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * requires the keys/delete permission.
      *
      * @param name The name of the key.
-     * @param context A cancellation token controlling the request lifetime.
+     * @contextParameter
      * @return A #Azure::Security::KeyVault::Keys::DeleteKeyOperation to wait on this long-running
      * operation. If the key is soft delete-enabled, you only need to wait for the operation to
      * complete if you need to recover or purge the key; otherwise, the key is deleted automatically
@@ -243,7 +243,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * soft-delete enabled vault. This operation requires the keys/get permission.
      *
      * @param name The name of the key.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return Azure::Response<DeletedKey>
      */
     Azure::Response<DeletedKey> GetDeletedKey(
@@ -265,7 +265,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * next page of the response if there is a next page.
      *
      * @param options The #GetDeletedKeysOptions object to for setting the operation up.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return Azure::Response<DeletedKeyPageResult>
      */
     DeletedKeyPageResult GetDeletedKeys(
@@ -280,7 +280,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * soft-delete enabled vault. This operation requires the keys/purge permission.
      *
      * @param name The name of the key.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      */
     Azure::Response<PurgedKey> PurgeDeletedKey(
         std::string const& name,
@@ -296,7 +296,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * permission.
      *
      * @param name The name of the key.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return Azure::Security::KeyVault::Keys::RecoverDeletedKeyOperation
      */
     Azure::Security::KeyVault::Keys::RecoverDeletedKeyOperation StartRecoverDeletedKey(
@@ -314,7 +314,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * @param properties The #KeyProperties object with updated properties.
      * @param keyOperations Optional list of supported #KeyOperation. If no operation list provided,
      * no changes will be made to existing key operations.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return Azure::Response<KeyVaultKey>
      */
     Azure::Response<KeyVaultKey> UpdateKeyProperties(
@@ -339,7 +339,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * key/backup permission.
      *
      * @param name The name of the key.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      */
     Azure::Response<std::vector<uint8_t>> BackupKey(
         std::string const& name,
@@ -361,7 +361,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * permission.
      *
      * @param backup The backup blob associated with a key.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      */
     Azure::Response<KeyVaultKey> RestoreKeyBackup(
         std::vector<uint8_t> const& backup,
@@ -377,7 +377,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      *
      * @param name The name of the key.
      * @param keyMaterial The #JsonWebKey being imported.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return Azure::Response<KeyVaultKey>
      */
     Azure::Response<KeyVaultKey> ImportKey(
@@ -395,7 +395,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      *
      * @param importKeyOptions The key import configuration object containing information about the
      * #JsonWebKey being imported.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      */
     Azure::Response<KeyVaultKey> ImportKey(
         ImportKeyOptions const& importKeyOptions,

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/recover_deleted_key_operation.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/recover_deleted_key_operation.hpp
@@ -115,7 +115,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      *
      * @param resumeToken A previously generated token used to resume the polling of the operation.
      * @param client A #KeyClient that is used for getting status updates.
-     * @param context A #Azure::Core::Context controlling the request lifetime.
+     * @contextParameter
      * @return DeleteKeyOperation
      */
     static RecoverDeletedKeyOperation CreateFromResumeToken(

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/append_blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/append_blob_client.hpp
@@ -108,7 +108,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * overwritten with the newly initialized append blob.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A CreateAppendBlobResult describing the newly created append blob.
      */
     Azure::Response<Models::CreateAppendBlobResult> Create(
@@ -120,7 +120,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * exists.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A CreateAppendBlobResult describing the newly created append blob.
      * CreateAppendBlobResult.Created is false if the blob already exists.
      */
@@ -134,7 +134,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param content A BodyStream containing the content of the block to append.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A AppendBlockResult describing the state of the updated append blob.
      */
     Azure::Response<Models::AppendBlockResult> AppendBlock(
@@ -151,7 +151,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * must either be public or must be authenticated via a shared access signature. If the source
      * blob is public, no authentication is required to perform the operation.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A AppendBlockFromUriResult describing the state of the updated append blob.
      */
     Azure::Response<Models::AppendBlockFromUriResult> AppendBlockFromUri(
@@ -163,7 +163,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Seals the append blob, making it read only. Any subsequent appends will fail.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A SealAppendBlobResult describing the state of the sealed append blob.
      */
     Azure::Response<Models::SealAppendBlobResult> Seal(

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_client.hpp
@@ -154,7 +154,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * properties for the blob. It does not return the content of the blob.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BlobProperties describing the blob's properties.
      */
     Azure::Response<Models::BlobProperties> GetProperties(
@@ -166,7 +166,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param httpHeaders The standard HTTP header system properties to set.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A SetBlobHttpHeadersResult describing the updated blob.
      */
     Azure::Response<Models::SetBlobHttpHeadersResult> SetHttpHeaders(
@@ -180,7 +180,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param metadata Custom metadata to set for this blob.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A SetBlobMetadataResult describing the updated blob.
      */
     Azure::Response<Models::SetBlobMetadataResult> SetMetadata(
@@ -194,7 +194,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param accessTier Indicates the tier to be set on the blob.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A SetBlobAccessTierResult on successfully setting the tier.
      */
     Azure::Response<Models::SetBlobAccessTierResult> SetAccessTier(
@@ -212,7 +212,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * public or must be authenticated via a shared access signature. If the source blob is public,
      * no authentication is required to perform the copy operation.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A StartBlobCopyOperation describing the state of the copy operation.
      */
     StartBlobCopyOperation StartCopyFromUri(
@@ -226,7 +226,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param copyId ID of the copy operation to abort.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A AbortBlobCopyFromUriResult on successfully aborting.
      */
     Azure::Response<Models::AbortBlobCopyFromUriResult> AbortCopyFromUri(
@@ -239,7 +239,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * properties.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A DownloadBlobResult describing the downloaded blob.
      * BlobDownloadResponse.BodyStream contains the blob's data.
      */
@@ -255,7 +255,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param bufferSize Size of the memory buffer. Size must be larger or equal to size of the blob
      * or blob range.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A DownloadBlobToResult describing the downloaded blob.
      */
     Azure::Response<Models::DownloadBlobToResult> DownloadTo(
@@ -270,7 +270,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param fileName A file path to write the downloaded content to.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A DownloadBlobToResult describing the downloaded blob.
      */
     Azure::Response<Models::DownloadBlobToResult> DownloadTo(
@@ -282,7 +282,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Creates a read-only snapshot of a blob.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A CreateBlobSnapshotResult describing the new blob snapshot.
      */
     Azure::Response<Models::CreateBlobSnapshotResult> CreateSnapshot(
@@ -295,7 +295,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * snapshots. You can delete both at the same time using DeleteBlobOptions.DeleteSnapshots.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A DeleteBlobResult on successfully deleting.
      */
     Azure::Response<Models::DeleteBlobResult> Delete(
@@ -306,7 +306,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Marks the specified blob or snapshot for deletion if it exists.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A DeleteBlobResult on successfully deleting. DeleteBlobResult.Deleted is false if the
      * blob doesn't exist.
      */
@@ -319,7 +319,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * soft deleted snapshots.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A UndeleteBlobResult on successfully deleting.
      */
     Azure::Response<Models::UndeleteBlobResult> Undelete(
@@ -331,7 +331,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param tags The tags to set on the blob.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A SetBlobTagsInfo on successfully setting tags.
      */
     Azure::Response<Models::SetBlobTagsResult> SetTags(
@@ -343,7 +343,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Gets the tags associated with the underlying blob.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return BlobTags on successfully getting tags.
      */
     Azure::Response<std::map<std::string, std::string>> GetTags(

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
@@ -128,7 +128,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * same name already exists, the operation fails.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A CreateBlobContainerResult describing the newly created blob container.
      */
     Azure::Response<Models::CreateBlobContainerResult> Create(
@@ -140,7 +140,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * same name already exists, it is not changed.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A CreateBlobContainerResult describing the newly created blob container if the
      * container doesn't exist. CreateBlobContainerResult.Created is false if the container already
      * exists.
@@ -154,7 +154,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * contained within it are later deleted during garbage collection.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A DeleteBlobContainerResult if successful.
      */
     Azure::Response<Models::DeleteBlobContainerResult> Delete(
@@ -166,7 +166,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * contained within it are later deleted during garbage collection.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A DeleteBlobContainerResult if the container exists.
      * DeleteBlobContainerResult.Deleted is false if the container doesn't exist.
      */
@@ -179,7 +179,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * container. The data returned does not include the container's list of blobs.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BlobContainerProperties describing the container and its properties.
      */
     Azure::Response<Models::BlobContainerProperties> GetProperties(
@@ -191,7 +191,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param metadata Custom metadata to set for this container.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A SetBlobContainerMetadataResult if successful.
      */
     Azure::Response<Models::SetBlobContainerMetadataResult> SetMetadata(
@@ -205,7 +205,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * lexicographically by name.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ListBlobsPagedResponse describing the blobs in the container.
      */
     ListBlobsPagedResponse ListBlobs(
@@ -221,7 +221,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param delimiter This can be used to to traverse a virtual hierarchy of blobs as though it
      * were a file system. The delimiter may be a single character or a string.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ListBlobsByHierarchyPagedResponse describing the blobs in the container.
      */
     ListBlobsByHierarchyPagedResponse ListBlobsByHierarchy(
@@ -234,7 +234,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * container data may be accessed publicly.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BlobContainerAccessPolicy describing the container's access policy.
      */
     Azure::Response<Models::BlobContainerAccessPolicy> GetAccessPolicy(
@@ -246,7 +246,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * whether blob container data may be accessed publicly.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A SetBlobContainerAccessPolicyResult describing the updated container.
      */
     Azure::Response<Models::SetBlobContainerAccessPolicyResult> SetAccessPolicy(
@@ -260,7 +260,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param blobName The name of the blob to delete.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A DeleteBlobResult on successfully deleting.
      */
     Azure::Response<Models::DeleteBlobResult> DeleteBlob(
@@ -276,7 +276,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param blobName The name of the blob to create.
      * @param content A BodyStream containing the content to upload.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BlockBlobClient referencing the newly created block blob.
      */
     Azure::Response<BlockBlobClient> UploadBlob(

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_lease_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_lease_client.hpp
@@ -71,7 +71,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be
      * changed using renew or change.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return An AcquireLeaseResult describing the lease.
      */
     Azure::Response<Models::AcquireLeaseResult> Acquire(
@@ -83,7 +83,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Renews the blob or blob container's previously-acquired lease.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A RenewLeaseResult describing the lease.
      */
     Azure::Response<Models::RenewLeaseResult> Renew(
@@ -94,7 +94,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Releases the blob or blob container's previously-acquired lease.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ReleaseLeaseResult describing the updated container or blob.
      */
     Azure::Response<Models::ReleaseLeaseResult> Release(
@@ -106,7 +106,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param proposedLeaseId Proposed lease ID, in a GUID string format.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ChangeLeaseResult describing the changed lease.
      * @remarks The current BlobLeaseClient becomes invalid if this operation succeeds.
      */
@@ -119,7 +119,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Breaks the previously-acquired lease.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BreakLeaseResult describing the broken lease.
      */
     Azure::Response<Models::BreakLeaseResult> Break(

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_service_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_service_client.hpp
@@ -91,7 +91,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * Containers are ordered lexicographically by name.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ListBlobContainersPagedResponse describing the blob containers in the
      * storage account.
      */
@@ -106,7 +106,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param expiresOn Expiration of the key's validity. The time should be specified in UTC, and
      * will be truncated to second.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A deserialized UserDelegationKey instance.
      */
     Azure::Response<Models::UserDelegationKey> GetUserDelegationKey(
@@ -123,7 +123,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param
      * properties The blob service properties.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A SetServicePropertiesResult on successfully setting the properties.
      */
     Azure::Response<Models::SetServicePropertiesResult> SetProperties(
@@ -136,7 +136,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BlobServiceProperties describing the service properties.
      */
     Azure::Response<Models::BlobServiceProperties> GetProperties(
@@ -147,7 +147,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Returns the sku name and account kind for the specified account.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return AccountInfo describing the account.
      */
     Azure::Response<Models::AccountInfo> GetAccountInfo(
@@ -160,7 +160,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * enabled for the storage account.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ServiceStatistics describing the service replication statistics.
      */
     Azure::Response<Models::ServiceStatistics> GetStatistics(
@@ -178,7 +178,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * for the value of the where query parameter, however, only a subset of the OData filter syntax
      * is supported in the Blob service.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A FindBlobsByTagsPagedResponse describing the blobs.
      */
     FindBlobsByTagsPagedResponse FindBlobsByTags(
@@ -192,7 +192,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param blobContainerName The name of the container to create.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BlobContainerClient referencing the newly created container.
      */
     Azure::Response<BlobContainerClient> CreateBlobContainer(
@@ -206,7 +206,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param blobContainerName The name of the container to delete.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A DeleteBlobContainerResult if successful.
      */
     Azure::Response<Models::DeleteBlobContainerResult> DeleteBlobContainer(
@@ -220,7 +220,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param deletedBlobContainerName The name of the previously deleted container.
      * @param deletedBlobContainerVersion The version of the previously deleted container.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BlobContainerClient referencing the undeleted container.
      */
     Azure::Response<BlobContainerClient> UndeleteBlobContainer(

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/block_blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/block_blob_client.hpp
@@ -119,7 +119,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param content A BodyStream containing the content to upload.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A UploadBlockBlobResult describing the state of the updated block blob.
      */
     Azure::Response<Models::UploadBlockBlobResult> Upload(
@@ -134,7 +134,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param buffer A memory buffer containing the content to upload.
      * @param bufferSize Size of the memory buffer.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A UploadBlockBlobFromResult describing the state of the updated block blob.
      */
     Azure::Response<Models::UploadBlockBlobFromResult> UploadFrom(
@@ -149,7 +149,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param fileName A file containing the content to upload.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A UploadBlockBlobFromResult describing the state of the updated block blob.
      */
     Azure::Response<Models::UploadBlockBlobFromResult> UploadFrom(
@@ -165,7 +165,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * string must be less than or equal to 64 bytes in size.
      * @param content A BodyStream containing the content to upload.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A StageBlockResult describing the state of the updated block.
      */
     Azure::Response<Models::StageBlockResult> StageBlock(
@@ -185,7 +185,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * must either be public or must be authenticated via a shared access signature. If the source
      * blob is public, no authentication is required to perform the operation.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A StageBlockFromUriResult describing the state of the updated block blob.
      */
     Azure::Response<Models::StageBlockFromUriResult> StageBlockFromUri(
@@ -205,7 +205,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      *
      * @param blockIds Base64 encoded block IDs to indicate that make up the blob.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A CommitBlobBlockListResult describing the state of the updated block blob.
      */
     Azure::Response<Models::CommitBlockListResult> CommitBlockList(
@@ -221,7 +221,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * committed.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A GetBlobBlockListResult describing requested block list.
      */
     Azure::Response<Models::GetBlockListResult> GetBlockList(

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/page_blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/page_blob_client.hpp
@@ -112,7 +112,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param blobSize Specifies the maximum size for the page blob. The size must be
      * aligned to a 512-byte boundary.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A CreatePageBlobResult describing the newly created page blob.
      */
     Azure::Response<Models::CreatePageBlobResult> Create(
@@ -127,7 +127,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param blobContentLength Specifies the maximum size for the page blob. The size must be
      * aligned to a 512-byte boundary.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A CreatePageBlobResult describing the newly created page blob.
      * CreatePageBlobResult.Created is false if the blob already exists.
      */
@@ -144,7 +144,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * 512.
      * @param content A BodyStream containing the content of the pages to upload.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A UploadPagesResult describing the state of the updated pages.
      */
     Azure::Response<Models::UploadPagesResult> UploadPages(
@@ -166,7 +166,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * authentication is required to perform the operation.
      * @param sourceRange Only upload the bytes of the blob in the sourceUri in the specified range.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A UploadPagesFromUriResult describing the state of the updated pages.
      */
     Azure::Response<Models::UploadPagesFromUriResult> UploadPagesFromUri(
@@ -184,7 +184,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * blob's full size. Given that pages must be aligned with 512-byte boundaries, the start and
      * length of the range must be a modulus of 512.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ClearPagesResult describing the state of the updated pages.
      */
     Azure::Response<Models::ClearPagesResult> ClearPages(
@@ -200,7 +200,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param blobSize Specifies the maximum size for the page blob. The size must be
      * aligned to a 512-byte boundary.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ResizePageBlobResult describing the resized page blob.
      */
     Azure::Response<Models::ResizePageBlobResult> Resize(
@@ -212,7 +212,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @brief Returns the list of valid page ranges for a page blob or snapshot of a page blob.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A GetPageRangesResult describing the valid page ranges for this blob.
      */
     GetPageRangesPagedResponse GetPageRanges(
@@ -228,7 +228,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * pages. The target blob may be a snapshot, as long as the snapshot specified by
      * previousSnapshot is the older of the two.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A GetPageRangesResult describing the valid page ranges for this blob.
      */
     GetPageRangesDiffPagedResponse GetPageRangesDiff(
@@ -247,7 +247,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * be a snapshot, as long as the snapshot specified by previousSnapshotUrl is the older of the
      * two.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A GetPageRangesResult describing the valid page ranges for this blob.
      */
     GetPageRangesDiffPagedResponse GetManagedDiskPageRangesDiff(
@@ -264,7 +264,7 @@ namespace Azure { namespace Storage { namespace Blobs {
      * @param sourceUri Specifies the to the source page blob as a uri up to 2 KB in length. The
      * source blob must either be public or must be authenticated via a shared access signature.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A StartBlobCopyOperation describing the state of the copy operation.
      */
     StartBlobCopyOperation StartCopyIncremental(

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_directory_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_directory_client.hpp
@@ -92,7 +92,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Create a directory. By default, the destination is overwritten and
      *        if the destination already exists and has a lease the lease is broken.
      * @param options Optional parameters to create the directory the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateDirectoryResult> containing the
      * information of the created directory
      * @remark This request is sent to dfs endpoint.
@@ -107,7 +107,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Create a directory. If it already exists, nothing will happen.
      * @param options Optional parameters to create the directory the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateDirectoryResult> containing the
      * information of the created directory
      * @remark This request is sent to dfs endpoint.
@@ -126,7 +126,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param fileName The file that gets renamed.
      * @param destinationFilePath The path of the file the source file is renaming to.
      * @param options Optional parameters to rename a file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<DataLakeFileClient> The client targets the renamed file.
      * @remark This request is sent to dfs endpoint.
      */
@@ -142,7 +142,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param subdirectoryName The subdirectory that gets renamed.
      * @param destinationDirectoryPath The destinationPath the source subdirectory is renaming to.
      * @param options Optional parameters to rename a directory.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<DataLakeDirectoryClient> The client targets the renamed
      * directory.
      * @remark This request is sent to dfs endpoint.
@@ -156,7 +156,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Deletes the empty directory. Throws exception if directory is not empty.
      * @param options Optional parameters to delete the directory the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory.
      * @remark This request is sent to dfs endpoint.
@@ -172,7 +172,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Deletes the empty directory if it already exists. Throws exception if directory is not
      * empty.
      * @param options Optional parameters to delete the directory the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory.
      * @remark This request is sent to dfs endpoint.
@@ -187,7 +187,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Deletes the directory and all its subdirectories and files.
      * @param options Optional parameters to delete the directory the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory.
      * @remark This request is sent to dfs endpoint.
@@ -202,7 +202,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Deletes the directory and all its subdirectories and files if the directory exists.
      * @param options Optional parameters to delete the directory the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory.
      * @remark This request is sent to dfs endpoint.
@@ -220,7 +220,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param recursive If "true", all paths are listed; otherwise, the list will only
      *                  include paths that share the same root.
      * @param options Optional parameters to list the paths in file system.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return ListPathsPagedResponse describing the paths in a directory.
      * @remark This request is sent to dfs endpoint.
      */

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_client.hpp
@@ -87,7 +87,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *                 written, and there must not be a request entity body included with the
      *                 request.
      * @param options Optional parameters to append data to the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::AppendFileResult> containing the
      * information returned when appending some data to the path.
      * @remark This request is sent to dfs endpoint.
@@ -109,7 +109,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *                 written, and there must not be a request entity body included with the
      *                 request.
      * @param options Optional parameters to flush data to the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::FlushFileResult> containing the information
      * returned when flushing the data appended to the path.
      * @remark This request is sent to dfs endpoint.
@@ -123,7 +123,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Create a file. By default, the destination is overwritten and
      *        if the destination already exists and has a lease the lease is broken.
      * @param options Optional parameters to create the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateFileResult> containing the information
      * returned when creating the file.
      * @remark This request is sent to dfs endpoint.
@@ -138,7 +138,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Create a file. If it already exists, it will remain unchanged.
      * @param options Optional parameters to create the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateFileResult> containing the information
      * returned when creating the file.
      * @remark This request is sent to dfs endpoint.
@@ -154,7 +154,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Deletes the file.
      * @param options Optional parameters to delete the file the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteFileResult>
      * @remark This request is sent to dfs endpoint.
      */
@@ -165,7 +165,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Deletes the file if it already exists.
      * @param options Optional parameters to delete the file the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteFileResult>
      * @remark This request is sent to dfs endpoint.
      */
@@ -178,7 +178,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * supported.
      * @param options Optional parameters to download the content from the resource the path points
      * to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DownloadFileResult> containing the information
      * and content returned when downloading from a file.
      * @remark This request is sent to blob endpoint.
@@ -193,7 +193,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param buffer A memory buffer containing the content to upload.
      * @param bufferSize Size of the memory buffer.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<UploadFileFromResult> containing the information
      * returned when uploading a file from a buffer.
      * @remark This request is sent to blob endpoint.
@@ -209,7 +209,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * an existing file overwrites any existing metadata on the file.
      * @param fileName A file containing the content to upload.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::UploadFileFromResult> containing the
      * information returned when uploading a file from a local file.
      * @remark This request is sent to blob endpoint.
@@ -226,7 +226,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param bufferSize Size of the memory buffer. Size must be larger or equal to size of the file
      * or file range.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DownloadFileToResult> containing the
      * information returned when downloading a file to a local buffer.
      * @remark This request is sent to blob endpoint.
@@ -242,7 +242,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * requests.
      * @param fileName A file path to write the downloaded content to.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DownloadFileToResult> containing the
      * information returned when downloading a file to a local file.
      * @remark This request is sent to blob endpoint.
@@ -256,7 +256,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Schedules the file for deletion.
      * @param expiryOrigin Specify the origin of expiry.
      * @param options Optional parameters to schedule the file for deletion.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::ScheduleFileDeletionResult> containing the
      * information and content returned when schedule the file for deletion.
      * @remark This request is sent to blob endpoint.

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_system_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_file_system_client.hpp
@@ -93,7 +93,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Creates the file system.
      * @param options Optional parameters to create this file system.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateFileSystemResult> containing the
      * information of create a file system.
      * @remark This request is sent to blob endpoint.
@@ -105,7 +105,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Creates the file system if it does not exists.
      * @param options Optional parameters to create this file system.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateFileSystemResult> containing the
      * information of create a file system. Only valid when successfully created the file system.
      * @remark This request is sent to blob endpoint.
@@ -117,7 +117,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Deletes the file system.
      * @param options Optional parameters to delete this file system.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteFileSystemResult> containing the
      * information returned when deleting file systems.
      * @remark This request is sent to blob endpoint.
@@ -129,7 +129,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Deletes the file system if it exists.
      * @param options Optional parameters to delete this file system.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteFileSystemResult> containing the
      * information returned when deleting file systems. Only valid when successfully deleted the
      * file system.
@@ -144,7 +144,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param metadata User-defined metadata to be stored with the filesystem. Note that the string
      *                 may only contain ASCII characters in the ISO-8859-1 character set.
      * @param options Optional parameters to set the metadata to this file system.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetFileSystemMetadataResult> containing the
      * information returned when setting the metadata onto the file system.
      * @remark This request is sent to blob endpoint.
@@ -157,7 +157,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Gets the properties of file system.
      * @param options Optional parameters to get the metadata of this file system.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::FileSystemProperties> containing the
      * information when getting the file system's properties.
      * @remark This request is sent to blob endpoint.
@@ -172,7 +172,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param recursive If "true", all paths are listed; otherwise, only paths at the root of the
      *                  filesystem are listed.
      * @param options Optional parameters to list the paths in file system.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return ListPathsPagedResponse describing the paths in this filesystem.
      * @remark This request is sent to dfs endpoint.
      */
@@ -186,7 +186,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * file system data may be accessed publicly.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A FileSystemAccessPolicy describing the container's access policy.
      * @remark This request is sent to blob endpoint.
      */
@@ -199,7 +199,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * whether file system's data may be accessed publicly.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A SetFileSystemAccessPolicyResult describing the updated file system.
      * @remark This request is sent to blob endpoint.
      */
@@ -213,7 +213,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param fileName The file that gets renamed.
      * @param destinationFilePath The path of the file the source file is renaming to.
      * @param options Optional parameters to rename a file
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<DataLakeFileClient> The client targets the renamed file.
      * @remark This request is sent to dfs endpoint.
      */
@@ -229,7 +229,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param directoryName The directory that gets renamed.
      * @param destinationDirectoryPath The destinationPath the source directory is renaming to.
      * @param options Optional parameters to rename a directory.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<DataLakeDirectoryClient> The client targets the renamed
      * directory.
      * @remark This request is sent to dfs endpoint.

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_lease_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_lease_client.hpp
@@ -70,7 +70,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be
      * changed using renew or change.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return An AcquireLeaseResult describing the lease.
      */
     Azure::Response<Models::AcquireLeaseResult> Acquire(
@@ -85,7 +85,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Renews the datalake path or datalake path container's previously-acquired lease.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A RenewLeaseResult describing the lease.
      */
     Azure::Response<Models::RenewLeaseResult> Renew(
@@ -99,7 +99,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Releases the datalake path or datalake path container's previously-acquired lease.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ReleaseLeaseResult describing the updated container or blob.
      */
     Azure::Response<Models::ReleaseLeaseResult> Release(
@@ -114,7 +114,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *
      * @param proposedLeaseId Proposed lease ID, in a GUID string format.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ChangeLeaseResult describing the changed lease.
      * @remarks The current DataLakeLeaseClient becomes invalid if this operation succeeds.
      */
@@ -130,7 +130,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Breaks the previously-acquired lease.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BreakLeaseResult describing the broken lease.
      */
     Azure::Response<Models::BreakLeaseResult> Break(

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_path_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_path_client.hpp
@@ -86,7 +86,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Creates a file or directory. By default, the destination is overwritten and
      *        if the destination already exists and has a lease the lease is broken.
      * @param options Optional parameters to create the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreatePathResult> containing the information
      * returned when creating a path.
      * @remark This request is sent to dfs endpoint.
@@ -100,7 +100,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Creates a file or directory. By default, the destination is not changed if it already
      * exists.
      * @param options Optional parameters to create the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreatePathResult> containing the information
      * returned when creating a path, the information will only be valid when the create operation
      * is successful.
@@ -114,7 +114,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Deletes the resource the path points to.
      * @param options Optional parameters to delete the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeletePathResult> which is current empty but
      * preserved for future usage.
      * @remark This request is sent to dfs endpoint.
@@ -126,7 +126,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Deletes the resource the path points to if it exists.
      * @param options Optional parameters to delete the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeletePathResult> which is current empty but
      * preserved for future usage. The result will only valid if the delete operation is successful.
      * @remark This request is sent to dfs endpoint.
@@ -144,7 +144,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *             permissions.
      * @param options Optional parameters to set an access control to the resource the path points
      *                to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetPathAccessControlListResult> containing the
      * information returned when setting path's access control.
      * @remark This request is sent to dfs endpoint.
@@ -160,7 +160,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *        access control.
      * @param permissions Sets the permissions on the path
      * @param options Optional parameters to set permissions to the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetPathPermissionsResult> containing the
      * information returned when setting path's permissions.
      * @remark This request is sent to dfs endpoint.
@@ -174,7 +174,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @brief Sets the properties of a resource the path points to.
      * @param options Optional parameters to set the HTTP headers to the resource the path points
      * to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<SetPathHttpHeadersResult> containing the information
      * returned when setting the path's HTTP headers.
      * @remark This request is sent to blob endpoint.
@@ -190,7 +190,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      *        access control list for a path.
      * @param options Optional parameters to get the properties from the resource the path points
      *                to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::PathProperties> containing the
      * properties of the path.
      * @remark This request is sent to blob endpoint.
@@ -202,7 +202,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     /**
      * @brief Returns all access control list stored for the given path.
      * @param options Optional parameters to get the ACLs from the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::GetPathAccessControlListResult> containing the
      * access control list of the path.
      * @remark This request is sent to dfs endpoint.
@@ -216,7 +216,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param metadata User-defined metadata to be stored with the filesystem. Note that the string
      *                 may only contain ASCII characters in the ISO-8859-1 character set.
      * @param options Optional parameters to set the metadata to the resource the path points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetPathMetadataResult> containing the
      * information returned when setting the metadata.
      * @remark This request is sent to blob endpoint.
@@ -233,7 +233,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * entry (ACE) consists of a scope, a type, a user or group identifier, and permissions.
      * @param options Optional parameters to set an access control recursively to the resource the
      * directory points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return SetPathAccessControlListRecursivePagedResponse containing summary stats of the
      * operation.
      * @remark This request is sent to dfs endpoint.
@@ -255,7 +255,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * entry (ACE) consists of a scope, a type, a user or group identifier, and permissions.
      * @param options Optional parameters to set an access control recursively to the resource the
      * directory points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return UpdatePathAccessControlListRecursivePagedResponse containing summary stats of the
      * operation.
      * @remark This request is sent to dfs endpoint.
@@ -277,7 +277,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * entry (ACE) consists of a scope, a type, a user or group identifier, and permissions.
      * @param options Optional parameters to set an access control recursively to the resource the
      * directory points to.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return RemovePathAccessControlListRecursivePagedResponse containing summary stats of the
      * operation.
      * @remark This request is sent to dfs endpoint.

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_service_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/datalake_service_client.hpp
@@ -83,7 +83,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * systems may make multiple requests to the service while fetching all the values. File systems
      * are ordered lexicographically by name.
      * @param options Optional parameters to list the file systems.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return ListFileSystemsPagedResponse describing the file systems in the storage account.
      * @remark This request is sent to blob endpoint.
      */
@@ -98,7 +98,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
      * @param expiresOn Expiration of the key's validity. The time should be specified in UTC, and
      * will be truncated to second.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::UserDelegationKey> containing the user delegation key.
      * @remark This request is sent to blob endpoint.
      */

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_client.hpp
@@ -80,7 +80,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Creates the file share.
      * @param options Optional parameters to create this file share.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateShareResult> containing the information including
      * the version and modified time of a share.
      */
@@ -92,7 +92,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Creates the file share if it does not exist, nothing will happen if the file share
      * already exists.
      * @param options Optional parameters to create this file share.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateShareResult> containing the information including
      * the version and modified time of a share if it is successfully created.
      */
@@ -103,7 +103,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Deletes the file share.
      * @param options Optional parameters to delete this file share.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteShareResult> currently empty and reserved for
      * future usage.
      */
@@ -114,7 +114,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Deletes the file share if it exists.
      * @param options Optional parameters to delete this file share.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteShareResult> currently empty and reserved for
      * future usage.
      */
@@ -125,7 +125,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Creates a snapshot for the share.
      * @param options Optional parameters to create the share snapshot.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateShareSnapshotResult> containing the information
      * for ths snapshot.
      */
@@ -136,7 +136,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Sets the properties of the share.
      * @param options Optional parameters to set the share properties.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetSharePropertiesResult> containing the information
      * including the version and modified time of a share.
      */
@@ -147,7 +147,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Gets the properties of the share.
      * @param options Optional parameters to get the share properties.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::ShareProperties> containing the properties for
      * ths share or one of its snapshot.
      */
@@ -159,7 +159,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Sets the metadata to the share.
      * @param metadata A name-value pair to associate with a file storage 'Share' object..
      * @param options Optional parameters to set the share metadata.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetShareMetadataResult> containing the information
      * including the version and modified time of a share.
      */
@@ -171,7 +171,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Gets the access policy of the share.
      * @param options Optional parameters to get the share's access policy.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::ShareAccessPolicy> containing the access
      * policy of the share.
      */
@@ -183,7 +183,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Sets the access policy of the share.
      * @param accessPolicy Specifies the access policy to be set to the share.
      * @param options Optional parameters to Set the share's access policy.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetShareAccessPolicyResult> containing the information
      * including the version and modified time of a share.
      */
@@ -195,7 +195,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Gets the stats of the share.
      * @param options Optional parameters to get share's statistics.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::ShareStatistics> containing the information
      * including the bytes used in by the share, the version and modified time of a share.
      */
@@ -207,7 +207,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Creates a permission on the share.
      * @param permission Specifies the permission to be created on the share.
      * @param options Optional parameters to create the share's permission.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateSharePermissionResult> containing the information
      * including the permission key of the permission.
      */
@@ -220,7 +220,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Gets the permission of the share using the specific key.
      * @param permissionKey The permission key of a permission.
      * @param options Optional parameters to get share's permission.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<std::string> containing the permission string with specified key.
      */
     Azure::Response<std::string> GetPermission(

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_directory_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_directory_client.hpp
@@ -95,7 +95,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Creates the directory.
      * @param options Optional parameters to create this directory.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateDirectoryResult> containing the information
      * returned when creating the directory.
      */
@@ -106,7 +106,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Creates the directory if it does not exist.
      * @param options Optional parameters to create this directory.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::CreateDirectoryResult> containing the information
      * returned when creating the directory if successfully created.
      */
@@ -117,7 +117,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Deletes the directory.
      * @param options Optional parameters to delete this directory.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory. Currently empty but preserved for future usage.
      */
@@ -128,7 +128,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Deletes the directory if it exists.
      * @param options Optional parameters to delete this directory.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DeleteDirectoryResult> containing the information
      * returned when deleting the directory. Currently empty but preserved for future usage.
      * Only when the delete operation if successful, the returned information other than 'Deleted'
@@ -141,7 +141,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Gets the properties of the directory.
      * @param options Optional parameters to get this directory's properties.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DirectoryProperties> containing the
      * properties of the directory returned from the server.
      */
@@ -153,7 +153,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Sets the properties of the directory.
      * @param smbProperties The SMB properties to be set to the directory.
      * @param options Optional parameters to set this directory's properties.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetDirectoryPropertiesResult> containing the
      * properties of the directory returned from the server.
      */
@@ -167,7 +167,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param metadata User-defined metadata to be stored with the directory. Note that the string
      *                 may only contain ASCII characters in the ISO-8859-1 character set.
      * @param options Optional parameters to set this directory's metadata.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetDirectoryMetadataResult> containing the
      * information of the directory returned from the server.
      */
@@ -181,7 +181,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * files and directories may make multiple requests to the service while fetching all the
      * values.
      * @param options Optional parameters to list the files and directories under this directory.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return ListFilesAndDirectoriesPagedResponse describing the items in the directory.
      */
     ListFilesAndDirectoriesPagedResponse ListFilesAndDirectories(
@@ -192,7 +192,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Returns a sequence of the open handles on a directory or a file. Enumerating the
      * handles may make multiple requests to the service while fetching all the values.
      * @param options Optional parameters to list this directory's open handles.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return ListDirectoryHandlesPagedResponse describing the handles in the directory.
      */
     ListDirectoryHandlesPagedResponse ListHandles(
@@ -203,7 +203,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Closes a handle opened on a directory at the service.
      * @param handleId The ID of the handle to be closed.
      * @param options Optional parameters to close one of this directory's open handles.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::ForceCloseDirectoryHandleResult> containing the
      * information of the closed handle. Current empty but preserved for future usage.
      */
@@ -216,7 +216,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Closes all handles opened on a directory at the service. Optionally supports
      * recursively closing handles on subresources.
      * @param options Optional parameters to close all this directory's open handles.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return ForceCloseAllDirectoryHandlesPagedResponse containing the information of the closed
      * handles.
      */

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
@@ -78,7 +78,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Creates the file.
      * @param fileSize Size of the file in bytes.
      * @param options Optional parameters to create this file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<CreateFileResult> containing the information returned when
      * creating the file.
      */
@@ -90,7 +90,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Deletes the file.
      * @param options Optional parameters to delete this file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<DeleteFileResult> containing the information returned when
      * deleting the file.
      */
@@ -101,7 +101,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Deletes the file if it exists.
      * @param options Optional parameters to delete this file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<DeleteFileResult> containing the information returned when
      * deleting the file. Only valid when successfully deleted.
      */
@@ -113,7 +113,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Open a stream for the file's content, or a range of the file's content that can be
      * used to download the server end data.
      * @param options Optional parameters to get the content of this file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DownloadFileResult> containing the range or full
      * content and the information of the file.
      */
@@ -129,7 +129,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param bufferSize Size of the memory buffer. Size must be larger or equal to size of the file
      * or file range.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DownloadFileToResult> containing the information
      * of the downloaded file/file range.
      */
@@ -145,7 +145,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      *
      * @param fileName A file path to write the downloaded content to.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::DownloadFileToResult> containing the information
      * of the downloaded file/file range.
      */
@@ -161,7 +161,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param buffer A memory buffer containing the content to upload.
      * @param bufferSize Size of the memory buffer.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::UploadFileFromResult> describing the state of the
      * updated file.
      */
@@ -177,7 +177,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      *
      * @param fileName A file containing the content to upload.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::UploadFileFromResult> describing the state of the
      * updated file.
      */
@@ -196,7 +196,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * public file, no authentication is required to perform the copy operation. A file in a share
      * snapshot can also be specified as a copy source.
      * @param options Optional parameters to copy the content of this file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return StartFileCopyOperation containing the copy related information.
      */
     StartFileCopyOperation StartCopy(
@@ -209,7 +209,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param copyId The copy identifier provided in the StartCopyShareFileResult of the original
      * StartCopy operation.
      * @param options Optional parameters to abort copying the content of this file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::AbortFileCopyResult> containing the abort copy
      * related information, current empty but preserved for future usage.
      */
@@ -221,7 +221,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Gets the properties of a file.
      * @param options Optional parameters to get the properties of this file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::FileProperties> containing the file
      * properties.
      */
@@ -234,7 +234,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param httpHeaders The HTTP headers to be set to the file.
      * @param smbProperties The SMB properties to be set to the file.
      * @param options Optional parameters to set this file's properties.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetFilePropertiesResult> containing the properties
      * of the file returned from the server.
      */
@@ -249,7 +249,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param metadata User-defined metadata to be stored with the file. Note that the string
      *                 may only contain ASCII characters in the ISO-8859-1 character set.
      * @param options Optional parameters to set this file's metadata.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetFileMetadataResult> containing the information
      * of the file returned from the server.
      */
@@ -262,7 +262,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Uploads some data to a range of the file.
      * @param offset Specifies the starting offset for the content to be written as a range.
      * @param content A BodyStream containing the content of the range to upload.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::UploadFileRange> containing the information of the
      * uploaded range and the file returned from the server.
      */
@@ -276,7 +276,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Clears some range of data within the file.
      * @param offset Specifies the starting offset for the content to be cleared within the file.
      * @param length Specifies the length for the content to be cleared within the file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::ClearFileRangeResult> containing the information
      * of the cleared range returned from the server.
      */
@@ -288,7 +288,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     /**
      * @brief Gets the list of valid range from the file within specified range.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::GetFileRangeListResult> containing the valid
      * ranges within the file for the specified range.
      */
@@ -300,7 +300,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Gets the list of valid range from the file within specified range that have changed
      * since previousShareSnapshot was taken.
      * @param previousShareSnapshot Specifies the previous snapshot.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::GetFileRangeListResult> containing the valid
      * ranges within the file for the specified range.
      */
@@ -313,7 +313,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Returns a sequence of the open handles on a directory or a file. Enumerating the
      * handles may make multiple requests to the service while fetching all the values.
      * @param options Optional parameters to list this file's open handles.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return ListFileHandlesPagedResponse describing the handles of the file.
      */
     ListFileHandlesPagedResponse ListHandles(
@@ -324,7 +324,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Closes a handle opened on a file at the service.
      * @param handleId The ID of the handle to be closed.
      * @param options Optional parameters to close one of this file's open handles.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::ForceCloseFileHandleResult> containing the
      * information of the closed handle. Current empty but preserved for future usage.
      */
@@ -336,7 +336,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Closes all handles opened on a file at the service.
      * @param options Optional parameters to close all this file's open handles.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return ForceCloseAllFileHandlesPagedResponse containing the information of the closed
      * handles.
      */
@@ -350,7 +350,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @param sourceUri The source URI of the content to be uploaded.
      * @param sourceRange The source URI's range to be uploaded to file.
      * @param options Optional parameters to upload a range to file.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::UploadFileRangeFromUriResult> containing the returned
      * information.
      */

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_lease_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_lease_client.hpp
@@ -58,7 +58,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease
      * duration cannot be changed using renew or change.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return An AcquireLeaseResult describing the lease.
      */
     Azure::Response<Models::AcquireLeaseResult> Acquire(
@@ -70,7 +70,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Releases the file or share's previously-acquired lease.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ReleaseLeaseResult describing the updated share or file.
      */
     Azure::Response<Models::ReleaseLeaseResult> Release(
@@ -82,7 +82,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      *
      * @param proposedLeaseId Proposed lease ID, in a GUID string format.
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A ChangeLeaseResult describing the updated lease.
      * @remarks The current ShareLeaseClient becomes invalid if this operation succeeds.
      */
@@ -95,7 +95,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Breaks the previously-acquired lease.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A BreakLeaseResult describing the broken lease.
      */
     Azure::Response<Models::BreakLeaseResult> Break(
@@ -118,7 +118,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Renews the file or share's previously-acquired lease.
      *
      * @param options Optional parameters to execute this function.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return A RenewLeaseResult describing the lease.
      */
     Azure::Response<Models::RenewLeaseResult> Renew(

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_service_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_service_client.hpp
@@ -70,7 +70,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Returns a paginated collection of the shares in the storage account. Enumerating the
      * shares may make multiple requests to the service while fetching all the values.
      * @param options Optional parameters to list the shares.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return ListSharesPagedResponse describing the shares in this storage account.
      */
     ListSharesPagedResponse ListShares(
@@ -81,7 +81,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
      * @brief Set the service's properties.
      * @param properties The properties of the service that is to be set.
      * @param options Optional parameters to set the properties of the service.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::SetServicePropertiesResult> The information returned
      * when setting the service properties.
      */
@@ -93,7 +93,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     /**
      * @brief Get the service's properties.
      * @param options Optional parameters to get the properties of the service.
-     * @param context Context for cancelling long running operations.
+     * @contextParameter
      * @return Azure::Response<Models::FileServiceProperties> The properties of the service.
      */
     Azure::Response<Models::ShareServiceProperties> GetProperties(


### PR DESCRIPTION
Doxygen ALIASES can be use to define custom commands. See: https://www.doxygen.nl/manual/config.html#cfg_aliases

If the team like this approach, there might be other places where we can create an Alias and use it everywhere.