### PR TITLE
StorageException: Reuse code from RequestFailedException

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -145,10 +145,9 @@ namespace Azure { namespace Core {
      *
      */
     ~RequestFailedException() = default;
-
-  private:
-    std::string GetRawResponseField(
-        std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse,
-        std::string fieldName);
   };
+
+  std::string GetRawResponseField(
+      std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse,
+      std::string fieldName);
 }} // namespace Azure::Core

--- a/sdk/core/azure-core/src/exception.cpp
+++ b/sdk/core/azure-core/src/exception.cpp
@@ -24,10 +24,13 @@ namespace Azure { namespace Core {
 
     StatusCode = rawResponse->GetStatusCode();
     ReasonPhrase = rawResponse->GetReasonPhrase();
-    RequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsRequestId);
-    ClientRequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsClientRequestId);
-    Message = message;
     RawResponse = std::move(rawResponse);
+
+    // The response body may or may not have these fields
+    ErrorCode = GetRawResponseField(RawResponse, "code");
+
+    ClientRequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsClientRequestId);
+    RequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsRequestId);
   }
 
   RequestFailedException::RequestFailedException(
@@ -49,7 +52,7 @@ namespace Azure { namespace Core {
     RequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsRequestId);
   }
 
-  std::string RequestFailedException::GetRawResponseField(
+  std::string GetRawResponseField(
       std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse,
       std::string fieldName)
   {

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp
@@ -38,5 +38,13 @@ namespace Azure { namespace Storage {
      */
     static StorageException CreateFromResponse(
         std::unique_ptr<Azure::Core::Http::RawResponse> response);
+
+  private:
+    StorageException(
+        const std::string& whatArg,
+        std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse)
+        : RequestFailedException(whatArg, std::move(rawResponse))
+    {
+    }
   };
 }} // namespace Azure::Storage


### PR DESCRIPTION
This PR modifies the creation of `StorageException` to reuse code of its baseclass `RequestFailedException` to initialize the shared fields. In particular, this fixes the issue that `ErrorCode` was not set.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [ ] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [ ] Related issue listed
- [x] Comments in source
- [x] No typos
- [ ] Update changelog
- [x] Not work-in-progress
- [ ] External references or docs updated
- [x] Self review of PR done
- [ ] Any breaking changes?
