### PR TITLE
Bump dependency on azure core for all upstream SDKs and client libraries to the latest shipped version

### DIFF
--- a/sdk/identity/azure-identity/vcpkg/Config.cmake.in
+++ b/sdk/identity/azure-identity/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-core-cpp "1.2.0")
+find_dependency(azure-core-cpp "1.3.1")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-identity-cppTargets.cmake")
 

--- a/sdk/identity/azure-identity/vcpkg/vcpkg.json
+++ b/sdk/identity/azure-identity/vcpkg/vcpkg.json
@@ -14,7 +14,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.2.0"
+      "version>=": "1.3.1"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-common/vcpkg/Config.cmake.in
+++ b/sdk/storage/azure-storage-common/vcpkg/Config.cmake.in
@@ -5,7 +5,7 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
-find_dependency(azure-core-cpp "1.0.0")
+find_dependency(azure-core-cpp "1.3.1")
 
 if(NOT WIN32)
   find_dependency(LibXml2)

--- a/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
@@ -14,7 +14,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.0.0"
+      "version>=": "1.3.1"
     },
     {
       "name": "libxml2",

--- a/sdk/template/azure-template/vcpkg/Config.cmake.in
+++ b/sdk/template/azure-template/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-core-cpp "1.2.0")
+find_dependency(azure-core-cpp "1.3.1")
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-template-cppTargets.cmake")
 

--- a/sdk/template/azure-template/vcpkg/vcpkg.json
+++ b/sdk/template/azure-template/vcpkg/vcpkg.json
@@ -15,7 +15,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.2.0"
+      "version>=": "1.3.1"
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
First step of https://github.com/Azure/azure-sdk-for-cpp/issues/3214

Keyvault keys and certificates are already pointing to latest version of  core, 1.3.1