### PR TITLE
Avoid time domain casting exception during request cancellation

### DIFF
--- a/sdk/storage/azure-storage-blobs/test/ut/storage_timeout_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/storage_timeout_test.cpp
@@ -69,4 +69,18 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_LE(timeout.Value(), 301);
   }
 
+  TEST(StoragetimeoutTest, Cancelled)
+  {
+    Blobs::BlobClientOptions clientOptions;
+    auto containerClient = Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
+        StandardStorageConnectionString(), LowercaseRandomString(), clientOptions);
+
+    Azure::Core::Context context;
+    context.Cancel();
+    // Should not throw an error on time point casting.
+    EXPECT_THROW(
+        containerClient.DeleteIfExists(Storage::Blobs::DeleteBlobContainerOptions(), context),
+        Core::OperationCancelledException);
+  }
+
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-common/src/storage_per_retry_policy.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_per_retry_policy.cpp
@@ -37,11 +37,11 @@ namespace Azure { namespace Storage { namespace _internal {
     }
     else
     {
-      auto currentTimepoint = std::chrono::system_clock::now();
-      int64_t numSeconds
-          = std::chrono::duration_cast<std::chrono::seconds>(
-                std::chrono::system_clock::time_point(cancelTimepoint) - currentTimepoint)
-                .count();
+      auto currentTimepoint = DateTime(std::chrono::system_clock::now());
+      int64_t numSeconds = (cancelTimepoint > currentTimepoint)
+          ? std::chrono::duration_cast<std::chrono::seconds>(cancelTimepoint - currentTimepoint)
+                .count()
+          : -1;
       request.GetUrl().AppendQueryParameter(
           HttpHeaderTimeout, std::to_string(std::max(numSeconds, int64_t(1))));
     }


### PR DESCRIPTION
Context::Cancel() sets the deadline to DateTime::min(), which throws a range
exception when cast to system_clock::time_point.  Instead, cast
system_clock::now() to DateTime.

