### PR TITLE
Add dependency on LiveTest to release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -3,13 +3,15 @@ parameters:
   ArtifactName: 'not-specified'
   ServiceDirectory: not-specified
   TestPipeline: false
+  DependsOn:
+    - Build
 
 stages:
   - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
     - ${{ each artifact in parameters.Artifacts }}:
       - stage: Release_${{ replace(artifact.Name, '-', '_') }}
         displayName: 'Release ${{artifact.name}}'
-        dependsOn: Build
+        dependsOn: ${{ parameters.DependsOn }}
         condition:  and(succeeded(), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-cpp'), ne(variables['Skip.AllRelease'], 'true'))
 
         jobs:
@@ -190,7 +192,7 @@ stages:
 
   - ${{if eq(variables['System.TeamProject'], 'internal') }}:
     - stage: Integration
-      dependsOn: Build
+      dependsOn: ${{ parameters.DependsOn }}
       condition: and(succeeded(), or(eq(variables['PublishDailyVcpkg'], 'true'), eq(variables['Build.Reason'],'Schedule')))
       jobs:
         - job: PublishDailyVcpkg

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -60,6 +60,7 @@ stages:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
         DependsOn:
         - Build
+        - LiveTest
         Artifacts: ${{ parameters.Artifacts }}
         ArtifactName: packages
         ${{ if eq(parameters.ServiceDirectory, 'template') }}:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -61,8 +61,8 @@ stages:
         DependsOn:
           - Build
           # Only depend on `LiveTest` if there are live tests to execute
-          # - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
-          - LiveTest
+          - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
+            - LiveTest
         Artifacts: ${{ parameters.Artifacts }}
         ArtifactName: packages
         ${{ if eq(parameters.ServiceDirectory, 'template') }}:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -61,8 +61,8 @@ stages:
         DependsOn:
           - Build
           # Only depend on `LiveTest` if there are live tests to execute
-          - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
-            - LiveTest
+          # - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
+          - LiveTest
         Artifacts: ${{ parameters.Artifacts }}
         ArtifactName: packages
         ${{ if eq(parameters.ServiceDirectory, 'template') }}:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -59,8 +59,10 @@ stages:
       parameters:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
         DependsOn:
-        - Build
-        - LiveTest
+          - Build
+          # Only depend on `LiveTest` if there are live tests to execute
+          - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
+            - LiveTest
         Artifacts: ${{ parameters.Artifacts }}
         ArtifactName: packages
         ${{ if eq(parameters.ServiceDirectory, 'template') }}:


### PR DESCRIPTION
Add `LiveTest` to release dependencies. Failing live tests will block releasing.

Example pipeline executions: 
Core (has live tests) -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=965463&view=results 
Template (does not have live tests) -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=965464&view=results 

In both cases I canceled the release. 