### PR TITLE
remove encrypt decrypt overload

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Removed `CryptographyClient::RemoteClient()` and `CryptographyClient::LocalOnly()`.
 - Removed the general constructor from `EncryptParameters` and `DecryptParameters`.
 - Removed access to `Iv` field member from `EncryptParameters` and `DecryptParameters`.
+- Removed `Encrypt(EncryptionAlgorithm, std::vector, context)`.
+- Removed `Decrypt(DecryptAlgorithm, std::vector, context)`.
 
 ### Key Bugs Fixed
 

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/cryptography/cryptography_client.hpp
@@ -103,23 +103,6 @@ namespace Azure {
         Azure::Core::Context const& context = Azure::Core::Context());
 
     /**
-     * @brief Encrypts the specified plaintext.
-     *
-     * @param algorithm The #EncryptionAlgorithm to use.
-     * @param plaintext The data to encrypt.
-     * @param context A #Azure::Core::Context to cancel the operation.
-     * @return An #EncryptResult containing the encrypted data along with all other information
-     * needed to decrypt it. This information should be stored with the encrypted data.
-     */
-    EncryptResult Encrypt(
-        EncryptionAlgorithm algorithm,
-        std::vector<uint8_t> const& plaintext,
-        Azure::Core::Context const& context = Azure::Core::Context())
-    {
-      return Encrypt(EncryptParameters(algorithm, plaintext), context);
-    }
-
-    /**
      * @brief Decrypts ciphertext.
      *
      * @param parameters A #DecryptParameters containing the data to decrypt and other parameters
@@ -131,23 +114,6 @@ namespace Azure {
     DecryptResult Decrypt(
         DecryptParameters const& parameters,
         Azure::Core::Context const& context = Azure::Core::Context());
-
-    /**
-     * @brief Decrypts the specified ciphertext.
-     *
-     * @param algorithm The #EncryptionAlgorithm to use.
-     * @param ciphertext The encrypted data to decrypt..
-     * @param context A #Azure::Core::Context to cancel the operation.
-     * @return An #DecryptResult containing the Decrypted data along with all other information
-     * needed to decrypt it. This information should be stored with the Decrypted data.
-     */
-    DecryptResult Decrypt(
-        EncryptionAlgorithm algorithm,
-        std::vector<uint8_t> const& ciphertext,
-        Azure::Core::Context const& context = Azure::Core::Context())
-    {
-      return Decrypt(DecryptParameters(algorithm, ciphertext), context);
-    }
 
     /**
      * @brief Encrypts the specified key.

--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample4-encrypt-decrypt/sample4_encrypt_decrypt.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample4-encrypt-decrypt/sample4_encrypt_decrypt.cpp
@@ -51,13 +51,14 @@ int main()
 
   uint8_t const data[] = "A single block of plaintext";
   std::vector<uint8_t> plaintext(std::begin(data), std::end(data));
-  EncryptResult encryptResult = cryptoClient.Encrypt(EncryptionAlgorithm::RsaOaep, plaintext);
+  EncryptResult encryptResult
+      = cryptoClient.Encrypt(EncryptParameters::RsaOaepParameters(plaintext));
   std::cout << " - Encrypted data using the algorithm " << encryptResult.Algorithm.ToString()
             << ", with key " << encryptResult.KeyId << ". The resulting encrypted data is: "
             << Azure::Core::Convert::Base64Encode(encryptResult.Ciphertext) << std::endl;
 
   DecryptResult decryptResult
-      = cryptoClient.Decrypt(EncryptionAlgorithm::RsaOaep, encryptResult.Ciphertext);
+      = cryptoClient.Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext));
   std::cout << " - Decrypted data using the algorithm " << decryptResult.Algorithm.ToString()
             << ", with key " << decryptResult.KeyId << ". The resulting decrypted data is: "
             << std::string(decryptResult.Plaintext.begin(), decryptResult.Plaintext.end())

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_cryptographic_client_test_live.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_cryptographic_client_test_live.cpp
@@ -42,7 +42,8 @@ TEST_P(KeyVaultClientTest, RemoteEncrypt)
     EXPECT_EQ(encryptResult.KeyId, rsaKey.Id());
     EXPECT_TRUE(encryptResult.Ciphertext.size() > 0);
 
-    auto decryptResult = cryptoClient.Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext));
+    auto decryptResult
+        = cryptoClient.Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext));
     EXPECT_EQ(decryptResult.Algorithm.ToString(), encryptResult.Algorithm.ToString());
     EXPECT_EQ(decryptResult.Plaintext, plaintext);
     EXPECT_EQ(decryptResult.KeyId, encryptResult.KeyId);

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_cryptographic_client_test_live.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_cryptographic_client_test_live.cpp
@@ -37,12 +37,12 @@ TEST_P(KeyVaultClientTest, RemoteEncrypt)
     uint8_t plaintextSource[] = "A single block of plaintext";
     std::vector<uint8_t> plaintext(std::begin(plaintextSource), std::end(plaintextSource));
 
-    auto encryptResult = cryptoClient.Encrypt(EncryptionAlgorithm::RsaOaep, plaintext);
+    auto encryptResult = cryptoClient.Encrypt(EncryptParameters::RsaOaepParameters(plaintext));
     EXPECT_EQ(encryptResult.Algorithm.ToString(), EncryptionAlgorithm::RsaOaep.ToString());
     EXPECT_EQ(encryptResult.KeyId, rsaKey.Id());
     EXPECT_TRUE(encryptResult.Ciphertext.size() > 0);
 
-    auto decryptResult = cryptoClient.Decrypt(encryptResult.Algorithm, encryptResult.Ciphertext);
+    auto decryptResult = cryptoClient.Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext));
     EXPECT_EQ(decryptResult.Algorithm.ToString(), encryptResult.Algorithm.ToString());
     EXPECT_EQ(decryptResult.Plaintext, plaintext);
     EXPECT_EQ(decryptResult.KeyId, encryptResult.KeyId);


### PR DESCRIPTION
Removing Encrypt and Decrypt overloads which takes algorithm name. Instead, leaving only the APIs which takes EncryptParameters and DecryptParameters.

This change prevents customers from calling encrypt and decrypt with AES CBC without IV. Customers needs to use the factory method which will require IV for AES CBC.

Fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/2219