### PR TITLE
Removed the `MaxPageResults` field from `GetPropertiesOfKeysOptions`, `GetPropertiesOfKeyVersionsOptions`, and `GetDeletedKeysOptions`.

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Removed access to `Iv` field member from `EncryptParameters` and `DecryptParameters`.
 - Removed `Encrypt(EncryptionAlgorithm, std::vector, context)`.
 - Removed `Decrypt(DecryptAlgorithm, std::vector, context)`.
+- Removed the `MaxPageResults` field from `GetPropertiesOfKeysOptions`, `GetPropertiesOfKeyVersionsOptions`, and `GetDeletedKeysOptions`.
 - Renamed header `list_keys_single_page_result.hpp` to `list_keys_responses.hpp`.
 
 ## 4.0.0-beta.3 (2021-06-08)

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/list_keys_responses.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/list_keys_responses.hpp
@@ -125,7 +125,6 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
   struct GetPropertiesOfKeysOptions final
   {
     Azure::Nullable<std::string> NextPageToken;
-    Azure::Nullable<int32_t> MaxPageResults;
   };
 
   /**
@@ -135,7 +134,6 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
   struct GetPropertiesOfKeyVersionsOptions final
   {
     Azure::Nullable<std::string> NextPageToken;
-    Azure::Nullable<int32_t> MaxPageResults;
   };
 
   /**
@@ -145,6 +143,5 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
   struct GetDeletedKeysOptions final
   {
     Azure::Nullable<std::string> NextPageToken;
-    Azure::Nullable<int32_t> MaxPageResults;
   };
 }}}} // namespace Azure::Security::KeyVault::Keys

--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -45,14 +45,6 @@ static inline RequestWithContinuationToken BuildRequestFromContinuationToken(
     request.Path.clear();
     request.Path.emplace_back(nextPageUrl.GetPath());
   }
-  if (options.MaxPageResults)
-  {
-    if (request.Query == nullptr)
-    {
-      request.Query = std::make_unique<std::map<std::string, std::string>>();
-    }
-    request.Query->emplace("maxResults", std::to_string(options.MaxPageResults.Value()));
-  }
   return request;
 }
 
@@ -72,14 +64,6 @@ static inline RequestWithContinuationToken BuildRequestFromContinuationToken(
     request.Path.clear();
     request.Path.emplace_back(nextPageUrl.GetPath());
   }
-  if (options.MaxPageResults)
-  {
-    if (request.Query == nullptr)
-    {
-      request.Query = std::make_unique<std::map<std::string, std::string>>();
-    }
-    request.Query->emplace("maxResults", std::to_string(options.MaxPageResults.Value()));
-  }
   return request;
 }
 
@@ -98,14 +82,6 @@ static inline RequestWithContinuationToken BuildRequestFromContinuationToken(
         = std::make_unique<std::map<std::string, std::string>>(nextPageUrl.GetQueryParameters());
     request.Path.clear();
     request.Path.emplace_back(nextPageUrl.GetPath());
-  }
-  if (options.MaxPageResults)
-  {
-    if (request.Query == nullptr)
-    {
-      request.Query = std::make_unique<std::map<std::string, std::string>>();
-    }
-    request.Query->emplace("maxResults", std::to_string(options.MaxPageResults.Value()));
   }
   return request;
 }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/2599