### PR TITLE
Proposal: (Slightly) Breaking Change: Move AzureNoReturnPath() from global namespace to Azure internal namespace

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -49,7 +49,9 @@
 
 #endif
 
-[[noreturn]] void AzureNoReturnPath(std::string const& msg);
+namespace Azure { namespace Core { namespace _internal {
+  [[noreturn]] void AzureNoReturnPath(std::string const& msg);
+}}} // namespace Azure::Core::_internal
 
 #define AZURE_ASSERT_FALSE(exp) AZURE_ASSERT(!(exp))
 #define AZURE_UNREACHABLE_CODE() AzureNoReturnPath("unreachable code!")

--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -54,5 +54,5 @@ namespace Azure { namespace Core { namespace _internal {
 }}} // namespace Azure::Core::_internal
 
 #define AZURE_ASSERT_FALSE(exp) AZURE_ASSERT(!(exp))
-#define AZURE_UNREACHABLE_CODE() AzureNoReturnPath("unreachable code!")
-#define AZURE_NOT_IMPLEMENTED() AzureNoReturnPath("not implemented code!")
+#define AZURE_UNREACHABLE_CODE() ::Azure::Core::_internal::AzureNoReturnPath("unreachable code!")
+#define AZURE_NOT_IMPLEMENTED() ::Azure::Core::_internal::AzureNoReturnPath("not implemented code!")

--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -50,7 +50,7 @@
 #endif
 
 namespace Azure { namespace Core { namespace _internal {
-  [[noreturn]] void AzureNoReturnPath(std::string const& msg);
+  extern [[noreturn]] void AzureNoReturnPath(std::string const& msg);
 }}} // namespace Azure::Core::_internal
 
 #define AZURE_ASSERT_FALSE(exp) AZURE_ASSERT(!(exp))

--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -50,7 +50,7 @@
 #endif
 
 namespace Azure { namespace Core { namespace _internal {
-  [[noreturn]] extern void AzureNoReturnPath(std::string const& msg);
+  [[noreturn]] void AzureNoReturnPath(std::string const& msg);
 }}} // namespace Azure::Core::_internal
 
 #define AZURE_ASSERT_FALSE(exp) AZURE_ASSERT(!(exp))

--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include "platform.hpp"
+#include "azure/core/platform.hpp"
 
 #include <cstdlib>
 #include <string>

--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -50,7 +50,7 @@
 #endif
 
 namespace Azure { namespace Core { namespace _internal {
-  extern [[noreturn]] void AzureNoReturnPath(std::string const& msg);
+  [[noreturn]] extern void AzureNoReturnPath(std::string const& msg);
 }}} // namespace Azure::Core::_internal
 
 #define AZURE_ASSERT_FALSE(exp) AZURE_ASSERT(!(exp))

--- a/sdk/core/azure-core/src/azure_assert.cpp
+++ b/sdk/core/azure-core/src/azure_assert.cpp
@@ -3,9 +3,7 @@
 
 #include "azure/core/azure_assert.hpp"
 
-using namespace Azure::Core::_internal;
-
-[[noreturn]] void AzureNoReturnPath(std::string const& msg)
+[[noreturn]] void Azure::Core::_internal::AzureNoReturnPath(std::string const& msg)
 {
   // void msg for Release build where Assert is ignored
   (void)msg;

--- a/sdk/core/azure-core/src/azure_assert.cpp
+++ b/sdk/core/azure-core/src/azure_assert.cpp
@@ -3,6 +3,8 @@
 
 #include "azure/core/azure_assert.hpp"
 
+using namespace Azure::Core::_internal;
+
 [[noreturn]] void AzureNoReturnPath(std::string const& msg)
 {
   // void msg for Release build where Assert is ignored


### PR DESCRIPTION
Closes #2834.

This is a lite (less breaking) version of #3059. See that PR for context.

"Still breaking" because, in theory, users may have been calling `AzureNoReturnPath()` from their code. No reasons to do that, but to be pedantically correct, that's hypothetically possible.