### PR TITLE
Remove vcpkg dependency from keyvault-keys on keyvault-common.

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/Config.cmake.in
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-security-keyvault-common-cpp)
+find_dependency(azure-core-cpp)
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-security-keyvault-keys-cppTargets.cmake")
 

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
@@ -13,9 +13,9 @@
   "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
-      "name": "azure-security-keyvault-common-cpp",
+      "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "4.0.0"
+      "version>=": "1.1.0"
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
Follow-up to https://github.com/Azure/azure-sdk-for-cpp/issues/2506