### PR TITLE
Update vcpkg version dependencies

### DIFF
--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -10,7 +10,6 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/core/azure-core",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "openssl",

--- a/sdk/identity/azure-identity/vcpkg/vcpkg.json
+++ b/sdk/identity/azure-identity/vcpkg/vcpkg.json
@@ -10,12 +10,10 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false,
-      "version>=": "1.2.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp "1.1.0" CONFIG QUIET)
+  find_package(azure-core-cpp "1.2.0" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp "1.1.0" REQUIRED)
+    find_package(azure-core-cpp "1.2.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/Config.cmake.in
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-core-cpp "1.1.0")
+find_dependency(azure-core-cpp "1.2.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-security-keyvault-common-cppTargets.cmake")
 

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/Config.cmake.in
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-core-cpp)
+find_dependency(azure-core-cpp "1.1.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-security-keyvault-common-cppTargets.cmake")
 

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
@@ -10,12 +10,10 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-common",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false,
-      "version>=": "1.1.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp "1.1.0" CONFIG QUIET)
+  find_package(azure-core-cpp "1.2.0" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp "1.1.0" REQUIRED)
+    find_package(azure-core-cpp "1.2.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/Config.cmake.in
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-core-cpp)
+find_dependency(azure-core-cpp "1.1.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-security-keyvault-keys-cppTargets.cmake")
 

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/Config.cmake.in
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-core-cpp "1.1.0")
+find_dependency(azure-core-cpp "1.2.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-security-keyvault-keys-cppTargets.cmake")
 

--- a/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-core-cpp "1.1.0" CONFIG QUIET)
+  find_package(azure-core-cpp "1.2.0" CONFIG QUIET)
   if(NOT azure-core-cpp_FOUND)
-    find_package(azure-core-cpp "1.1.0" REQUIRED)
+    find_package(azure-core-cpp "1.2.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/Config.cmake.in
+++ b/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-core-cpp "1.1.0")
+find_dependency(azure-core-cpp "1.2.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-security-keyvault-secrets-cppTargets.cmake")
 

--- a/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/Config.cmake.in
+++ b/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/Config.cmake.in
@@ -4,6 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
+find_dependency(azure-core-cpp "1.1.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-security-keyvault-secrets-cppTargets.cmake")
 

--- a/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/vcpkg.json
@@ -10,8 +10,11 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-secrets",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
+    {
+      "name": "azure-core-cpp",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/sdk/storage/azure-storage-blobs/CMakeLists.txt
+++ b/sdk/storage/azure-storage-blobs/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-storage-common-cpp "12.0.0" CONFIG QUIET)
+  find_package(azure-storage-common-cpp "12.1.0" CONFIG QUIET)
   if(NOT azure-storage-common-cpp_FOUND)
-    find_package(azure-storage-common-cpp "12.0.0" REQUIRED)
+    find_package(azure-storage-common-cpp "12.1.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/storage/azure-storage-blobs/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-blobs/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-storage-common-cpp "12.0.0")
+find_dependency(azure-storage-common-cpp "12.1.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-storage-blobs-cppTargets.cmake")
 

--- a/sdk/storage/azure-storage-blobs/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-blobs/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-storage-common-cpp)
+find_dependency(azure-storage-common-cpp "12.0.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-storage-blobs-cppTargets.cmake")
 

--- a/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
@@ -10,12 +10,10 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",
-      "default-features": false,
-      "version>=": "12.0.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-common/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-common/vcpkg/Config.cmake.in
@@ -6,7 +6,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(LibXml2)
 find_dependency(Threads)
-find_dependency(azure-core-cpp)
+find_dependency(azure-core-cpp "1.0.0")
 
 if(NOT WIN32)
   find_dependency(OpenSSL)

--- a/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
@@ -10,12 +10,10 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-common",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false,
-      "version>=": "1.0.0"
+      "default-features": false
     },
     "libxml2",
     {

--- a/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-storage-blobs-cpp "12.0.0" CONFIG QUIET)
+  find_package(azure-storage-blobs-cpp "12.1.0" CONFIG QUIET)
   if(NOT azure-storage-blobs-cpp_FOUND)
-    find_package(azure-storage-blobs-cpp "12.0.0" REQUIRED)
+    find_package(azure-storage-blobs-cpp "12.1.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-storage-blobs-cpp "12.0.0")
+find_dependency(azure-storage-blobs-cpp "12.1.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-storage-files-datalake-cppTargets.cmake")
 

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-storage-blobs-cpp)
+find_dependency(azure-storage-blobs-cpp "12.0.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-storage-files-datalake-cppTargets.cmake")
 

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
@@ -10,12 +10,10 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-storage-blobs-cpp",
-      "default-features": false,
-      "version>=": "12.0.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-files-shares/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-shares/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-storage-common-cpp "12.0.0" CONFIG QUIET)
+  find_package(azure-storage-common-cpp "12.1.0" CONFIG QUIET)
   if(NOT azure-storage-common-cpp_FOUND)
-    find_package(azure-storage-common-cpp "12.0.0" REQUIRED)
+    find_package(azure-storage-common-cpp "12.1.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/storage/azure-storage-files-shares/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-storage-common-cpp "12.0.0")
+find_dependency(azure-storage-common-cpp "12.1.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-storage-files-shares-cppTargets.cmake")
 

--- a/sdk/storage/azure-storage-files-shares/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-storage-common-cpp)
+find_dependency(azure-storage-common-cpp "12.0.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-storage-files-shares-cppTargets.cmake")
 

--- a/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
@@ -10,12 +10,10 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-shares",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",
-      "default-features": false,
-      "version>=": "12.0.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-queues/CMakeLists.txt
+++ b/sdk/storage/azure-storage-queues/CMakeLists.txt
@@ -20,9 +20,9 @@ include(AzureGlobalCompileOptions)
 az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
-  find_package(azure-storage-common-cpp "12.0.0" CONFIG QUIET)
+  find_package(azure-storage-common-cpp "12.1.0" CONFIG QUIET)
   if(NOT azure-storage-common-cpp_FOUND)
-    find_package(azure-storage-common-cpp "12.0.0" REQUIRED)
+    find_package(azure-storage-common-cpp "12.1.0" REQUIRED)
   endif()
 endif()
 

--- a/sdk/storage/azure-storage-queues/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-queues/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-storage-common-cpp)
+find_dependency(azure-storage-common-cpp "12.0.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-storage-queues-cppTargets.cmake")
 

--- a/sdk/storage/azure-storage-queues/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-queues/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-storage-common-cpp "12.0.0")
+find_dependency(azure-storage-common-cpp "12.1.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-storage-queues-cppTargets.cmake")
 

--- a/sdk/storage/azure-storage-queues/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-queues/vcpkg/vcpkg.json
@@ -13,8 +13,7 @@
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",
-      "default-features": false,
-      "version>=": "12.0.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/template/azure-template/vcpkg/Config.cmake.in
+++ b/sdk/template/azure-template/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-core-cpp)
+find_dependency(azure-core-cpp "1.0.0")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-template-cppTargets.cmake")
 

--- a/sdk/template/azure-template/vcpkg/vcpkg.json
+++ b/sdk/template/azure-template/vcpkg/vcpkg.json
@@ -11,12 +11,10 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/template/azure-template",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false,
-      "version>=": "1.0.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
Closes #2702

1. VcPkg have a bug currently so at a moment we can't use `version>=` and `builtin-baseline`: https://github.com/microsoft/vcpkg/pull/19299#issuecomment-894497720

2. Identity depends on `core 1.2.0`.

3. Keyvault-Keys depends on `core 1.1.0` - @vhvb1989, please correct me if I am wrong.

4. Storage depends on `core 1.0.0`, and all storage libs that depend on `storage-common` do depend on `12.0.0`. But datalake depends on `storage-blobs 12.1.0` - @Jinming-Hu, please correct me if I am wrong. This also applies to the new azure-storage-queues lib.

5. Keyvault-Secrets was missing a core dependency in the vcpkg manifest. Per cmakelists.txt, it was depending on `core 1.1.0`. I updated vcpkg manifest files to reflect that - @gearama, please correct me if I am wrong.
