### PR TITLE
kv-common vcpkg fix: Option A: revert to original constructor

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -90,7 +90,7 @@ namespace Azure { namespace Core {
      */
     explicit RequestFailedException(
         const std::string& what,
-        std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse);
+        std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse);
 
     /**
      * @brief Constructs a new `%RequestFailedException` object with an HTTP raw response.

--- a/sdk/core/azure-core/src/exception.cpp
+++ b/sdk/core/azure-core/src/exception.cpp
@@ -17,7 +17,7 @@ namespace Azure { namespace Core {
 
   RequestFailedException::RequestFailedException(
       const std::string& what,
-      std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse)
+      std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse)
       : std::runtime_error(what)
   {
     const auto& headers = rawResponse->GetHeaders();
@@ -37,7 +37,7 @@ namespace Azure { namespace Core {
 
   RequestFailedException::RequestFailedException(
       std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse)
-      : RequestFailedException("Received an HTTP unsuccessful status code.", rawResponse)
+      : RequestFailedException("Received an HTTP unsuccessful status code.", std::move(rawResponse))
   {
   }
 

--- a/sdk/core/azure-core/test/ut/exception_test.cpp
+++ b/sdk/core/azure-core/test/ut/exception_test.cpp
@@ -93,7 +93,7 @@ TEST(RequestFailedException, Message)
   response->SetBodyStream(std::make_unique<Azure::Core::IO::MemoryBodyStream>(
       responseBodyStream, sizeof(responseBodyStream) - 1));
 
-  auto exception = Azure::Core::RequestFailedException("what", response);
+  auto exception = Azure::Core::RequestFailedException("what", std::move(response));
 
   EXPECT_EQ(exception.StatusCode, Azure::Core::Http::HttpStatusCode::ServiceUnavailable);
   EXPECT_EQ(exception.Message, "JT");


### PR DESCRIPTION
Fix for the vcpkg failing to build `azure-security-keyvault-common-cpp` that we deletedfrom our repo a long ago, but it is still in vcpkg.

The build error is the following:
```
sdk\keyvault\azure-security-keyvault-common\src\keyvault_exception.cpp(35):
error C2664: 'Azure::Core::RequestFailedException::RequestFailedException(
  const std::string &,std::unique_ptr<Azure::Core::Http::RawResponse,
  std::default_delete<Azure::Core::Http::RawResponse>> &)':
    cannot convert argument 2
      from 'std::unique_ptr<Azure::Core::Http::RawResponse,std::default_delete<Azure::Core::Http::RawResponse>>'
      to 'std::unique_ptr<Azure::Core::Http::RawResponse,std::default_delete<Azure::Core::Http::RawResponse>> &'
```

Which was caused by us updating the constructor just recently. This PR reverts that.

 But with this PR, there is not clear path to drop the constructor in the future, as we wanted (#3215).

Other options are #3238 and #3239.