### PR TITLE
[Core] - Support azure-core version without OpenSSL dependency

### DIFF
--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -22,6 +22,10 @@ az_vcpkg_integrate()
 
 find_package(Threads REQUIRED)
 
+# Allow building azure-core without OpenSSL dependency and hence without Crypto-functions
+# This is a work-around for anyone consuming azure-core without a need for Crypto like the cognitive services.
+option(BUILD_CRYPTO "Build the cryto namespace. Build will depend on OpenSSL." ON)
+
 if(BUILD_TRANSPORT_CURL)
   # min version for `CURLSSLOPT_NO_REVOKE`
   # https://curl.haxx.se/libcurl/c/CURLOPT_SSL_OPTIONS.html
@@ -47,13 +51,25 @@ if(BUILD_TRANSPORT_WINHTTP)
   SET(WIN_TRANSPORT_ADAPTER_INC inc/azure/core/http/win_http_transport.hpp)
 endif()
 
+if(BUILD_CRYPTO)
+  add_compile_definitions(AZURE_BUILD_CRYPTO)
+  SET(AZURE_SDK_CRYPTO_INC
+    inc/azure/core/cryptography/hash.hpp
+    inc/azure/core/internal/cryptography/sha_hash.hpp
+  )
+  SET(AZURE_SDK_CRYPTO_SRC
+    src/cryptography/md5.cpp
+    src/cryptography/sha_hash.cpp
+  )
+endif()
+
 set(
   AZURE_CORE_HEADER
     ${CURL_TRANSPORT_ADAPTER_INC}
     ${WIN_TRANSPORT_ADAPTER_INC}
     inc/azure/core/credentials/credentials.hpp
     inc/azure/core/credentials/token_credential_options.hpp
-    inc/azure/core/cryptography/hash.hpp
+    ${AZURE_SDK_CRYPTO_INC}
     inc/azure/core/diagnostics/logger.hpp
     inc/azure/core/http/http_status_code.hpp
     inc/azure/core/http/http.hpp
@@ -62,7 +78,6 @@ set(
     inc/azure/core/http/transport.hpp
     inc/azure/core/internal/client_options.hpp
     inc/azure/core/internal/contract.hpp
-    inc/azure/core/internal/cryptography/sha_hash.hpp
     inc/azure/core/internal/diagnostics/log.hpp
     inc/azure/core/internal/http/pipeline.hpp
     inc/azure/core/internal/io/null_body_stream.hpp
@@ -96,8 +111,7 @@ set(
     ${CURL_TRANSPORT_ADAPTER_SRC}
     ${WIN_TRANSPORT_ADAPTER_SRC}
     src/azure_assert.cpp
-    src/cryptography/md5.cpp
-    src/cryptography/sha_hash.cpp
+    ${AZURE_SDK_CRYPTO_SRC}
     src/http/bearer_token_authentication_policy.cpp
     src/http/http.cpp
     src/http/log_policy.cpp
@@ -140,11 +154,13 @@ create_code_coverage(core azure-core azure-core-test)
 
 target_link_libraries(azure-core INTERFACE Threads::Threads)
 
-if(WIN32)
-    target_link_libraries(azure-core PRIVATE bcrypt crypt32)
-else()
-    find_package(OpenSSL REQUIRED)
-    target_link_libraries(azure-core PRIVATE OpenSSL::SSL)
+if(BUILD_CRYPTO)
+  if(WIN32)
+      target_link_libraries(azure-core PRIVATE bcrypt crypt32)
+  else()
+      find_package(OpenSSL REQUIRED)
+      target_link_libraries(azure-core PRIVATE OpenSSL::SSL)
+  endif()
 endif()
 
 if(BUILD_TRANSPORT_CURL)

--- a/sdk/core/azure-core/src/base64.cpp
+++ b/sdk/core/azure-core/src/base64.cpp
@@ -387,7 +387,7 @@ static void base64WriteThreeLowOrderBytes(std::vector<uint8_t>::iterator destina
 std::vector<uint8_t> base64Decode(const std::string& text)
 {
 
-  if (text.size() == 0)
+  if (text.size() < 4)
   {
     return std::vector<uint8_t>(0);
   }

--- a/sdk/core/azure-core/src/uuid.cpp
+++ b/sdk/core/azure-core/src/uuid.cpp
@@ -3,10 +3,6 @@
 
 #include "azure/core/uuid.hpp"
 
-#if defined(AZ_PLATFORM_POSIX)
-#include <openssl/rand.h> //for RAND_bytes
-#endif
-
 #include <cstdio>
 #include <random>
 
@@ -45,7 +41,6 @@ namespace Azure { namespace Core {
   {
     uint8_t uuid[UuidSize] = {};
 
-#if defined(AZ_PLATFORM_WINDOWS)
     std::random_device rd;
 
     for (size_t i = 0; i < UuidSize; i += 4)
@@ -53,16 +48,6 @@ namespace Azure { namespace Core {
       const uint32_t x = rd();
       std::memcpy(uuid + i, &x, 4);
     }
-#elif defined(AZ_PLATFORM_POSIX)
-    // This static cast is safe since we know Uuid size, which is a const, will always fit an int.
-    int ret = RAND_bytes(uuid, static_cast<int>(UuidSize));
-    if (ret <= 0)
-    {
-      abort();
-    }
-#else
-    abort();
-#endif
 
     // SetVariant to ReservedRFC4122
     uuid[8] = (uuid[8] | ReservedRFC4122) & 0x7F;

--- a/sdk/core/azure-core/test/perf/inc/azure/core/test/uuid_test.hpp
+++ b/sdk/core/azure-core/test/perf/inc/azure/core/test/uuid_test.hpp
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ * @brief Test the Uuid component performance.
+ *
+ */
+
+#pragma once
+
+#include <azure/core.hpp>
+#include <azure/perf.hpp>
+
+#include <memory>
+
+namespace Azure { namespace Core { namespace Test {
+
+  /**
+   * @brief Measure the Uuid object performance.
+   */
+  class UuidTest : public Azure::Perf::PerfTest {
+  public:
+    /**
+     * @brief Construct a new Uuid test.
+     *
+     * @param options The test options.
+     */
+    UuidTest(Azure::Perf::TestOptions options) : PerfTest(options) {}
+
+    /**
+     * @brief Use Uuid to assing and read.
+     *
+     */
+    void Run(Azure::Core::Context const&) override
+    {
+      auto const total = m_options.GetMandatoryOption<int>("count");
+      for (auto count = 0; count < total; count++)
+      {
+        Azure::Core::Uuid::CreateUuid();
+      }
+    }
+
+    /**
+     * @brief Define the test options for the test.
+     *
+     * @return The list of test options.
+     */
+    std::vector<Azure::Perf::TestOption> GetTestOptions() override
+    {
+      return {{"count", {"-c"}, "The number of uuid objects to be created.", 1, true}};
+    }
+
+    /**
+     * @brief Get the static Test Metadata for the test.
+     *
+     * @return Azure::Perf::TestMetadata describing the test.
+     */
+    static Azure::Perf::TestMetadata GetTestMetadata()
+    {
+      return {
+          "UuidTest",
+          "Measures the overhead of using Uuid objects",
+          [](Azure::Perf::TestOptions options) {
+            return std::make_unique<Azure::Core::Test::UuidTest>(options);
+          }};
+    }
+  };
+
+}}} // namespace Azure::Core::Test

--- a/sdk/core/azure-core/test/perf/src/azure_core_perf_test.cpp
+++ b/sdk/core/azure-core/test/perf/src/azure_core_perf_test.cpp
@@ -4,6 +4,7 @@
 #include <azure/perf.hpp>
 
 #include "azure/core/test/nullable_test.hpp"
+#include "azure/core/test/uuid_test.hpp"
 
 #include <vector>
 
@@ -11,7 +12,9 @@ int main(int argc, char** argv)
 {
 
   // Create the test list
-  std::vector<Azure::Perf::TestMetadata> tests{Azure::Core::Test::NullableTest::GetTestMetadata()};
+  std::vector<Azure::Perf::TestMetadata> tests{
+      Azure::Core::Test::NullableTest::GetTestMetadata(),
+      Azure::Core::Test::UuidTest::GetTestMetadata()};
 
   Azure::Perf::Program::Run(Azure::Core::Context::ApplicationContext, tests, argc, argv);
 

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -33,6 +33,13 @@ endif()
 
 include(GoogleTest)
 
+if(BUILD_CRYPTO)
+ SET(AZURE_SDK_TEST_CRYPTO_SRC
+  md5_test.cpp
+  sha_test.cpp
+ )
+endif()
+
 add_executable (
   azure-core-test
     azure_core_test.cpp
@@ -56,7 +63,7 @@ add_executable (
     logging_test.cpp
     macro_guard_test.cpp
     match_conditions_test.cpp
-    md5_test.cpp
+    ${AZURE_SDK_TEST_CRYPTO_SRC}
     modified_conditions_test.cpp
     nullable_test.cpp
     operation_test.cpp
@@ -67,7 +74,6 @@ add_executable (
     request_id_policy_test.cpp
     response_t_test.cpp
     retry_policy_test.cpp
-    sha_test.cpp
     simplified_header_test.cpp
     string_test.cpp
     telemetry_policy_test.cpp

--- a/sdk/core/azure-core/test/ut/simplified_header_test.cpp
+++ b/sdk/core/azure-core/test/ut/simplified_header_test.cpp
@@ -34,7 +34,9 @@ TEST(SimplifiedHeader, core)
   EXPECT_NO_THROW(Azure::DateTime(2020, 11, 03, 15, 30, 44));
   EXPECT_NO_THROW(Azure::ETag e);
   EXPECT_NO_THROW(Azure::Core::Convert::Base64Decode("foo"));
+#if defined(AZURE_BUILD_CRYPTO)
   EXPECT_NO_THROW(Azure::Core::Cryptography::Md5Hash m);
+#endif
   EXPECT_NO_THROW(Azure::Core::Http::RawResponse r(
       1, 1, Azure::Core::Http::HttpStatusCode::Accepted, "phrase"));
   EXPECT_NO_THROW({


### PR DESCRIPTION
An azure-core lib version without OpenSSL is required for the speech service which will consume only UUID (and HTTP in some future).

This PR makes some changes to the current azure core components consuming OpenSSL :

- Uuid on Linux :  It is used to generate a random buffer.  Switching to use the win-implementation which uses the std lib <random> lib.
- base64 :  Removing the current implementation calling openSSL for base64 for the azure-core for C99 implementation created in the past by @antkmsft 
- Crypto / Hashing :  MD5 and Sha hashing is currently exposed on the public surface and implemented by calling OpenSSL lib.  This PR is making all the Cryptographic namespace an optional feature that can be opt-out when building the azure-core lib