### PR TITLE
Remove cspell enforcement

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -279,8 +279,6 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
     steps:
       - template: /eng/common/pipelines/templates/steps/check-spelling.yml
-        parameters:
-          ContinueOnError: false
 
       - template: /eng/common/pipelines/templates/steps/verify-links.yml
         parameters:


### PR DESCRIPTION
There are cases where cspell will fail incorrectly based on undocumented configuration behavior. 

This is being addressed in https://github.com/Azure/azure-sdk-tools/pull/1946