### PR TITLE
RequestFailedException: decouple Message and what().

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -30,11 +30,9 @@ namespace Azure { namespace Core {
     /**
      * @brief Constructs an `OperationCancelledException` with message string as the description.
      *
-     * @param whatArg The explanatory string.
+     * @param what The explanatory string.
      */
-    explicit OperationCancelledException(std::string const& whatArg) : std::runtime_error(whatArg)
-    {
-    }
+    explicit OperationCancelledException(std::string const& what) : std::runtime_error(what) {}
   };
 
   /**

--- a/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
+++ b/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
@@ -98,15 +98,15 @@ namespace Azure { namespace Core { namespace Credentials {
    * @brief An exception that gets thrown when an authentication error occurs.
    */
   class AuthenticationException final : public std::exception {
-    std::string m_whatArg;
+    std::string m_what;
 
   public:
     /**
      * @brief Constructs `%AuthenticationException` with a message string.
      *
-     * @param whatArg The explanatory string.
+     * @param what The explanatory string.
      */
-    explicit AuthenticationException(std::string whatArg) : m_whatArg(std::move(whatArg)) {}
+    explicit AuthenticationException(std::string what) : m_what(std::move(what)) {}
 
     /**
      * Gets the explanatory string.
@@ -115,6 +115,6 @@ namespace Azure { namespace Core { namespace Credentials {
      *
      * @return C string with explanatory information.
      */
-    char const* what() const noexcept override { return m_whatArg.c_str(); }
+    char const* what() const noexcept override { return m_what.c_str(); }
   };
 }}} // namespace Azure::Core::Credentials

--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -73,9 +73,9 @@ namespace Azure { namespace Core {
      * @note An Exception without an HTTP raw response represents an exception that happened
      * before sending the request to the server.
      *
-     * @param whatArg The explanatory string.
+     * @param what The explanatory string.
      */
-    explicit RequestFailedException(std::string const& whatArg) : std::runtime_error(whatArg) {}
+    explicit RequestFailedException(std::string const& what) : std::runtime_error(what) {}
 
     /**
      * @brief Constructs a new `%RequestFailedException` object with an HTTP raw response.
@@ -85,12 +85,12 @@ namespace Azure { namespace Core {
      * Service exception which derives from this exception uses its constructor to parse the HTTP
      * raw response adding the service specific values to the exception.
      *
-     * @param message The error description.
+     * @param what The explanatory string.
      * @param rawResponse The HTTP raw response from the service.
      */
     explicit RequestFailedException(
-        const std::string& message,
-        std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse);
+        const std::string& what,
+        std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse);
 
     /**
      * @brief Constructs a new `%RequestFailedException` object with an HTTP raw response.

--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -61,10 +61,9 @@ namespace Azure { namespace Core { namespace Http {
      * @remark The transport policy will throw this error whenever the transport adapter fail to
      * perform a request.
      *
-     * @param whatArg The explanatory string.
+     * @param what The explanatory string.
      */
-    explicit TransportException(std::string const& whatArg)
-        : Azure::Core::RequestFailedException(whatArg)
+    explicit TransportException(std::string const& what) : Azure::Core::RequestFailedException(what)
     {
     }
   };

--- a/sdk/core/azure-core/src/exception.cpp
+++ b/sdk/core/azure-core/src/exception.cpp
@@ -16,25 +16,11 @@ using namespace Azure::Core::Http::_internal;
 namespace Azure { namespace Core {
 
   RequestFailedException::RequestFailedException(
-      const std::string& message,
-      std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse)
-      : std::runtime_error(message), Message(message)
-  {
-    auto const& headers = rawResponse->GetHeaders();
-
-    StatusCode = rawResponse->GetStatusCode();
-    ReasonPhrase = rawResponse->GetReasonPhrase();
-    RequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsRequestId);
-    ClientRequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsClientRequestId);
-    Message = message;
-    RawResponse = std::move(rawResponse);
-  }
-
-  RequestFailedException::RequestFailedException(
+      const std::string& what,
       std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse)
-      : std::runtime_error("Received an HTTP unsuccessful status code.")
+      : std::runtime_error(what)
   {
-    auto& headers = rawResponse->GetHeaders();
+    const auto& headers = rawResponse->GetHeaders();
 
     // These are guaranteed to always be present in the rawResponse.
     StatusCode = rawResponse->GetStatusCode();
@@ -47,6 +33,12 @@ namespace Azure { namespace Core {
 
     ClientRequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsClientRequestId);
     RequestId = HttpShared::GetHeaderOrEmptyString(headers, HttpShared::MsRequestId);
+  }
+
+  RequestFailedException::RequestFailedException(
+      std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse)
+      : RequestFailedException("Received an HTTP unsuccessful status code.", rawResponse)
+  {
   }
 
   std::string RequestFailedException::GetRawResponseField(

--- a/sdk/core/azure-core/test/ut/exception_test.cpp
+++ b/sdk/core/azure-core/test/ut/exception_test.cpp
@@ -93,13 +93,13 @@ TEST(RequestFailedException, Message)
   response->SetBodyStream(std::make_unique<Azure::Core::IO::MemoryBodyStream>(
       responseBodyStream, sizeof(responseBodyStream) - 1));
 
-  auto exception = Azure::Core::RequestFailedException("Msg", std::move(response));
+  auto exception = Azure::Core::RequestFailedException("what", response);
 
   EXPECT_EQ(exception.StatusCode, Azure::Core::Http::HttpStatusCode::ServiceUnavailable);
-  EXPECT_EQ(exception.Message, "Msg");
-  EXPECT_EQ(exception.ErrorCode, "");
+  EXPECT_EQ(exception.Message, "JT");
+  EXPECT_EQ(exception.ErrorCode, "503");
   EXPECT_EQ(exception.RequestId, "1");
   EXPECT_EQ(exception.ClientRequestId, "2");
   EXPECT_EQ(exception.ReasonPhrase, "retry please :");
-  EXPECT_EQ(exception.what(), std::string("Msg"));
+  EXPECT_EQ(exception.what(), std::string("what"));
 }

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp
@@ -21,9 +21,9 @@ namespace Azure { namespace Storage {
     /**
      * @brief Constructs a #StorageException with a message.
      *
-     * @param whatArg The explanatory string.
+     * @param what The explanatory string.
      */
-    explicit StorageException(const std::string& whatArg) : RequestFailedException(whatArg) {}
+    explicit StorageException(const std::string& what) : RequestFailedException(what) {}
 
     /**
      * Some storage-specific information in response body.


### PR DESCRIPTION
Closes #2542.

1. Rename `whatArg` to `what` per Jeffrey's feedback: https://github.com/Azure/azure-sdk-for-cpp/pull/2782#discussion_r701242944
2. The only user of `RequestFailedException(what, response)` is the unit test.
3. Delegate construction to a constructor that makes the best effort to parse the response.
4. `what` is what we set programmatically, `Message` is what gets returned from the service.