### PR TITLE
Expand docs docs for RetryOptions

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -87,7 +87,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     std::chrono::milliseconds MaxRetryDelay = std::chrono::minutes(2);
 
     /**
-     * @brief The HTTP status codes that indicate the operation should be retried.
+     * @brief The HTTP status codes that indicate when an operation should be retried.
      *
      */
     std::set<HttpStatusCode> StatusCodes{

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -59,34 +59,35 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
   };
 
   /**
-   * @brief HTTP request retry options.
+   * @brief The set of options that can be specified to influence how retry attempts are made, and a
+   * failure is eligible to be retried.
    * @note See https://azure.github.io/azure-sdk/general_azurecore.html#retry-policy.
    *
    */
   struct RetryOptions final
   {
     /**
-     * @brief Maximum number of attempts to retry.
+     * @brief The maximum number of retry attempts before giving up.
      *
      */
     int32_t MaxRetries = 3;
 
     /**
-     * @brief Mimimum amount of milliseconds between retry attempts.
+     * @brief The minimum permissible delay between retry attempts.
      * @note See https://en.cppreference.com/w/cpp/chrono/duration.
      *
      */
     std::chrono::milliseconds RetryDelay = std::chrono::seconds(4);
 
     /**
-     * @brief Mimimum amount of milliseconds between retry attempts.
+     * @brief The maximum permissible delay between retry attempts.
      * @note See https://en.cppreference.com/w/cpp/chrono/duration.
      *
      */
     std::chrono::milliseconds MaxRetryDelay = std::chrono::minutes(2);
 
     /**
-     * @brief HTTP status codes to retry on.
+     * @brief The HTTP status codes that indicate the operation should be retried.
      *
      */
     std::set<HttpStatusCode> StatusCodes{


### PR DESCRIPTION
Closes #2297.


Wording was taken from

* Go SDK (StatusCodes): https://github.com/Azure/azure-sdk-for-go/blob/702d79cb3b822c36ab5eed83d7516ba9b81602e9/sdk/azcore/policy_retry.go#L24

* .NET SDK (everything else): https://github.com/Azure/azure-sdk-for-net/blob/850df4dc21246f6d216e8ed472313b741a8362b7/sdk/core/Azure.Core/src/RetryOptions.cs#L12