### PR TITLE
Exclude test, samples, and 3rd party code from code coverage

### DIFF
--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -143,7 +143,7 @@ target_include_directories(
 add_library(Azure::azure-core ALIAS azure-core)
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(core azure-core azure-core-test)
+create_code_coverage(core azure-core azure-core-test "tests?/*;samples?/*;inc/azure/core/internal/json/json.hpp")
 
 target_link_libraries(azure-core INTERFACE Threads::Threads)
 

--- a/sdk/identity/azure-identity/CMakeLists.txt
+++ b/sdk/identity/azure-identity/CMakeLists.txt
@@ -55,8 +55,7 @@ add_library(azure-identity ${AZURE_IDENTITY_HEADER} ${AZURE_IDENTITY_SOURCE})
 # make sure that users can consume the project as a library.
 add_library(Azure::azure-identity ALIAS azure-identity)
 
-create_code_coverage(identity azure-identity azure-identity-test)
-create_code_coverage(identity azure-identity-livetest azure-identity-livetest)
+create_code_coverage(identity azure-identity azure-identity-test "tests?/*;samples?/*")
 
 target_include_directories(
   azure-identity

--- a/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(
 target_link_libraries(azure-security-keyvault-certificates PUBLIC Azure::azure-core)
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(keyvault azure-security-keyvault-certificates "tests?/*;samples?/*")
+create_code_coverage(keyvault azure-security-keyvault-certificates azure-security-keyvault-certificates-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
 generate_documentation(azure-security-keyvault-certificates ${AZ_LIBRARY_VERSION})

--- a/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(
 target_link_libraries(azure-security-keyvault-certificates PUBLIC Azure::azure-core)
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(keyvault azure-security-keyvault-certificates azure-security-keyvault-certificates-test)
+create_code_coverage(keyvault azure-security-keyvault-certificates "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
 generate_documentation(azure-security-keyvault-certificates ${AZ_LIBRARY_VERSION})

--- a/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
@@ -107,7 +107,7 @@ target_include_directories(
 target_link_libraries(azure-security-keyvault-keys PUBLIC Azure::azure-core)
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(keyvault azure-security-keyvault-keys azure-security-keyvault-keys-test)
+create_code_coverage(keyvault azure-security-keyvault-keys azure-security-keyvault-keys-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
 generate_documentation(azure-security-keyvault-keys ${AZ_LIBRARY_VERSION})

--- a/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
@@ -76,7 +76,7 @@ target_include_directories(
 target_link_libraries(azure-security-keyvault-secrets PUBLIC Azure::azure-core)
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(keyvault azure-security-keyvault-secrets azure-security-keyvault-secrets-test)
+create_code_coverage(keyvault azure-security-keyvault-secrets azure-security-keyvault-secrets-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
 generate_documentation(azure-security-keyvault-secrets ${AZ_LIBRARY_VERSION})

--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -30,7 +30,7 @@ stages:
       LiveTestCtestRegex: "azure-security-keyvault.*"
       LiveTestTimeoutInMinutes: 120
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-      LineCoverageTarget: 37
+      LineCoverageTarget: 35
       BranchCoverageTarget: 15
       Artifacts:
         - Name: azure-security-keyvault-keys

--- a/sdk/storage/azure-storage-blobs/CMakeLists.txt
+++ b/sdk/storage/azure-storage-blobs/CMakeLists.txt
@@ -89,7 +89,7 @@ az_rtti_setup(
 )
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(storage azure-storage-blobs azure-storage-test)
+create_code_coverage(storage azure-storage-blobs azure-storage-test "tests?/*;samples?/*")
 
 if(BUILD_TESTING)
   target_sources(

--- a/sdk/storage/azure-storage-common/CMakeLists.txt
+++ b/sdk/storage/azure-storage-common/CMakeLists.txt
@@ -108,7 +108,7 @@ az_rtti_setup(
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
 # excluding json from coverage report
-create_code_coverage(storage azure-storage-common azure-storage-test "inc/azure/storage/common/json*")
+create_code_coverage(storage azure-storage-common azure-storage-test "tests?/*;samples?/*")
 
 if(BUILD_TESTING)
   target_sources(

--- a/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
@@ -90,7 +90,7 @@ az_rtti_setup(
 )
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(storage azure-storage-files-datalake azure-storage-test)
+create_code_coverage(storage azure-storage-files-datalake azure-storage-test "tests?/*;samples?/*")
 
 if(BUILD_TESTING)
   target_sources(

--- a/sdk/storage/azure-storage-files-shares/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-shares/CMakeLists.txt
@@ -88,7 +88,7 @@ az_rtti_setup(
 )
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(storage azure-storage-files-shares azure-storage-test)
+create_code_coverage(storage azure-storage-files-shares azure-storage-test "tests?/*;samples?/*")
 
 if(BUILD_TESTING)
   target_sources(

--- a/sdk/storage/azure-storage-queues/CMakeLists.txt
+++ b/sdk/storage/azure-storage-queues/CMakeLists.txt
@@ -80,7 +80,7 @@ az_rtti_setup(
 )
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(storage azure-storage-queues azure-storage-test)
+create_code_coverage(storage azure-storage-queues azure-storage-test "tests?/*;samples?/*")
 
 if(BUILD_TESTING)
   target_sources(

--- a/sdk/template/azure-template/CMakeLists.txt
+++ b/sdk/template/azure-template/CMakeLists.txt
@@ -58,9 +58,9 @@ target_include_directories(
 add_library(Azure::azure-template ALIAS azure-template)
 
 # coverage. Has no effect if BUILD_CODE_COVERAGE is OFF
-create_code_coverage(template azure-template azure-template-test)
+create_code_coverage(template azure-template azure-template-test "tests?/*;samples?/*")
 
-get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private//package_version.hpp")
+get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
 generate_documentation(azure-template ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(


### PR DESCRIPTION
Much more clarity, less noise, more accurate, reliable, and actionable coverage numbers.

We should only measure SDK code as our first priority, and we should do it well.
In the future, when we figure out how to do it, we can measure the amount of code that is covered by samples. But the way we do it currently is not the way how we should do it anyways.

It does not make sense to measure the coverage numbers of tests. Little sense/actionability for samples and 3rd party.