### PR TITLE
Fixed a bug where unspecified SMB properties got overwritten rather than preserved by `SetProperties()`

### DIFF
--- a/sdk/storage/azure-storage-files-shares/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-shares/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where unspecified SMB properties got overwritten rather than preserved by `SetProperties()`.
+
 ### Other Changes
 
 ## 12.0.1 (2021-07-07)

--- a/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
@@ -241,6 +241,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     auto protocolLayerOptions = _detail::ShareRestClient::Directory::SetPropertiesOptions();
     protocolLayerOptions.FileAttributes = smbProperties.Attributes.ToString();
+    if (protocolLayerOptions.FileAttributes.empty())
+    {
+      protocolLayerOptions.FileAttributes = FilePreserveSmbProperties;
+    }
     if (smbProperties.CreatedOn.HasValue())
     {
       protocolLayerOptions.FileCreationTime = smbProperties.CreatedOn.Value().ToString(
@@ -248,7 +252,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     else
     {
-      protocolLayerOptions.FileCreationTime = std::string(FileDefaultTimeValue);
+      protocolLayerOptions.FileCreationTime = FilePreserveSmbProperties;
     }
     if (smbProperties.LastWrittenOn.HasValue())
     {
@@ -257,7 +261,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     else
     {
-      protocolLayerOptions.FileLastWriteTime = std::string(FileDefaultTimeValue);
+      protocolLayerOptions.FileLastWriteTime = FilePreserveSmbProperties;
     }
     if (options.FilePermission.HasValue())
     {
@@ -269,7 +273,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     else
     {
-      protocolLayerOptions.FilePermission = std::string(FileInheritPermission);
+      protocolLayerOptions.FilePermission = FilePreserveSmbProperties;
     }
     return _detail::ShareRestClient::Directory::SetProperties(
         m_shareDirectoryUrl, *m_pipeline, context, protocolLayerOptions);

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -402,7 +402,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.FileAttributes = smbProperties.Attributes.ToString();
     if (protocolLayerOptions.FileAttributes.empty())
     {
-      protocolLayerOptions.FileAttributes = Models::FileAttributes::None.ToString();
+      protocolLayerOptions.FileAttributes = FilePreserveSmbProperties;
     }
     if (smbProperties.CreatedOn.HasValue())
     {
@@ -411,7 +411,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     else
     {
-      protocolLayerOptions.FileCreationTime = std::string(FileDefaultTimeValue);
+      protocolLayerOptions.FileCreationTime = FilePreserveSmbProperties;
     }
     if (smbProperties.LastWrittenOn.HasValue())
     {
@@ -420,7 +420,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     else
     {
-      protocolLayerOptions.FileLastWriteTime = std::string(FileDefaultTimeValue);
+      protocolLayerOptions.FileLastWriteTime = FilePreserveSmbProperties;
     }
     protocolLayerOptions.XMsContentLength = options.Size;
     protocolLayerOptions.LeaseIdOptional = options.AccessConditions.LeaseId;
@@ -434,7 +434,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     else
     {
-      protocolLayerOptions.FilePermission = std::string(FileInheritPermission);
+      protocolLayerOptions.FilePermission = FilePreserveSmbProperties;
     }
 
     if (!httpHeaders.ContentType.empty())

--- a/sdk/storage/azure-storage-files-shares/test/share_directory_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_directory_client_test.cpp
@@ -316,6 +316,30 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
+  TEST_F(FileShareDirectoryClientTest, SmbPropertiesDefaultValue)
+  {
+    auto directoryClient
+        = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
+    directoryClient.Create();
+    auto smbProperties = directoryClient.GetProperties().Value.SmbProperties;
+    EXPECT_EQ(smbProperties.Attributes, Files::Shares::Models::FileAttributes::Directory);
+    ASSERT_TRUE(smbProperties.CreatedOn.HasValue());
+    EXPECT_TRUE(IsValidTime(smbProperties.CreatedOn.Value()));
+    ASSERT_TRUE(smbProperties.LastWrittenOn.HasValue());
+    EXPECT_TRUE(IsValidTime(smbProperties.LastWrittenOn.Value()));
+    ASSERT_TRUE(smbProperties.ChangedOn.HasValue());
+    EXPECT_TRUE(IsValidTime(smbProperties.ChangedOn.Value()));
+
+    directoryClient.SetProperties(Files::Shares::Models::FileSmbProperties());
+
+    auto smbProperties2 = directoryClient.GetProperties().Value.SmbProperties;
+    EXPECT_EQ(smbProperties2.PermissionKey.Value(), smbProperties.PermissionKey.Value());
+    EXPECT_EQ(smbProperties2.Attributes, smbProperties.Attributes);
+    EXPECT_EQ(smbProperties2.CreatedOn.Value(), smbProperties.CreatedOn.Value());
+    EXPECT_EQ(smbProperties2.LastWrittenOn.Value(), smbProperties.LastWrittenOn.Value());
+    EXPECT_NE(smbProperties2.ChangedOn.Value(), smbProperties.ChangedOn.Value());
+  }
+
   TEST_F(FileShareDirectoryClientTest, ListFilesAndDirectoriesSinglePageTest)
   {
     // Setup

--- a/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/share_file_client_test.cpp
@@ -258,6 +258,30 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
+  TEST_F(FileShareFileClientTest, SmbPropertiesDefaultValue)
+  {
+    auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
+    fileClient.Create(1024);
+    auto smbProperties = fileClient.GetProperties().Value.SmbProperties;
+    EXPECT_EQ(smbProperties.Attributes, Files::Shares::Models::FileAttributes::Archive);
+    ASSERT_TRUE(smbProperties.CreatedOn.HasValue());
+    EXPECT_TRUE(IsValidTime(smbProperties.CreatedOn.Value()));
+    ASSERT_TRUE(smbProperties.LastWrittenOn.HasValue());
+    EXPECT_TRUE(IsValidTime(smbProperties.LastWrittenOn.Value()));
+    ASSERT_TRUE(smbProperties.ChangedOn.HasValue());
+    EXPECT_TRUE(IsValidTime(smbProperties.ChangedOn.Value()));
+
+    fileClient.SetProperties(
+        Files::Shares::Models::FileHttpHeaders(), Files::Shares::Models::FileSmbProperties());
+
+    auto smbProperties2 = fileClient.GetProperties().Value.SmbProperties;
+    EXPECT_EQ(smbProperties2.PermissionKey.Value(), smbProperties.PermissionKey.Value());
+    EXPECT_EQ(smbProperties2.Attributes, smbProperties.Attributes);
+    EXPECT_EQ(smbProperties2.CreatedOn.Value(), smbProperties.CreatedOn.Value());
+    EXPECT_EQ(smbProperties2.LastWrittenOn.Value(), smbProperties.LastWrittenOn.Value());
+    EXPECT_NE(smbProperties2.ChangedOn.Value(), smbProperties.ChangedOn.Value());
+  }
+
   TEST_F(FileShareFileClientTest, HandlesFunctionalityWorks)
   {
     auto result = m_fileClient->ListHandles();


### PR DESCRIPTION

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/master/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
