### PR TITLE
We should NOT deal with any network connections while holding mutex

### DIFF
--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -215,7 +215,8 @@ static void CleanupThread()
       return;
     }
 
-    decltype(CurlConnectionPool::g_curlConnectionPool.ConnectionPoolIndex)::mapped_type connectionsToBeCleaned;
+    decltype(CurlConnectionPool::g_curlConnectionPool
+                 .ConnectionPoolIndex)::mapped_type connectionsToBeCleaned;
 
     Log::Write(Logger::Level::Verbose, "Clean pool - inspect pool");
     // loop the connection pool index - Note: lock is re-taken for the mutex


### PR DESCRIPTION
Storage team feels confident that some code in core sdk can cause the program to hang for a while in some extreme conditions. This is a PR trying to fix the issue.

BTW @vhvb1989 , I'm astonished to find out these two files [curl_connection_pool_private.hpp](https://github.com/Azure/azure-sdk-for-cpp/blob/master/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp) and [curl_connection_pool.hpp](https://github.com/Azure/azure-sdk-for-cpp/blob/master/sdk/core/azure-core/src/private/curl_connection_pool.hpp) have exactly the same content. I feel this is out of ordinary from the perspective of code version control and software development. It's likely to happen that some developer modifies one and forgets the other sometime, then the two files are not identical anymore.
Can you help me understand what problem we're trying to solve with two identical files?