### PR TITLE
Change the order of some built-in policies and client policies

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/internal/http/pipeline.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/http/pipeline.hpp
@@ -94,11 +94,6 @@ namespace Azure { namespace Core { namespace Http { namespace _internal {
       {
         m_policies.emplace_back(policy->Clone());
       }
-      // client-options per call policies.
-      for (auto& policy : perCallClientPolicies)
-      {
-        m_policies.emplace_back(policy->Clone());
-      }
 
       // Request Id
       m_policies.emplace_back(
@@ -107,6 +102,12 @@ namespace Azure { namespace Core { namespace Http { namespace _internal {
       m_policies.emplace_back(
           std::make_unique<Azure::Core::Http::Policies::_internal::TelemetryPolicy>(
               telemetryServiceName, telemetryServiceVersion, clientOptions.Telemetry));
+
+      // client-options per call policies.
+      for (auto& policy : perCallClientPolicies)
+      {
+        m_policies.emplace_back(policy->Clone());
+      }
 
       // Retry policy
       m_policies.emplace_back(std::make_unique<Azure::Core::Http::Policies::_internal::RetryPolicy>(


### PR DESCRIPTION
closes https://github.com/Azure/azure-sdk-for-cpp/issues/2655

I made this change so that the HTTP headers `x-ms-client-request-id` and `User-Agent` are visible to customers. They can do something accordingly (overwrite or log) if they want.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/master/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
