### PR TITLE
kv-common vcpkg fix: Option C: release a no-op version of kv-common, then re-delete it from our SDK

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-common/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-common/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Release History
+
+## 4.0.0-beta.4 (Unreleased)
+
+### Breaking Changes
+
+- All code is removed, the library is deprecated.
+
+### Breaking Changes
+
+- Removed `SHA256`, `SHA384`, and `SHA512` hashing classes by making them internal since the end user doesn't need them.
+- Removed header `single_page.hpp`.
+
+## 4.0.0-beta.3 (2021-06-08)
+
+No breaking changes or new features added. Includes only implementation enhancements.
+
+## 4.0.0-beta.2 (2021-05-18)
+
+### Breaking Changes
+
+- Added `final` specifier to classes and structures that are are not expected to be inheritable at the moment.
+- Removed `KeyVaultException`.
+- Removed `ClientOptions`.
+
+## 4.0.0-beta.1 (2021-04-07)
+
+### New Features
+
+- KeyVaultException.

--- a/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-common/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required (VERSION 3.13)
+project(azure-security-keyvault-common LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake-modules")
+
+include(AzureVcpkg)
+include(AzureVersion)
+include(AzureGlobalCompileOptions)
+
+az_vcpkg_integrate()
+
+set(
+  AZURE_KEYVAULT_COMMON_SOURCE
+    src/private/package_version.hpp
+)
+
+add_library(
+    azure-security-keyvault-common
+      inc/azure/keyvault/common/dll_import_export.hpp
+      src/private/package_version.hpp
+)
+add_library(Azure::azure-security-keyvault-common ALIAS azure-security-keyvault-common)
+
+target_include_directories(
+    azure-security-keyvault-common
+      PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+        $<INSTALL_INTERFACE:include>
+)
+
+get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+
+az_vcpkg_export(
+    azure-security-keyvault-common
+    SECURITY_KEYVAULT_COMMON
+    "azure/keyvault/common/dll_import_export.hpp"
+  )

--- a/sdk/keyvault/azure-security-keyvault-common/NOTICE.txt
+++ b/sdk/keyvault/azure-security-keyvault-common/NOTICE.txt
@@ -1,0 +1,32 @@
+azure-sdk-for-cpp
+
+NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This software incorporates material from third parties. Microsoft makes certain
+open source code available at https://3rdpartysource.microsoft.com, or you may
+send a check or money order for US $5.00, including the product name, the open
+source component name, and version number, to:
+
+Source Code Compliance Team
+Microsoft Corporation
+One Microsoft Way
+Redmond, WA 98052
+USA
+
+Notwithstanding any other terms, you may reverse engineer this software to the
+extent required to debug changes to any libraries licensed under the GNU Lesser
+General Public License.
+
+------------------------------------------------------------------------------
+
+Azure SDK for C++ uses third-party libraries or other resources that may be
+distributed under licenses different than the Azure SDK for C++ software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention. Post an issue or email us:
+
+           azcppsdkhelp@microsoft.com
+
+The attached notices are provided for information only.
+

--- a/sdk/keyvault/azure-security-keyvault-common/cgmanifest.json
+++ b/sdk/keyvault/azure-security-keyvault-common/cgmanifest.json
@@ -1,0 +1,15 @@
+{
+    "Registrations": [
+        {
+            "Component": {
+                "Type": "other",
+                "Other": {
+                    "Name": "clang-format",
+                    "Version": "9.0.0-2",
+                    "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
+                }
+            },
+            "DevelopmentDependency": true
+        }
+    ]
+}

--- a/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/dll_import_export.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/inc/azure/keyvault/common/dll_import_export.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ * @brief DLL export macro.
+ */
+
+// For explanation, see the comment in azure/core/dll_import_export.hpp
+
+#pragma once
+
+/**
+ * @def AZ_SECURITY_KEYVAULT_COMMON_DLLEXPORT
+ * @brief Applies DLL export attribute, when applicable.
+ * @note See https://docs.microsoft.com/cpp/cpp/dllexport-dllimport?view=msvc-160.
+ */
+
+#if defined(AZ_SECURITY_KEYVAULT_COMMON_DLL) \
+    || (0 /*@AZ_SECURITY_KEYVAULT_COMMON_DLL_INSTALLED_AS_PACKAGE@*/)
+#define AZ_SECURITY_KEYVAULT_COMMON_BUILT_AS_DLL 1
+#else
+#define AZ_SECURITY_KEYVAULT_COMMON_BUILT_AS_DLL 0
+#endif
+
+#if AZ_SECURITY_KEYVAULT_COMMON_BUILT_AS_DLL
+#if defined(_MSC_VER)
+#if defined(AZ_SECURITY_KEYVAULT_COMMON_BEING_BUILT)
+#define AZ_SECURITY_KEYVAULT_COMMON_DLLEXPORT __declspec(dllexport)
+#else // !defined(AZ_SECURITY_KEYVAULT_COMMON_BEING_BUILT)
+#define AZ_SECURITY_KEYVAULT_COMMON_DLLEXPORT __declspec(dllimport)
+#endif // AZ_SECURITY_KEYVAULT_COMMON_BEING_BUILT
+#else // !defined(_MSC_VER)
+#define AZ_SECURITY_KEYVAULT_COMMON_DLLEXPORT
+#endif // _MSC_VER
+#else // !AZ_SECURITY_KEYVAULT_COMMON_BUILT_AS_DLL
+#define AZ_SECURITY_KEYVAULT_COMMON_DLLEXPORT
+#endif // AZ_SECURITY_KEYVAULT_COMMON_BUILT_AS_DLL
+
+#undef AZ_SECURITY_KEYVAULT_COMMON_BUILT_AS_DLL

--- a/sdk/keyvault/azure-security-keyvault-common/src/private/package_version.hpp
+++ b/sdk/keyvault/azure-security-keyvault-common/src/private/package_version.hpp
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ * @brief Provides version information.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#define AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MAJOR 4
+#define AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MINOR 0
+#define AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PATCH 0
+#define AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PRERELEASE "beta.4"
+
+#define AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA_HELPER(i) #i
+#define AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA(i) \
+  AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA_HELPER(i)
+
+namespace Azure { namespace Security { namespace KeyVault { namespace Common { namespace _detail {
+  /**
+   * @brief Provides version information.
+   *
+   */
+  class PackageVersion final {
+  public:
+    /// Major numeric identifier.
+    static constexpr int32_t Major = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MAJOR;
+
+    /// Minor numeric identifier.
+    static constexpr int32_t Minor = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MINOR;
+
+    /// Patch numeric identifier.
+    static constexpr int32_t Patch = AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PATCH;
+
+    /// Indicates whether the SDK is in a pre-release state.
+    static constexpr bool IsPreRelease
+        = sizeof(AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PRERELEASE) != sizeof("");
+
+    /**
+     * @brief The version in string format used for telemetry following the `semver.org` standard
+     * (https://semver.org).
+     */
+    static constexpr const char* ToString()
+    {
+      return IsPreRelease
+          ? AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA(AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MAJOR) "." AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA(
+              AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MINOR) "." AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA(AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PATCH) "-" AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PRERELEASE
+          : AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA(AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MAJOR) "." AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA(
+              AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MINOR) "." AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA(AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PATCH);
+    }
+  };
+}}}}} // namespace Azure::Security::KeyVault::Common::_detail
+
+#undef AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA_HELPER
+#undef AZURE_SECURITY_KEYVAULT_COMMON_VERSION_ITOA
+
+#undef AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MAJOR
+#undef AZURE_SECURITY_KEYVAULT_COMMON_VERSION_MINOR
+#undef AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PATCH
+#undef AZURE_SECURITY_KEYVAULT_COMMON_VERSION_PRERELEASE

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/Config.cmake.in
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/Config.cmake.in
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/azure-security-keyvault-common-cppTargets.cmake")
+
+check_required_components("azure-security-keyvault-common-cpp")

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/portfile.cmake
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Azure/azure-sdk-for-cpp
+    REF azure-security-keyvault-common_@AZ_LIBRARY_VERSION@
+    SHA512 0
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-common/
+    OPTIONS
+        -DWARNINGS_AS_ERRORS=OFF
+)
+
+vcpkg_cmake_install()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_cmake_config_fixup()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_copy_pdbs()

--- a/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-common/vcpkg/vcpkg.json
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+{
+  "name": "azure-security-keyvault-common-cpp",
+  "version-semver": "@AZ_LIBRARY_VERSION@",
+  "description": [
+    "Microsoft Azure Common Key Vault SDK for C++",
+    "This library provides common Azure Key Vault related abstractions for Azure SDK."
+  ],
+  "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-common",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
This is the best option, in my opinion.

We will have to re-create the kv-common, release it together with core, then we can delete it from our SDK again, as we did initially.