### PR TITLE
Fix docs version dropdown

### DIFF
--- a/eng/docs/api/assets/header.html
+++ b/eng/docs/api/assets/header.html
@@ -73,7 +73,7 @@ function populateOptions(optionSelector, otherSelectors) {
       if (responseText) {
         let options = responseText.match(/[^\r\n]+/g);
 
-        if (!(currentVersion() in options)) {
+        if (!options.some(item => item == currentVersion())) {
           // If the current version isn't in the array of options, prepend the
           // current version to the list so it renders on the client side.
           options.unshift(currentVersion());

--- a/eng/docs/api/assets/header.html
+++ b/eng/docs/api/assets/header.html
@@ -34,10 +34,8 @@ function currentVersion() {
 }
 
 function currentPackage() {
-  // C docs are generated as a monolith, the correct path is:
-  // https://azuresdkdocs.blob.core.windows.net/$web/c/docs/{version}/index.html
-  // This sets the "docs" piece of the URL path
-  return "docs";
+  // Filled in by Doxygen template
+  return "$projectname";
 }
 
 function httpGetAsync(targetUrl, callback) {
@@ -75,15 +73,18 @@ function populateOptions(optionSelector, otherSelectors) {
       if (responseText) {
         let options = responseText.match(/[^\r\n]+/g);
 
+        if (!(currentVersion() in options)) {
+          // If the current version isn't in the array of options, prepend the
+          // current version to the list so it renders on the client side.
+          options.unshift(currentVersion());
+        }
+
         populateVersionDropDown(optionSelector, options);
         showSelectors(otherSelectors);
 
         $(optionSelector).change(function() {
           targetVersion = $(this).val();
-
-          url = WINDOW_CONTENTS.slice();
-          url[6] = targetVersion;
-          window.location.href = url.join("/");
+          window.location.href = getPackageUrl(SELECTED_LANGUAGE, currentPackage(), targetVersion);
         });
       }
     });

--- a/eng/docs/api/assets/header.html
+++ b/eng/docs/api/assets/header.html
@@ -72,13 +72,6 @@ function populateOptions(optionSelector, otherSelectors) {
     httpGetAsync(versionRequestUrl, function(responseText) {
       if (responseText) {
         let options = responseText.match(/[^\r\n]+/g);
-
-        if (!options.some(item => item == currentVersion())) {
-          // If the current version isn't in the array of options, prepend the
-          // current version to the list so it renders on the client side.
-          options.unshift(currentVersion());
-        }
-
         populateVersionDropDown(optionSelector, options);
         showSelectors(otherSelectors);
 


### PR DESCRIPTION
Docs version dropdown has some old code from the C repo which makes incorrect assumptions about how the URL which contains the list of versions is formed. This uses the correct function to build the URL to the version file. It also uses the correct generator function for switching between versions. 

Examples can be seen here: https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-template/1.0.0-beta.925043/index.html 

NB: 
* Versions 1.0.0-beta.903803 and earlier have the bug that does not properly populate the dropdown. To fix those earlier versions we will have to patch a file in each affected version. 
* I deleted the tags created in each release so links and resources that rely on those tags existing in GitHub will not work. 