### PR TITLE
Put dependency versions

### DIFF
--- a/eng/scripts/Initialize-VcpkgRelease.ps1
+++ b/eng/scripts/Initialize-VcpkgRelease.ps1
@@ -60,12 +60,12 @@ Write-Host "SHA512: $sha512"
 Write-Verbose "Writing the SHA512 hash"
 $portfileLocation = "$SourceDirectory/port/portfile.cmake"
 
-# Regex replace SHA512 preserving spaces. The placeholder "SHA512 1" is
+# Regex replace SHA512 preserving spaces. The placeholder "SHA512 0" is
 # recommended in vcpkg documentation
-# Before: "   SHA512   1"
+# Before: "   SHA512   0"
 # After:  "   SHA512   f6cf1c16c52" 
 $portFileContent = Get-Content -Raw -Path $portfileLocation 
-$newContent = $portFileContent -replace '(SHA512\s+)1', "`${1}$sha512"
+$newContent = $portFileContent -replace '(SHA512\s+)0', "`${1}$sha512"
 
 if ($DailyReleaseRef) {
     Write-Verbose "Overriding REF with test release ref: $DailyReleaseRef"

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
+## 1.0.1 (Unreleased)
 
 ### Bug Fixes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
+## 1.1.0 (Unreleased)
 
 ### Bug Fixes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.1.0-beta.1 (Unreleased)
 
 ### Bug Fixes
 

--- a/sdk/core/azure-core/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core/vcpkg/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
     REF azure-core_@AZ_LIBRARY_VERSION@
-    SHA512 1
+    SHA512 0
 )
 
 vcpkg_check_features(

--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -10,6 +10,7 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/core/azure-core",
   "license": "MIT",
+  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "openssl",
@@ -40,7 +41,8 @@
           "default-features": false,
           "features": [
             "ssl"
-          ]
+          ],
+          "version>=": "7.44"
         }
       ]
     },

--- a/sdk/identity/azure-identity/CMakeLists.txt
+++ b/sdk/identity/azure-identity/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp CONFIG QUIET)
+  find_package(azure-core-cpp "1.0.0" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp REQUIRED)
+    find_package(azure-core-cpp "1.0.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/identity/azure-identity/vcpkg/portfile.cmake
+++ b/sdk/identity/azure-identity/vcpkg/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
     REF azure-identity_@AZ_LIBRARY_VERSION@
-    SHA512 1
+    SHA512 0
 )
 
 vcpkg_cmake_configure(

--- a/sdk/identity/azure-identity/vcpkg/vcpkg.json
+++ b/sdk/identity/azure-identity/vcpkg/vcpkg.json
@@ -10,10 +10,12 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity",
   "license": "MIT",
+  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false
+      "default-features": false,
+      "version>=": "1.0.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp "1.0.1" CONFIG QUIET)
+  find_package(azure-core-cpp "1.1.0" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp "1.0.1" REQUIRED)
+    find_package(azure-core-cpp "1.1.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp "1.1.0" CONFIG QUIET)
+  find_package(azure-core-cpp "1.0.0" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp "1.1.0" REQUIRED)
+    find_package(azure-core-cpp "1.0.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp "1.0.0" CONFIG QUIET)
+  find_package(azure-core-cpp "1.1.0" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp "1.0.0" REQUIRED)
+    find_package(azure-core-cpp "1.1.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp CONFIG QUIET)
+  find_package(azure-core-cpp "1.0.1" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp REQUIRED)
+    find_package(azure-core-cpp "1.0.1" REQUIRED)
   endif()
 endif()
 

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
     REF azure-security-keyvault-common_@AZ_LIBRARY_VERSION@
-    SHA512 1
+    SHA512 0
 )
 
 vcpkg_cmake_configure(

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
@@ -15,7 +15,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.0.0"
+      "version>=": "1.1.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
@@ -10,10 +10,12 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-common",
   "license": "MIT",
+  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false
+      "default-features": false,
+      "version>=": "1.1.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
@@ -15,7 +15,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.1.0"
+      "version>=": "1.0.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-security-keyvault-common-cpp CONFIG QUIET)
+  find_package(azure-security-keyvault-common-cpp "4.0.0" CONFIG QUIET)
   if(NOT azure-security-keyvault-common-cpp_FOUND)
-    find_package(azure-security-keyvault-common-cpp REQUIRED)
+    find_package(azure-security-keyvault-common-cpp "4.0.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
     REF azure-security-keyvault-keys_@AZ_LIBRARY_VERSION@
-    SHA512 1
+    SHA512 0
 )
 
 vcpkg_cmake_configure(

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
@@ -10,10 +10,12 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-keys",
   "license": "MIT",
+  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-security-keyvault-common-cpp",
-      "default-features": false
+      "default-features": false,
+      "version>=": "4.0.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-blobs/CMakeLists.txt
+++ b/sdk/storage/azure-storage-blobs/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-storage-common-cpp CONFIG QUIET)
+  find_package(azure-storage-common-cpp "12.0.0" CONFIG QUIET)
   if(NOT azure-storage-common-cpp_FOUND)
-    find_package(azure-storage-common-cpp REQUIRED)
+    find_package(azure-storage-common-cpp "12.0.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
     REF azure-storage-blobs_@AZ_LIBRARY_VERSION@
-    SHA512 1
+    SHA512 0
 )
 
 vcpkg_cmake_configure(

--- a/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
@@ -10,10 +10,12 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs",
   "license": "MIT",
+  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",
-      "default-features": false
+      "default-features": false,
+      "version>=": "12.0.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-common/CMakeLists.txt
+++ b/sdk/storage/azure-storage-common/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp CONFIG QUIET)
+  find_package(azure-core-cpp "1.0.0" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp REQUIRED)
+    find_package(azure-core-cpp "1.0.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
     REF azure-storage-common_@AZ_LIBRARY_VERSION@
-    SHA512 1
+    SHA512 0
 )
 
 vcpkg_cmake_configure(

--- a/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
@@ -10,10 +10,12 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-common",
   "license": "MIT",
+  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false
+      "default-features": false,
+      "version>=": "1.0.0"
     },
     "libxml2",
     {

--- a/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-storage-blobs-cpp CONFIG QUIET)
+  find_package(azure-storage-blobs-cpp "12.0.0" CONFIG QUIET)
   if(NOT azure-storage-blobs-cpp_FOUND)
-    find_package(azure-storage-blobs-cpp REQUIRED)
+    find_package(azure-storage-blobs-cpp "12.0.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
     REF azure-storage-files-datalake_@AZ_LIBRARY_VERSION@
-    SHA512 1
+    SHA512 0
 )
 
 vcpkg_cmake_configure(

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
@@ -10,10 +10,12 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake",
   "license": "MIT",
+  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-storage-blobs-cpp",
-      "default-features": false
+      "default-features": false,
+      "version>=": "12.0.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-files-shares/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-shares/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-storage-common-cpp CONFIG QUIET)
+  find_package(azure-storage-common-cpp "12.0.0" CONFIG QUIET)
   if(NOT azure-storage-common-cpp_FOUND)
-    find_package(azure-storage-common-cpp REQUIRED)
+    find_package(azure-storage-common-cpp "12.0.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
     REF azure-storage-files-shares_@AZ_LIBRARY_VERSION@
-    SHA512 1
+    SHA512 0
 )
 
 vcpkg_cmake_configure(

--- a/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
@@ -10,10 +10,12 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-shares",
   "license": "MIT",
+  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",
-      "default-features": false
+      "default-features": false,
+      "version>=": "12.0.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/template/azure-template/CMakeLists.txt
+++ b/sdk/template/azure-template/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp CONFIG QUIET)
+  find_package(azure-core-cpp "1.0.0" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp REQUIRED)
+    find_package(azure-core-cpp "1.0.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/template/azure-template/vcpkg/portfile.cmake
+++ b/sdk/template/azure-template/vcpkg/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
     REF azure-template_@AZ_LIBRARY_VERSION@
-    SHA512 1
+    SHA512 0
 )
 
 vcpkg_cmake_configure(

--- a/sdk/template/azure-template/vcpkg/vcpkg.json
+++ b/sdk/template/azure-template/vcpkg/vcpkg.json
@@ -11,10 +11,12 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/template/azure-template",
   "license": "MIT",
+  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false
+      "default-features": false,
+      "version>=": "1.0.0"
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
Closes #2470

Also, updated dev-time `SHA512 1` to `0` - vcpkg tool now recommends it in the error message, and does not show the expacted SHA with `1` (that was recommended before).

I tested that vcpkg succeeds in my local vcpkg fork - https://github.com/antkmsft/vcpkg/pull/1.