### PR TITLE
Update readme headers retroactively

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 1.1.0 (Unreleased)
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fixed a memory leak issue in `Base64Encode()`. (A community contribution, courtesy of _[jorgen](https://github.com/jorgen)_)
+
+### Other Changes
+
+- Made internal-only changes to support the Azure Key Vault client library.
 
 ### Acknowledgments
 
@@ -14,14 +18,14 @@ Thank you to our developer community members who helped to make Azure Core bette
 
 ## 1.0.0 (2021-06-04)
 
-### Bug Fixes
+### Bugs Fixed
 
 - Make `RequestFailedException` copiable so it can be propagated across thread.
 - By default, add `x-ms-request-id` header to the allow list of headers to log.
 
 ## 1.0.0-beta.9 (2021-05-18)
 
-### New Features
+### Features Added
 
 - Added `Azure::PagedResponse<T>`.
 
@@ -34,13 +38,13 @@ Thank you to our developer community members who helped to make Azure Core bette
 - Changed integer size parameters for buffers from `int64_t` to `size_t` in various places such as `Azure::Core::IO::BodyStream::Read()` APIs.
 - Removed the `Azure::Core::Diagnostics::Logger::Listener` typedef.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Do not re-use a libcurl connection to same host but different port.
 - Fixed curl transport issue to avoid crash at exit when curl connection pool cleanup thread is running.
 - Ensure uniqueness of `Azure::Core::Uuid` on POSIX platforms.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Modified precondition validation of function arguments to now result in assert failures rather than throwing an exception.
 - Remove exposing windows.h header from our public headers.
@@ -48,7 +52,7 @@ Thank you to our developer community members who helped to make Azure Core bette
 
 ## 1.0.0-beta.8 (2021-04-07)
 
-### New Features
+### Features Added
 
 - Added `Azure::Core::Url::GetScheme()`.
 - Added `Azure::Core::Context::TryGetValue()`.
@@ -84,14 +88,14 @@ Thank you to our developer community members who helped to make Azure Core bette
   - Renamed member `Azure::Core::Http::CurlTransportOptions::SSLOptions` to `SslOptions`.
   - Renamed member `Azure::Core::Http::CurlTransportOptions::SSLVerifyPeer` to `SslVerifyPeer`.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Moved `Azure::Core::Http::Request` to its own header file from `http.hpp` to `inc/azure/core/http/raw_response.hpp`.
 - Moved `Azure::Core::Http::HttpStatusCode` to its own header file from `http.hpp` to `inc/azure/core/http/http_status_code.hpp`.
 
 ## 1.0.0-beta.7 (2021-03-11)
 
-### New Features
+### Features Added
 
 - Added `HttpPolicyOrder` for adding custom Http policies to SDK clients.
 - Added `Azure::Core::Operation<T>::GetRawResponse()`.
@@ -148,7 +152,7 @@ Thank you to our developer community members who helped to make Azure Core bette
   - Renamed `azure/core/http/curl/curl.hpp` to `azure/core/http/curl_transport.hpp`.
   - Renamed `azure/core/http/winhttp/win_http_client.hpp` to `azure/core/http/win_http_transport.hpp`.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Make sure to rewind the body stream at the start of each request retry attempt, including the first.
 - Connection pool resets when all connections are closed.
@@ -157,7 +161,7 @@ Thank you to our developer community members who helped to make Azure Core bette
 
 ## 1.0.0-beta.6 (2021-02-09)
 
-### New Features
+### Features Added
 
 - Added support for HTTP conditional requests `MatchConditions` and `RequestConditions`.
 - Added the `Hash` base class and MD5 hashing APIs to the `Azure::Core::Cryptography` namespace available from `azure/core/cryptography/hash.hpp`.
@@ -167,7 +171,7 @@ Thank you to our developer community members who helped to make Azure Core bette
 - Removed `Context::CancelWhen()`.
 - Removed `LogClassification` and related functionality, added `LogLevel` instead.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fixed computation of the token expiration time in `BearerTokenAuthenticationPolicy`. (A community contribution, courtesy of _[sjoubert](https://github.com/sjoubert)_)
 - Fixed `Retry-After` HTTP header to be treated as case-insensitive. (A community contribution, courtesy of _[sjoubert](https://github.com/sjoubert)_)
@@ -182,7 +186,7 @@ Thank you to our developer community members who helped to make Azure Core bette
 
 ## 1.0.0-beta.5 (2021-02-02)
 
-### New Features
+### Features Added
 
 - Added support for HTTP validators `ETag`.
 
@@ -192,7 +196,7 @@ Thank you to our developer community members who helped to make Azure Core bette
 - `BearerTokenAuthenticationPolicy` constructor takes `TokenRequestOptions` struct instead of scopes vector. `TokenRequestOptions` struct has scopes vector as data member.
 - `TokenCredential::GetToken()` takes `TokenRequestOptions` instead of scopes vector.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fixed the parsing of the last chunk of a chunked response when using the curl transport adapter.
 - Fixed reading the value from `retry-after` header in `RetryPolicy`.
@@ -202,7 +206,7 @@ Thank you to our developer community members who helped to make Azure Core bette
 
 ## 1.0.0-beta.4 (2021-01-13)
 
-### New Features
+### Features Added
 
 - Added a WinHTTP-based `HttpTransport` called `WinHttpTransport` and use that as the default `TransportPolicyOptions.Transport` on Windows when sending and receiving requests and responses over the wire.
 - Added `Range` type to `Azure::Core::Http` namespace.
@@ -229,7 +233,7 @@ Thank you to our developer community members who helped to make Azure Core bette
 - Removed option `AllowBeast` from `CurlTransportSSLOptions` in `CurlTransportOptions`.
 - Changed default option `NoRevoke` from `CurlTransportSSLOptions` for the `CurlTransportOptions` to `true`. This disables the revocation list checking by default.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fixed the Curl transport adapter connection pooling when setting options.
 - Fixed setting up the default transport adapter.
@@ -237,7 +241,7 @@ Thank you to our developer community members who helped to make Azure Core bette
 - Initialize class data members to avoid MSVC warning.
 - Throw `Azure::Core::Http::TransportException` if `curl_easy_init()` returns a null handle. (A community contribution, courtesy of _[ku-sourav](https://github.com/ku-sourav)_)
 
-### Other Changes and Improvements
+### Other Changes
 
 - Added support for distributing the C++ SDK as a source package via vcpkg.
 - Fixed installation error when the SDK is being installed under a non-standard prefix. (A community contribution, courtesy of _[juchem](https://github.com/juchem)_)
@@ -253,7 +257,7 @@ Thank you to our developer community members who helped to make Azure Core bette
 
 ## 1.0.0-beta.3 (2020-11-11)
 
-### New Features
+### Features Added
 
 - Added `strings.hpp` with `Azure::Core::Strings::LocaleInvariantCaseInsensitiveEqual` and `Azure::Core::Strings::ToLower`.
 - Added `GetPort()` to `Url`.
@@ -281,13 +285,13 @@ Thank you to our developer community members who helped to make Azure Core bette
   - Renamed `RemoveQuery` to `RemoveQueryParameter`.
   - Renamed `GetQuery` to `GetQueryParameters`.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Prevent pipeline of length zero to be created.
 - Avoid re-using a connection when a request to upload data fails while using the `CurlTransport`.
 - Add entropy to `Uuid` generation.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Add high-level and simplified core.hpp file for simpler include experience for customers.
 - Add code coverage using gcov with gcc.
@@ -305,12 +309,12 @@ Thank you to our developer community members who helped to make Azure Core bette
 - Throw Azure::Http::TransportException if creating new connection fails.
 - Response objects store Nullable\<T\>.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Switched to a more stable wait on sockets to address connection timeouts.
 - Replace `Nullable(const T&)` with `Nullable(T)` to avoid extra copy when initialized with an rvalue.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Improved performance on windows when using libcurl.
 - Pinned the version of package dependencies.

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 1.1.0-beta.1 (Unreleased)
 
-### New Features
+### Features Added
 
 - Added `ManagedIdentityCredential`.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fixed minor memory leak when obtaining a token.
 
@@ -22,7 +22,7 @@ No API changes since `1.0.0-beta.6`.
 
 ## 1.0.0-beta.5 (2021-04-07)
 
-### New Features
+### Features Added
 
 - Add Active Directory Federation Service (ADFS) support to `ClientSecretCredential`.
 
@@ -32,7 +32,7 @@ No API changes since `1.0.0-beta.6`.
 
 ## 1.0.0-beta.4 (2021-03-11)
 
-### New Features
+### Features Added
 
 - Added `Azure::Identity::PackageVersion`.
 
@@ -52,13 +52,13 @@ No API changes since `1.0.0-beta.6`.
 
 - Moved `Azure::Identity::Version`, defined in `azure/identity/version.hpp` to the `Azure::Identity::Details` namespace.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Add high-level and simplified identity.hpp file for simpler include experience for customers.
 
 ## 1.0.0-beta.1 (2020-11-11)
 
-### New Features
+### Features Added
 
 - Support for Client Secret Credential.
 - Support for Environment Credential.

--- a/sdk/keyvault/azure-security-keyvault-common/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-common/CHANGELOG.md
@@ -27,6 +27,6 @@ No breaking changes or new features added. Includes only implementation enhancem
 
 ## 4.0.0-beta.1 (2021-04-07)
 
-### New Features
+### Features Added
 
-- KeyVaultException.
+- `KeyVaultException`.

--- a/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ## 4.0.0-beta.2 (2021-05-18)
 
-### New Features
+### Features Added
 
 - Added support for importing and deserializing EC and OCT keys.
 - Added cryptography client.
@@ -51,13 +51,13 @@
   - `GetDeletedKeysSinglePage()` now returns `DeletedKey`.
 - Removed `ResumeDeleteKeyOperation()` and `ResumeRecoverKeyOperation()`.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fix getting a resume token from delete and recover key operations.
 
 ## 4.0.0-beta.1 (2021-04-07)
 
-### New Features
+### Features Added
 
 - Added `Azure::Security::KeyVault::Keys::KeyClient` for get, create, list, delete, backup, restore, and import key operations.
 - Added high-level and simplified `key_vault.hpp` file for simpler include experience for customers.

--- a/sdk/storage/azure-storage-blobs/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blobs/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## 12.0.0 (2021-06-08)
 
-### Other Changes and Improvements
+### Other Changes
 
 - Added and updated some samples.
 - Fixed a read consistency issue.
@@ -42,7 +42,7 @@
 
 ## 12.0.0-beta.9 (2021-03-23)
 
-### New Features
+### Features Added
 
 - Added support for telemetry options.
 - Added `Azure::Storage::Blobs::PackageVersion`.
@@ -92,7 +92,7 @@
 
 ## 12.0.0-beta.7 (2021-02-03)
 
-### New Features
+### Features Added
 
 - Added `RequestId` in API return types.
 - Added some new properties in `GetBlobPropertiesResult`, `DownloadBlobResult` and `DownloadBlobToResult`.
@@ -123,7 +123,7 @@
 
 ## 12.0.0-beta.6 (2021-01-14)
 
-### New Features
+### Features Added
 
 - Added `CreateIfNotExists` and `DeleteIfExists` for blob containers and blobs.
 - Added `IsHierarchicalNamespaceEnabled` in `GetAccountInfoResult`.
@@ -200,7 +200,7 @@
 
 ## 12.0.0-beta.5 (2020-11-13)
 
-### New Features
+### Features Added
 
 - Support for replaceable HTTP transport layer.
 - Add `version.hpp`.
@@ -213,14 +213,14 @@
 - Remove `BlockBlobClientOptions`, `AppendBlobClientOptions` and `PageBlobClientOptions`, use `BlobClientOptions` instead.
 - Rename `BlobSasBuilder::ToSasQueryParameters` to `BlobSasBuilder::GenerateSasToken`.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Default uploading/downloading concurrency is changed from 1 to 5.
 - Remove support for specifying SAS version.
 
 ## 1.0.0-beta.4 (2020-10-16)
 
-### New Features
+### Features Added
 
 - Bump up API version to 2020-02-10.
 - Support for Last Accessting Time.
@@ -235,13 +235,13 @@
 - Variable name change: `Marker` is renamed to `ContinuationToken` for `ListContainersSegmentOptions`, `FindBlobsByTagsOptions` and `ListBlobsSegmentOptions`.
 - Variable name change: `Marker` is renamed to `PreviousContinuationToken`, `NextMarker` is renamed to `ContinuationToken` for `FilterBlobsSegmentResult`, `ListContainersSegmentResult`, `ListBlobsByHierarchySegmentResult` and `ListBlobsFlatSegmentResult`.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Unencoded Container/Blob name is now encoded.
 
 ## 1.0.0-beta.2 (2020-09-09)
 
-### New Features
+### Features Added
 
 - Support for Blob Batch.
 - Support for Blob Index.
@@ -249,7 +249,7 @@
 
 ## 1.0.0-beta.1 (2020-08-28)
 
-### New Features
+### Features Added
 
 - Added support for Blob features:
   - BlobServiceClient::ListBlobContainersSegment

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## 12.1.0-beta.1 (Unreleased)
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fixed a memory leak issue while parsing XML.
 
 ## 12.0.0 (2021-06-08)
 
-### Other Changes and Improvements
+### Other Changes
 
 - Fixed a filename encoding issue.
 
@@ -19,13 +19,13 @@
 - Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.
 - Removed `Azure::PagedResponse<T>`.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fixed a stream leak issue in `ReliableStream`.
 
 ## 12.0.0-beta.10 (2021-04-16)
 
-### New Features
+### Features Added
 
 - Added server timeout support.
 - Added `Azure::PagedResponse<T>` for returning paginated collections.
@@ -38,7 +38,7 @@
 
 ## 12.0.0-beta.9 (2021-03-23)
 
-### New Features
+### Features Added
 
 - Added `Azure::Storage::Common::PackageVersion`.
 
@@ -51,7 +51,7 @@
 
 ## 12.0.0-beta.7 (2021-02-03)
 
-### New Features
+### Features Added
 
 - Added additional information in `StorageException`.
 
@@ -59,13 +59,13 @@
 
 - `AccountSasResource::BlobContainer` was renamed to `AccountSasResource::Container`.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fixed `ClientRequestId` wasn't filled in `StorageException`.
 
 ## 12.0.0-beta.6 (2021-01-14)
 
-### New Features
+### Features Added
 
 - Added new type `ContentHash`.
 - Added definition of `Metadata`.
@@ -83,7 +83,7 @@
 - Moved `Base64Encode` and `Base64Decode` from the `Azure::Storage` namespace to `Azure::Core` and removed the string accepting overload of `Base64Encode`.
 - Renamed public constants so they no longer start with the prefix `c_`. For example, `c_InfiniteLeaseDuration` became `InfiniteLeaseDuration`.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Fixed default EndpointSuffix when parsing a connection string. (A community contribution, courtesy of _[lordgamez](https://github.com/lordgamez)_)
 
@@ -105,25 +105,25 @@ Thank you to our developer community members who helped to make Azure Core bette
 - Remove `storage_version.hpp` and add `version.hpp`.
 - Make `SharedKeyCredential` a class.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Remove support for specifying SAS version.
 
 ## 1.0.0-beta.3 (2020-10-13)
 
-### New Features
+### Features Added
 
 - Support for customizable retry policy.
 
 ## 1.0.0-beta.2 (2020-09-09)
 
-### New Features
+### Features Added
 
 - Release based on azure-core_1.0.0-beta.1.
 
 ## 1.0.0-beta.1 (2020-08-28)
 
-### New Features
+### Features Added
 
 - Support for Account SAS.
 - Support for Base64 Encoding/Decoding.

--- a/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - Renamed `ContentLength` in `FlushFileResult` to `FileSize`.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Removed `IfUnmodifiedSince` from access conditions of setting filesystem metadata operation.
 - Updated some samples.
@@ -17,7 +17,7 @@
 
 ## 12.0.0-beta.11 (2021-05-19)
 
-### New Features
+### Features Added
 
 - Added `DataLakePathClient::SetAccessControlListRecursive()`, `UpdateAccessControlListRecursive()` and `RemoveAccessControlListRecursive()`.
 
@@ -40,13 +40,13 @@
   - `DataLakeDirectoryClient::ListPaths()`.
 - Removed `DataLakePathClient::SetAccessControlListRecursiveSinglePage()`, `UpdateAccessControlListRecursiveSinglePage()` and `RemoveAccessControlListRecursiveSinglePage()`.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Rename functions always fail because `/` was left out in the renamed source path.
 
 ## 12.0.0-beta.9 (2021-03-23)
 
-### New Features
+### Features Added
 
 - Added support for telemetry options.
 - Added `Azure::Storage::Files::DataLake::PackageVersion`.
@@ -88,7 +88,7 @@
 
 ## 12.0.0-beta.7 (2021-02-03)
 
-### New Features
+### Features Added
 
 - Added `Owner`, `Permissions`, and `Group` to `GetDataLakePathAccessControlResult`.
 - `DownloadDataLakeFileResult` now has a new field `FileSize`.
@@ -136,7 +136,7 @@
 - Renamed `DataLakeFileClient::Read` to `DataLakeFileClient::Download`. Also changed the member `Azure::Core::Nullable<bool> RangeGetContentMd5` in the option to be `Azure::Core::Nullable<HashAlgorithm> RangeHashAlgorithm` instead.
 - Moved some less commonly used properties into a details data structure for `Download`, `DownloadTo` and `ListFileSystemsSinglePage` API, and enriched the content of the mentioned details data structure.
  
-### Other Changes and Improvements
+### Other Changes
 
 - Changed `DataLakeFileClient::Flush`'s `endingOffset` parameter's name to `position`.
 - Renamed `DataLakePathClient::GetAccessControls` to `DataLakePathClient::GetAccessControlList`.
@@ -144,7 +144,7 @@
 
 ## 12.0.0-beta.6 (2021-01-14)
 
-### New Features
+### Features Added
 
 - Support setting DataLake SAS permission with a raw string.
 - Added support for `CreateIfNotExists` and `DeleteIfExists` for FileSystem, Path, Directory and File clients.
@@ -182,7 +182,7 @@
 
 ## 1.0.0-beta.4 (2020-10-16)
 
-### New Features
+### Features Added
 
 - Service version is now 2020-02-10.
 - Added support for SAS generation in DataLake service.
@@ -196,19 +196,19 @@
 - `ETag` and `LastModified` is now `std::string` instead of `Azure::Core::Nullable<std::string>` in `CreateDirectoryResult`, `CreateFileResult` and `CreatePathResult`.
 - `Continuation` is renamed to `ContinuationToken` in options and returned result objects.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Unencoded FileSystem/File/Path/Directory name is now encoded.
 
 ## 1.0.0-beta.2 (2020-09-09)
 
-### New Features
+### Features Added
 
 - Release based on azure-core_1.0.0-beta.1.
 
 ## 1.0.0-beta.1 (2020-08-28)
 
-### New Features
+### Features Added
 
 - Added support for DataLake features:
   - ServiceClient::ListFileSystems

--- a/sdk/storage/azure-storage-files-shares/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-shares/CHANGELOG.md
@@ -9,14 +9,14 @@
 
 - Renamed `ContentLength` in `FileItemDetails` to `FileSize`.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Updated some samples.
 - Fixed a read consistency issue.
 
 ## 12.0.0-beta.11 (2021-05-19)
 
-### New Features
+### Features Added
 
 - Added `ShareDirectoryClient::ForceCloseAllHandles()` and `ShareFileClient::ForceCloseAllHandles()`.
 
@@ -43,7 +43,7 @@
   
 ## 12.0.0-beta.9 (2021-03-23)
 
-### New Features
+### Features Added
 
 - Added support for telemetry options.
 - Added `Azure::Storage::Files::Shares::PackageVersion`.
@@ -78,7 +78,7 @@
 
 ## 12.0.0-beta.8 (2021-02-12)
 
-### New Features
+### Features Added
 
 - Changed type of `FileAttributes` to extensible enum.
 
@@ -111,7 +111,7 @@
 
 ## 12.0.0-beta.7 (2021-02-04)
 
-### New Features
+### Features Added
 
 - Added support for `UploadRangeFromUri` in file client.
 - Added support for `SetProperties` in share client. This API supports update share tier and adjusting share's quota.
@@ -139,13 +139,13 @@
 - Renamed `FileProperty` to `FileItemDetails` to align with other SDK's naming pattern for returned items for list operation.
 - Renamed `ShareProperties` to `ShareItemDetails` to align with other SDK's naming pattern for returned items for list operation.
 
-### Other Changes and Improvements
+### Other Changes
 
 - Removed `c_` for constants and renamed to pascal format.
 
 ## 12.0.0-beta.6 (2021-01-14)
 
-### New Features
+### Features Added
 
 - Added support for `CreateIfNotExists` for Share and Directory clients, and `DeleteIfExists` for Share, Directory and File clients.
 - Support setting file SAS permission with a raw string.
@@ -180,7 +180,7 @@
 
 ## 1.0.0-beta.4 (2020-10-16)
 
-### New Features
+### Features Added
 
 - Service version is now 2020-02-10.
 - Added support for leasing a share:
@@ -200,20 +200,20 @@
 - `NextMarker` is renamed to `ContinuationToken` in returned result objects.
 - `Marker` is renamed to `PreviousContinuationToken` in returned result objects.
 
-### Bug Fixes
+### Bugs Fixed
 
 - Unencoded Share/File/Directory name is now encoded.
 
 ## 1.0.0-beta.2 (2020-09-09)
 
-### New Features
+### Features Added
 
 - Added File SAS generation support.
 - Release based on azure-core_1.0.0-beta.1.
 
 ## 1.0.0-beta.1 (2020-08-28)
 
-### New Features
+### Features Added
 
 - Added support for File features:
   - ServiceClient::ListSharesSegment


### PR DESCRIPTION
I don't see why we can't update the document "retroactively".