### PR TITLE
Reduce incidence of build storms

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -14,6 +14,9 @@ parameters:
   - name: CtestRegex
     type: string
     default: .*
+  - name: CtestExcludeRegex
+    type: string
+    default: ''
   - name: BuildReleaseArtifacts
     type: boolean
     default: true
@@ -41,6 +44,7 @@ jobs:
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
         TestPipeline: ${{ parameters.TestPipeline }}
         CtestRegex: ${{ parameters.CtestRegex }}
+        CtestExcludeRegex: ${{ parameters.CtestExcludeRegex }}
         CoverageReportPath: ${{ parameters.CoverageReportPath }}
         CoverageEnabled: ${{ parameters.CoverageEnabled }}
         LineCoverageTarget: ${{ parameters.LineCoverageTarget }}

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -137,6 +137,7 @@ jobs:
             --no-compress-output `
             -T Test
         workingDirectory: build
+        displayName: Test
 
       - task: PublishTestResults@2
         inputs:

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -11,6 +11,9 @@ parameters:
   - name: CtestRegex
     type: string
     default: .*
+  - name: CtestExcludeRegex
+    type: string
+    default: ''
   - name: CoverageReportPath
     type: string
     default: 'sdk/*/*/*cov_xml.xml'
@@ -125,7 +128,14 @@ jobs:
           BuildArgs: "$(BuildArgs)"
           Env: "$(CmakeEnvArg)"
 
-      - script: ctest -C Debug -V --tests-regex ${{ parameters.CtestRegex }} --no-compress-output -T Test
+      - pwsh: |
+          ctest `
+            -C Debug `
+            -V `
+            --tests-regex '${{ parameters.CtestRegex }}' `
+            --exclude-regex '${{ parameters.CtestExcludeRegex }}' `
+            --no-compress-output `
+            -T Test
         workingDirectory: build
 
       - task: PublishTestResults@2

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -153,7 +153,7 @@ stages:
                         parameters:
                           WorkingDirectory: $(Pipeline.Workspace)/vcpkg
 
-                      # SkipCheckingForChanges is true to skip the commit step 
+                      # SkipCheckingForChanges is true to skip the commit step
                       # (which is already done by Update-VcpkgPort.ps1)
                       - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                         parameters:
@@ -220,6 +220,8 @@ stages:
                             -IssueNumber "$(Submitted.PullRequest.Number)" `
                             -Comment $prComment
                         displayName: Comment notification to PR
+                        # Failure to comment on the PR should not block release
+                        continueOnError: true
 
           - ${{if ne(artifact.skipUpdatePackageVersion, 'true')}}:
             - deployment: UpdatePackageVersion

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -220,8 +220,6 @@ stages:
                             -IssueNumber "$(Submitted.PullRequest.Number)" `
                             -Comment $prComment
                         displayName: Comment notification to PR
-                        # Failure to comment on the PR should not block release
-                        continueOnError: true
 
           - ${{if ne(artifact.skipUpdatePackageVersion, 'true')}}:
             - deployment: UpdatePackageVersion

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -5,6 +5,9 @@ parameters:
 - name: CtestRegex
   type: string
   default: .*
+- name: CtestExcludeRegex
+  type: string
+  default: ''
 - name: CoverageEnabled
   type: boolean
   default: true
@@ -41,6 +44,7 @@ stages:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           Artifacts: ${{ parameters.Artifacts }}
           CtestRegex: ${{ parameters.CtestRegex }}
+          CtestExcludeRegex: ${{ parameters.CtestExcludeRegex }}
           CoverageEnabled: ${{ parameters.CoverageEnabled }}
           CoverageReportPath: ${{ parameters.CoverageReportPath }}
           LineCoverageTarget: ${{ parameters.LineCoverageTarget }}

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -38,7 +38,8 @@ stages:
       # In the case of changes to core we want to re-run all CI tests for all
       # libraries to check for potential regressions everywhere.
       CtestRegex: .*
-      CtestExcludeRegex: livetest
+      # Storage tests are live-only tests and must be excluded from CI runs
+      CtestExcludeRegex: livetest|azure-storage
       LiveTestCtestRegex: '"azure-core.|json-test"'
       LiveTestTimeoutInMinutes: 90 # default is 60 min. We need a little longer on worst case for Win+jsonTests
       LineCoverageTarget: 77

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -38,6 +38,7 @@ stages:
       # In the case of changes to core we want to re-run all CI tests for all
       # libraries to check for potential regressions everywhere.
       CtestRegex: .*
+      CtestExcludeRegex: livetest
       LiveTestCtestRegex: '"azure-core.|json-test"'
       LiveTestTimeoutInMinutes: 90 # default is 60 min. We need a little longer on worst case for Win+jsonTests
       LineCoverageTarget: 77

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -1,5 +1,6 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 trigger:
+  batch: true
   branches:
     include:
       - master
@@ -34,7 +35,9 @@ stages:
     parameters:
       ServiceDirectory: core
       # CI has static code analysis disabled, while LiveTest will have it enabled
-      CtestRegex: azure-core.
+      # In the case of changes to core we want to re-run all CI tests for all
+      # libraries to check for potential regressions everywhere.
+      CtestRegex: .*
       LiveTestCtestRegex: '"azure-core.|json-test"'
       LiveTestTimeoutInMinutes: 90 # default is 60 min. We need a little longer on worst case for Win+jsonTests
       LineCoverageTarget: 77

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -1,5 +1,6 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 trigger:
+  batch: true
   branches:
     include:
       - main
@@ -8,9 +9,6 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - eng/
-      - CMakeLists.txt
-      - sdk/core
       - sdk/identity
 
 pr:
@@ -22,9 +20,6 @@ pr:
       - hotfix/*
   paths:
     include:
-      - eng/
-      - CMakeLists.txt
-      - sdk/core
       - sdk/identity
 
 stages:

--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -1,5 +1,6 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 trigger:
+  batch: true
   branches:
     include:
       - main
@@ -8,10 +9,6 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - cmake-modules/
-      - eng/
-      - CMakeLists.txt
-      - sdk/core
       - sdk/keyvault
 
 pr:
@@ -23,10 +20,6 @@ pr:
       - hotfix/*
   paths:
     include:
-      - cmake-modules/
-      - eng/
-      - CMakeLists.txt
-      - sdk/core/
       - sdk/keyvault
 
 stages:

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -15,6 +15,19 @@ trigger:
       - sdk/identity
       - sdk/storage
 
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+triggers:
+  batch: true
+  branches:
+    include:
+      - main
+      - feature/*
+      - release/*
+      - hotfix/*
+  paths:
+    include:
+      - sdk/storage
+
 pr:
   branches:
     include:
@@ -24,11 +37,6 @@ pr:
       - hotfix/*
   paths:
     include:
-      - cmake-modules/
-      - eng/
-      - CMakeLists.txt
-      - sdk/core/
-      - sdk/identity/
       - sdk/storage
 
 stages:

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -8,24 +8,6 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - cmake-modules/
-      - eng/
-      - CMakeLists.txt
-      - sdk/core
-      - sdk/identity
-      - sdk/storage
-
-# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
-triggers:
-  batch: true
-  branches:
-    include:
-      - main
-      - feature/*
-      - release/*
-      - hotfix/*
-  paths:
-    include:
       - sdk/storage
 
 pr:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -1,5 +1,6 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 trigger:
+  batch: true
   branches:
     include:
       - main
@@ -8,10 +9,6 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - cmake-modules/
-      - eng/
-      - CMakeLists.txt
-      - sdk/core
       - sdk/template
 
 pr:
@@ -23,10 +20,6 @@ pr:
       - hotfix/*
   paths:
     include:
-      - cmake-modules/
-      - eng/
-      - CMakeLists.txt
-      - sdk/core/
       - sdk/template
 
 stages:


### PR DESCRIPTION
* Narrow build targeting
* Use batching so changes to `main` don't trigger builds for every checkin if there are other builds running [docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#batching-ci-runs)
* Expand core CI to test everything (this may not be sustainable as projects grow) ... A sparse testing matrix in these scenarios may be preferable. 