### PR TITLE
Test Cmake generate configs

### DIFF
--- a/cmake-modules/AzureTransportAdapters.cmake
+++ b/cmake-modules/AzureTransportAdapters.cmake
@@ -17,26 +17,43 @@ endif()
 # On POSIX: Make sure to build Curl either if it was user-requested or no transport was selected at all.
 if (WIN32 OR MINGW OR MSYS OR CYGWIN)
   if (BUILD_TRANSPORT_CURL)
+    # Specified by user on CMake input Libcurl
     add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
   endif()
   if (BUILD_TRANSPORT_WINHTTP OR (NOT BUILD_TRANSPORT_CURL AND NOT BUILD_TRANSPORT_CUSTOM))
-    message("By default, if no option is selected, on Windows, WinHTTP transport adapter is used.")
+    # WinHTTP selected by user on CMake input 
+    # OR Nothing selected by CMake input (not libcurl or custom). Then set default for Windows.
+    
+    if (NOT BUILD_TRANSPORT_WINHTTP AND NOT BUILD_TRANSPORT_CUSTOM)
+      # No custom and No winHTTP. 
+      message("No transport adapter was selected, using WinHTTP as the default option for Windows.")
+    endif()
+    
     add_compile_definitions(BUILD_TRANSPORT_WINHTTP_ADAPTER)
-    if(AZ_ALL_LIBRARIES)
+    
+    if (NOT BUILD_TRANSPORT_WINHTTP)
+      # When user did not provide the input option, we need to turn it ON as it is used to include the src code
       SET(BUILD_TRANSPORT_WINHTTP ON)
     endif()
+
   endif()
 elseif (UNIX)
   if (BUILD_TRANSPORT_WINHTTP)
     message(FATAL_ERROR "WinHTTP transport adapter is not supported for POSIX platforms.")
   endif()
-  if (BUILD_TRANSPORT_CURL OR (NOT BUILD_TRANSPORT_CUSTOM))
-    message("By default, if no option is selected, on POSIX, libcurl transport adapter is used.")
-    add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
-    if(AZ_ALL_LIBRARIES)
-      SET(BUILD_TRANSPORT_CURL ON)
+
+  if (BUILD_TRANSPORT_CURL OR (NOT BUILD_TRANSPORT_CURL AND NOT BUILD_TRANSPORT_CUSTOM))
+
+    if(NOT BUILD_TRANSPORT_CURL)
+      message("No transport adapter was selected, using libcurl as the default option for POSIX.")
     endif()
+
+    add_compile_definitions(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
+
+    
+    SET(BUILD_TRANSPORT_CURL ON)
   endif()
+
 else()
   message(FATAL_ERROR "Unsupported platform.")
 endif()

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -1,0 +1,57 @@
+parameters:
+- name: Location
+  type: string
+  default: ''
+- name: SubscriptionConfiguration
+  type: string
+  default: $(sub-config-azure-cloud-test-resources)
+- name: ServiceDirectory
+  type: string
+  default: not-specified
+- name: CtestRegex
+  type: string
+  default: .*
+- name: Coverage
+  type: string
+  default: 'enabled'
+- name: CoverageReportPath
+  type: string
+  default: sdk/*/*/*cov_xml.xml
+- name: TimeoutInMinutes
+  type: number
+  default: 60
+
+jobs:
+- job: CMakeGenerate
+  condition: and(succeededOrFailed(), ne(variables['Skip.CMakeGenerate'], 'true'))
+  timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
+  strategy:
+    matrix:
+      Linux_x64_gcc5_with_unit_test:
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage: MMSUbuntu18.04
+        CmakeEnvArg: 'CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 cmake'
+        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON'
+        CmakeGeneratePath: "sdk/core/azure-core"
+  pool:
+    name: $(Pool)
+    vmImage: $(OSVmImage)
+  variables:
+    CMOCKA_XML_FILE: "%g-test-results.xml"
+    CMOCKA_MESSAGE_OUTPUT: "xml"
+
+  steps:
+  - checkout: self
+    submodules: recursive
+
+  - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+    parameters:
+      AgentImage: $(OSVmImage)
+
+  - template: /eng/common/pipelines/templates/steps/bypass-local-dns.yml
+
+  - template: /eng/pipelines/templates/steps/cmake-generate.yml
+    parameters:
+      Path: ${CmakeGeneratePath}
+      GenerateArgs: $(CmakeArgs)
+      Env: "$(CmakeEnvArg)"

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -27,7 +27,7 @@ jobs:
         Pool: Azure Pipelines
         OSVmImage: macOS-10.15
         CmakeEnvArg: ''
-        VcpkgInstall: 'openssl'
+        VcpkgInstall: 'curl[ssl] openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
   pool:
     name: $(Pool)

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -5,6 +5,9 @@ parameters:
   - name: ServiceDirectory
     type: string
     default: not-specified
+  - name: CMakeTestOptions
+    type: object
+    default: []
 
 jobs:
 - job: CMakeGenerate
@@ -15,18 +18,15 @@ jobs:
         Pool: azsdk-pool-mms-ubuntu-1804-general
         OSVmImage: MMSUbuntu18.04
         CmakeEnvArg: ''
-        CmakeArgs: ''
         AptDependencies: 'libcurl4-openssl-dev'
       Windows:
         Pool: azsdk-pool-mms-win-2019-general
         OSVmImage: MMS2019
         CmakeEnvArg: ''
-        CmakeArgs: ''
       Mac:
         Pool: Azure Pipelines
         OSVmImage: macOS-10.15
         CmakeEnvArg: ''
-        CmakeArgs: ''
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)
@@ -61,8 +61,9 @@ jobs:
       DependenciesVariableName: VcpkgInstall
 
   - ${{ each artifact in parameters.Artifacts }}:
-    - template: /eng/pipelines/templates/steps/cmake-generate.yml
-      parameters:
-        CmakeGeneratePath: sdk/${{ parameters.ServiceDirectory }}/${{ artifact.Path }}
-        GenerateArgs: $(CmakeArgs)
-        Env: "$(CmakeEnvArg)"
+    - ${{ each cmakeOption in parameters.CMakeTestOptions }}:
+      - template: /eng/pipelines/templates/steps/cmake-generate.yml
+        parameters:
+          CmakeGeneratePath: sdk/${{ parameters.ServiceDirectory }}/${{ artifact.Path }}
+          GenerateArgs: ${{ cmakeOption.Value }}
+          Env: "$(CmakeEnvArg)"

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -64,6 +64,8 @@ jobs:
     displayName: cmake --version
 
   - ${{ each artifact in parameters.Artifacts }}:
+    - script: echo 'CMake generate tests for ${{ artifact.Name }}'
+        displayName: ${{ artifact.Name }}
     - ${{ each cmakeOption in parameters.CMakeTestOptions }}:
       - template: /eng/pipelines/templates/steps/cmake-generate.yml
         parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -28,6 +28,7 @@ jobs:
         OSVmImage: macOS-10.15
         CmakeEnvArg: ''
         VcpkgInstall: 'openssl'
+        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -22,10 +22,12 @@ jobs:
         OSVmImage: MMSUbuntu18.04
         CmakeEnvArg: ''
         AptDependencies: 'libcurl4-openssl-dev'
+        VcpkgInstall: ${{ parameters.CMakeTestDependencies }}
       Windows:
         Pool: azsdk-pool-mms-win-2019-general
         OSVmImage: MMS2019
         CmakeEnvArg: ''
+        VcpkgInstall: ${{ parameters.CMakeTestDependencies }}
       Mac:
         Pool: Azure Pipelines
         OSVmImage: macOS-10.15

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -27,7 +27,6 @@ jobs:
         OSVmImage: macOS-10.15
         CmakeEnvArg: ''
         CmakeArgs: ''
-        AptDependencies: 'libcurl4-openssl-dev'
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -27,7 +27,7 @@ jobs:
         Pool: Azure Pipelines
         OSVmImage: macOS-10.15
         CmakeEnvArg: ''
-        VcpkgInstall: 'curl[ssl] openssl'
+        VcpkgInstall: 'openssl'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
   pool:
     name: $(Pool)

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -1,7 +1,6 @@
 jobs:
 - job: CMakeGenerate
   condition: and(succeededOrFailed(), ne(variables['Skip.CMakeGenerate'], 'true'))
-  timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
   strategy:
     matrix:
       Linux_x64_gcc5_with_unit_test:

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -8,6 +8,9 @@ parameters:
   - name: CMakeTestOptions
     type: object
     default: []
+  - name: CMakeTestDependencies
+    type: string
+    default: ''
 
 jobs:
 - job: CMakeGenerate
@@ -27,7 +30,7 @@ jobs:
         Pool: Azure Pipelines
         OSVmImage: macOS-10.15
         CmakeEnvArg: ''
-        VcpkgInstall: 'openssl'
+        VcpkgInstall: 'openssl ${{ parameters.CMakeTestDependencies }}'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
   pool:
     name: $(Pool)

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -47,14 +47,13 @@ jobs:
     condition: and(succeeded(), ne(variables['AptDependencies'], ''))
     displayName: Install dependencies from apt
 
-  - pwsh: sudo xcode-select -s /Applications/Xcode_$(XCODE_VERSION).app/Contents/Developer
+  - pwsh: brew install openssl
     condition: >-
       and(
         succeeded(),
-        contains(variables['OSVmImage'], 'macOS'),
-        ne(variables['XCODE_VERSION'], '')
+        contains(variables['OSVmImage'], 'macOS')
       )
-    displayName: Set Xcode version
+    displayName: Install openSSL for Mac
 
   - template: /eng/pipelines/templates/steps/vcpkg.yml
     parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -3,11 +3,11 @@ jobs:
   condition: and(succeededOrFailed(), ne(variables['Skip.CMakeGenerate'], 'true'))
   strategy:
     matrix:
-      Linux_x64_gcc5_with_unit_test:
+      Linux_Core:
         Pool: azsdk-pool-mms-ubuntu-1804-general
         OSVmImage: MMSUbuntu18.04
-        CmakeEnvArg: 'CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 cmake'
-        CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON'
+        CmakeEnvArg: ''
+        CmakeArgs: ''
         CmakeGeneratePath: "sdk/core/azure-core"
   pool:
     name: $(Pool)

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -28,6 +28,6 @@ jobs:
 
   - template: /eng/pipelines/templates/steps/cmake-generate.yml
     parameters:
-      Path: ${CmakeGeneratePath}
+      CmakeGeneratePath: ${CmakeGeneratePath}
       GenerateArgs: $(CmakeArgs)
       Env: "$(CmakeEnvArg)"

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -27,6 +27,7 @@ jobs:
         Pool: Azure Pipelines
         OSVmImage: macOS-10.15
         CmakeEnvArg: ''
+        VcpkgInstall: 'openssl'
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)
@@ -46,14 +47,6 @@ jobs:
   - pwsh: sudo apt update && sudo apt install -y $(AptDependencies)
     condition: and(succeeded(), ne(variables['AptDependencies'], ''))
     displayName: Install dependencies from apt
-
-  - pwsh: brew install openssl
-    condition: >-
-      and(
-        succeeded(),
-        contains(variables['OSVmImage'], 'macOS')
-      )
-    displayName: Install openSSL for Mac
 
   - template: /eng/pipelines/templates/steps/vcpkg.yml
     parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -28,6 +28,6 @@ jobs:
 
   - template: /eng/pipelines/templates/steps/cmake-generate.yml
     parameters:
-      CmakeGeneratePath: ${CmakeGeneratePath}
+      CmakeGeneratePath: $(CmakeGeneratePath)
       GenerateArgs: $(CmakeArgs)
       Env: "$(CmakeEnvArg)"

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -9,6 +9,7 @@ jobs:
         CmakeEnvArg: ''
         CmakeArgs: ''
         CmakeGeneratePath: "sdk/core/azure-core"
+        AptDependencies: 'libcurl4-openssl-dev'
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)
@@ -25,6 +26,23 @@ jobs:
       AgentImage: $(OSVmImage)
 
   - template: /eng/common/pipelines/templates/steps/bypass-local-dns.yml
+
+  - pwsh: sudo apt update && sudo apt install -y $(AptDependencies)
+    condition: and(succeeded(), ne(variables['AptDependencies'], ''))
+    displayName: Install dependencies from apt
+
+  - pwsh: sudo xcode-select -s /Applications/Xcode_$(XCODE_VERSION).app/Contents/Developer
+    condition: >-
+      and(
+        succeeded(),
+        contains(variables['OSVmImage'], 'macOS'),
+        ne(variables['XCODE_VERSION'], '')
+      )
+    displayName: Set Xcode version
+
+  - template: /eng/pipelines/templates/steps/vcpkg.yml
+    parameters:
+      DependenciesVariableName: VcpkgInstall
 
   - template: /eng/pipelines/templates/steps/cmake-generate.yml
     parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -1,21 +1,38 @@
+parameters:
+  - name: Artifacts
+    type: object
+    default: []
+  - name: ServiceDirectory
+    type: string
+    default: not-specified
+
 jobs:
 - job: CMakeGenerate
   condition: and(succeededOrFailed(), ne(variables['Skip.CMakeGenerate'], 'true'))
   strategy:
     matrix:
-      Linux_Core:
+      Linux:
         Pool: azsdk-pool-mms-ubuntu-1804-general
         OSVmImage: MMSUbuntu18.04
         CmakeEnvArg: ''
         CmakeArgs: ''
-        CmakeGeneratePath: "sdk/core/azure-core"
+        AptDependencies: 'libcurl4-openssl-dev'
+      Windows:
+        Pool: azsdk-pool-mms-win-2019-general
+        OSVmImage: MMS2019
+        CmakeEnvArg: ''
+        CmakeArgs: ''
+      Mac:
+        Pool: Azure Pipelines
+        OSVmImage: macOS-10.15
+        CmakeEnvArg: ''
+        CmakeArgs: ''
         AptDependencies: 'libcurl4-openssl-dev'
   pool:
     name: $(Pool)
     vmImage: $(OSVmImage)
   variables:
     CMOCKA_XML_FILE: "%g-test-results.xml"
-    CMOCKA_MESSAGE_OUTPUT: "xml"
 
   steps:
   - checkout: self
@@ -44,8 +61,9 @@ jobs:
     parameters:
       DependenciesVariableName: VcpkgInstall
 
-  - template: /eng/pipelines/templates/steps/cmake-generate.yml
-    parameters:
-      CmakeGeneratePath: $(CmakeGeneratePath)
-      GenerateArgs: $(CmakeArgs)
-      Env: "$(CmakeEnvArg)"
+  - ${{ each artifact in parameters.Artifacts }}:
+    - template: /eng/pipelines/templates/steps/cmake-generate.yml
+      parameters:
+        CmakeGeneratePath: sdk/${{ parameters.ServiceDirectory }}/${{ artifact.Path }}
+        GenerateArgs: $(CmakeArgs)
+        Env: "$(CmakeEnvArg)"

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -1,26 +1,3 @@
-parameters:
-- name: Location
-  type: string
-  default: ''
-- name: SubscriptionConfiguration
-  type: string
-  default: $(sub-config-azure-cloud-test-resources)
-- name: ServiceDirectory
-  type: string
-  default: not-specified
-- name: CtestRegex
-  type: string
-  default: .*
-- name: Coverage
-  type: string
-  default: 'enabled'
-- name: CoverageReportPath
-  type: string
-  default: sdk/*/*/*cov_xml.xml
-- name: TimeoutInMinutes
-  type: number
-  default: 60
-
 jobs:
 - job: CMakeGenerate
   condition: and(succeededOrFailed(), ne(variables['Skip.CMakeGenerate'], 'true'))

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -65,7 +65,7 @@ jobs:
 
   - ${{ each artifact in parameters.Artifacts }}:
     - script: echo 'CMake generate tests for ${{ artifact.Name }}'
-        displayName: ${{ artifact.Name }}
+      displayName: ${{ artifact.Name }}
     - ${{ each cmakeOption in parameters.CMakeTestOptions }}:
       - template: /eng/pipelines/templates/steps/cmake-generate.yml
         parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -60,6 +60,9 @@ jobs:
     parameters:
       DependenciesVariableName: VcpkgInstall
 
+  - script: cmake --version
+    displayName: cmake --version
+
   - ${{ each artifact in parameters.Artifacts }}:
     - ${{ each cmakeOption in parameters.CMakeTestOptions }}:
       - template: /eng/pipelines/templates/steps/cmake-generate.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
@@ -23,11 +23,13 @@ jobs:
         CmakeEnvArg: ''
         AptDependencies: 'libcurl4-openssl-dev'
         VcpkgInstall: ${{ parameters.CMakeTestDependencies }}
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
       Windows:
         Pool: azsdk-pool-mms-win-2019-general
         OSVmImage: MMS2019
         CmakeEnvArg: ''
         VcpkgInstall: ${{ parameters.CMakeTestDependencies }}
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows'
       Mac:
         Pool: Azure Pipelines
         OSVmImage: macOS-10.15

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -41,6 +41,9 @@ parameters:
 - name: CMakeTestOptions
   type: object
   default: []
+- name: CMakeTestDependencies
+  type: string
+  default: ''
 
 stages:
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -51,6 +54,7 @@ stages:
             ServiceDirectory: ${{ parameters.ServiceDirectory }}
             Artifacts: ${{ parameters.Artifacts }}
             CMakeTestOptions: ${{ parameters.CMakeTestOptions }}
+            CMakeTestDependencies: ${{ parameters.CMakeTestDependencies }}
 
   - stage: Build
     dependsOn: []

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -40,6 +40,11 @@ parameters:
   default: []
 
 stages:
+  - stage: CMakeGeneration
+    dependsOn: []
+    jobs:
+      - template: /eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+      
   - stage: Build
     jobs:
       - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -55,11 +60,6 @@ stages:
           ${{ if eq(parameters.ServiceDirectory, 'template') }}:
             TestPipeline: true
           TestEnv: ${{ parameters.TestEnv }}
-  
-  - stage: CMakeGeneration
-    dependsOn: []
-    jobs:
-      - template: /eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
 
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
     - stage: LiveTest

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -58,7 +58,7 @@ stages:
   
   - stage: CMake Generation
     jobs:
-      - template: /eng/pipelines/templates/steps/archetype-sdk-cmake-generate.yml
+      - template: /eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
         parameters:
           Path: "sdk/core/azure-core"
           Env: "$(CmakeEnvArg)"

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -55,6 +55,14 @@ stages:
           ${{ if eq(parameters.ServiceDirectory, 'template') }}:
             TestPipeline: true
           TestEnv: ${{ parameters.TestEnv }}
+  
+  - stage: CMake Generation
+    jobs:
+      - template: /eng/pipelines/templates/steps/cmake-generate.yml
+        parameters:
+          Path: "sdk/core/azure-core"
+          Env: "$(CmakeEnvArg)"
+          GenerateArgs: "$(CmakeArgs)"
 
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
     - stage: LiveTest

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -56,7 +56,7 @@ stages:
             TestPipeline: true
           TestEnv: ${{ parameters.TestEnv }}
   
-  - stage: CMake Generation
+  - stage: CMakeGeneration
     jobs:
       - template: /eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
 

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -38,6 +38,9 @@ parameters:
 - name: TestEnv
   type: object
   default: []
+- name: CMakeTestOptions
+  type: object
+  default: []
 
 stages:
   - stage: CMakeGeneration
@@ -47,6 +50,7 @@ stages:
         parameters:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}
           Artifacts: ${{ parameters.Artifacts }}
+          CMakeTestOptions: ${{ parameters.CMakeTestOptions }}
 
   - stage: Build
     jobs:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -59,10 +59,6 @@ stages:
   - stage: CMake Generation
     jobs:
       - template: /eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
-        parameters:
-          Path: "sdk/core/azure-core"
-          Env: "$(CmakeEnvArg)"
-          GenerateArgs: "$(CmakeArgs)"
 
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
     - stage: LiveTest

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -57,12 +57,11 @@ stages:
           TestEnv: ${{ parameters.TestEnv }}
   
   - stage: CMake Generation
-    jobs:
-      - template: /eng/pipelines/templates/steps/cmake-generate.yml
-        parameters:
-          Path: "sdk/core/azure-core"
-          Env: "$(CmakeEnvArg)"
-          GenerateArgs: "$(CmakeArgs)"
+    - template: /eng/pipelines/templates/steps/cmake-generate.yml
+      parameters:
+        Path: "sdk/core/azure-core"
+        Env: "$(CmakeEnvArg)"
+        GenerateArgs: "$(CmakeArgs)"
 
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
     - stage: LiveTest

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -57,11 +57,12 @@ stages:
           TestEnv: ${{ parameters.TestEnv }}
   
   - stage: CMake Generation
-    - template: /eng/pipelines/templates/steps/cmake-generate.yml
-      parameters:
-        Path: "sdk/core/azure-core"
-        Env: "$(CmakeEnvArg)"
-        GenerateArgs: "$(CmakeArgs)"
+    jobs:
+      - template: /eng/pipelines/templates/steps/archetype-sdk-cmake-generate.yml
+        parameters:
+          Path: "sdk/core/azure-core"
+          Env: "$(CmakeEnvArg)"
+          GenerateArgs: "$(CmakeArgs)"
 
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.LiveTestCtestRegex, '')) }}:
     - stage: LiveTest

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -43,16 +43,17 @@ parameters:
   default: []
 
 stages:
-  - stage: CMakeGeneration
-    dependsOn: []
-    jobs:
-      - template: /eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
-        parameters:
-          ServiceDirectory: ${{ parameters.ServiceDirectory }}
-          Artifacts: ${{ parameters.Artifacts }}
-          CMakeTestOptions: ${{ parameters.CMakeTestOptions }}
+  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    - stage: CMakeGeneration
+      jobs:
+        - template: /eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
+          parameters:
+            ServiceDirectory: ${{ parameters.ServiceDirectory }}
+            Artifacts: ${{ parameters.Artifacts }}
+            CMakeTestOptions: ${{ parameters.CMakeTestOptions }}
 
   - stage: Build
+    dependsOn: []
     jobs:
       - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
         parameters:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -44,7 +44,10 @@ stages:
     dependsOn: []
     jobs:
       - template: /eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
-      
+        parameters:
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          Artifacts: ${{ parameters.Artifacts }}
+
   - stage: Build
     jobs:
       - template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -57,6 +57,7 @@ stages:
           TestEnv: ${{ parameters.TestEnv }}
   
   - stage: CMakeGeneration
+    dependsOn: []
     jobs:
       - template: /eng/pipelines/templates/jobs/archetype-sdk-cmake-generate.yml
 

--- a/eng/pipelines/templates/steps/cmake-generate.yml
+++ b/eng/pipelines/templates/steps/cmake-generate.yml
@@ -1,11 +1,11 @@
 parameters:
-  Path: ''
+  CmakeGeneratePath: ''
   Env: ''
   GenerateArgs: ''
 
 steps:
-  - script: cd ${{ Path }}
-    displayName: Navigate to ${{ Path }}
+  - script: cd ${{ parameters.CmakeGeneratePath }}
+    displayName: Navigate to ${{ parameters.CmakeGeneratePath }}
 
   - script: mkdir build
     displayName: create working directory

--- a/eng/pipelines/templates/steps/cmake-generate.yml
+++ b/eng/pipelines/templates/steps/cmake-generate.yml
@@ -1,0 +1,19 @@
+parameters:
+  Path: ''
+  Env: ''
+  GenerateArgs: ''
+
+steps:
+  - script: cd ${{ Path }}
+    displayName: Navigate to ${{ Path }}
+
+  - script: mkdir build
+    displayName: create working directory
+
+  - script: cmake --version
+    workingDirectory: build
+    displayName: cmake --version
+
+  - script: ${{ parameters.Env }} cmake ${{ parameters.GenerateArgs }} ..
+    workingDirectory: build
+    displayName: cmake generate

--- a/eng/pipelines/templates/steps/cmake-generate.yml
+++ b/eng/pipelines/templates/steps/cmake-generate.yml
@@ -9,10 +9,6 @@ steps:
     workingDirectory: ${{ parameters.CmakeGeneratePath }}
     displayName: create working directory
 
-  - script: cmake --version
-    workingDirectory: ${{ parameters.CmakeGeneratePath }}/build
-    displayName: cmake --version
-
   - script: pwd
     workingDirectory: ${{ parameters.CmakeGeneratePath }}/build
     displayName: Show current path

--- a/eng/pipelines/templates/steps/cmake-generate.yml
+++ b/eng/pipelines/templates/steps/cmake-generate.yml
@@ -4,16 +4,19 @@ parameters:
   GenerateArgs: ''
 
 steps:
-  - script: cd ${{ parameters.CmakeGeneratePath }}
-    displayName: Navigate to ${{ parameters.CmakeGeneratePath }}
 
   - script: mkdir build
+    workingDirectory: ${{ parameters.CmakeGeneratePath }}
     displayName: create working directory
 
   - script: cmake --version
-    workingDirectory: build
+    workingDirectory: ${{ parameters.CmakeGeneratePath }}/build
+    displayName: cmake --version
+
+  - script: pwd
+    workingDirectory: ${{ parameters.CmakeGeneratePath }}/build
     displayName: cmake --version
 
   - script: ${{ parameters.Env }} cmake ${{ parameters.GenerateArgs }} ..
-    workingDirectory: build
+    workingDirectory: ${{ parameters.CmakeGeneratePath }}/build
     displayName: cmake generate

--- a/eng/pipelines/templates/steps/cmake-generate.yml
+++ b/eng/pipelines/templates/steps/cmake-generate.yml
@@ -15,8 +15,12 @@ steps:
 
   - script: pwd
     workingDirectory: ${{ parameters.CmakeGeneratePath }}/build
-    displayName: cmake --version
+    displayName: Show current path
 
   - script: ${{ parameters.Env }} cmake ${{ parameters.GenerateArgs }} ..
     workingDirectory: ${{ parameters.CmakeGeneratePath }}/build
     displayName: cmake generate
+
+  - script: rm -rf build
+    workingDirectory: ${{ parameters.CmakeGeneratePath }}
+    displayName: clean build folder

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # setting CMAKE_TOOLCHAIN_FILE must happen before creating the project
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
 include(AzureVcpkg)
 if (NOT AZ_ALL_LIBRARIES)
   # only if root integration didn't run
@@ -15,8 +16,6 @@ project(azure-core LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
 
 include(AzureVersion)
 include(AzureCodeCoverage)

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -4,10 +4,8 @@
 # setting CMAKE_TOOLCHAIN_FILE must happen before creating the project
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
 include(AzureVcpkg)
-if (NOT AZ_ALL_LIBRARIES)
-  # only if root integration didn't run
-  az_vcpkg_integrate()
-endif()
+az_vcpkg_integrate()
+
 
 # Azure core is compatible with CMake 3.12
 cmake_minimum_required (VERSION 3.12)

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -18,6 +18,8 @@ include(AzureTransportAdapters)
 include(AzureDoxygen)
 include(AzureGlobalCompileOptions)
 include(AzureConfigRTTI)
+# Add create_map_file function
+include(CreateMapFile)
 
 az_vcpkg_integrate()
 

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -1,6 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+# setting CMAKE_TOOLCHAIN_FILE must happen before creating the project
+include(AzureVcpkg)
+if (NOT AZ_ALL_LIBRARIES)
+  # only if root integration didn't run
+  az_vcpkg_integrate()
+endif()
+
 # Azure core is compatible with CMake 3.12
 cmake_minimum_required (VERSION 3.12)
 project(azure-core LANGUAGES CXX)
@@ -11,7 +18,6 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
 
-include(AzureVcpkg)
 include(AzureVersion)
 include(AzureCodeCoverage)
 include(AzureTransportAdapters)
@@ -20,8 +26,6 @@ include(AzureGlobalCompileOptions)
 include(AzureConfigRTTI)
 # Add create_map_file function
 include(CreateMapFile)
-
-az_vcpkg_integrate()
 
 find_package(Threads REQUIRED)
 

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -72,4 +72,9 @@ stages:
         - Name: STANDARD_STORAGE_CONNECTION_STRING
           Value: "DefaultEndpointsProtocol=https;AccountName=fake;AccountKey=X;EndpointSuffix=core.windows.net"
         - Name: ADLS_GEN2_CONNECTION_STRING
-          Value: "DefaultEndpointsProtocol=https;AccountName=fake;AccountKey=X;EndpointSuffix=core.windows.net"          
+          Value: "DefaultEndpointsProtocol=https;AccountName=fake;AccountKey=X;EndpointSuffix=core.windows.net"
+      CMakeTestOptions:
+        - Name: Default
+          Value: ''
+        - Name: Test
+          Value: '-DBUILD_TESTING=ON'

--- a/sdk/identity/azure-identity/CMakeLists.txt
+++ b/sdk/identity/azure-identity/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+# setting CMAKE_TOOLCHAIN_FILE must happen before creating the project
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
+include(AzureVcpkg)
+az_vcpkg_integrate()
+
 cmake_minimum_required (VERSION 3.13)
 project(azure-identity LANGUAGES CXX)
 
@@ -8,17 +13,14 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
-
-include(AzureVcpkg)
 include(AzureVersion)
 include(AzureCodeCoverage)
 include(AzureTransportAdapters)
 include(AzureDoxygen)
 include(AzureGlobalCompileOptions)
 include(AzureConfigRTTI)
-
-az_vcpkg_integrate()
+# Add create_map_file function
+include(CreateMapFile)
 
 if(NOT AZ_ALL_LIBRARIES)
   find_package(azure-core-cpp "1.2.0" CONFIG QUIET)

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -30,6 +30,8 @@ stages:
       LiveTestCtestRegex: azure-identity.
       LineCoverageTarget: 99
       BranchCoverageTarget: 63
+# Dependencies per package is not supported. List the dependencies for all packages.
+      CMakeTestDependencies: 'azure-core-cpp'
       Artifacts:
         - Name: azure-identity
           Path: azure-identity

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -42,3 +42,12 @@ stages:
           Value: "non-real-client"
         - Name: AZURE_CLIENT_SECRET
           Value: "non-real-secret"
+      CMakeTestOptions:
+        - Name: Default
+          Value: ''
+        - Name: Test
+          Value: '-DBUILD_TESTING=ON'
+        - Name: Samples
+          Value: '-DBUILD_TESTING=ON -DBUILD_SAMPLES=ON'
+        - Name: Performance
+          Value: '-DBUILD_TESTING=ON -DBUILD_SAMPLES=ON -DBUILD_PERFORMANCE_TESTS=ON'

--- a/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+# setting CMAKE_TOOLCHAIN_FILE must happen before creating the project
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
+include(AzureVcpkg)
+az_vcpkg_integrate()
+
 cmake_minimum_required (VERSION 3.13)
 project(azure-security-keyvault-certificates LANGUAGES CXX)
 
@@ -8,17 +13,14 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
-
-include(AzureVcpkg)
 include(AzureVersion)
 include(AzureCodeCoverage)
 include(AzureTransportAdapters)
 include(AzureDoxygen)
 include(AzureGlobalCompileOptions)
 include(AzureConfigRTTI)
-
-az_vcpkg_integrate()
+# Add create_map_file function
+include(CreateMapFile)
 
 if(NOT AZ_ALL_LIBRARIES)
   find_package(azure-core-cpp "1.2.0" CONFIG QUIET)

--- a/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
@@ -19,6 +19,8 @@ include(AzureTransportAdapters)
 include(AzureDoxygen)
 include(AzureGlobalCompileOptions)
 include(AzureConfigRTTI)
+# Add create_map_file function
+include(CreateMapFile)
 
 if(NOT AZ_ALL_LIBRARIES)
   find_package(azure-core-cpp "1.2.0" CONFIG QUIET)

--- a/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+# setting CMAKE_TOOLCHAIN_FILE must happen before creating the project
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
+include(AzureVcpkg)
+az_vcpkg_integrate()
+
 cmake_minimum_required (VERSION 3.13)
 project(azure-security-keyvault-keys LANGUAGES CXX)
 
@@ -8,17 +13,12 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
-
-include(AzureVcpkg)
 include(AzureVersion)
 include(AzureCodeCoverage)
 include(AzureTransportAdapters)
 include(AzureDoxygen)
 include(AzureGlobalCompileOptions)
 include(AzureConfigRTTI)
-
-az_vcpkg_integrate()
 
 if(NOT AZ_ALL_LIBRARIES)
   find_package(azure-core-cpp "1.2.0" CONFIG QUIET)

--- a/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+# setting CMAKE_TOOLCHAIN_FILE must happen before creating the project
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
+include(AzureVcpkg)
+az_vcpkg_integrate()
+
 cmake_minimum_required (VERSION 3.13)
 project(azure-security-keyvault-secrets LANGUAGES CXX)
 
@@ -8,17 +13,14 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
-
-include(AzureVcpkg)
 include(AzureVersion)
 include(AzureCodeCoverage)
 include(AzureTransportAdapters)
 include(AzureDoxygen)
 include(AzureGlobalCompileOptions)
 include(AzureConfigRTTI)
-
-az_vcpkg_integrate()
+# Add create_map_file function
+include(CreateMapFile)
 
 if(NOT AZ_ALL_LIBRARIES)
   find_package(azure-core-cpp "1.2.0" CONFIG QUIET)

--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -32,6 +32,8 @@ stages:
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
       LineCoverageTarget: 81
       BranchCoverageTarget: 42
+# Dependencies per package is not supported. List the dependencies for all packages.
+      CMakeTestDependencies: 'azure-core-cpp azure-identity-cpp'
       Artifacts:
         - Name: azure-security-keyvault-keys
           Path: azure-security-keyvault-keys
@@ -54,3 +56,8 @@ stages:
           Value: "non-real-client"
         - Name: AZURE_CLIENT_SECRET
           Value: "non-real-secret"
+      CMakeTestOptions:
+        - Name: Default
+          Value: ''
+        - Name: Test
+          Value: '-DBUILD_TESTING=ON'

--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -61,3 +61,7 @@ stages:
           Value: ''
         - Name: Test
           Value: '-DBUILD_TESTING=ON'
+        - Name: Samples
+          Value: '-DBUILD_TESTING=ON -DBUILD_SAMPLES=ON'
+        - Name: Performance
+          Value: '-DBUILD_TESTING=ON -DBUILD_SAMPLES=ON -DBUILD_PERFORMANCE_TESTS=ON'


### PR DESCRIPTION
Adding new CI stage that generates different CMake configurations for individual packages.

Instead of building from root directory, this stage makes sure that each package's folder can work independently.

![image](https://user-images.githubusercontent.com/24213737/148895671-db139c01-eec1-4fa2-ba8d-edb785ca0dff.png)

 There is a job for each OS. each job would re-use a working directory to:

for `artifact` : `service-artifacts`:
  for `option` : `some options`:
      - cd a package folder ( like sdk/azure-core )
      - create build folder
      - run cmake with `option`
      - delete the build folder

fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/3232