### PR TITLE
Add dependency on LiveTest to release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -60,6 +60,7 @@ stages:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
         DependsOn:
         - Build
+        - LiveTest
         Artifacts: ${{ parameters.Artifacts }}
         ArtifactName: packages
         ${{ if eq(parameters.ServiceDirectory, 'template') }}:


### PR DESCRIPTION
Add `LiveTest` to release dependencies. Failing live tests will block releasing. 