### PR TITLE
Do not mix inline and non-inline delegating constructors in polymorphic types

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- [2741](https://github.com/Azure/azure-sdk-for-cpp/issues/2741) Fixed linking problem when Azure SDK is built as DLL.
+
 ### Other Changes
 
 ## 1.1.0 (2021-08-10)

--- a/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
@@ -73,10 +73,7 @@ namespace Azure { namespace Identity {
         std::string const& tenantId,
         std::string const& clientId,
         std::string const& clientSecret,
-        ClientSecretCredentialOptions const& options)
-        : ClientSecretCredential(tenantId, clientId, clientSecret, options.AuthorityHost, options)
-    {
-    }
+        ClientSecretCredentialOptions const& options);
 
     /**
      * @brief Constructs a Client Secret Credential.
@@ -97,9 +94,7 @@ namespace Azure { namespace Identity {
             clientId,
             clientSecret,
             _detail::g_aadGlobalAuthority,
-            options)
-    {
-    }
+            options);
 
     /**
      * @brief Destructs `%ClientSecretCredential`.

--- a/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
@@ -88,13 +88,7 @@ namespace Azure { namespace Identity {
         std::string clientId,
         std::string clientSecret,
         Core::Credentials::TokenCredentialOptions const& options
-        = Core::Credentials::TokenCredentialOptions())
-        : ClientSecretCredential(
-            tenantId,
-            clientId,
-            clientSecret,
-            _detail::g_aadGlobalAuthority,
-            options);
+        = Core::Credentials::TokenCredentialOptions());
 
     /**
      * @brief Destructs `%ClientSecretCredential`.

--- a/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
@@ -51,10 +51,7 @@ namespace Azure { namespace Identity {
      * @param options Options for token retrieval.
      */
     explicit ManagedIdentityCredential(
-        Azure::Core::Credentials::TokenCredentialOptions const& options)
-        : ManagedIdentityCredential(std::string(), options)
-    {
-    }
+        Azure::Core::Credentials::TokenCredentialOptions const& options);
 
     /**
      * @brief Gets an authentication token.

--- a/sdk/identity/azure-identity/src/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_secret_credential.cpp
@@ -10,7 +10,7 @@
 using namespace Azure::Identity;
 
 std::string const Azure::Identity::_detail::g_aadGlobalAuthority
-    = "https://login.microsoftonline.com/";
+= "https://login.microsoftonline.com/";
 
 ClientSecretCredential::ClientSecretCredential(
     std::string const& tenantId,
@@ -20,16 +20,40 @@ ClientSecretCredential::ClientSecretCredential(
     Azure::Core::Credentials::TokenCredentialOptions const& options)
     : m_tokenCredentialImpl(new _detail::TokenCredentialImpl(options)), m_isAdfs(tenantId == "adfs")
 {
-  using Azure::Core::Url;
-  m_requestUrl = Url(authorityHost);
-  m_requestUrl.AppendPath(tenantId);
-  m_requestUrl.AppendPath(m_isAdfs ? "oauth2/token" : "oauth2/v2.0/token");
+    using Azure::Core::Url;
+    m_requestUrl = Url(authorityHost);
+    m_requestUrl.AppendPath(tenantId);
+    m_requestUrl.AppendPath(m_isAdfs ? "oauth2/token" : "oauth2/v2.0/token");
 
-  std::ostringstream body;
-  body << "grant_type=client_credentials&client_id=" << Url::Encode(clientId)
-       << "&client_secret=" << Url::Encode(clientSecret);
+    std::ostringstream body;
+    body << "grant_type=client_credentials&client_id=" << Url::Encode(clientId)
+        << "&client_secret=" << Url::Encode(clientSecret);
 
-  m_requestBody = body.str();
+    m_requestBody = body.str();
+}
+
+ClientSecretCredential::ClientSecretCredential(
+    std::string const& tenantId,
+    std::string const& clientId,
+    std::string const& clientSecret,
+    ClientSecretCredentialOptions const& options)
+    : ClientSecretCredential(tenantId, clientId, clientSecret, options.AuthorityHost, options)
+{
+}
+
+ClientSecretCredential::ClientSecretCredential(
+    std::string tenantId,
+    std::string clientId,
+    std::string clientSecret,
+    Core::Credentials::TokenCredentialOptions const& options
+    = Core::Credentials::TokenCredentialOptions())
+    : ClientSecretCredential(
+        tenantId,
+        clientId,
+        clientSecret,
+        _detail::g_aadGlobalAuthority,
+        options)
+{
 }
 
 ClientSecretCredential::~ClientSecretCredential() = default;
@@ -38,28 +62,28 @@ Azure::Core::Credentials::AccessToken ClientSecretCredential::GetToken(
     Azure::Core::Credentials::TokenRequestContext const& tokenRequestContext,
     Azure::Core::Context const& context) const
 {
-  return m_tokenCredentialImpl->GetToken(context, [&]() {
-    using _detail::TokenCredentialImpl;
-    using Azure::Core::Http::HttpMethod;
+    return m_tokenCredentialImpl->GetToken(context, [&]() {
+        using _detail::TokenCredentialImpl;
+        using Azure::Core::Http::HttpMethod;
 
-    std::ostringstream body;
-    body << m_requestBody;
-    {
-      auto const& scopes = tokenRequestContext.Scopes;
-      if (!scopes.empty())
-      {
-        body << "&scope=" << TokenCredentialImpl::FormatScopes(scopes, m_isAdfs);
-      }
-    }
+        std::ostringstream body;
+        body << m_requestBody;
+        {
+            auto const& scopes = tokenRequestContext.Scopes;
+            if (!scopes.empty())
+            {
+                body << "&scope=" << TokenCredentialImpl::FormatScopes(scopes, m_isAdfs);
+            }
+        }
 
-    auto request = std::make_unique<TokenCredentialImpl::TokenRequest>(
-        HttpMethod::Post, m_requestUrl, body.str());
+        auto request = std::make_unique<TokenCredentialImpl::TokenRequest>(
+            HttpMethod::Post, m_requestUrl, body.str());
 
-    if (m_isAdfs)
-    {
-      request->HttpRequest.SetHeader("Host", m_requestUrl.GetHost());
-    }
+        if (m_isAdfs)
+        {
+            request->HttpRequest.SetHeader("Host", m_requestUrl.GetHost());
+        }
 
-    return request;
-  });
+        return request;
+    });
 }

--- a/sdk/identity/azure-identity/src/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_secret_credential.cpp
@@ -10,7 +10,7 @@
 using namespace Azure::Identity;
 
 std::string const Azure::Identity::_detail::g_aadGlobalAuthority
-= "https://login.microsoftonline.com/";
+    = "https://login.microsoftonline.com/";
 
 ClientSecretCredential::ClientSecretCredential(
     std::string const& tenantId,
@@ -20,16 +20,16 @@ ClientSecretCredential::ClientSecretCredential(
     Azure::Core::Credentials::TokenCredentialOptions const& options)
     : m_tokenCredentialImpl(new _detail::TokenCredentialImpl(options)), m_isAdfs(tenantId == "adfs")
 {
-    using Azure::Core::Url;
-    m_requestUrl = Url(authorityHost);
-    m_requestUrl.AppendPath(tenantId);
-    m_requestUrl.AppendPath(m_isAdfs ? "oauth2/token" : "oauth2/v2.0/token");
+  using Azure::Core::Url;
+  m_requestUrl = Url(authorityHost);
+  m_requestUrl.AppendPath(tenantId);
+  m_requestUrl.AppendPath(m_isAdfs ? "oauth2/token" : "oauth2/v2.0/token");
 
-    std::ostringstream body;
-    body << "grant_type=client_credentials&client_id=" << Url::Encode(clientId)
-        << "&client_secret=" << Url::Encode(clientSecret);
+  std::ostringstream body;
+  body << "grant_type=client_credentials&client_id=" << Url::Encode(clientId)
+       << "&client_secret=" << Url::Encode(clientSecret);
 
-    m_requestBody = body.str();
+  m_requestBody = body.str();
 }
 
 ClientSecretCredential::ClientSecretCredential(
@@ -62,28 +62,28 @@ Azure::Core::Credentials::AccessToken ClientSecretCredential::GetToken(
     Azure::Core::Credentials::TokenRequestContext const& tokenRequestContext,
     Azure::Core::Context const& context) const
 {
-    return m_tokenCredentialImpl->GetToken(context, [&]() {
-        using _detail::TokenCredentialImpl;
-        using Azure::Core::Http::HttpMethod;
+  return m_tokenCredentialImpl->GetToken(context, [&]() {
+    using _detail::TokenCredentialImpl;
+    using Azure::Core::Http::HttpMethod;
 
-        std::ostringstream body;
-        body << m_requestBody;
-        {
-            auto const& scopes = tokenRequestContext.Scopes;
-            if (!scopes.empty())
-            {
-                body << "&scope=" << TokenCredentialImpl::FormatScopes(scopes, m_isAdfs);
-            }
-        }
+    std::ostringstream body;
+    body << m_requestBody;
+    {
+      auto const& scopes = tokenRequestContext.Scopes;
+      if (!scopes.empty())
+      {
+        body << "&scope=" << TokenCredentialImpl::FormatScopes(scopes, m_isAdfs);
+      }
+    }
 
-        auto request = std::make_unique<TokenCredentialImpl::TokenRequest>(
-            HttpMethod::Post, m_requestUrl, body.str());
+    auto request = std::make_unique<TokenCredentialImpl::TokenRequest>(
+        HttpMethod::Post, m_requestUrl, body.str());
 
-        if (m_isAdfs)
-        {
-            request->HttpRequest.SetHeader("Host", m_requestUrl.GetHost());
-        }
+    if (m_isAdfs)
+    {
+      request->HttpRequest.SetHeader("Host", m_requestUrl.GetHost());
+    }
 
-        return request;
-    });
+    return request;
+  });
 }

--- a/sdk/identity/azure-identity/src/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_secret_credential.cpp
@@ -45,8 +45,7 @@ ClientSecretCredential::ClientSecretCredential(
     std::string tenantId,
     std::string clientId,
     std::string clientSecret,
-    Core::Credentials::TokenCredentialOptions const& options
-    = Core::Credentials::TokenCredentialOptions())
+    Core::Credentials::TokenCredentialOptions const& options)
     : ClientSecretCredential(
         tenantId,
         clientId,

--- a/sdk/identity/azure-identity/src/managed_identity_credential.cpp
+++ b/sdk/identity/azure-identity/src/managed_identity_credential.cpp
@@ -46,6 +46,12 @@ ManagedIdentityCredential::ManagedIdentityCredential(
 {
 }
 
+ManagedIdentityCredential::ManagedIdentityCredential(
+    Azure::Core::Credentials::TokenCredentialOptions const& options)
+    : ManagedIdentityCredential(std::string(), options)
+{
+}
+
 Azure::Core::Credentials::AccessToken ManagedIdentityCredential::GetToken(
     Azure::Core::Credentials::TokenRequestContext const& tokenRequestContext,
     Azure::Core::Context const& context) const


### PR DESCRIPTION
Closes #2741

I searched the entire codebase, these were the only occurrences.

There is nothing wrong with the old code, but the way how cmake symbol export works + what MSVC requires for DLL export, makes it impossible to have inline constructors to delegate to non-inline constructors in polymorphic types. One of the ways to fix it is to make either all inline, or all non-inline. Other would be to apply dll export attribute to constructor, but I prefer moving all to cpp. For more details, see #2771.

I simulated the vcpkg with the fix and verified that there are linking problems without the fix, and no problems with the fix.