### PR TITLE
Remove vcpkg version constraints for Key Vault Keys

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
@@ -10,12 +10,10 @@
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-keys",
   "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false,
-      "version>=": "1.1.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
I missed it in #2718, so https://github.com/microsoft/vcpkg/pull/19487#discussion_r686455528 needed a correction.
At some point, when vcpkg is fixed, we will undo all this - https://github.com/Azure/azure-sdk-for-cpp/issues/2735