### PR TITLE
Update keyvault codeowners to reduce noise to signal ratio

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /sdk/identity/           @antkmsft @schaabs @ahsonkhan @rickwinter @vhvb1989 @gearama
 
 # PRLabel: %KeyVault
-/sdk/keyvault/           @vhvb1989 @gearama @ahsonkhan @antkmsft @rickwinter
+/sdk/keyvault/           @vhvb1989 @gearama @antkmsft @rickwinter
 
 # PRLabel: %Storage
 /sdk/storage/            @vinjiang @katmsft @Jinming-Hu @antkmsft @rickwinter @vhvb1989 @gearama


### PR DESCRIPTION
Trying to reduce the noise to signal ratio and manage GitHub notifications to when I am explicitly tagged for relevant reviews and conversations, rather than during day-to-day keyvault code churn and features.