### PR TITLE
Add Manifest Generation

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -110,17 +110,6 @@ jobs:
               -DBUILD_TRANSPORT_CURL=OFF
               -DBUILD_DOCUMENTATION=YES
 
-        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-          displayName: 'Generate BOM'
-          inputs:
-            BuildDropPath: $(Build.SourcesDirectory)/build
-
-        - task: PublishPipelineArtifact@1
-          displayName: 'Publish BOM Manifest'
-          inputs:
-            artifact: 'manifest'
-            path: $(Build.SourcesDirectory)/build/_manifest
-
         - pwsh: npm install -g moxygen
           displayName: Install Moxygen to generate markdown for docs.microsoft.com
 
@@ -221,3 +210,13 @@ jobs:
             path: $(Build.ArtifactStagingDirectory)/docs
 
         - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
+
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Generate BOM'
+          inputs:
+            BuildDropPath: $(Build.SourcesDirectory)/build
+
+        - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+          parameters:
+            ArtifactPath: '$(Build.SourcesDirectory)/build/_manifest'
+            ArtifactName: 'release_artifact_manifest'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -63,6 +63,7 @@ jobs:
       variables:
         VcpkgDependencies: curl[winssl] libxml2
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        Package.EnableSBOMSigning: true
       steps:
         - template: /eng/common/pipelines/templates/steps/check-spelling.yml
           parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -109,6 +109,17 @@ jobs:
               -DBUILD_TRANSPORT_CURL=OFF
               -DBUILD_DOCUMENTATION=YES
 
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Generate BOM'
+          inputs:
+            BuildDropPath: $(Build.SourcesDirectory)/build
+
+        - task: PublishPipelineArtifact@1
+          displayName: 'Publish BOM Manifest'
+          inputs:
+            artifact: 'manifest'
+            path: $(Build.SourcesDirectory)/build/_manifest
+
         - pwsh: npm install -g moxygen
           displayName: Install Moxygen to generate markdown for docs.microsoft.com
 

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -228,3 +228,22 @@ jobs:
           path: $(Build.ArtifactStagingDirectory)
         condition: eq(variables['PublishMapFiles'], 'true')
         displayName : Publish map file artifacts
+        
+      - pwsh: |
+          $artifactName = "$(Agent.JobName)"
+          $parts = $artifactName -split ' '
+          if ($parts[1]) {
+            $artifactName = $parts[1]
+          }
+          Write-Host "##vso[task.setvariable variable=BomArtifactName;]$artifactName"
+        displayName: Set bom file artifact name
+
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 'Generate BOM'
+        inputs:
+          BuildDropPath: $(Build.ArtifactStagingDirectory)
+
+      - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+        parameters:
+          ArtifactPath: '$(Build.ArtifactStagingDirectory)/_manifest'
+          ArtifactName: 'bom_manifest_$(BomArtifactName)'


### PR DESCRIPTION
Related to Azure/azure-sdk-tools#2273

@danieljurek on this one I've made certain to add the manifest gen directly after the build. This way, if you respond on my C PR in a 

> yes you need to publish before build/ gets supplanted

then this PR is good. Otherwise I'll only have a single one to update :)