### PR TITLE
update test config for keyvault

### DIFF
--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -34,7 +34,7 @@ stages:
     parameters:
       ServiceDirectory: keyvault
       CtestRegex: "azure-security-keyvault.*-unittest"
-      LiveTestCtestRegex: "azure-security-keyvault.*-livetest"
+      LiveTestCtestRegex: "azure-security-keyvault.*"
       LiveTestTimeoutInMinutes: 120
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
       Artifacts:


### PR DESCRIPTION
Update CI test config for KeyVault so the internal pipelines will run all service tests and not only the one prefixed with `live`.

This will make secrets to run its tests on LIVE mode.
This will make Keys to run Live and non-live test, which is fine (just a few extra unit tests there)

In the future, Keys will be updated with recordings and to use only one test binary just like secrets. Then we can update the way Live and non-live test are ran un CI pipelines