### PR TITLE
fix blob/file read consistency issue

### DIFF
--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -191,10 +191,7 @@ namespace Azure { namespace Storage { namespace Blobs {
         {
           newOptions.Range.Value().Length = options.Range.Value().Length.Value() - retryOffset;
         }
-        if (!newOptions.AccessConditions.IfMatch.HasValue())
-        {
-          newOptions.AccessConditions.IfMatch = eTag;
-        }
+        newOptions.AccessConditions.IfMatch = eTag;
         return std::move(Download(newOptions, context).Value.BodyStream);
       };
 
@@ -291,10 +288,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             chunkOptions.Range = Core::Http::HttpRange();
             chunkOptions.Range.Value().Offset = offset;
             chunkOptions.Range.Value().Length = length;
-            if (!chunkOptions.AccessConditions.IfMatch.HasValue())
-            {
-              chunkOptions.AccessConditions.IfMatch = eTag;
-            }
+            chunkOptions.AccessConditions.IfMatch = eTag;
             auto chunk = Download(chunkOptions, context);
             int64_t bytesRead = chunk.Value.BodyStream->ReadToCount(
                 buffer + (offset - firstChunkOffset),
@@ -417,10 +411,7 @@ namespace Azure { namespace Storage { namespace Blobs {
             chunkOptions.Range = Core::Http::HttpRange();
             chunkOptions.Range.Value().Offset = offset;
             chunkOptions.Range.Value().Length = length;
-            if (!chunkOptions.AccessConditions.IfMatch.HasValue())
-            {
-              chunkOptions.AccessConditions.IfMatch = eTag;
-            }
+            chunkOptions.AccessConditions.IfMatch = eTag;
             auto chunk = Download(chunkOptions, context);
             bodyStreamToFile(
                 *(chunk.Value.BodyStream),


### PR DESCRIPTION
Hi @JeffreyRichter , this PR is to fix a data consistency issue where the blob/file is overwritten during a download process that requires more than one HTTP request. The behavior is now consistent across all language storage sdks after this PR is merged.

There's also another feature in other language sdk that allows customers to explicitly choose to risk this kind of inconsistency issue. It's like "Just download the blob/file and I don't care if it's modified during download". This feature can be useful when customers know for sure the data they care about won't be modified (like append only operations).
Do you think it's necessary for us to add such a feature in C++?