### PR TITLE
reinterpret_cast_review inspection

### DIFF
--- a/doc/CastingTypes.md
+++ b/doc/CastingTypes.md
@@ -1,0 +1,117 @@
+# Casting Types
+
+Using c-casting style must not be used within the code implementation. Below type-castings can be found in the SDK code which have been reviewed and approved as safe convertions.
+
+All type-casting statements are expected to include a comment to this file and the types should been verify and included to this list.
+
+## static cast
+
+## dynamic cast
+
+## const cast
+
+## reinterpret cast
+
+- `void*` to `T*` : Safe to use in Context class after doing a assertion on the typeid. Usages:
+
+  - Context : to cast the void\* type to the T value stored in the Context.
+
+- `DWORD\*` to `PBYTE` : ToBeConfirmed. Usages:
+
+  - md5.cpp : on Windows, calling `BCryptGetProperty` and `CryptStringToBinaryA`.
+
+  - sha_hash.cpp : on Windows, callng `BCryptGetProperty`.
+
+  - crypt.cpp : on Windows, callng `BCryptGetProperty`.
+
+- `char\*` to `PUCHAR` : ToBeConfirmed. Usages:
+
+  - md5.cpp : on Windows, calling `BCryptCreateHash`.
+
+  - sha_hash.cpp : on Windows, calling `BCryptCreateHash`.
+
+  - crypt.cpp : on Windows, callng `BCryptCreateHash`.
+
+- `const char\*` to `const uint8_t\*` : uint8_t is equivalent in size to char. Allowed. Usages:
+
+  - curl.cpp :
+
+    - `SetHeader` from std::string.
+    - `CreateHTTPResponse` from std::string.
+    - `SendBuffer` from std::string.
+
+  - win_http_transport.cpp :
+
+    - `SetHeader` from std::string.
+
+  - token_credential_impl.hpp :
+
+    - `TokenRequest` creating memoryBodyStream from std::string.
+
+  - Creating memoryBodyStream from std::string several times:
+
+    - blob_rest_client.hpp
+    - share_rest_client.hpp
+    - queue_rest_client.hpp
+
+- `const xmlChar\*` to `const char\*` : ToBeConfirmed. Usages:
+
+  - xml_wrapper.cpp : Multiple occurrences.
+
+- `const char\*` to `const xmlChar\*` : ToBeConfirmed. Usages:
+
+  - xml_wrapper.cpp : Multiple occurrences.
+
+- `const char\*` to `xmlChar\*` : ToBeConfirmed. Usages:
+
+  - xml_wrapper.cpp.
+
+- `const uint8_t*` to `const BYTE*` : Allowed it as long as BYTE is 8bit, which is true on Windows.h. Usages:
+
+  - base64.cpp : on Windows, need to call `CryptBinaryToStringA`.
+
+- `const uint8_t\*` to `const char\*` : uint8_t is equivalent in size to char. Allowed. Usages:
+
+  - Parsing xml from ResponseBody as char\* + length in several places :
+
+    - blob_rest_client.hpp.
+    - share_rest_client.hpp.
+    - queue_rest_client.hpp.
+
+- `const uint8_t\*` to `const uint64_t\*` : Fine as there's no overflow. Allowed. Usages:
+
+  - crypt.cpp : on Windows, callng `Crc64Hash::OnAppend`.
+
+- `uint8_t\*` to `char\*` : uint8_t is equivalent in size to char. Allowed. Usages:
+
+  - curl.cpp :
+
+    - `ParseChunkSize` Appending data from uint8_t array to std::string.
+
+- `uint8_t\*` to `const char\*` : uint8_t is equivalent in size to char. Allowed. Usages:
+
+  - storage_exception : Parsing XML from bodyBuffer, which is uint8_t as const char in `CreateFromResponse`.
+
+- `uint8_t\*` to `PBYTE` : ToBeConfirmed. Usages:
+
+  - md5.cpp : on Windows, calling `BCryptHashData`.
+
+  - sha_hash.cpp : on Windows, calling `BCryptHashData`.
+
+  - crypt.cpp : on Windows, callng `BCryptHashData`.
+
+- `uint8_t\*` to `PUCHAR` : ToBeConfirmed. Usages:
+
+  - md5.cpp : on Windows, calling `BCryptFinishHash`.
+
+  - sha_hash.cpp : on Windows, calling `BCryptFinishHash`.
+
+  - crypt.cpp : on Windows, callng `BCryptCreateHash` and `BCryptFinishHash`.
+
+- `uint8_t\*` to `const unsigned char\*` : ToBeConfirmed. Usages:
+
+  - crypt.cpp : on Posix, callng `HmacSha256`.
+
+- `uint8_t\*` to `unsigned char\*` : ToBeConfirmed. Usages:
+
+  - crypt.cpp : on Posix, callng `HmacSha256`.

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -200,6 +200,7 @@ namespace Azure { namespace Core {
           AZURE_ASSERT_MSG(
               typeid(T) == ptr->ValueType, "Type mismatch for Context::TryGetValue().");
 
+          // allowed cast. see: link-to-casting-types
           outputValue = *reinterpret_cast<const T*>(ptr->Value.get());
           return true;
         }

--- a/sdk/core/azure-core/src/base64.cpp
+++ b/sdk/core/azure-core/src/base64.cpp
@@ -26,6 +26,7 @@ namespace Azure { namespace Core {
     DWORD encodedLength = static_cast<DWORD>((data.size() + 2) / 3 * 4);
     encoded.resize(encodedLength);
 
+    // allowed cast. see: link-to-casting-types
     CryptBinaryToStringA(
         reinterpret_cast<const BYTE*>(data.data()),
         static_cast<DWORD>(data.size()),
@@ -44,6 +45,7 @@ namespace Azure { namespace Core {
     DWORD decodedLength = DWORD(text.length() / 4 * 3);
     decoded.resize(decodedLength);
 
+    // allowed cast. see: link-to-casting-types
     CryptStringToBinaryA(
         text.data(),
         static_cast<DWORD>(text.length()),

--- a/sdk/core/azure-core/src/cryptography/md5.cpp
+++ b/sdk/core/azure-core/src/cryptography/md5.cpp
@@ -42,6 +42,7 @@ public:
     // calculate the size of the buffer to hold the hash object
     DWORD objectLength = 0;
     DWORD dataLength = 0;
+    // allowed cast. see: link-to-casting-types
     if (!BCRYPT_SUCCESS(
             m_status = BCryptGetProperty(
                 Handle,
@@ -57,6 +58,7 @@ public:
     // calculate the length of the hash
     ContextSize = objectLength;
     DWORD hashLength = 0;
+    // allowed cast. see: link-to-casting-types
     if (!BCRYPT_SUCCESS(
             m_status = BCryptGetProperty(
                 Handle,
@@ -96,6 +98,7 @@ private:
 
   void OnAppend(const uint8_t* data, size_t length)
   {
+    // allowed cast. see: link-to-casting-types
     if (!BCRYPT_SUCCESS(
             m_status = BCryptHashData(
                 m_hashHandle,
@@ -113,6 +116,7 @@ private:
 
     std::vector<uint8_t> hash;
     hash.resize(m_hashLength);
+    // allowed cast. see: link-to-casting-types
     if (!BCRYPT_SUCCESS(
             m_status = BCryptFinishHash(
                 m_hashHandle,
@@ -131,6 +135,7 @@ public:
     m_buffer.resize(GetMD5AlgorithmProvider().ContextSize);
     m_hashLength = GetMD5AlgorithmProvider().HashLength;
 
+    // allowed cast. see: link-to-casting-types
     if (!BCRYPT_SUCCESS(
             m_status = BCryptCreateHash(
                 GetMD5AlgorithmProvider().Handle,

--- a/sdk/core/azure-core/src/cryptography/sha_hash.cpp
+++ b/sdk/core/azure-core/src/cryptography/sha_hash.cpp
@@ -131,6 +131,7 @@ struct AlgorithmProviderInstance final
     }
     DWORD objectLength = 0;
     DWORD dataLength = 0;
+    // allowed cast. see: link-to-casting-types
     status = BCryptGetProperty(
         Handle,
         BCRYPT_OBJECT_LENGTH,
@@ -144,6 +145,7 @@ struct AlgorithmProviderInstance final
     }
     ContextSize = objectLength;
     DWORD hashLength = 0;
+    // allowed cast. see: link-to-casting-types
     status = BCryptGetProperty(
         Handle,
         BCRYPT_HASH_LENGTH,
@@ -173,6 +175,7 @@ private:
 
     std::vector<uint8_t> hash;
     hash.resize(m_hashLength);
+    // allowed cast. see: link-to-casting-types
     NTSTATUS status = BCryptFinishHash(
         m_hashHandle, reinterpret_cast<PUCHAR>(&hash[0]), static_cast<ULONG>(hash.size()), 0);
     if (!BCRYPT_SUCCESS(status))
@@ -184,6 +187,7 @@ private:
 
   void OnAppend(const uint8_t* data, size_t length) override
   {
+    // allowed cast. see: link-to-casting-types
     NTSTATUS status = BCryptHashData(
         m_hashHandle,
         reinterpret_cast<PBYTE>(const_cast<uint8_t*>(data)),
@@ -203,6 +207,7 @@ public:
     m_buffer.resize(algorithmProvider.ContextSize);
     m_hashLength = algorithmProvider.HashLength;
 
+    // allowed cast. see: link-to-casting-types
     NTSTATUS status = BCryptCreateHash(
         algorithmProvider.Handle,
         &m_hashHandle,

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -149,6 +149,7 @@ void WinSocketSetBuffSize(curl_socket_t socket)
 
 void static inline SetHeader(Azure::Core::Http::RawResponse& response, std::string const& header)
 {
+  // allowed cast. see: link-to-casting-types
   return Azure::Core::Http::_detail::RawResponseHelpers::SetHeader(
       response,
       reinterpret_cast<uint8_t const*>(header.data()),
@@ -458,6 +459,7 @@ static std::unique_ptr<RawResponse> CreateHTTPResponse(
 // Creates an HTTP Response with specific bodyType
 static std::unique_ptr<RawResponse> CreateHTTPResponse(std::string const& header)
 {
+  // allowed cast. see: link-to-casting-types
   return CreateHTTPResponse(
       reinterpret_cast<const uint8_t*>(header.data()),
       reinterpret_cast<const uint8_t*>(header.data() + header.size()));
@@ -557,6 +559,7 @@ CURLcode CurlSession::SendRawHttp(Context const& context)
   auto rawRequest = GetHTTPMessagePreBody(this->m_request);
   auto rawRequestLen = rawRequest.size();
 
+  // allowed cast. see: link-to-casting-types
   CURLcode sendResult = m_connection->SendBuffer(
       reinterpret_cast<uint8_t const*>(rawRequest.data()),
       static_cast<size_t>(rawRequestLen),
@@ -583,6 +586,7 @@ void CurlSession::ParseChunkSize(Context const& context)
     for (size_t index = this->m_bodyStartInBuffer, iteration = 0; index < this->m_innerBufferSize;
          index++, iteration++)
     {
+      // allowed cast. see: link-to-casting-types
       strChunkSize.append(reinterpret_cast<char*>(&this->m_readBuffer[index]), 1);
       if (iteration > 1 && this->m_readBuffer[index] == '\n')
       {

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -167,6 +167,7 @@ void SetHeaders(std::string const& headers, std::unique_ptr<RawResponse>& rawRes
     auto delimiter = std::find(begin, end, '\0');
     if (delimiter < end)
     {
+      // allowed cast. see: link-to-casting-types
       Azure::Core::Http::_detail::RawResponseHelpers::SetHeader(
           *rawResponse,
           reinterpret_cast<uint8_t const*>(begin),

--- a/sdk/identity/azure-identity/src/private/token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/token_credential_impl.hpp
@@ -83,6 +83,7 @@ namespace Azure { namespace Identity { namespace _detail {
       explicit TokenRequest(Core::Http::HttpMethod httpMethod, Core::Url url, std::string body)
           : m_body(new std::string(std::move(body))),
             m_memoryBodyStream(new Core::IO::MemoryBodyStream(
+                // allowed cast. see: link-to-casting-types
                 reinterpret_cast<uint8_t const*>(m_body->data()),
                 m_body->size())),
             HttpRequest(std::move(httpMethod), std::move(url), m_memoryBodyStream.get())

--- a/sdk/storage/azure-storage-common/src/crypt.cpp
+++ b/sdk/storage/azure-storage-common/src/crypt.cpp
@@ -118,6 +118,7 @@ namespace Azure { namespace Storage {
         }
         DWORD objectLength = 0;
         DWORD dataLength = 0;
+        // allowed cast. see: link-to-casting-types
         status = BCryptGetProperty(
             Handle,
             BCRYPT_OBJECT_LENGTH,
@@ -131,6 +132,7 @@ namespace Azure { namespace Storage {
         }
         ContextSize = objectLength;
         DWORD hashLength = 0;
+        // allowed cast. see: link-to-casting-types
         status = BCryptGetProperty(
             Handle,
             BCRYPT_HASH_LENGTH,
@@ -160,6 +162,7 @@ namespace Azure { namespace Storage {
       context.resize(AlgorithmProvider.ContextSize);
 
       BCRYPT_HASH_HANDLE hashHandle;
+      // allowed cast. see: link-to-casting-types
       NTSTATUS status = BCryptCreateHash(
           AlgorithmProvider.Handle,
           &hashHandle,
@@ -173,6 +176,7 @@ namespace Azure { namespace Storage {
         throw std::runtime_error("BCryptCreateHash failed.");
       }
 
+      // allowed cast. see: link-to-casting-types
       status = BCryptHashData(
           hashHandle,
           reinterpret_cast<PBYTE>(const_cast<uint8_t*>(data.data())),
@@ -185,6 +189,7 @@ namespace Azure { namespace Storage {
 
       std::vector<uint8_t> hash;
       hash.resize(AlgorithmProvider.HashLength);
+      // allowed cast. see: link-to-casting-types
       status = BCryptFinishHash(
           hashHandle, reinterpret_cast<PUCHAR>(&hash[0]), static_cast<ULONG>(hash.size()), 0);
       if (!BCRYPT_SUCCESS(status))
@@ -208,6 +213,7 @@ namespace Azure { namespace Storage {
     {
       uint8_t hash[EVP_MAX_MD_SIZE];
       unsigned int hashLength = 0;
+      // allowed cast. see: link-to-casting-types
       HMAC(
           EVP_sha256(),
           key.data(),
@@ -866,6 +872,7 @@ namespace Azure { namespace Storage {
     size_t uStop = length - (length % 32);
     if (uStop >= 2 * 32)
     {
+      // allowed cast. see: link-to-casting-types
       const uint64_t* wdata = reinterpret_cast<const uint64_t*>(data);
 
       uint64_t uCrc0 = 0;

--- a/sdk/storage/azure-storage-common/src/storage_exception.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_exception.cpp
@@ -42,6 +42,7 @@ namespace Azure { namespace Storage {
       if (response->GetHeaders().at(_internal::HttpHeaderContentType).find("xml")
           != std::string::npos)
       {
+        // allowed cast. see: link-to-casting-types
         auto xmlReader = _internal::XmlReader(
             reinterpret_cast<const char*>(bodyBuffer.data()), bodyBuffer.size());
 

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -45,6 +45,7 @@ namespace Azure { namespace Storage { namespace _internal {
       int ret = xmlTextReaderMoveToNextAttribute(reader);
       if (ret == 1)
       {
+        // allowed cast. see: link-to-casting-types
         const char* name = reinterpret_cast<const char*>(xmlTextReaderConstName(reader));
         const char* value = reinterpret_cast<const char*>(xmlTextReaderConstValue(reader));
         return XmlNode{XmlNodeType::Attribute, name, value};
@@ -74,6 +75,7 @@ namespace Azure { namespace Storage { namespace _internal {
     bool has_value = xmlTextReaderHasValue(reader) == 1;
     bool has_attributes = xmlTextReaderHasAttributes(reader) == 1;
 
+    // allowed cast. see: link-to-casting-types
     const char* name = reinterpret_cast<const char*>(xmlTextReaderConstName(reader));
     const char* value = reinterpret_cast<const char*>(xmlTextReaderConstValue(reader));
 
@@ -130,6 +132,7 @@ namespace Azure { namespace Storage { namespace _internal {
   namespace {
     inline xmlChar* BadCast(const char* x)
     {
+      // allowed cast. see: link-to-casting-types
       return const_cast<xmlChar*>(reinterpret_cast<const xmlChar*>(x));
     }
   } // namespace
@@ -182,6 +185,7 @@ namespace Azure { namespace Storage { namespace _internal {
     xmlTextWriterPtr writer = static_cast<xmlTextWriterPtr>(m_writer);
     xmlBufferPtr buffer = static_cast<xmlBufferPtr>(m_buffer);
     xmlTextWriterFlush(writer);
+    // allowed cast. see: link-to-casting-types
     return std::string(reinterpret_cast<const char*>(buffer->content), buffer->use);
   }
 


### PR DESCRIPTION
Bringing to the Team's attention the list of reinterpret_cast usages as part of:
https://github.com/Azure/azure-sdk-for-cpp/issues/2416

I am introducing a new document for the repo where all the current casting usages are recorded. We can decide if any of these casts should not be happening and fix as part of this PR.

The audit covers only src code. No tests/samples or external 3rd party source (like json lib) is covered.
