### PR TITLE
Use Clang 11 in Ubuntu 20

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -159,11 +159,11 @@ jobs:
       )
 
   # Validate all the files are formatted correctly according to the
-  # .clang-format file. This step is macOS only to use clang-format-11
+  # .clang-format file. This step runs on linux only only and assumes that
+  # clang-format-11 is installed.
   - bash: |
       # Run clang-format recursively on each source and header file within the repo sdk folder.
       echo "Check clang-formatting"
-      brew install clang-format
       clang-format --version
       find ./sdk \( -iname '*.hpp' -o -iname '*.cpp' \) ! -iname 'json.hpp' -exec clang-format -i {} \;
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -80,10 +80,10 @@ jobs:
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         CHECK_CLANG_FORMAT: 1
+        CmakeArgs: -DCMAKE_VERBOSE_MAKEFILE=1
         AptDependencies: 'clang-11'
         CC: '/usr/bin/clang-11'
         CXX: '/usr/bin/clang++-11'
-        CmakeArgs:
 
       # Unit testing ON
       # Linux_x64_with_unit_test:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -71,10 +71,10 @@ jobs:
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         CHECK_CLANG_FORMAT: 1
-        CmakeArgs: -DCMAKE_VERBOSE_MAKEFILE=1
         AptDependencies: 'clang-11'
         CC: '/usr/bin/clang-11'
         CXX: '/usr/bin/clang++-11'
+        BuildArgs: '-j 4'
 
       # Unit testing ON
       Linux_x64_with_unit_test:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -26,104 +26,116 @@ jobs:
   condition: and(succeededOrFailed(), ne(variables['Skip.Test'], 'true'))
   strategy:
     matrix:
-      Linux_x64_gcc8:
-        Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage: MMSUbuntu18.04
-        VcpkgInstall: 'curl[ssl] libxml2 openssl'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        CC: '/usr/bin/gcc-8'
-        CXX: '/usr/bin/g++-8'
-        BuildArgs: '-j 10'
-      Linux_x64_gcc9:
-        Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage: MMSUbuntu18.04
-        VcpkgInstall: 'curl[ssl] libxml2 openssl'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        CC: '/usr/bin/gcc-9'
-        CXX: '/usr/bin/g++-9'
-        BuildArgs: '-j 10'
-      Linux_x64:
-        Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage: MMSUbuntu18.04
-        VcpkgInstall: 'curl[ssl] libxml2 openssl'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        BuildArgs: '-j 10'
-      Win_x86:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
-        VcpkgInstall: 'curl[winssl] libxml2'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-        CmakeArgs: ' -DBUILD_TRANSPORT_CURL=ON' #Leaving curl on here to explicitly test what the default behavior is on windows.
-        BuildArgs: '--parallel 8'
-      Win_x64:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
-        VcpkgInstall: 'curl[winssl] libxml2'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
-        BuildArgs: '--parallel 8'
+      # Linux_x64_gcc8:
+      #   Pool: azsdk-pool-mms-ubuntu-1804-general
+      #   OSVmImage: MMSUbuntu18.04
+      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   CC: '/usr/bin/gcc-8'
+      #   CXX: '/usr/bin/g++-8'
+      #   BuildArgs: '-j 10'
+      # Linux_x64_gcc9:
+      #   Pool: azsdk-pool-mms-ubuntu-1804-general
+      #   OSVmImage: MMSUbuntu18.04
+      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   CC: '/usr/bin/gcc-9'
+      #   CXX: '/usr/bin/g++-9'
+      #   BuildArgs: '-j 10'
+      # Linux_x64:
+      #   Pool: azsdk-pool-mms-ubuntu-1804-general
+      #   OSVmImage: MMSUbuntu18.04
+      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   BuildArgs: '-j 10'
+      # Win_x86:
+      #   Pool: azsdk-pool-mms-win-2019-general
+      #   OSVmImage: MMS2019
+      #   VcpkgInstall: 'curl[winssl] libxml2'
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      #   CmakeArgs: ' -DBUILD_TRANSPORT_CURL=ON' #Leaving curl on here to explicitly test what the default behavior is on windows.
+      #   BuildArgs: '--parallel 8'
+      # Win_x64:
+      #   Pool: azsdk-pool-mms-win-2019-general
+      #   OSVmImage: MMS2019
+      #   VcpkgInstall: 'curl[winssl] libxml2'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+      #   BuildArgs: '--parallel 8'
       MacOS_x64:
         Pool: Azure Pipelines
         OSVmImage: 'macOS-10.14'
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         CHECK_CLANG_FORMAT: 1
+        CmakeArgs: -DCMAKE_VERBOSE_MAKEFILE=1
         BuildArgs: '-j 4'
 
-      # Unit testing ON
-      Linux_x64_with_unit_test:
-        Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage: MMSUbuntu18.04
-        VcpkgInstall: 'curl[ssl] libxml2 openssl'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_CODE_COVERAGE=ON'
-        AptDependencies: 'gcovr lcov'
-        CODE_COVERAGE: '${{ parameters.Coverage }}'
-        # Make coverage report to avoid running the test exe because CI step will run it
-        CODE_COVERAGE_COLLECT_ONLY: 1
-        BuildArgs: '-j 10'
-      Linux_x64_with_unit_test_release:
-        Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage: MMSUbuntu18.04
-        VcpkgInstall: 'curl[ssl] libxml2 openssl'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        CmakeArgs: ' -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON'
-        BuildArgs: '-j 10'
-      Ubuntu20_x64_with_unit_test_release:
+      Ubuntu_20_x64_clang:
         Pool: azsdk-pool-mms-ubuntu-2004-general
         OSVmImage: MMSUbuntu20.04
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        CmakeArgs: ' -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON'
-        BuildArgs: '-j 10'
-      Win_x86_with_unit_test:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
-        VcpkgInstall: 'curl[winssl] libxml2'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-        CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
-        BuildArgs: '--parallel 8'
-      Win_x64_with_unit_test:
-        Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage: MMS2019
-        VcpkgInstall: 'curl[winssl] libxml2'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
-        CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
-        BuildArgs: '--parallel 8'
-      MacOS_x64_with_unit_test:
-        Pool: Azure Pipelines
-        OSVmImage: 'macOS-10.14'
-        VcpkgInstall: 'curl[ssl] libxml2 openssl'
-        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
-        BuildArgs: '-j 4'
+        CHECK_CLANG_FORMAT: 1
+        AptDependencies: 'clang-11'
+        CC: '/usr/bin/clang-11'
+        CXX: '/usr/bin/clang++-11'
+        CmakeArgs:
+
+      # Unit testing ON
+      # Linux_x64_with_unit_test:
+      #   Pool: azsdk-pool-mms-ubuntu-1804-general
+      #   OSVmImage: MMSUbuntu18.04
+      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_CODE_COVERAGE=ON'
+      #   AptDependencies: 'gcovr lcov'
+      #   CODE_COVERAGE: '${{ parameters.Coverage }}'
+      #   # Make coverage report to avoid running the test exe because CI step will run it
+      #   CODE_COVERAGE_COLLECT_ONLY: 1
+      #   BuildArgs: '-j 10'
+      # Linux_x64_with_unit_test_release:
+      #   Pool: azsdk-pool-mms-ubuntu-1804-general
+      #   OSVmImage: MMSUbuntu18.04
+      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   CmakeArgs: ' -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON'
+      #   BuildArgs: '-j 10'
+      # Ubuntu20_x64_with_unit_test_release:
+      #   Pool: azsdk-pool-mms-ubuntu-2004-general
+      #   OSVmImage: MMSUbuntu20.04
+      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   CmakeArgs: ' -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON'
+      #   BuildArgs: '-j 10'
+      # Win_x86_with_unit_test:
+      #   Pool: azsdk-pool-mms-win-2019-general
+      #   OSVmImage: MMS2019
+      #   VcpkgInstall: 'curl[winssl] libxml2'
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      #   CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
+      #   BuildArgs: '--parallel 8'
+      # Win_x64_with_unit_test:
+      #   Pool: azsdk-pool-mms-win-2019-general
+      #   OSVmImage: MMS2019
+      #   VcpkgInstall: 'curl[winssl] libxml2'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+      #   CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
+      #   BuildArgs: '--parallel 8'
+      # MacOS_x64_with_unit_test:
+      #   Pool: Azure Pipelines
+      #   OSVmImage: 'macOS-10.14'
+      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+      #   CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
+      #   BuildArgs: '-j 4'
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)
@@ -146,7 +158,7 @@ jobs:
 
   # Install gcc and g++ 8 if it is needed on the image.
   - bash: sudo apt-get install gcc-8 g++-8 -y
-    displayName: Install gcc and g++ 8 
+    displayName: Install gcc and g++ 8
     condition: >-
       and(
         succeeded(), 
@@ -179,7 +191,7 @@ jobs:
 
     displayName: Validate Clang Format
     condition: and(succeededOrFailed(), eq(variables['CHECK_CLANG_FORMAT'], 1))
-  
+
   - ${{ each artifact in parameters.Artifacts }}: 
     - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
       parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -26,54 +26,45 @@ jobs:
   condition: and(succeededOrFailed(), ne(variables['Skip.Test'], 'true'))
   strategy:
     matrix:
-      # Linux_x64_gcc8:
-      #   Pool: azsdk-pool-mms-ubuntu-1804-general
-      #   OSVmImage: MMSUbuntu18.04
-      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   CC: '/usr/bin/gcc-8'
-      #   CXX: '/usr/bin/g++-8'
-      #   BuildArgs: '-j 10'
-      # Linux_x64_gcc9:
-      #   Pool: azsdk-pool-mms-ubuntu-1804-general
-      #   OSVmImage: MMSUbuntu18.04
-      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   CC: '/usr/bin/gcc-9'
-      #   CXX: '/usr/bin/g++-9'
-      #   BuildArgs: '-j 10'
-      # Linux_x64:
-      #   Pool: azsdk-pool-mms-ubuntu-1804-general
-      #   OSVmImage: MMSUbuntu18.04
-      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   BuildArgs: '-j 10'
-      # Win_x86:
-      #   Pool: azsdk-pool-mms-win-2019-general
-      #   OSVmImage: MMS2019
-      #   VcpkgInstall: 'curl[winssl] libxml2'
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      #   CmakeArgs: ' -DBUILD_TRANSPORT_CURL=ON' #Leaving curl on here to explicitly test what the default behavior is on windows.
-      #   BuildArgs: '--parallel 8'
-      # Win_x64:
-      #   Pool: azsdk-pool-mms-win-2019-general
-      #   OSVmImage: MMS2019
-      #   VcpkgInstall: 'curl[winssl] libxml2'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-      #   BuildArgs: '--parallel 8'
-      MacOS_x64:
-        Pool: Azure Pipelines
-        OSVmImage: 'macOS-10.14'
+      Linux_x64_gcc8:
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage: MMSUbuntu18.04
         VcpkgInstall: 'curl[ssl] libxml2 openssl'
-        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        CHECK_CLANG_FORMAT: 1
-        CmakeArgs: -DCMAKE_VERBOSE_MAKEFILE=1
-        BuildArgs: '-j 4'
-
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        CC: '/usr/bin/gcc-8'
+        CXX: '/usr/bin/g++-8'
+        BuildArgs: '-j 10'
+      Linux_x64_gcc9:
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage: MMSUbuntu18.04
+        VcpkgInstall: 'curl[ssl] libxml2 openssl'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        CC: '/usr/bin/gcc-9'
+        CXX: '/usr/bin/g++-9'
+        BuildArgs: '-j 10'
+      Linux_x64:
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage: MMSUbuntu18.04
+        VcpkgInstall: 'curl[ssl] libxml2 openssl'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        BuildArgs: '-j 10'
+      Win_x86:
+        Pool: azsdk-pool-mms-win-2019-general
+        OSVmImage: MMS2019
+        VcpkgInstall: 'curl[winssl] libxml2'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        CmakeArgs: ' -DBUILD_TRANSPORT_CURL=ON' #Leaving curl on here to explicitly test what the default behavior is on windows.
+        BuildArgs: '--parallel 8'
+      Win_x64:
+        Pool: azsdk-pool-mms-win-2019-general
+        OSVmImage: MMS2019
+        VcpkgInstall: 'curl[winssl] libxml2'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        BuildArgs: '--parallel 8'
       Ubuntu_20_x64_clang:
         Pool: azsdk-pool-mms-ubuntu-2004-general
         OSVmImage: MMSUbuntu20.04
@@ -86,56 +77,56 @@ jobs:
         CXX: '/usr/bin/clang++-11'
 
       # Unit testing ON
-      # Linux_x64_with_unit_test:
-      #   Pool: azsdk-pool-mms-ubuntu-1804-general
-      #   OSVmImage: MMSUbuntu18.04
-      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_CODE_COVERAGE=ON'
-      #   AptDependencies: 'gcovr lcov'
-      #   CODE_COVERAGE: '${{ parameters.Coverage }}'
-      #   # Make coverage report to avoid running the test exe because CI step will run it
-      #   CODE_COVERAGE_COLLECT_ONLY: 1
-      #   BuildArgs: '-j 10'
-      # Linux_x64_with_unit_test_release:
-      #   Pool: azsdk-pool-mms-ubuntu-1804-general
-      #   OSVmImage: MMSUbuntu18.04
-      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   CmakeArgs: ' -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON'
-      #   BuildArgs: '-j 10'
-      # Ubuntu20_x64_with_unit_test_release:
-      #   Pool: azsdk-pool-mms-ubuntu-2004-general
-      #   OSVmImage: MMSUbuntu20.04
-      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   CmakeArgs: ' -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON'
-      #   BuildArgs: '-j 10'
-      # Win_x86_with_unit_test:
-      #   Pool: azsdk-pool-mms-win-2019-general
-      #   OSVmImage: MMS2019
-      #   VcpkgInstall: 'curl[winssl] libxml2'
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      #   CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
-      #   BuildArgs: '--parallel 8'
-      # Win_x64_with_unit_test:
-      #   Pool: azsdk-pool-mms-win-2019-general
-      #   OSVmImage: MMS2019
-      #   VcpkgInstall: 'curl[winssl] libxml2'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-      #   CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
-      #   BuildArgs: '--parallel 8'
-      # MacOS_x64_with_unit_test:
-      #   Pool: Azure Pipelines
-      #   OSVmImage: 'macOS-10.14'
-      #   VcpkgInstall: 'curl[ssl] libxml2 openssl'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-      #   CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
-      #   BuildArgs: '-j 4'
+      Linux_x64_with_unit_test:
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage: MMSUbuntu18.04
+        VcpkgInstall: 'curl[ssl] libxml2 openssl'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_CODE_COVERAGE=ON'
+        AptDependencies: 'gcovr lcov'
+        CODE_COVERAGE: '${{ parameters.Coverage }}'
+        # Make coverage report to avoid running the test exe because CI step will run it
+        CODE_COVERAGE_COLLECT_ONLY: 1
+        BuildArgs: '-j 10'
+      Linux_x64_with_unit_test_release:
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage: MMSUbuntu18.04
+        VcpkgInstall: 'curl[ssl] libxml2 openssl'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        CmakeArgs: ' -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON'
+        BuildArgs: '-j 10'
+      Ubuntu20_x64_with_unit_test_release:
+        Pool: azsdk-pool-mms-ubuntu-2004-general
+        OSVmImage: MMSUbuntu20.04
+        VcpkgInstall: 'curl[ssl] libxml2 openssl'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        CmakeArgs: ' -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON'
+        BuildArgs: '-j 10'
+      Win_x86_with_unit_test:
+        Pool: azsdk-pool-mms-win-2019-general
+        OSVmImage: MMS2019
+        VcpkgInstall: 'curl[winssl] libxml2'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
+        BuildArgs: '--parallel 8'
+      Win_x64_with_unit_test:
+        Pool: azsdk-pool-mms-win-2019-general
+        OSVmImage: MMS2019
+        VcpkgInstall: 'curl[winssl] libxml2'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON'
+        BuildArgs: '--parallel 8'
+      MacOS_x64_with_unit_test:
+        Pool: Azure Pipelines
+        OSVmImage: 'macOS-10.14'
+        VcpkgInstall: 'curl[ssl] libxml2 openssl'
+        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+        CmakeArgs: ' -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON'
+        BuildArgs: '-j 4'
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)

--- a/sdk/identity/azure-identity/src/managed_identity_credential.cpp
+++ b/sdk/identity/azure-identity/src/managed_identity_credential.cpp
@@ -1,50 +1,73 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "azure/identity/managed_identity_credential.hpp"
-#include "private/managed_identity_source.hpp"
+/**
+ * @file
+ * @brief Managed Identity Credential and options.
+ */
 
-using namespace Azure::Identity;
+#pragma once
 
-namespace {
-std::unique_ptr<_detail::ManagedIdentitySource> CreateManagedIdentitySource(
-    std::string const& clientId,
-    Azure::Core::Credentials::TokenCredentialOptions const& options)
-{
-  using namespace Azure::Core::Credentials;
-  using namespace Azure::Identity::_detail;
-  static std::unique_ptr<ManagedIdentitySource> (*managedIdentitySourceCreate[])(
-      std::string const& clientId, TokenCredentialOptions const& options)
-      = {AppServiceManagedIdentitySource::Create,
-         CloudShellManagedIdentitySource::Create,
-         AzureArcManagedIdentitySource::Create,
-         ImdsManagedIdentitySource::Create};
+#include <azure/core/credentials/credentials.hpp>
+#include <azure/core/credentials/token_credential_options.hpp>
 
-  for (auto create : managedIdentitySourceCreate)
-  {
-    if (auto source = create(clientId, options))
-    {
-      return source;
-    }
+#include <memory>
+#include <string>
+
+namespace Azure { namespace Identity {
+  namespace _detail {
+    class ManagedIdentitySource;
   }
 
-  throw AuthenticationException(
-      "ManagedIdentityCredential authentication unavailable. No Managed Identity endpoint found.");
-}
-} // namespace
+  /**
+   * @brief Client Secret Credential authenticates with the Azure services using a Tenant ID, Client
+   * ID and a client secret.
+   */
+  class ManagedIdentityCredential final : public Core::Credentials::TokenCredential {
+  private:
+    std::unique_ptr<_detail::ManagedIdentitySource> m_managedIdentitySource;
 
-ManagedIdentityCredential::~ManagedIdentityCredential() = default;
+  public:
+    /**
+     * @brief Destructs `%TokenCredential`.
+     *
+     */
+    ~ManagedIdentityCredential() override;
 
-ManagedIdentityCredential::ManagedIdentityCredential(
-    std::string const& clientId,
-    Azure::Core::Credentials::TokenCredentialOptions const& options)
-    : m_managedIdentitySource(CreateManagedIdentitySource(clientId, options))
-{
-}
+    /**
+     * @brief Constructs a Managed Identity Credential.
+     *
+     * @param clientId Client ID.
+     * @param options Options for token retrieval.
+     */
+    explicit ManagedIdentityCredential(
+        std::string const& clientId = std::string(),
+        Azure::Core::Credentials::TokenCredentialOptions const& options
+        = Azure::Core::Credentials::TokenCredentialOptions());
 
-Azure::Core::Credentials::AccessToken ManagedIdentityCredential::GetToken(
-    Azure::Core::Credentials::TokenRequestContext const& tokenRequestContext,
-    Azure::Core::Context const& context) const
-{
-  return m_managedIdentitySource->GetToken(tokenRequestContext, context);
-}
+    /**
+     * @brief Constructs a Managed Identity Credential.
+     *
+     * @param clientId Client ID.
+     * @param options Options for token retrieval.
+     */
+    explicit ManagedIdentityCredential(
+        Azure::Core::Credentials::TokenCredentialOptions const& options)
+        : ManagedIdentityCredential(std::string(), options)
+    {
+    }
+
+    /**
+     * @brief Gets an authentication token.
+     *
+     * @param tokenRequestContext A context to get the token in.
+     * @param context A context to control the request lifetime.
+     *
+     * @throw Azure::Core::Credentials::AuthenticationException Authentication error occurred.
+     */
+    Core::Credentials::AccessToken GetToken(
+        Core::Credentials::TokenRequestContext const& tokenRequestContext,
+        Core::Context const& context) const override;
+  };
+
+}} // namespace Azure::Identity


### PR DESCRIPTION
Clang in Ubuntu 20 has better support for generating warnings and errors for `-Wdocumentation` 

Example expected failure using Clang on Ubuntu 20 -- https://dev.azure.com/azure-sdk/public/_build/results?buildId=1057382&view=logs&j=51bbdecf-b8c8-57b3-5444-f22dc18cafe9&t=35a3d1b9-c9a6-57f7-470a-e23a781b8c45&l=98

Doc failure also in identity pipeline: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1057385&view=logs&j=51bbdecf-b8c8-57b3-5444-f22dc18cafe9&t=35a3d1b9-c9a6-57f7-470a-e23a781b8c45&l=99