### PR TITLE
Fix implicit conversion that clang rejects.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/datetime.hpp
+++ b/sdk/core/azure-core/inc/azure/core/datetime.hpp
@@ -282,7 +282,7 @@ namespace Core { namespace _internal {
      */
     static DateTime PosixTimeToDateTime(int64_t posixTime)
     {
-      return DateTime(1970) + std::chrono::seconds(posixTime);
+      return {DateTime(1970) + std::chrono::seconds(posixTime)};
     }
 
     /**


### PR DESCRIPTION
With clang 11, the build fails with:

```
azure-sdk-for-cpp/sdk/core/azure-core/inc/azure/core/datetime.hpp:285:14: error: no viable conversion from returned value of type 'time_point<Azure::_detail::Clock, typename common_type<duration<long, ratio<1, 10000000> >, duration<long long, ratio<1, 1> > >::type>' (aka 'time_point<Azure::_detail::Clock, duration<long long, ratio<__static_gcd<ratio<1, 10000000>::num, ratio<1, 1>::num>::value, __static_lcm<ratio<1, 10000000>::den, ratio<1, 1>::den>::value> > >') to function return type 'Azure::DateTime'
      return DateTime(1970) + std::chrono::seconds(posixTime);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
