### PR TITLE
Exclude uncoverable lines from code coverage

### DIFF
--- a/sdk/core/azure-core/src/azure_assert.cpp
+++ b/sdk/core/azure-core/src/azure_assert.cpp
@@ -3,6 +3,7 @@
 
 #include "azure/core/internal/azure_assert.hpp"
 
+// Calling this function would terminate program, therefore this function can't be covered in tests.
 // LCOV_EXCL_START
 [[noreturn]] void Azure::Core::_internal::AzureNoReturnPath(std::string const& msg)
 {

--- a/sdk/core/azure-core/src/azure_assert.cpp
+++ b/sdk/core/azure-core/src/azure_assert.cpp
@@ -3,6 +3,7 @@
 
 #include "azure/core/internal/azure_assert.hpp"
 
+// LCOV_EXCL_START
 [[noreturn]] void Azure::Core::_internal::AzureNoReturnPath(std::string const& msg)
 {
   // void msg for Release build where Assert is ignored
@@ -10,3 +11,4 @@
   _azure_ASSERT_MSG(false, msg);
   std::abort();
 }
+// LCOV_EXCL_STOP

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -342,6 +342,9 @@ T ParseNumber(
   }
 
   ThrowParseError(description);
+
+  // ThrowParseError() will always throw, but there's no way to tell that to compiler, so a return
+  // statement is required. It is not possible to cover the return line with tests.
   return T(); // LCOV_EXCL_LINE
 }
 

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -342,7 +342,7 @@ T ParseNumber(
   }
 
   ThrowParseError(description);
-  return T();
+  return T(); // LCOV_EXCL_LINE
 }
 
 template <typename T>

--- a/sdk/identity/azure-identity/src/managed_identity_credential.cpp
+++ b/sdk/identity/azure-identity/src/managed_identity_credential.cpp
@@ -20,7 +20,9 @@ std::unique_ptr<_detail::ManagedIdentitySource> CreateManagedIdentitySource(
          AzureArcManagedIdentitySource::Create,
          ImdsManagedIdentitySource::Create};
 
-  for (auto create : managedIdentitySourceCreate)
+  // IMDS ManagedIdentity, which comes last in the list, will never return nullptr from Create().
+  // For that reason, it is not possible to cover that execution branch in tests.
+  for (auto create : managedIdentitySourceCreate) // LCOV_EXCL_LINE
   {
     if (auto source = create(clientId, options))
     {
@@ -28,8 +30,10 @@ std::unique_ptr<_detail::ManagedIdentitySource> CreateManagedIdentitySource(
     }
   }
 
+  // LCOV_EXCL_START
   throw AuthenticationException(
       "ManagedIdentityCredential authentication unavailable. No Managed Identity endpoint found.");
+  // LCOV_EXCL_STOP
 }
 } // namespace
 

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -29,7 +29,7 @@ stages:
       CtestRegex: azure-identity-unittest.
       LiveTestCtestRegex: azure-identity-livetest.
       LineCoverageTarget: 99
-      BranchCoverageTarget: 62
+      BranchCoverageTarget: 63
       Artifacts:
         - Name: azure-identity
           Path: azure-identity


### PR DESCRIPTION
There is a PR that does this more extensively: https://github.com/Azure/azure-sdk-for-cpp/pull/3152, and you might disagree with it.

In that PR, we are working around gcovr false positives, and excluding `_azure_ASSERT` and `_azure_UNREACHABLE_CODE`. But you might say that it is not worth it to go after gcovr false positives, or that it is possible to cover assert macros by writing a debug version of `AzureNoReturnPath` with test hooks.

But these three instances marked in this PR aren't any of that, and code comments explain why it is not possible to cover them.