### PR TITLE
add multithread build to macOS

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -71,6 +71,7 @@ jobs:
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         CHECK_CLANG_FORMAT: 1
+        BuildArgs: '-j 4'
 
       # Unit testing ON
       Linux_x64_with_unit_test:
@@ -115,6 +116,7 @@ jobs:
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
+        BuildArgs: '-j 4'
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -38,6 +38,7 @@ jobs:
         # Avoid re-running tests again for code coverage since the tests were previously ran
         CODE_COVERAGE_COLLECT_ONLY: 1
         AZURE_CORE_ENABLE_JSON_TESTS: 1
+        BuildArgs: '-j 4'
       # Not asking for any transport adapter will default to OS -> windows:winHttp or !windows:libcurl
       Win_x86_with_unit_test_winHttp:
         Pool: azsdk-pool-mms-win-2019-general
@@ -87,6 +88,7 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON'
         AZURE_CORE_ENABLE_JSON_TESTS: 1
+        BuildArgs: '-j 4'
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)


### PR DESCRIPTION
Noticed macOS is taking too long for building gates with tests because it uses only one thread.

This is a little improvement