### PR TITLE
Catch as const whenever possible

### DIFF
--- a/sdk/core/azure-core/src/io/body_stream.cpp
+++ b/sdk/core/azure-core/src/io/body_stream.cpp
@@ -130,7 +130,7 @@ FileBodyStream::FileBodyStream(const std::string& filename)
     m_randomAccessFileBodyStream = std::make_unique<_internal::RandomAccessFileBodyStream>(
         _internal::RandomAccessFileBodyStream(m_filehandle, 0, fileSize.QuadPart));
   }
-  catch (std::exception&)
+  catch (const std::exception&)
   {
     if (fileHandle != INVALID_HANDLE_VALUE)
     {
@@ -156,7 +156,7 @@ FileBodyStream::FileBodyStream(const std::string& filename)
     m_randomAccessFileBodyStream = std::make_unique<_internal::RandomAccessFileBodyStream>(
         _internal::RandomAccessFileBodyStream(m_fileDescriptor, 0, fileSize));
   }
-  catch (std::exception&)
+  catch (const std::exception&)
   {
     close(m_fileDescriptor);
     throw;

--- a/sdk/core/azure-core/test/ut/transport_adapter_base_test.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base_test.cpp
@@ -482,12 +482,12 @@ namespace Azure { namespace Core { namespace Test {
     {
       auto result = m_pipeline->Send(request, Azure::Core::Context::ApplicationContext);
     }
-    catch (Azure::Core::RequestFailedException& err)
+    catch (const Azure::Core::RequestFailedException& err)
     {
       // if ref can't be cast, it throws
-      EXPECT_NO_THROW((void)dynamic_cast<Azure::Core::Http::TransportException&>(err));
-      EXPECT_NO_THROW((void)dynamic_cast<std::runtime_error&>(err));
-      EXPECT_THROW((void)dynamic_cast<std::range_error&>(err), std::bad_cast);
+      EXPECT_NO_THROW((void)dynamic_cast<const Azure::Core::Http::TransportException&>(err));
+      EXPECT_NO_THROW((void)dynamic_cast<const std::runtime_error&>(err));
+      EXPECT_THROW((void)dynamic_cast<const std::range_error&>(err), std::bad_cast);
     }
   }
 

--- a/sdk/core/perf/inc/azure/perf/argagg.hpp
+++ b/sdk/core/perf/inc/azure/perf/argagg.hpp
@@ -771,7 +771,7 @@ try
 {
   return this->options.at(name);
 }
-catch (std::out_of_range const& e)
+catch (const std::out_of_range const& e)
 {
   std::ostringstream msg;
   msg << "no option named \"" << name << "\" in parser_results." << e.what();

--- a/sdk/storage/azure-storage-blobs/sample/blob_sas.cpp
+++ b/sdk/storage/azure-storage-blobs/sample/blob_sas.cpp
@@ -57,7 +57,7 @@ void BlobSas()
     // Never reach here
     std::abort();
   }
-  catch (Azure::Storage::StorageException&)
+  catch (const Azure::Storage::StorageException&)
   {
   }
 }

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
@@ -94,7 +94,7 @@ namespace Azure { namespace Storage { namespace Test {
       {
         blobClient0.Delete();
       }
-      catch (StorageException&)
+      catch (const StorageException&)
       {
       }
       auto blobClient = Blobs::AppendBlobClient(blobUrl + sas);

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
@@ -395,7 +395,7 @@ namespace Azure { namespace Storage { namespace Test {
             deletedContainerItem.Name, deletedContainerItem.VersionId.Value());
         break;
       }
-      catch (StorageException& e)
+      catch (const StorageException& e)
       {
         if (e.StatusCode == Azure::Core::Http::HttpStatusCode::Conflict
             && e.ReasonPhrase == "The specified container is being deleted.")

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -897,7 +897,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       blockBlobClient.Download();
     }
-    catch (StorageException& e)
+    catch (const StorageException& e)
     {
       exceptionCaught = true;
       EXPECT_EQ(e.StatusCode, Azure::Core::Http::HttpStatusCode::NotFound);

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/concurrent_transfer.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/concurrent_transfer.hpp
@@ -41,7 +41,7 @@ namespace Azure { namespace Storage { namespace _internal {
         {
           transferFunc(chunkOffset, chunkLength, chunkId, numChunks);
         }
-        catch (std::exception&)
+        catch (const std::exception&)
         {
           if (failed.exchange(true) == false)
           {

--- a/sdk/storage/azure-storage-files-datalake/sample/datalake_getting_started.cpp
+++ b/sdk/storage/azure-storage-files-datalake/sample/datalake_getting_started.cpp
@@ -33,7 +33,7 @@ void DataLakeGettingStarted()
     {
       fileSystemClient.Create();
     }
-    catch (Azure::Storage::StorageException& e)
+    catch (const Azure::Storage::StorageException& e)
     {
       if (e.ErrorCode != "ContainerAlreadyExists")
       {

--- a/sdk/storage/azure-storage-files-datalake/test/datalake_sas_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/datalake_sas_test.cpp
@@ -105,7 +105,7 @@ namespace Azure { namespace Storage { namespace Test {
       {
         fileClient0.Delete();
       }
-      catch (StorageException&)
+      catch (const StorageException&)
       {
       }
       auto fileClient = Files::DataLake::DataLakeFileClient(fileUrl + sas);
@@ -117,7 +117,7 @@ namespace Azure { namespace Storage { namespace Test {
       {
         fileClient0.Delete();
       }
-      catch (StorageException&)
+      catch (const StorageException&)
       {
       }
       std::string newFilename = RandomString();

--- a/sdk/storage/azure-storage-files-shares/sample/file_share_getting_started.cpp
+++ b/sdk/storage/azure-storage-files-shares/sample/file_share_getting_started.cpp
@@ -21,7 +21,7 @@ void FileShareGettingStarted()
   {
     shareClient.Create();
   }
-  catch (std::runtime_error& e)
+  catch (const std::runtime_error& e)
   {
     // The share may already exist
     std::cout << e.what() << std::endl;

--- a/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
@@ -824,7 +824,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       fileClient.Create(1024);
     }
-    catch (StorageException& e)
+    catch (const StorageException& e)
     {
       EXPECT_NE(e.StatusCode, Azure::Core::Http::HttpStatusCode::None);
       EXPECT_FALSE(e.ReasonPhrase.empty());


### PR DESCRIPTION
Inspired by https://github.com/Azure/azure-sdk-for-cpp/pull/2350#discussion_r640834624

Catch by **const** ref, unless you want to modify the exception. An example where we modify the exception is when we do `std::move(ex.RawResponse)`. In other cases, it is a good practice to catch by const.