### PR TITLE
Optional RTTI idea demo

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -79,7 +79,9 @@ namespace Azure { namespace Core {
       std::atomic<DateTime::rep> Deadline;
       Context::Key Key;
       std::shared_ptr<void> Value;
+#if __cpp_rtti
       const std::type_info& ValueType;
+#endif
 
       static constexpr DateTime::rep ToDateTimeRepresentation(DateTime const& dateTime)
       {
@@ -92,16 +94,22 @@ namespace Azure { namespace Core {
       }
 
       explicit ContextSharedState()
-          : Deadline(ToDateTimeRepresentation((DateTime::max)())), Value(nullptr),
+          : Deadline(ToDateTimeRepresentation((DateTime::max)())), Value(nullptr)
+#if __cpp_rtti
+            ,
             ValueType(typeid(std::nullptr_t))
+#endif
       {
       }
 
       explicit ContextSharedState(
           const std::shared_ptr<ContextSharedState>& parent,
           DateTime const& deadline)
-          : Parent(parent), Deadline(ToDateTimeRepresentation(deadline)), Value(nullptr),
+          : Parent(parent), Deadline(ToDateTimeRepresentation(deadline)), Value(nullptr)
+#if __cpp_rtti
+            ,
             ValueType(typeid(std::nullptr_t))
+#endif
       {
       }
 
@@ -112,7 +120,11 @@ namespace Azure { namespace Core {
           Context::Key const& key,
           T value) // NOTE, should this be T&&
           : Parent(parent), Deadline(ToDateTimeRepresentation(deadline)), Key(key),
-            Value(std::make_shared<T>(std::move(value))), ValueType(typeid(T))
+            Value(std::make_shared<T>(std::move(value)))
+#if __cpp_rtti
+            ,
+            ValueType(typeid(T))
+#endif
       {
       }
     };
@@ -197,8 +209,10 @@ namespace Azure { namespace Core {
       {
         if (ptr->Key == key)
         {
+#if __cpp_rtti
           AZURE_ASSERT_MSG(
               typeid(T) == ptr->ValueType, "Type mismatch for Context::TryGetValue().");
+#endif
 
           outputValue = *reinterpret_cast<const T*>(ptr->Value.get());
           return true;


### PR DESCRIPTION
This is a demo of the idea of how I think it could be done, as possible idea for Victor.

I did not check it extensively.

`__cpp_rtti` is C++20 (https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros), if I understand correctly, so we need a better mechanism, probably something compiler specific. Or, we can define a Cmake configuration option.

And this is more to illustrate the non-criticalness of the RTTI in Context implementation.