### PR TITLE
Macro rename compatibility layer

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
+#pragma once
+
+/**
+ * @file
+ * @brief Deprecated assert macros.
+ *
+ */
+
 #include "azure/core/internal/azure_assert.hpp"
 
 #define AZURE_ASSERT(exp) _azure_ASSERT(exp)

--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -5,7 +5,7 @@
 
 /**
  * @file
- * @brief Deprecated assert macros.
+ * @brief Deprecated assert macros. It is only temporarily made available for compatibility and should NOT be used by any callers outside of the SDK.
  *
  */
 

--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -5,7 +5,8 @@
 
 /**
  * @file
- * @brief Deprecated assert macros. It is only temporarily made available for compatibility and should NOT be used by any callers outside of the SDK.
+ * @brief Deprecated assert macros. It is only temporarily made available for compatibility and
+ * should NOT be used by any callers outside of the SDK.
  *
  */
 

--- a/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
+++ b/sdk/core/azure-core/inc/azure/core/azure_assert.hpp
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "azure/core/internal/azure_assert.hpp"
+
+#define AZURE_ASSERT(exp) _azure_ASSERT(exp)
+#define AZURE_ASSERT_MSG(exp, msg) _azure_ASSERT_MSG(exp, msg)
+#define AZURE_ASSERT_FALSE(exp) _azure_ASSERT_FALSE(exp)
+#define AZURE_UNREACHABLE_CODE() _azure_UNREACHABLE_CODE()
+#define AZURE_NOT_IMPLEMENTED() _azure_NOT_IMPLEMENTED()


### PR DESCRIPTION
We made a breaking change, but if we still want to keep compatibility at least for some time, complete this PR before the Core release.
If not, we'll have to release all the updated packages in one vcpkg PR.
All the packages should depend on azure_core >= 1.4.0

We have 3 options, really:
1. Complete this PR, release core, release anything else as needed, remove this header in future core releases.
2. Don't go with this PR, release all packages (including all keyvault) in one vcpkg PR.
3. Revert the breaking change before anyone releases.