### PR TITLE
remove the const double ref and use move instead

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -33,10 +33,10 @@ struct RequestWithContinuationToken final
 
 static inline RequestWithContinuationToken BuildRequestFromContinuationToken(
     const Azure::Nullable<std::string>& NextPageToken,
-    const std::vector<std::string>&& defaultPath)
+    std::vector<std::string> defaultPath)
 {
   RequestWithContinuationToken request;
-  request.Path = defaultPath;
+  request.Path = std::move(defaultPath);
   if (NextPageToken)
   {
     // Using a continuation token requires to send the request to the continuation token URL instead


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/2659