### PR TITLE
Disable cert tests until CreateCertificateOperation is fixed.

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-certificates/test/ut/certificate_client_test.cpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/test/ut/certificate_client_test.cpp
@@ -15,10 +15,14 @@ using namespace Azure::Security::KeyVault::Certificates::Test;
 
 using namespace std::chrono_literals;
 
-TEST_F(KeyVaultCertificateClientTest, CreateCertificate)
+// NOTE:
+// Disabling test as the createCertificate operation is currently broken. See:
+// https://github.com/Azure/azure-sdk-for-cpp/issues/2938
+
+TEST_F(KeyVaultCertificateClientTest, DISABLED_CreateCertificate)
 {
   // cspell: disable-next-line
-  std::string const certificateName("vivazqu");
+  std::string const certificateName("magiqStuff289123");
 
   auto const& client
       = GetClientForTest(::testing::UnitTest::GetInstance()->current_test_info()->name());
@@ -29,7 +33,7 @@ TEST_F(KeyVaultCertificateClientTest, CreateCertificate)
   params.Policy.Enabled = true;
 
   params.Properties.Enabled = true;
-  params.Properties.Name = "magiqStuff2";
+  params.Properties.Name = certificateName;
   params.Policy.ContentType = CertificateContentType::Pkcs12;
   params.Policy.IssuerName = "Self";
 
@@ -38,14 +42,14 @@ TEST_F(KeyVaultCertificateClientTest, CreateCertificate)
   action.Action = CertificatePolicyAction::AutoRenew;
   params.Policy.LifetimeActions.emplace_back(action);
 
-  auto response = client.StartCreateCertificate("magiqStuff2", params);
+  auto response = client.StartCreateCertificate(certificateName, params);
   auto result = response.PollUntilDone(m_defaultWait);
 
   EXPECT_EQ(result.Value.Name(), params.Properties.Name);
   EXPECT_EQ(result.Value.Properties.Enabled.Value(), true);
 }
 
-TEST_F(KeyVaultCertificateClientTest, GetCertificate)
+TEST_F(KeyVaultCertificateClientTest, DISABLED_GetCertificate)
 {
   // cspell: disable-next-line
   std::string const certificateName("vivazqu");
@@ -132,7 +136,7 @@ TEST_F(KeyVaultCertificateClientTest, GetCertificate)
   }
 }
 
-TEST_F(KeyVaultCertificateClientTest, GetCertificateVersion)
+TEST_F(KeyVaultCertificateClientTest, DISABLED_GetCertificateVersion)
 {
   // cspell: disable-next-line
   std::string const certificateName("vivazqu2");


### PR DESCRIPTION
Workaround for: https://github.com/Azure/azure-sdk-for-cpp/issues/2938