### PR TITLE
Consider making the RFE ctor as an internal factory method.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -147,7 +147,7 @@ namespace Azure { namespace Core {
     ~RequestFailedException() = default;
 
   private:
-    std::string getRawResponseField(
+    std::string GetRawResponseField(
         std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse,
         std::string fieldName);
   };

--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -93,18 +93,6 @@ namespace Azure { namespace Core {
         std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse);
 
     /**
-     * @brief Constructs a new `%RequestFailedException` object with an HTTP raw response.
-     *
-     * @note The HTTP raw response is parsed to populate information expected from all Azure
-     * Services like the status code, reason phrase and some headers like the request ID. A concrete
-     * Service exception which derives from this exception uses its constructor to parse the HTTP
-     * raw response adding the service specific values to the exception.
-     *
-     * @param rawResponse The HTTP raw response from the service.
-     */
-    explicit RequestFailedException(std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse);
-
-    /**
      * @brief Constructs a new `%RequestFailedException` by copying from an existing one.
      * @note Copies the #Azure::Core::Http::RawResponse into the new `RequestFailedException`.
      *
@@ -145,10 +133,23 @@ namespace Azure { namespace Core {
      *
      */
     ~RequestFailedException() = default;
-
-  private:
-    std::string GetRawResponseField(
-        std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse,
-        std::string fieldName);
   };
+
+  namespace _internal {
+    class ExceptionFactory final {
+    public:
+      /**
+       * @brief Constructs a new `%RequestFailedException` object with an HTTP raw response.
+       *
+       * @note The HTTP raw response is parsed to populate information expected from all Azure
+       * Services like the status code, reason phrase and some headers like the request ID. A
+       * concrete Service exception which derives from this exception uses its constructor to parse
+       * the HTTP raw response adding the service specific values to the exception.
+       *
+       * @param rawResponse The HTTP raw response from the service.
+       */
+      static Azure::Core::RequestFailedException CreateException(
+          std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse);
+    };
+  } // namespace _internal
 }} // namespace Azure::Core

--- a/sdk/core/azure-core/src/exception.cpp
+++ b/sdk/core/azure-core/src/exception.cpp
@@ -32,20 +32,20 @@ namespace Azure { namespace Core {
 
   RequestFailedException::RequestFailedException(
       std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse)
-      : std::runtime_error(getRawResponseField(rawResponse, "message"))
+      : std::runtime_error(GetRawResponseField(rawResponse, "message"))
   {
     auto& headers = rawResponse->GetHeaders();
 
     StatusCode = rawResponse->GetStatusCode();
-    ErrorCode = getRawResponseField(rawResponse, "code");
-    StatusCode = rawResponse->GetStatusCode();
+    ErrorCode = GetRawResponseField(rawResponse, "code");
     ReasonPhrase = rawResponse->GetReasonPhrase();
     RequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsRequestId);
     ClientRequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsClientRequestId);
     Message = this->what();
+    RawResponse = std::move(rawResponse);
   }
 
-  std::string RequestFailedException::getRawResponseField(
+  std::string RequestFailedException::GetRawResponseField(
       std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse,
       std::string fieldName)
   {
@@ -62,14 +62,6 @@ namespace Azure { namespace Core {
       {
         result = error.value()[fieldName].get<std::string>();
       }
-      else if (fieldName == "message")
-      {
-        result = std::string(bodyBuffer.begin(), bodyBuffer.end());
-      }
-    }
-    else if (fieldName == "message")
-    {
-      result = std::string(bodyBuffer.begin(), bodyBuffer.end());
     }
 
     return result;

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -101,7 +101,7 @@ target_link_libraries(azure-core-test PRIVATE azure-core gtest gmock)
 add_executable (
   azure-core-global-context-test
   global_context_test.cpp
- )
+)
 if (MSVC)
   # Disable gtest warnings for MSVC
   target_compile_options(azure-core-global-context-test PUBLIC /wd26495 /wd26812 /wd6326 /wd28204 /wd28020 /wd6330 /wd4389)
@@ -123,7 +123,7 @@ if(BUILD_TRANSPORT_CURL)
   add_executable (
     azure-core-libcurl-test
     azure_libcurl_core_main_test.cpp
-   )
+  )
 
   if (MSVC)
     # warning C4389: '==': signed/unsigned mismatch

--- a/sdk/core/azure-core/test/ut/exception_test.cpp
+++ b/sdk/core/azure-core/test/ut/exception_test.cpp
@@ -25,7 +25,7 @@ TEST(RequestFailedException, JSONError)
   response->SetBodyStream(std::make_unique<Azure::Core::IO::MemoryBodyStream>(
       responseBodyStream, sizeof(responseBodyStream) - 1));
 
-  auto exception = Azure::Core::RequestFailedException(response);
+  auto exception = Azure::Core::_internal::ExceptionFactory::CreateException(std::move(response));
 
   EXPECT_EQ(exception.StatusCode, Azure::Core::Http::HttpStatusCode::ServiceUnavailable);
   EXPECT_EQ(exception.Message, "JT");
@@ -48,7 +48,7 @@ TEST(RequestFailedException, JSONErrorNoError)
   response->SetBodyStream(std::make_unique<Azure::Core::IO::MemoryBodyStream>(
       responseBodyStream, sizeof(responseBodyStream) - 1));
 
-  auto exception = Azure::Core::RequestFailedException(response);
+  auto exception = Azure::Core::_internal::ExceptionFactory::CreateException(std::move(response));
 
   EXPECT_EQ(exception.StatusCode, Azure::Core::Http::HttpStatusCode::ServiceUnavailable);
   EXPECT_EQ(exception.Message, "");

--- a/sdk/core/azure-core/test/ut/exception_test.cpp
+++ b/sdk/core/azure-core/test/ut/exception_test.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
+
 #include <azure/core/exception.hpp>
 #include <azure/core/http/http.hpp>
 #include <gtest/gtest.h>
@@ -50,30 +51,8 @@ TEST(RequestFailedException, JSONErrorNoError)
   auto exception = Azure::Core::RequestFailedException(response);
 
   EXPECT_EQ(exception.StatusCode, Azure::Core::Http::HttpStatusCode::ServiceUnavailable);
-  EXPECT_EQ(exception.Message, "{\"text\" :\"some text\"}");
+  EXPECT_EQ(exception.Message, "");
   EXPECT_EQ(exception.ErrorCode, "");
-  EXPECT_EQ(exception.RequestId, "1");
-  EXPECT_EQ(exception.ClientRequestId, "2");
-}
-
-TEST(RequestFailedException, NonJSONError)
-{
-  auto response = std::make_unique<Azure::Core::Http::RawResponse>(
-      1, 1, Azure::Core::Http::HttpStatusCode::ServiceUnavailable, "reason");
-  static constexpr uint8_t const responseBody[] = "NJT";
-  static constexpr uint8_t const responseBodyStream[] = "NJT";
-
-  response->SetHeader(HttpShared::ContentType, "application/text");
-  response->SetHeader(HttpShared::MsRequestId, "1");
-  response->SetHeader(HttpShared::MsClientRequestId, "2");
-  response->SetBody(std::vector<uint8_t>(responseBody, responseBody + sizeof(responseBody)));
-  response->SetBodyStream(std::make_unique<Azure::Core::IO::MemoryBodyStream>(
-      responseBodyStream, sizeof(responseBodyStream) - 1));
-
-  auto exception = Azure::Core::RequestFailedException(response);
-
-  EXPECT_EQ(exception.StatusCode, Azure::Core::Http::HttpStatusCode::ServiceUnavailable);
-  EXPECT_EQ(exception.Message, "NJT");
   EXPECT_EQ(exception.RequestId, "1");
   EXPECT_EQ(exception.ClientRequestId, "2");
 }

--- a/sdk/keyvault/azure-security-keyvault-common/src/keyvault_pipeline.cpp
+++ b/sdk/keyvault/azure-security-keyvault-common/src/keyvault_pipeline.cpp
@@ -70,7 +70,7 @@ std::unique_ptr<Azure::Core::Http::RawResponse> _internal::KeyVaultPipeline::Sen
     case Azure::Core::Http::HttpStatusCode::NoContent:
       break;
     default:
-      throw Azure::Core::RequestFailedException(response);
+      throw Azure::Core::_internal::ExceptionFactory::CreateException(std::move(response));
   }
   return response;
 }

--- a/sdk/keyvault/azure-security-keyvault-keys/src/delete_key_operation.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/delete_key_operation.cpp
@@ -43,7 +43,7 @@ Azure::Security::KeyVault::Keys::DeleteKeyOperation::PollInternal(
         break;
       }
       default:
-        throw Azure::Core::RequestFailedException(rawResponse);
+        throw Azure::Core::_internal::ExceptionFactory::CreateException(std::move(rawResponse));
     }
 
     if (m_status == Azure::Core::OperationStatus::Succeeded)

--- a/sdk/keyvault/azure-security-keyvault-keys/src/recover_deleted_key_operation.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/recover_deleted_key_operation.cpp
@@ -40,7 +40,7 @@ Azure::Security::KeyVault::Keys::RecoverDeletedKeyOperation::PollInternal(
         break;
       }
       default:
-        throw Azure::Core::RequestFailedException(rawResponse);
+        throw Azure::Core::_internal::ExceptionFactory::CreateException(std::move(rawResponse));
     }
     if (m_status == Azure::Core::OperationStatus::Succeeded)
     {


### PR DESCRIPTION
Currently, the public RFE ctors look weird and it is hard to discern which parameter is optional:
```C++
explicit RequestFailedException(std::string const& message);
explicit RequestFailedException( const std::string& message, std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse);

// newly added
explicit RequestFailedException(std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse);
```