### PR TITLE
supresss gtest warning from test pw

### DIFF
--- a/sdk/core/azure-core-test/CMakeLists.txt
+++ b/sdk/core/azure-core-test/CMakeLists.txt
@@ -35,6 +35,11 @@ add_library (
   ${AZURE_CORE_TEST_SOURCE}
   )
 
+if (MSVC)
+  # - C6326: Google comparisons 
+  target_compile_options(azure-core-test-fw PUBLIC /wd6326)
+endif()
+
 target_include_directories (azure-core-test-fw
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>


### PR DESCRIPTION
The latest merged azure-core-test-fw with the recording feature is failing due to gtest warnings complaining about constant comparisons.  Adding the warning supress here to fix that