### PR TITLE
Fix `throw new`

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/base64url.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/internal/base64url.hpp
@@ -52,7 +52,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace _internal 
           base64url.append("=");
           break;
         default:
-          throw new std::invalid_argument("Unexpected Base64URL encoding in the HTTP response.");
+          throw std::invalid_argument("Unexpected Base64URL encoding in the HTTP response.");
       }
       return Azure::Core::Convert::Base64Decode(base64url);
     }


### PR DESCRIPTION
Never `throw new`.
In C++ you can throw anything - an int or a pointer.
What `throw new X` does - it allocates a new instance of `X`, and then throws the raw pointer.
It is the same difference as between `X x = X();` and `X* x = new X();`. If you `new` something, someone should `delete` it, or it is a memory leak. And who should delete it - the code that caught the exception? If they forget, it will leak. It is unneccessary to allocate an exception in dynamic memory, and to pass raw pointers around, without clear model of ownership.
And simply, this model is not used in C++. You can do it, it will compile, but it is an antipattern.
BTW, `catch (const std::invalid_argument&)` would not catch this exception. The user will need to write `catch (std::invalid_argument*)` in order to catch it.