### PR TITLE
kv-common vcpkg fix: Option B: compatibility layer for azure-security-keyvault-common

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -27,6 +27,7 @@ namespace Core {
    * @brief An error while trying to send a request to Azure service.
    */
   class RequestFailedException : public std::runtime_error {
+    // Compatibility layer for azure-security-keyvault-common using constructor with old signature.
     friend class Azure::Security::Keyvault::_internal::KeyVaultException;
 
     explicit RequestFailedException(

--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -27,6 +27,14 @@ namespace Core {
    * @brief An error while trying to send a request to Azure service.
    */
   class RequestFailedException : public std::runtime_error {
+  private:
+    // Compatibility layer for azure-security-keyvault-common using constructor with old signature.
+    friend class Azure::Security::Keyvault::_internal::KeyVaultException;
+
+    explicit RequestFailedException(
+        const std::string& what,
+        std::unique_ptr<Azure::Core::Http::RawResponse>&& rawResponse);
+
   public:
     /**
      * @brief The HTTP response code.
@@ -97,21 +105,6 @@ namespace Core {
     explicit RequestFailedException(
         const std::string& what,
         std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse);
-
-  private:
-    // Compatibility layer for azure-security-keyvault-common using constructor with old signature.
-    friend class Azure::Security::Keyvault::_internal::KeyVaultException;
-
-    // LCOV_EXCL_START
-    explicit RequestFailedException(
-        const std::string& what,
-        std::unique_ptr<Azure::Core::Http::RawResponse>&& rawResponse)
-        : RequestFailedException(
-            what,
-            static_cast<std::unique_ptr<Azure::Core::Http::RawResponse>&>(rawResponse))
-    {
-    }
-    // LCOV_EXCL_STOP
 
   public:
     /**

--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -16,11 +16,28 @@
 #include <string>
 #include <vector>
 
-namespace Azure { namespace Core {
+namespace Azure {
+namespace Security { namespace Keyvault { namespace _internal {
+  class KeyVaultException;
+}}} // namespace Security::Keyvault::_internal
+
+namespace Core {
+
   /**
    * @brief An error while trying to send a request to Azure service.
    */
   class RequestFailedException : public std::runtime_error {
+    friend class Azure::Security::Keyvault::_internal::KeyVaultException;
+
+    explicit RequestFailedException(
+        const std::string& what,
+        std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse)
+        : RequestFailedException(
+            what,
+            static_cast<std::unique_ptr<Azure::Core::Http::RawResponse>&>(rawResponse))
+    {
+    }
+
   public:
     /**
      * @brief The HTTP response code.
@@ -151,4 +168,5 @@ namespace Azure { namespace Core {
         std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse,
         std::string fieldName);
   };
-}} // namespace Azure::Core
+} // namespace Core
+} // namespace Azure

--- a/sdk/core/azure-core/inc/azure/core/exception.hpp
+++ b/sdk/core/azure-core/inc/azure/core/exception.hpp
@@ -27,18 +27,6 @@ namespace Core {
    * @brief An error while trying to send a request to Azure service.
    */
   class RequestFailedException : public std::runtime_error {
-    // Compatibility layer for azure-security-keyvault-common using constructor with old signature.
-    friend class Azure::Security::Keyvault::_internal::KeyVaultException;
-
-    explicit RequestFailedException(
-        const std::string& what,
-        std::unique_ptr<Azure::Core::Http::RawResponse> rawResponse)
-        : RequestFailedException(
-            what,
-            static_cast<std::unique_ptr<Azure::Core::Http::RawResponse>&>(rawResponse))
-    {
-    }
-
   public:
     /**
      * @brief The HTTP response code.
@@ -110,6 +98,22 @@ namespace Core {
         const std::string& what,
         std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse);
 
+  private:
+    // Compatibility layer for azure-security-keyvault-common using constructor with old signature.
+    friend class Azure::Security::Keyvault::_internal::KeyVaultException;
+
+    // LCOV_EXCL_START
+    explicit RequestFailedException(
+        const std::string& what,
+        std::unique_ptr<Azure::Core::Http::RawResponse>&& rawResponse)
+        : RequestFailedException(
+            what,
+            static_cast<std::unique_ptr<Azure::Core::Http::RawResponse>&>(rawResponse))
+    {
+    }
+    // LCOV_EXCL_STOP
+
+  public:
     /**
      * @brief Constructs a new `%RequestFailedException` object with an HTTP raw response.
      *

--- a/sdk/core/azure-core/src/exception.cpp
+++ b/sdk/core/azure-core/src/exception.cpp
@@ -15,6 +15,18 @@ using namespace Azure::Core::Http::_internal;
 
 namespace Azure { namespace Core {
 
+  // LCOV_EXCL_START
+  // This constructor is only kept for compatibility with the old azure-security-keyvault-common.
+  RequestFailedException::RequestFailedException(
+      const std::string& what,
+      std::unique_ptr<Azure::Core::Http::RawResponse>&& rawResponse)
+      : RequestFailedException(
+          what,
+          static_cast<std::unique_ptr<Azure::Core::Http::RawResponse>&>(rawResponse))
+  {
+  }
+  // LCOV_EXCL_STOP
+
   RequestFailedException::RequestFailedException(
       const std::string& what,
       std::unique_ptr<Azure::Core::Http::RawResponse>& rawResponse)


### PR DESCRIPTION
See what #3237 is about first (you don't have to see the code, just read the description).

This gives us the path to drop the constructor in the future, as we wanted (#3215).

Other options are #3237 and #3239.