### PR TITLE
Consolidate the use of std::size_t and always use size_t instead, since it is a "primitive" type.

### DIFF
--- a/samples/integration/vcpkg-storage/src/main.cpp
+++ b/samples/integration/vcpkg-storage/src/main.cpp
@@ -41,7 +41,7 @@ int main()
   {
     std::cout << metadata.first << ":" << metadata.second << std::endl;
   }
-  blobContent.resize(static_cast<std::size_t>(properties.BlobSize));
+  blobContent.resize(static_cast<size_t>(properties.BlobSize));
 
   blobClient.DownloadTo(reinterpret_cast<uint8_t*>(&blobContent[0]), blobContent.size());
 

--- a/sdk/core/azure-core/inc/azure/core/cryptography/hash.hpp
+++ b/sdk/core/azure-core/inc/azure/core/cryptography/hash.hpp
@@ -33,7 +33,7 @@ namespace Azure { namespace Core { namespace Cryptography {
      * calculation.
      * @param length The size of the data provided.
      */
-    virtual void OnAppend(const uint8_t* data, std::size_t length) = 0;
+    virtual void OnAppend(const uint8_t* data, size_t length) = 0;
 
     /**
      * @brief Computes the hash value of the specified binary input data, including any previously
@@ -43,7 +43,7 @@ namespace Azure { namespace Core { namespace Cryptography {
      * @return The computed hash value corresponding to the input provided including any previously
      * appended.
      */
-    virtual std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length) = 0;
+    virtual std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length) = 0;
 
   protected:
     /**
@@ -62,7 +62,7 @@ namespace Azure { namespace Core { namespace Cryptography {
      * calculation.
      * @param length The size of the data provided.
      */
-    void Append(const uint8_t* data, std::size_t length)
+    void Append(const uint8_t* data, size_t length)
     {
       AZURE_ASSERT(data || length == 0);
       AZURE_ASSERT_MSG(!m_isDone, "Cannot call Append after calling Final().");
@@ -78,7 +78,7 @@ namespace Azure { namespace Core { namespace Cryptography {
      * @return The computed hash value corresponding to the input provided, including any previously
      * appended.
      */
-    std::vector<uint8_t> Final(const uint8_t* data, std::size_t length)
+    std::vector<uint8_t> Final(const uint8_t* data, size_t length)
     {
       AZURE_ASSERT(data || length == 0);
       AZURE_ASSERT_MSG(!m_isDone, "Cannot call Final() multiple times.");
@@ -147,7 +147,7 @@ namespace Azure { namespace Core { namespace Cryptography {
      * @return The computed MD5 hash value corresponding to the input provided including any
      * previously appended.
      */
-    std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length) override;
+    std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length) override;
 
     /**
      * @brief Used to append partial binary input data to compute the MD5 hash in a streaming
@@ -158,7 +158,7 @@ namespace Azure { namespace Core { namespace Cryptography {
      * calculation.
      * @param length The size of the data provided.
      */
-    void OnAppend(const uint8_t* data, std::size_t length) override;
+    void OnAppend(const uint8_t* data, size_t length) override;
   };
 
 }}} // namespace Azure::Core::Cryptography

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -234,9 +234,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * @param policies A vector of unique pointers next in the line to be invoked after the current
      * policy.
      */
-    explicit NextHttpPolicy(
-        size_t index,
-        const std::vector<std::unique_ptr<HttpPolicy>>& policies)
+    explicit NextHttpPolicy(size_t index, const std::vector<std::unique_ptr<HttpPolicy>>& policies)
         : m_index(index), m_policies(policies)
     {
     }

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -222,7 +222,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
    *
    */
   class NextHttpPolicy final {
-    const std::size_t m_index;
+    const size_t m_index;
     const std::vector<std::unique_ptr<HttpPolicy>>& m_policies;
 
   public:
@@ -235,7 +235,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * policy.
      */
     explicit NextHttpPolicy(
-        std::size_t index,
+        size_t index,
         const std::vector<std::unique_ptr<HttpPolicy>>& policies)
         : m_index(index), m_policies(policies)
     {

--- a/sdk/core/azure-core/src/base64.cpp
+++ b/sdk/core/azure-core/src/base64.cpp
@@ -78,7 +78,7 @@ namespace Azure { namespace Core {
     std::vector<uint8_t> decoded;
     // According to RFC 4648, the encoded length should be ceiling(n / 3) * 4, so we can infer an
     // upper bound here
-    std::size_t maxDecodedLength = text.length() / 4 * 3;
+    size_t maxDecodedLength = text.length() / 4 * 3;
     decoded.resize(maxDecodedLength);
 
     BIO* bio = BIO_new_mem_buf(text.data(), -1);

--- a/sdk/core/azure-core/src/cryptography/md5.cpp
+++ b/sdk/core/azure-core/src/cryptography/md5.cpp
@@ -163,10 +163,7 @@ class Md5OpenSSL final : public Azure::Core::Cryptography::Hash {
 private:
   std::unique_ptr<MD5_CTX> m_context;
 
-  void OnAppend(const uint8_t* data, size_t length)
-  {
-    MD5_Update(m_context.get(), data, length);
-  }
+  void OnAppend(const uint8_t* data, size_t length) { MD5_Update(m_context.get(), data, length); }
 
   std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length)
   {

--- a/sdk/core/azure-core/src/cryptography/md5.cpp
+++ b/sdk/core/azure-core/src/cryptography/md5.cpp
@@ -27,8 +27,8 @@ private:
 
 public:
   BCRYPT_ALG_HANDLE Handle;
-  std::size_t ContextSize;
-  std::size_t HashLength;
+  size_t ContextSize;
+  size_t HashLength;
 
   Md5AlgorithmProvider()
   {
@@ -91,10 +91,10 @@ private:
   // Make sure the initial state of status is non-successful
   NTSTATUS m_status = 0;
   BCRYPT_HASH_HANDLE m_hashHandle = nullptr;
-  std::size_t m_hashLength = 0;
+  size_t m_hashLength = 0;
   std::string m_buffer;
 
-  void OnAppend(const uint8_t* data, std::size_t length)
+  void OnAppend(const uint8_t* data, size_t length)
   {
     if (!BCRYPT_SUCCESS(
             m_status = BCryptHashData(
@@ -107,7 +107,7 @@ private:
     }
   }
 
-  std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length)
+  std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length)
   {
     OnAppend(data, length);
 
@@ -163,12 +163,12 @@ class Md5OpenSSL final : public Azure::Core::Cryptography::Hash {
 private:
   std::unique_ptr<MD5_CTX> m_context;
 
-  void OnAppend(const uint8_t* data, std::size_t length)
+  void OnAppend(const uint8_t* data, size_t length)
   {
     MD5_Update(m_context.get(), data, length);
   }
 
-  std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length)
+  std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length)
   {
     OnAppend(data, length);
     unsigned char hash[MD5_DIGEST_LENGTH];
@@ -191,12 +191,12 @@ Azure::Core::Cryptography::Md5Hash::Md5Hash() : m_implementation(std::make_uniqu
 namespace Azure { namespace Core { namespace Cryptography {
   Md5Hash::~Md5Hash() {}
 
-  void Md5Hash::OnAppend(const uint8_t* data, std::size_t length)
+  void Md5Hash::OnAppend(const uint8_t* data, size_t length)
   {
     m_implementation->Append(data, length);
   }
 
-  std::vector<uint8_t> Md5Hash::OnFinal(const uint8_t* data, std::size_t length)
+  std::vector<uint8_t> Md5Hash::OnFinal(const uint8_t* data, size_t length)
   {
     return m_implementation->Final(data, length);
   }

--- a/sdk/core/azure-core/src/http/url.cpp
+++ b/sdk/core/azure-core/src/http/url.cpp
@@ -82,18 +82,18 @@ std::string Url::Decode(const std::string& value)
     std::vector<int> t(256, -1);
     for (int i = 0; i < 10; ++i)
     {
-      t[static_cast<std::size_t>('0') + i] = i;
+      t[static_cast<size_t>('0') + i] = i;
     }
     for (int i = 10; i < 16; ++i)
     {
-      t[static_cast<std::size_t>('A') + i - 10] = i;
-      t[static_cast<std::size_t>('a') + i - 10] = i;
+      t[static_cast<size_t>('A') + i - 10] = i;
+      t[static_cast<size_t>('a') + i - 10] = i;
     }
     return t;
   }();
 
   std::string decodedValue;
-  for (std::size_t i = 0; i < value.size();)
+  for (size_t i = 0; i < value.size();)
   {
     char c = value[i];
     if (c == '+')

--- a/sdk/core/azure-core/test/ut/base64_test.cpp
+++ b/sdk/core/azure-core/test/ut/base64_test.cpp
@@ -74,16 +74,16 @@ static thread_local std::mt19937_64 random_generator(std::random_device{}());
 static char RandomChar()
 {
   const char charset[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  std::uniform_int_distribution<std::size_t> distribution(0, sizeof(charset) - 2);
+  std::uniform_int_distribution<size_t> distribution(0, sizeof(charset) - 2);
   return charset[distribution(random_generator)];
 }
 
-void RandomBuffer(char* buffer, std::size_t length)
+void RandomBuffer(char* buffer, size_t length)
 {
   char* start_addr = buffer;
   char* end_addr = buffer + length;
 
-  const std::size_t rand_int_size = sizeof(uint64_t);
+  const size_t rand_int_size = sizeof(uint64_t);
 
   while (uintptr_t(start_addr) % rand_int_size != 0 && start_addr < end_addr)
   {
@@ -102,14 +102,14 @@ void RandomBuffer(char* buffer, std::size_t length)
   }
 }
 
-inline void RandomBuffer(uint8_t* buffer, std::size_t length)
+inline void RandomBuffer(uint8_t* buffer, size_t length)
 {
   RandomBuffer(reinterpret_cast<char*>(buffer), length);
 }
 
 TEST(Base64, Roundtrip)
 {
-  for (std::size_t len : {0, 10, 100, 1000, 10000})
+  for (size_t len : {0, 10, 100, 1000, 10000})
   {
     std::vector<uint8_t> data;
     data.resize(len);

--- a/sdk/core/azure-core/test/ut/md5_test.cpp
+++ b/sdk/core/azure-core/test/ut/md5_test.cpp
@@ -25,11 +25,11 @@ static thread_local std::mt19937_64 random_generator(std::random_device{}());
 static char RandomCharGenerator()
 {
   const char charset[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  std::uniform_int_distribution<std::size_t> distribution(0, sizeof(charset) - 2);
+  std::uniform_int_distribution<size_t> distribution(0, sizeof(charset) - 2);
   return charset[distribution(random_generator)];
 }
 
-std::vector<uint8_t> RandomBuffer(std::size_t length)
+std::vector<uint8_t> RandomBuffer(size_t length)
 {
   std::vector<uint8_t> result(length);
   char* dataPtr = reinterpret_cast<char*>(&result[0]);
@@ -37,7 +37,7 @@ std::vector<uint8_t> RandomBuffer(std::size_t length)
   char* start_addr = dataPtr;
   char* end_addr = dataPtr + length;
 
-  const std::size_t rand_int_size = sizeof(uint64_t);
+  const size_t rand_int_size = sizeof(uint64_t);
 
   while (uintptr_t(start_addr) % rand_int_size != 0 && start_addr < end_addr)
   {
@@ -72,7 +72,7 @@ TEST(Md5Hash, Basic)
   EXPECT_EQ(
       Azure::Core::Convert::Base64Encode(ComputeHash("Hello Azure!")), "Pz8543xut4RVSbb2g52Mww==");
 
-  auto data = RandomBuffer(static_cast<std::size_t>(16777216));
+  auto data = RandomBuffer(static_cast<size_t>(16777216));
 
   Md5Hash md5Single;
   Md5Hash md5Streaming;
@@ -85,10 +85,10 @@ TEST(Md5Hash, Basic)
   // computed hash value when you have all the data with the streaming approach, and validate they
   // are equal.
 
-  std::size_t length = 0;
+  size_t length = 0;
   while (length < data.size())
   {
-    std::size_t s = static_cast<std::size_t>(RandomInt(0, 4194304));
+    size_t s = static_cast<size_t>(RandomInt(0, 4194304));
     s = std::min(s, data.size() - length);
     md5Streaming.Append(&data[length], s);
     md5Streaming.Append(&data[length], 0);

--- a/sdk/core/perf/inc/azure/perf/argagg.hpp
+++ b/sdk/core/perf/inc/azure/perf/argagg.hpp
@@ -794,10 +794,7 @@ inline size_t parser_results::count() const { return this->pos.size(); }
 
 inline const char* parser_results::operator[](size_t index) const { return this->pos[index]; }
 
-template <typename T> T parser_results::as(size_t i) const
-{
-  return convert::arg<T>(this->pos[i]);
-}
+template <typename T> T parser_results::as(size_t i) const { return convert::arg<T>(this->pos[i]); }
 
 template <typename T> std::vector<T> parser_results::all_as() const
 {

--- a/sdk/core/perf/inc/azure/perf/argagg.hpp
+++ b/sdk/core/perf/inc/azure/perf/argagg.hpp
@@ -323,19 +323,19 @@ struct option_results
    * @brief
    * Gets the number of times the option shows up.
    */
-  std::size_t count() const;
+  size_t count() const;
 
   /**
    * @brief
    * Gets a single option parse result by index.
    */
-  option_result& operator[](std::size_t index);
+  option_result& operator[](size_t index);
 
   /**
    * @brief
    * Gets a single option result by index.
    */
-  const option_result& operator[](std::size_t index) const;
+  const option_result& operator[](size_t index) const;
 
   /**
    * @brief
@@ -434,19 +434,19 @@ struct parser_results
    * @brief
    * Gets the number of positional arguments.
    */
-  std::size_t count() const;
+  size_t count() const;
 
   /**
    * @brief
    * Gets a positional argument by index.
    */
-  const char* operator[](std::size_t index) const;
+  const char* operator[](size_t index) const;
 
   /**
    * @brief
    * Gets a positional argument converted to the given type.
    */
-  template <typename T> T as(std::size_t i = 0) const;
+  template <typename T> T as(size_t i = 0) const;
 
   /**
    * @brief
@@ -727,11 +727,11 @@ template <> inline option_result::operator bool() const { return this->arg != nu
 
 inline bool option_result::operator!() const { return !static_cast<bool>(*this); }
 
-inline std::size_t option_results::count() const { return this->all.size(); }
+inline size_t option_results::count() const { return this->all.size(); }
 
-inline option_result& option_results::operator[](std::size_t index) { return this->all[index]; }
+inline option_result& option_results::operator[](size_t index) { return this->all[index]; }
 
-inline const option_result& option_results::operator[](std::size_t index) const
+inline const option_result& option_results::operator[](size_t index) const
 {
   return this->all[index];
 }
@@ -790,11 +790,11 @@ catch (const std::out_of_range& e)
   throw unknown_option(msg.str());
 }
 
-inline std::size_t parser_results::count() const { return this->pos.size(); }
+inline size_t parser_results::count() const { return this->pos.size(); }
 
-inline const char* parser_results::operator[](std::size_t index) const { return this->pos[index]; }
+inline const char* parser_results::operator[](size_t index) const { return this->pos[index]; }
 
-template <typename T> T parser_results::as(std::size_t i) const
+template <typename T> T parser_results::as(size_t i) const
 {
   return convert::arg<T>(this->pos[i]);
 }
@@ -1158,7 +1158,7 @@ inline parser_results parser::parse(int argc, const char** argv, bool posOnly) c
         // long_flag_arg is nullptr then we didn't find '='. We need the
         // flag_len to construct long_flag_str below.
         auto long_flag_arg = std::strchr(arg_i_cstr, '=');
-        std::size_t flag_len = arg_i_len;
+        size_t flag_len = arg_i_len;
         if (long_flag_arg != nullptr)
         {
           flag_len = long_flag_arg - arg_i_cstr;
@@ -1216,7 +1216,7 @@ inline parser_results parser::parse(int argc, const char** argv, bool posOnly) c
       // not). So starting after the dash we're going to process each character
       // as if it were a separate flag. Note "sf_idx" stands for "short flag
       // index".
-      for (std::size_t sf_idx = 1; sf_idx < arg_i_len; ++sf_idx)
+      for (size_t sf_idx = 1; sf_idx < arg_i_len; ++sf_idx)
       {
         const auto short_flag = arg_i_cstr[sf_idx];
 
@@ -1468,7 +1468,7 @@ inline std::string construct_line(const std::string& indent, const std::string& 
  * @brief
  * Return a wrapped version of a single line of text.
  */
-inline std::string wrap_line(const std::string& single_line, const std::size_t wrap_width)
+inline std::string wrap_line(const std::string& single_line, const size_t wrap_width)
 {
   auto indentation_spaces = single_line.find_first_not_of(" ");
   if (indentation_spaces == std::string::npos)
@@ -1481,8 +1481,8 @@ inline std::string wrap_line(const std::string& single_line, const std::size_t w
 
   std::string result;
 
-  std::size_t position = 0;
-  std::size_t line_start = 0;
+  size_t position = 0;
+  size_t line_start = 0;
   while (true)
   {
     const auto new_position = line.find_first_of(" ", position);

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/sha.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/sha.hpp
@@ -50,7 +50,7 @@ namespace Azure { namespace Security { namespace KeyVault {
      * @return The computed SHA256 hash value corresponding to the input provided including any
      * previously appended.
      */
-    std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length) override
+    std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length) override
     {
       return m_portableImplementation->Final(data, length);
     }
@@ -63,7 +63,7 @@ namespace Azure { namespace Security { namespace KeyVault {
      * calculation.
      * @param length The size of the data provided.
      */
-    void OnAppend(const uint8_t* data, std::size_t length) override
+    void OnAppend(const uint8_t* data, size_t length) override
     {
       return m_portableImplementation->Append(data, length);
     }
@@ -102,7 +102,7 @@ namespace Azure { namespace Security { namespace KeyVault {
      * @return The computed SHA384 hash value corresponding to the input provided including any
      * previously appended.
      */
-    std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length) override
+    std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length) override
     {
       return m_portableImplementation->Final(data, length);
     }
@@ -115,7 +115,7 @@ namespace Azure { namespace Security { namespace KeyVault {
      * calculation.
      * @param length The size of the data provided.
      */
-    void OnAppend(const uint8_t* data, std::size_t length) override
+    void OnAppend(const uint8_t* data, size_t length) override
     {
       return m_portableImplementation->Append(data, length);
     }
@@ -154,7 +154,7 @@ namespace Azure { namespace Security { namespace KeyVault {
      * @return The computed SHA512 hash value corresponding to the input provided including any
      * previously appended.
      */
-    std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length) override
+    std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length) override
     {
       return m_portableImplementation->Final(data, length);
     }
@@ -167,7 +167,7 @@ namespace Azure { namespace Security { namespace KeyVault {
      * calculation.
      * @param length The size of the data provided.
      */
-    void OnAppend(const uint8_t* data, std::size_t length) override
+    void OnAppend(const uint8_t* data, size_t length) override
     {
       return m_portableImplementation->Append(data, length);
     }

--- a/sdk/keyvault/azure-security-keyvault-common/src/sha.cpp
+++ b/sdk/keyvault/azure-security-keyvault-common/src/sha.cpp
@@ -36,7 +36,7 @@ class SHAWithOpenSSL final : public Azure::Core::Cryptography::Hash {
 private:
   EVP_MD_CTX* m_context;
 
-  std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length) override
+  std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length) override
   {
     OnAppend(data, length);
     unsigned int size;
@@ -48,7 +48,7 @@ private:
     return std::vector<uint8_t>(std::begin(finalHash), std::begin(finalHash) + size);
   }
 
-  void OnAppend(const uint8_t* data, std::size_t length) override
+  void OnAppend(const uint8_t* data, size_t length) override
   {
     if (1 != EVP_DigestUpdate(m_context, data, length))
     {
@@ -119,8 +119,8 @@ namespace {
 struct AlgorithmProviderInstance final
 {
   BCRYPT_ALG_HANDLE Handle;
-  std::size_t ContextSize;
-  std::size_t HashLength;
+  size_t ContextSize;
+  size_t HashLength;
 
   AlgorithmProviderInstance(LPCWSTR hashAlgorithm)
   {
@@ -165,9 +165,9 @@ class SHAWithBCrypt final : public Azure::Core::Cryptography::Hash {
 private:
   std::string m_buffer;
   BCRYPT_HASH_HANDLE m_hashHandle = nullptr;
-  std::size_t m_hashLength = 0;
+  size_t m_hashLength = 0;
 
-  std::vector<uint8_t> OnFinal(const uint8_t* data, std::size_t length) override
+  std::vector<uint8_t> OnFinal(const uint8_t* data, size_t length) override
   {
     OnAppend(data, length);
 
@@ -182,7 +182,7 @@ private:
     return hash;
   }
 
-  void OnAppend(const uint8_t* data, std::size_t length) override
+  void OnAppend(const uint8_t* data, size_t length) override
   {
     NTSTATUS status = BCryptHashData(
         m_hashHandle,


### PR DESCRIPTION
Fixes the azure core and keyvault parts of https://github.com/Azure/azure-sdk-for-cpp/issues/2319

We don't have an instances of types like `std::[u]int`, and functions like `std::memcpy` can remain as is. Left other things, within storage, like `ptrdiff_t` to be fixed separately.