### PR TITLE
Adding timeout option to the libcurl transport adapter

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Features Added
 
 - Add the static libcurl transport adapter.
-- Add `NoSignal` option to the `curlTransportAdapter`.
+- Add `NoSignal` option to the `CurlTransportAdapter`.
+- Add `ConnectionTimeout` option to the `CurlTransportAdapter`.
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -40,6 +40,13 @@ namespace Azure { namespace Core { namespace Http {
   struct CurlTransportOptions final
   {
     /**
+     * @brief Default Maximum time in seconds that you allow the connection phase to the server to
+     * take.
+     *
+     */
+    AZ_CORE_DLLEXPORT static const long DefaultConnectionTimeout = 300;
+
+    /**
      * @brief The string for the proxy is passed directly to the libcurl handle without any parsing
      *
      * @remark No validation for the string is done by the Azure SDK. More about this option:
@@ -98,6 +105,15 @@ namespace Azure { namespace Core { namespace Http {
      *
      */
     bool NoSignal = false;
+
+    /**
+     * @brief Contain the maximum time in seconds that you allow the connection phase to the server
+     * to take.
+     *
+     * @details This only limits the connection phase, it has no impact once it has connected.
+     *
+     */
+    long ConnectionTimeout = DefaultConnectionTimeout;
   };
 
   /**

--- a/sdk/core/azure-core/inc/azure/core/http/static_curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/static_curl_transport.hpp
@@ -44,6 +44,14 @@ namespace Azure { namespace Core { namespace Http {
    */
   struct StaticCurlTransportOptions final
   {
+
+    /**
+     * @brief Default Maximum time in seconds that you allow the connection phase to the server to
+     * take.
+     *
+     */
+    AZ_CORE_DLLEXPORT static const long DefaultConnectionTimeout = 300;
+
     /**
      * @brief The string for the proxy is passed directly to the libcurl handle without any parsing
      *
@@ -103,6 +111,15 @@ namespace Azure { namespace Core { namespace Http {
      *
      */
     bool NoSignal = false;
+
+    /**
+     * @brief Contain the maximum time in seconds that you allow the connection phase to the server
+     * to take.
+     *
+     * @details This only limits the connection phase, it has no impact once it has connected.
+     *
+     */
+    long ConnectionTimeout = DefaultConnectionTimeout;
   };
 
   /**

--- a/sdk/core/azure-core/src/http/curl/static_curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/static_curl.cpp
@@ -300,6 +300,19 @@ public:
       }
     }
 
+    if (m_options.ConnectionTimeout
+        != Azure::Core::Http::StaticCurlTransportOptions::DefaultConnectionTimeout)
+    {
+      if (!SetStaticLibcurlOption(
+              m_libcurlHandle, CURLOPT_CONNECTTIMEOUT, m_options.ConnectionTimeout, &result))
+      {
+        throw Azure::Core::Http::TransportException(
+            FailedToGetNewConnectionTemplate + host
+            + ". Fail setting connect timeout to: " + std::to_string(m_options.ConnectionTimeout)
+            + ". " + std::string(curl_easy_strerror(result)));
+      }
+    }
+
     // headers sep-up
     auto const& headers = request.GetHeaders();
     if (headers.size() > 0)

--- a/sdk/core/azure-core/test/ut/curl_connection_pool_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_connection_pool_test.cpp
@@ -45,7 +45,7 @@ namespace Azure { namespace Core { namespace Test {
       Azure::Core::Http::Request req(
           Azure::Core::Http::HttpMethod::Get, Azure::Core::Url(AzureSdkHttpbinServer::Get()));
       std::string const expectedConnectionKey
-          = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "00110";
+          = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "001100";
 
       {
         // Creating a new connection with default options
@@ -114,7 +114,7 @@ namespace Azure { namespace Core { namespace Test {
 
       // Now test that using a different connection config won't re-use the same connection
       std::string const secondExpectedKey
-          = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "00100";
+          = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "001000";
       {
         // Creating a new connection with options
         Azure::Core::Http::CurlTransportOptions options;
@@ -394,7 +394,7 @@ namespace Azure { namespace Core { namespace Test {
         Azure::Core::Http::Request req(
             Azure::Core::Http::HttpMethod::Get, Azure::Core::Url(authority));
         std::string const expectedConnectionKey
-            = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "00110";
+            = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "001100";
 
         // Creating a new connection with default options
         auto connection = Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool
@@ -430,7 +430,7 @@ namespace Azure { namespace Core { namespace Test {
         Azure::Core::Http::Request req(
             Azure::Core::Http::HttpMethod::Get, Azure::Core::Url(authority));
         std::string const expectedConnectionKey
-            = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "44300110";
+            = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "443001100";
 
         // Creating a new connection with default options
         auto connection = Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool
@@ -467,7 +467,7 @@ namespace Azure { namespace Core { namespace Test {
         Azure::Core::Http::Request req(
             Azure::Core::Http::HttpMethod::Get, Azure::Core::Url(authority));
         std::string const expectedConnectionKey
-            = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "00110";
+            = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "001100";
 
         // Creating a new connection with default options
         auto connection = Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool
@@ -502,7 +502,7 @@ namespace Azure { namespace Core { namespace Test {
         Azure::Core::Http::Request req(
             Azure::Core::Http::HttpMethod::Get, Azure::Core::Url(authority));
         std::string const expectedConnectionKey
-            = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "44300110";
+            = AzureSdkHttpbinServer::Schema() + AzureSdkHttpbinServer::Host() + "443001100";
 
         // Creating a new connection with default options
         auto connection = Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/2990
