### PR TITLE
Fix BOM artifact upload failure on failed cmake

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -213,6 +213,7 @@ jobs:
 
         - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
           displayName: 'Generate BOM'
+          condition: succeededOrFailed()
           inputs:
             BuildDropPath: $(Build.SourcesDirectory)/build
 

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -239,9 +239,11 @@ jobs:
           }
           Write-Host "##vso[task.setvariable variable=BomArtifactName;]$artifactName"
         displayName: Set bom file artifact name
+        condition: succeededOrFailed()
 
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
         displayName: 'Generate BOM'
+        condition: succeededOrFailed()
         inputs:
           BuildDropPath: $(Build.ArtifactStagingDirectory)
 


### PR DESCRIPTION
[Example Build Failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1308436&view=logs&j=e71eac3d-89c8-52e0-61cd-202dc96cdaa6&t=2f09371a-b479-520a-00a4-b9ac8141a941)

Step progression:

![image](https://user-images.githubusercontent.com/45376673/150013448-9106d69b-d434-4fea-8eeb-7f95aa2024c0.png)

The issue here is that there is no condition on `generate bom`. Given that the `publish-artifact` template always uploads an artifact (even in failure state), we need to ensure that the artifact upload path isn't actually empty.

Simplest way to do that is to adjust `generate bom` to always run, rather than getting into the weeds with additional conditions within the `publish-artifact` template.



