### PR TITLE
Do not initialize statics in inline functions

### DIFF
--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -118,15 +118,16 @@ set(
     src/io/random_access_file_body_stream.cpp
     src/private/environment_log_level_listener.hpp
     src/private/package_version.hpp
-    src/uuid.cpp
     src/base64.cpp
     src/context.cpp
     src/datetime.cpp
     src/environment_log_level_listener.cpp
+    src/etag.cpp
     src/exception.cpp
     src/logger.cpp
     src/operation_status.cpp
     src/strings.cpp
+    src/uuid.cpp
 )
 
 add_library(azure-core ${AZURE_CORE_HEADER} ${AZURE_CORE_SOURCE})

--- a/sdk/core/azure-core/inc/azure/core/etag.hpp
+++ b/sdk/core/azure-core/inc/azure/core/etag.hpp
@@ -183,10 +183,6 @@ public:
    * @brief #Azure::Core::ETag representing everything.
    * @note The any #Azure::Core::ETag is *, (unquoted).  It is NOT the same as "*".
    */
-  static const ETag& Any()
-  {
-    static ETag any = ETag("*");
-    return any;
-  }
+  static const ETag& Any();
 };
 } // namespace Azure

--- a/sdk/core/azure-core/inc/azure/core/internal/io/null_body_stream.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/io/null_body_stream.hpp
@@ -38,11 +38,7 @@ namespace Azure { namespace Core { namespace IO { namespace _internal {
      * @brief Gets a singleton instance of a #Azure::Core::IO::_internal::NullBodyStream.
      *
      */
-    static NullBodyStream* GetNullBodyStream()
-    {
-      static NullBodyStream nullBodyStream;
-      return &nullBodyStream;
-    }
+    static NullBodyStream* GetNullBodyStream();
   };
 
 }}}} // namespace Azure::Core::IO::_internal

--- a/sdk/core/azure-core/src/etag.cpp
+++ b/sdk/core/azure-core/src/etag.cpp
@@ -7,6 +7,6 @@ using Azure::ETag;
 
 const ETag& ETag::Any()
 {
-  static ETag any = ETag("*"); // LCOV_EXCL_LINE
+  static ETag any = ETag("*");
   return any;
 }

--- a/sdk/core/azure-core/src/etag.cpp
+++ b/sdk/core/azure-core/src/etag.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "azure/core/etag.hpp"
+
+using Azure::ETag;
+
+const ETag& ETag::Any()
+{
+  static ETag any = ETag("*"); // LCOV_EXCL_LINE
+  return any;
+}

--- a/sdk/core/azure-core/src/io/body_stream.cpp
+++ b/sdk/core/azure-core/src/io/body_stream.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include "azure/core/context.hpp"
+#include "azure/core/internal/io/null_body_stream.hpp"
 #include "azure/core/io/body_stream.hpp"
 
 #include <algorithm>
@@ -218,3 +219,11 @@ size_t ProgressBodyStream::OnRead(
 }
 
 int64_t ProgressBodyStream::Length() const { return m_bodyStream->Length(); }
+
+using Azure::Core::IO::_internal::NullBodyStream;
+
+NullBodyStream* NullBodyStream::GetNullBodyStream()
+{
+  static NullBodyStream nullBodyStream;
+  return &nullBodyStream;
+}


### PR DESCRIPTION
This came up during improving code coverage.

But there is a problem, if you initialize static variable in an inline method, because each translation unit gets its own copy of an inline function, so there will be multiple statics. It would be just an ineffectiveness (duplicates) if the variable is immutable, which are the cases here. But should've these been mutable variables, then it will be out of sync between different translation units.