### PR TITLE
Disable Key Vault Certificate live tests

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-certificates/test/ut/certificate_client_test.cpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/test/ut/certificate_client_test.cpp
@@ -13,7 +13,7 @@ using namespace std::chrono_literals;
 using namespace Azure::Security::KeyVault::Certificates;
 using namespace Azure::Security::KeyVault::Certificates::Test;
 
-TEST_F(KeyVaultCertificateClientTest, GetCertificate)
+TEST_F(KeyVaultCertificateClientTest, DISABLED_GetCertificate)
 {
   // cspell: disable-next-line
   std::string const certificateName("vivazqu");
@@ -80,7 +80,7 @@ TEST_F(KeyVaultCertificateClientTest, GetCertificate)
   }
 }
 
-TEST_F(KeyVaultCertificateClientTest, GetCertificateVersion)
+TEST_F(KeyVaultCertificateClientTest, DISABLED_GetCertificateVersion)
 {
   // cspell: disable-next-line
   std::string const certificateName("vivazqu");


### PR DESCRIPTION
Test are not ready on live mode as the ARM template is not updated with the required resources to be deployed.

This is blocking Keys and Secrets release.

Disabling tests for now and creating issue to re-enable the tests next: https://github.com/Azure/azure-sdk-for-cpp/issues/2850