### PR TITLE
Adding a static-blocking libcurl transport adapter

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Add the static libcurl transport adapter.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -39,8 +39,11 @@ if(BUILD_TRANSPORT_CURL)
     src/http/curl/curl_connection_private.hpp
     src/http/curl/curl_session_private.hpp
     src/http/curl/curl.cpp
+    src/http/curl/static_curl.cpp
   )
-  SET(CURL_TRANSPORT_ADAPTER_INC inc/azure/core/http/curl_transport.hpp)
+  SET(CURL_TRANSPORT_ADAPTER_INC
+    inc/azure/core/http/curl_transport.hpp
+    inc/azure/core/http/static_curl_transport.hpp)
 endif()
 if(BUILD_TRANSPORT_WINHTTP)
   SET(WIN_TRANSPORT_ADAPTER_SRC src/http/winhttp/win_http_transport.cpp)

--- a/sdk/core/azure-core/inc/azure/core/http/static_curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/static_curl_transport.hpp
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ * @brief #Azure::Core::Http::HttpTransport static implementation using libcurl won't produce real
+ * response streams. The HTTP responses are first statically downloaded within the transport
+ * adapter.
+ *
+ * @remark This transport adapater is less efficient than the non-static version. Use this
+ * implementation where performance ( memory and time ) is not a concern.
+ */
+
+#pragma once
+
+#include "azure/core/context.hpp"
+#include "azure/core/http/http.hpp"
+#include "azure/core/http/transport.hpp"
+
+namespace Azure { namespace Core { namespace Http {
+
+  /**
+   * @brief The available options to set libcurl SSL options.
+   *
+   * @remark The SDK will map the enum option to libcurl's specific option. See more info here:
+   * https://curl.haxx.se/libcurl/c/CURLOPT_SSL_OPTIONS.html
+   *
+   */
+  struct StaticCurlTransportSslOptions final
+  {
+    /**
+     * @brief This option can enable the revocation list check.
+     *
+     * @remark Libcurl does revocation list check by default for SSL backends that supports this
+     * feature. However, the Azure SDK overrides libcurl's behavior and disables the revocation list
+     * check by default.
+     *
+     */
+    bool EnableCertificateRevocationListCheck = false;
+  };
+
+  /**
+   * @brief Set the libcurl connection options like a proxy and CA path.
+   */
+  struct StaticCurlTransportOptions final
+  {
+    /**
+     * @brief The string for the proxy is passed directly to the libcurl handle without any parsing
+     *
+     * @remark No validation for the string is done by the Azure SDK. More about this option:
+     * https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html.
+     *
+     * @remark The default value is an empty string (no proxy).
+     *
+     */
+    std::string Proxy;
+    /**
+     * @brief The string for the certificate authenticator is sent to libcurl handle directly.
+     *
+     * @remark The Azure SDK will not check if the path is valid or not.
+     *
+     * @remark The default is the built-in system specific path. More about this option:
+     * https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html
+     *
+     */
+    std::string CAInfo;
+    /**
+     * @brief All HTTP requests will keep the connection channel open to the service.
+     *
+     * @remark The channel might be closed by the server if the server response has an error code.
+     * A connection won't be re-used if it is abandoned in the middle of an operation.
+     * operation.
+     *
+     * @remark This option is managed directly by the Azure SDK. No option is set for the curl
+     * handle. It is `true` by default.
+     */
+    bool HttpKeepAlive = true;
+    /**
+     * @brief This option determines whether libcurl verifies the authenticity of the peer's
+     * certificate.
+     *
+     * @remark The default value is `true`. More about this option:
+     * https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html
+     *
+     */
+    bool SslVerifyPeer = true;
+
+    /**
+     * @brief Define the SSL options for the libcurl handle.
+     *
+     * @remark See more info here: https://curl.haxx.se/libcurl/c/CURLOPT_SSL_OPTIONS.html.
+     * The default option is all options `false`.
+     *
+     */
+    StaticCurlTransportSslOptions SslOptions;
+  };
+
+  /**
+   * @brief Concrete implementation of an HTTP Transport that uses libcurl.
+   */
+  class StaticCurlTransport final : public HttpTransport {
+  private:
+    StaticCurlTransportOptions m_options;
+
+  public:
+    /**
+     * @brief Construct a new CurlTransport object.
+     *
+     * @param options Optional parameter to override the default options.
+     */
+    StaticCurlTransport(StaticCurlTransportOptions const& options = StaticCurlTransportOptions())
+        : m_options(options)
+    {
+    }
+
+    /**
+     * @brief Implements interface to send an HTTP Request and produce an HTTP RawResponse
+     *
+     * @param request an HTTP Request to be send.
+     * @param context A context to control the request lifetime.
+     *
+     * @return unique ptr to an HTTP RawResponse.
+     */
+    std::unique_ptr<RawResponse> Send(Request& request, Context const& context) override;
+  };
+
+}}} // namespace Azure::Core::Http

--- a/sdk/core/azure-core/src/http/curl/static_curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/static_curl.cpp
@@ -1,0 +1,485 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "azure/core/http/policies/policy.hpp"
+#include "azure/core/http/static_curl_transport.hpp"
+#include "azure/core/internal/diagnostics/log.hpp"
+
+#include <memory>
+
+#if defined(_MSC_VER)
+// C6101 : Returning uninitialized memory '*Mtu'->libcurl calling WSAGetIPUserMtu from WS2tcpip.h
+#pragma warning(push)
+#pragma warning(disable : 6101)
+#endif
+
+#include <curl/curl.h>
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+using Azure::Core::Context;
+using Azure::Core::Http::HttpStatusCode;
+using Azure::Core::Http::RawResponse;
+using Azure::Core::Http::Request;
+using Azure::Core::Http::TransportException;
+
+namespace {
+constexpr static const char* FailedToGetNewConnectionTemplate
+    = "[static impl] Fail to get a new connection for: ";
+
+template <typename T>
+#if defined(_MSC_VER)
+#pragma warning(push)
+// C26812: The enum type 'CURLoption' is un-scoped. Prefer 'enum class' over 'enum' (Enum.3)
+#pragma warning(disable : 26812)
+#endif
+inline bool SetStaticLibcurlOption(CURL* handle, CURLoption option, T value, CURLcode* outError)
+{
+  *outError = curl_easy_setopt(handle, option, value);
+  return *outError == CURLE_OK;
+}
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+class StaticCurlImpl final : public Azure::Core::IO::BodyStream {
+private:
+  CURL* m_libcurlHandle;
+  struct curl_slist* m_headerHandle = NULL;
+  Azure::Core::Http::StaticCurlTransportOptions m_options;
+  std::unique_ptr<RawResponse> m_response = nullptr;
+  std::vector<uint8_t> m_responseData;
+  std::vector<uint8_t> m_sendBuffer;
+  std::unique_ptr<Azure::Core::IO::BodyStream> m_responseStream;
+  bool m_isTransferEncodingChunked = false;
+
+  static std::unique_ptr<RawResponse> CreateHTTPResponse(
+      char const* const begin,
+      char const* const last)
+  {
+    // set response code, HTTP version and reason phrase (i.e. HTTP/1.1 200 OK)
+    auto start = begin + 5; // HTTP = 4, / = 1, moving to 5th place for version
+    auto end = std::find(start, last, '.');
+    auto majorVersion = std::stoi(std::string(start, end));
+
+    start = end + 1; // start of minor version
+    end = std::find(start, last, ' ');
+    auto minorVersion = std::stoi(std::string(start, end));
+
+    start = end + 1; // start of status code
+    end = std::find(start, last, ' ');
+    auto statusCode = std::stoi(std::string(start, end));
+
+    start = end + 1; // start of reason phrase
+    end = std::find(start, last, '\r');
+    auto reasonPhrase = std::string(start, end); // remove \r
+
+    // allocate the instance of response to heap with shared ptr
+    // So this memory gets delegated outside CurlTransport as a shared_ptr so memory will be
+    // eventually released
+    return std::make_unique<RawResponse>(
+        static_cast<uint16_t>(majorVersion),
+        static_cast<uint16_t>(minorVersion),
+        HttpStatusCode(statusCode),
+        reasonPhrase);
+  }
+
+  static void StaticSetHeader(
+      Azure::Core::Http::RawResponse& response,
+      char const* const first,
+      char const* const last)
+  {
+    // get name and value from header
+    auto start = first;
+    auto end = std::find(start, last, ':');
+
+    if ((last - first) == 2 && *start == '\r' && *(start + 1) == '\n')
+    {
+      // Libcurl gives the end of headers as `\r\n`, we just ignore it
+      return;
+    }
+
+    if (end == last)
+    {
+      throw std::invalid_argument("Invalid header. No delimiter ':' found.");
+    }
+
+    // Always toLower() headers
+    auto headerName = Azure::Core::_internal::StringExtensions::ToLower(std::string(start, end));
+    start = end + 1; // start value
+    while (start < last && (*start == ' ' || *start == '\t'))
+    {
+      ++start;
+    }
+
+    end = std::find(start, last, '\r');
+    auto headerValue = std::string(start, end); // remove \r
+
+    response.SetHeader(headerName, headerValue);
+  }
+
+  /***************************  CALL BACKS */
+
+  /**
+   * @brief This is the function that curl will use to write response into a user provider span
+   * Function receives the size of the response and must return this same number, otherwise it is
+   * consider that function failed
+   *
+   * @param contents response data from Curl response
+   * @param size size of the curl response data
+   * @param nmemb number of blocks in response
+   * @param userp this represent a structure linked to response by us before
+   * @return int
+   */
+  static size_t ReceiveInitialResponse(char* contents, size_t size, size_t nmemb, void* userp)
+  {
+    size_t const expectedSize = size * nmemb;
+    std::unique_ptr<RawResponse>* responseP = static_cast<std::unique_ptr<RawResponse>*>(userp);
+
+    // First response
+    if (*responseP == nullptr)
+    {
+      // parse header to get init data
+      *responseP = CreateHTTPResponse(contents, contents + expectedSize);
+    }
+    else
+    {
+      StaticSetHeader(*(*responseP), contents, contents + expectedSize);
+    }
+
+    // This callback needs to return the response size or curl will consider it as it failed
+    return expectedSize;
+  }
+
+  static size_t ReceiveData(void* contents, size_t size, size_t nmemb, void* userp)
+  {
+    size_t const expectedSize = size * nmemb;
+    std::vector<uint8_t>& responseP = *(static_cast<std::vector<uint8_t>*>(userp));
+    uint8_t* data = static_cast<uint8_t*>(contents);
+
+    responseP.insert(responseP.end(), data, data + expectedSize);
+
+    // This callback needs to return the response size or curl will consider it as it failed
+    return expectedSize;
+  }
+
+  static size_t UploadData(void* dst, size_t size, size_t nmemb, void* userdata)
+  {
+    // Calculate the size of the *dst buffer
+    auto destSize = nmemb * size;
+    Azure::Core::IO::BodyStream* uploadStream = static_cast<Azure::Core::IO::BodyStream*>(userdata);
+
+    // Terminate the upload if the destination buffer is too small
+    if (destSize < 1)
+    {
+      throw Azure::Core::Http::TransportException("Not enough size to continue to upload data.");
+    }
+
+    // Copy as many bytes as possible from the stream to libcurl's destination buffer
+    return uploadStream->Read(static_cast<uint8_t*>(dst), destSize);
+  }
+
+  size_t OnRead(uint8_t* buffer, size_t count, Azure::Core::Context const& context) override
+  {
+    return m_responseStream->Read(buffer, count, context);
+  }
+
+public:
+  StaticCurlImpl(
+      Azure::Core::Http::StaticCurlTransportOptions const& options
+      = Azure::Core::Http::StaticCurlTransportOptions())
+      : m_options(options)
+  {
+    // ******************************************************************
+    // ***************************************************  INIT ******
+    // ******************************************************************
+    m_libcurlHandle = curl_easy_init();
+    if (!m_libcurlHandle)
+    {
+      throw Azure::Core::Http::TransportException("Failed to create libcurl handle");
+    }
+  }
+
+  ~StaticCurlImpl()
+  {
+    if (m_headerHandle)
+    {
+      curl_slist_free_all(m_headerHandle);
+    }
+
+    if (m_libcurlHandle)
+    {
+      curl_easy_cleanup(m_libcurlHandle);
+    }
+  }
+
+  std::unique_ptr<RawResponse> Send(Request& request, Context const& context)
+  {
+    context.ThrowIfCancelled();
+    uint16_t port = request.GetUrl().GetPort();
+    std::string const& host = request.GetUrl().GetScheme() + request.GetUrl().GetHost()
+        + (port != 0 ? std::to_string(port) : "");
+
+    // ******************************************************************
+    // ***************************************************  SET UP ******
+    // ******************************************************************
+    CURLcode result;
+    // Libcurl setup before open connection (url, connect_only, timeout)
+    if (!SetStaticLibcurlOption(
+            m_libcurlHandle, CURLOPT_URL, request.GetUrl().GetAbsoluteUrl().data(), &result))
+    {
+      throw Azure::Core::Http::TransportException(
+          FailedToGetNewConnectionTemplate + host + ". " + std::string(curl_easy_strerror(result)));
+    }
+    if (port != 0 && !SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_PORT, port, &result))
+    {
+      throw Azure::Core::Http::TransportException(
+          FailedToGetNewConnectionTemplate + host + ". " + std::string(curl_easy_strerror(result)));
+    }
+    if (!m_options.Proxy.empty())
+    {
+      if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_PROXY, m_options.Proxy.c_str(), &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set proxy to:" + m_options.Proxy
+            + ". " + std::string(curl_easy_strerror(result)));
+      }
+    }
+    if (!m_options.CAInfo.empty())
+    {
+      if (!SetStaticLibcurlOption(
+              m_libcurlHandle, CURLOPT_CAINFO, m_options.CAInfo.c_str(), &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set CA cert to:"
+            + m_options.CAInfo + ". " + std::string(curl_easy_strerror(result)));
+      }
+    }
+    long sslOption = 0;
+    if (!m_options.SslOptions.EnableCertificateRevocationListCheck)
+    {
+      sslOption |= CURLSSLOPT_NO_REVOKE;
+    }
+    if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_SSL_OPTIONS, sslOption, &result))
+    {
+      throw Azure::Core::Http::TransportException(
+          FailedToGetNewConnectionTemplate + host + ". Failed to set ssl options to long bitmask:"
+          + std::to_string(sslOption) + ". " + std::string(curl_easy_strerror(result)));
+    }
+    if (!m_options.SslVerifyPeer)
+    {
+      if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_SSL_VERIFYPEER, 0L, &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to disable ssl verify peer." + ". "
+            + std::string(curl_easy_strerror(result)));
+      }
+    }
+
+    // headers sep-up
+    auto const& headers = request.GetHeaders();
+    if (headers.size() > 0)
+    {
+      for (auto const& header : headers)
+      {
+        auto newHandle
+            = curl_slist_append(m_headerHandle, (header.first + ":" + header.second).c_str());
+        if (newHandle == NULL)
+        {
+          throw Azure::Core::Http::TransportException("Failing creating header list for libcurl");
+        }
+        m_headerHandle = newHandle;
+      }
+      if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_HTTPHEADER, m_headerHandle, &result))
+      {
+        throw Azure::Core::Http::TransportException(". Failed to set header.");
+      }
+    }
+
+    // Callback set up
+    if (!SetStaticLibcurlOption(
+            m_libcurlHandle, CURLOPT_HEADERFUNCTION, ReceiveInitialResponse, &result))
+    {
+      throw Azure::Core::Http::TransportException(
+          FailedToGetNewConnectionTemplate + host + ". Failed to set headers callback." + ". "
+          + std::string(curl_easy_strerror(result)));
+    }
+
+    if (!SetStaticLibcurlOption(
+            m_libcurlHandle, CURLOPT_HEADERDATA, static_cast<void*>(&m_response), &result))
+    {
+      throw Azure::Core::Http::TransportException(
+          FailedToGetNewConnectionTemplate + host + ". Failed to set headers data." + ". "
+          + std::string(curl_easy_strerror(result)));
+    }
+    if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_WRITEFUNCTION, ReceiveData, &result))
+    {
+      throw Azure::Core::Http::TransportException(
+          FailedToGetNewConnectionTemplate + host + ". Failed to set data callback." + ". "
+          + std::string(curl_easy_strerror(result)));
+    }
+
+    if (!SetStaticLibcurlOption(
+            m_libcurlHandle, CURLOPT_WRITEDATA, static_cast<void*>(&m_responseData), &result))
+    {
+      throw Azure::Core::Http::TransportException(
+          FailedToGetNewConnectionTemplate + host + ". Failed to set write data." + ". "
+          + std::string(curl_easy_strerror(result)));
+    }
+
+    // Method set up
+    auto const& method = request.GetMethod();
+    if (method == Azure::Core::Http::HttpMethod::Delete)
+    {
+      if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_CUSTOMREQUEST, "DELETE", &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set DELETE Method." + ". "
+            + std::string(curl_easy_strerror(result)));
+      }
+    }
+    else if (method == Azure::Core::Http::HttpMethod::Patch)
+    {
+      if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_CUSTOMREQUEST, "PATCH", &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set PATCH Method." + ". "
+            + std::string(curl_easy_strerror(result)));
+      }
+    }
+    else if (method == Azure::Core::Http::HttpMethod::Head)
+    {
+      if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_NOBODY, 1L, &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set HEAD Method." + ". "
+            + std::string(curl_easy_strerror(result)));
+      }
+    }
+    else if (method == Azure::Core::Http::HttpMethod::Post)
+    {
+      // Adds special header "Expect:" for libcurl to avoid sending only headers to server and wait
+      // for a 100 Continue response before sending a PUT method
+      auto newHandle = curl_slist_append(m_headerHandle, "Expect:");
+      if (newHandle == NULL)
+      {
+        throw Azure::Core::Http::TransportException("Failing adding Expect header for POST");
+      }
+      m_headerHandle = newHandle;
+
+      m_sendBuffer = request.GetBodyStream()->ReadToEnd();
+      m_sendBuffer.emplace_back('\0'); // the body is expected to be null terminated
+      if (!SetStaticLibcurlOption(
+              m_libcurlHandle,
+              CURLOPT_POSTFIELDS,
+              reinterpret_cast<char*>(m_sendBuffer.data()),
+              &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set POST Data." + ". "
+            + std::string(curl_easy_strerror(result)));
+      }
+    }
+    else if (method == Azure::Core::Http::HttpMethod::Put)
+    {
+      // As of CURL 7.12.1 CURLOPT_PUT is deprecated.  PUT requests should be made using
+      // CURLOPT_UPLOAD
+
+      // Adds special header "Expect:" for libcurl to avoid sending only headers to server and wait
+      // for a 100 Continue response before sending a PUT method
+      auto newHandle = curl_slist_append(m_headerHandle, "Expect:");
+      if (newHandle == NULL)
+      {
+        throw Azure::Core::Http::TransportException("Failing adding Expect header for POST");
+      }
+      m_headerHandle = newHandle;
+
+      if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_UPLOAD, 1L, &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set Curl handle to PUT mode"
+            + ". " + std::string(curl_easy_strerror(result)));
+      }
+
+      if (!SetStaticLibcurlOption(m_libcurlHandle, CURLOPT_READFUNCTION, UploadData, &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set Upload callback" + ". "
+            + std::string(curl_easy_strerror(result)));
+      }
+
+      auto uploadStream = request.GetBodyStream();
+      if (!SetStaticLibcurlOption(
+              m_libcurlHandle, CURLOPT_READDATA, static_cast<void*>(uploadStream), &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set Upload body Stream" + ". "
+            + std::string(curl_easy_strerror(result)));
+      }
+      if (!SetStaticLibcurlOption(
+              m_libcurlHandle,
+              CURLOPT_INFILESIZE,
+              static_cast<curl_off_t>(uploadStream->Length()),
+              &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host + ". Failed to set Upload body Stream Size"
+            + ". " + std::string(curl_easy_strerror(result)));
+      }
+    }
+
+    // ******************************************************************
+    // ***************************************************  PERFORM & RECEIVE ******
+    // ******************************************************************
+    // curl_easy_perform will block the program until all the response is received
+    auto performResult = curl_easy_perform(m_libcurlHandle);
+    if (performResult != CURLE_OK)
+    {
+      throw Azure::Core::Http::TransportException(
+          FailedToGetNewConnectionTemplate + host + ". "
+          + std::string(curl_easy_strerror(performResult)));
+    }
+
+    // At this point, libcurl has read all the response from server successfully and the response
+    // was written to `m_responseData`. Let's init a memoryBodyStream to enable this class to bahave
+    // as a bodyStream.
+    m_responseStream = std::make_unique<Azure::Core::IO::MemoryBodyStream>(m_responseData);
+
+    auto const& responseHeaders = m_response->GetHeaders();
+    auto isTransferEncodingHeaderInResponse = responseHeaders.find("transfer-encoding");
+    if (isTransferEncodingHeaderInResponse != responseHeaders.end())
+    {
+      // if `chunked` is found inside the transfer-encoding, we activate the
+      // isTransferEncodingChunked flag. The static-libcurl implementation handles downloading a
+      // chunked response. The entire response is already downloaded, so we will just use the header
+      // to modify the way the body stream behaves so it acts as an unknown-size memory stream.
+      auto headerValue = isTransferEncodingHeaderInResponse->second;
+      m_isTransferEncodingChunked = headerValue.find("chunked") != std::string::npos;
+    }
+
+    // ******************************************************************
+    // ***************************************************  Return response ******
+    // ******************************************************************
+    return std::move(m_response);
+  }
+
+  int64_t Length() const override
+  {
+    return m_isTransferEncodingChunked ? -1 : m_responseStream->Length();
+  }
+
+  void Rewind() override { return m_responseStream->Rewind(); }
+};
+} // namespace
+
+std::unique_ptr<RawResponse> Azure::Core::Http::StaticCurlTransport::Send(
+    Request& request,
+    Context const& context)
+{
+  auto client = std::make_unique<StaticCurlImpl>(m_options);
+  auto response = client->Send(request, context);
+  response->SetBodyStream(std::move(client));
+  return response;
+}

--- a/sdk/core/azure-core/test/ut/transport_adapter_base_test.hpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base_test.hpp
@@ -80,19 +80,14 @@ namespace Azure { namespace Core { namespace Test {
     // Befor each test, create pipeline
     virtual void SetUp() override
     {
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> retryPolicies;
       std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-      Azure::Core::Http::Policies::RetryOptions opt;
-      opt.RetryDelay = std::chrono::milliseconds(10);
 
-      // Retry policy will help to prevent server-occasionally-errors
-      policies.push_back(
-          std::make_unique<Azure::Core::Http::Policies::_internal::RetryPolicy>(opt));
-      // Will get transport policy options from test param
-      // auto param = GetParam();
-      policies.push_back(std::make_unique<Azure::Core::Http::Policies::_internal::TransportPolicy>(
-          GetParam().TransportAdapter));
-
-      m_pipeline = std::make_unique<Azure::Core::Http::_internal::HttpPipeline>(policies);
+      Azure::Core::_internal::ClientOptions op;
+      op.Retry.RetryDelay = std::chrono::milliseconds(10);
+      op.Transport = GetParam().TransportAdapter;
+      m_pipeline = std::make_unique<Azure::Core::Http::_internal::HttpPipeline>(
+          op, "TransportTest", "X.X", std::move(retryPolicies), std::move(policies));
     }
 
     static void CheckBodyFromBuffer(

--- a/sdk/core/azure-core/test/ut/transport_adapter_implementation_test.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_implementation_test.cpp
@@ -8,6 +8,7 @@
 
 #if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
 #include "azure/core/http/curl_transport.hpp"
+#include "azure/core/http/static_curl_transport.hpp"
 #endif
 
 #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
@@ -54,7 +55,10 @@ namespace Azure { namespace Core { namespace Test {
       TransportAdapter,
       testing::Values(
           GetTransportOptions("winHttp", std::make_shared<Azure::Core::Http::WinHttpTransport>()),
-          GetTransportOptions("libCurl", std::make_shared<Azure::Core::Http::CurlTransport>())),
+          GetTransportOptions("libCurl", std::make_shared<Azure::Core::Http::CurlTransport>()),
+          GetTransportOptions(
+              "staticLibCurl",
+              std::make_shared<Azure::Core::Http::StaticCurlTransport>())),
       GetSuffix);
 
 #elif defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
@@ -72,7 +76,10 @@ namespace Azure { namespace Core { namespace Test {
       Test,
       TransportAdapter,
       testing::Values(
-          GetTransportOptions("libCurl", std::make_shared<Azure::Core::Http::CurlTransport>())),
+          GetTransportOptions("libCurl", std::make_shared<Azure::Core::Http::CurlTransport>()),
+          GetTransportOptions(
+              "staticLibCurl",
+              std::make_shared<Azure::Core::Http::StaticCurlTransport>())),
       GetSuffix);
 #else
   /* Custom adapter. Not adding tests */


### PR DESCRIPTION
This is an alternative implementation of the main libcurl transport adapter.

This implementation downloads an entire http response as the last step of the `send()` routine. Because of that, this adapter will fake the delayed-response-download from a bodyStream ( will not pull bytes directly from the network/socket, but from the already downloaded response in memory).  The implementation causes a buffer of the same size as the response payload.

Do not use this adapter for big downloads (like big blob download).

This adapter is a quick alternative in case of the main libcurl adapter for cases when performance and size of the response payload is not a concern. 