### PR TITLE
Fix build warning in no-RTTI config

### DIFF
--- a/sdk/core/azure-core/test/ut/context_test.cpp
+++ b/sdk/core/azure-core/test/ut/context_test.cpp
@@ -437,6 +437,7 @@ TEST(Context, Deadline)
   }
 }
 
+#if defined(AZ_CORE_RTTI)
 TEST(Context, PreCondition)
 {
   // Get a mismatch type from the context
@@ -450,17 +451,14 @@ TEST(Context, PreCondition)
   int value;
 
 // Type-safe assert requires RTTI build
-#if defined(AZ_CORE_RTTI)
 #if defined(NDEBUG)
   // Release build won't provide assert msg
   ASSERT_DEATH(c2.TryGetValue<int>(key, value), "");
 #else
   ASSERT_DEATH(c2.TryGetValue<int>(key, value), "Type mismatch for Context::TryGetValue");
 #endif
-#else
-  static_cast<void>(value);
-#endif
 }
+#endif
 
 TEST(Context, KeyTypePairPrecondition)
 {


### PR DESCRIPTION
Fixes nightly Live Test build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1149929&view=logs&j=72f2a3f5-1430-5491-11d2-f6b8dc003a51&t=e385f59f-a70d-517a-2e2c-0aa9d5c04cf2