### PR TITLE
Fix unit test compilation on UWP

### DIFF
--- a/sdk/core/azure-core/test/ut/bodystream_test.cpp
+++ b/sdk/core/azure-core/test/ut/bodystream_test.cpp
@@ -34,6 +34,7 @@ TEST(BodyStream, Rewind)
 {
   TestBodyStream tb;
 
+#if GTEST_HAS_DEATH_TEST
 #if defined(NDEBUG)
   // Release build won't provide assert msg
   ASSERT_DEATH(tb.Rewind(), "");
@@ -41,6 +42,7 @@ TEST(BodyStream, Rewind)
   ASSERT_DEATH(
       tb.Rewind(),
       "The specified BodyStream doesn't support Rewind which is required to guarantee fault ");
+#endif
 #endif
 
   std::string testDataPath(AZURE_TEST_DATA_PATH);
@@ -61,6 +63,7 @@ TEST(BodyStream, Rewind)
   EXPECT_NO_THROW(ms.Rewind());
 }
 
+#if GTEST_HAS_DEATH_TEST
 TEST(BodyStream, BadInput)
 {
   TestBodyStream tb;
@@ -71,14 +74,17 @@ TEST(BodyStream, BadInput)
 }
 
 TEST(MemoryBodyStream, BadInput) { ASSERT_DEATH(MemoryBodyStream(NULL, 1), ""); }
+#endif
 
 TEST(FileBodyStream, BadInput)
 {
+#if GTEST_HAS_DEATH_TEST
 #if defined(NDEBUG)
   // Release build won't provide assert msg
   ASSERT_DEATH(FileBodyStream(""), "");
 #else
   ASSERT_DEATH(FileBodyStream(""), "The file name must not be an empty string.");
+#endif
 #endif
 
   EXPECT_THROW(Azure::Core::IO::FileBodyStream("FileNotFound"), std::runtime_error);

--- a/sdk/core/azure-core/test/ut/context_test.cpp
+++ b/sdk/core/azure-core/test/ut/context_test.cpp
@@ -437,7 +437,7 @@ TEST(Context, Deadline)
   }
 }
 
-#if defined(AZ_CORE_RTTI)
+#if defined(AZ_CORE_RTTI) && GTEST_HAS_DEATH_TEST
 TEST(Context, PreCondition)
 {
   // Get a mismatch type from the context
@@ -478,6 +478,7 @@ TEST(Context, KeyTypePairPrecondition)
   EXPECT_FALSE(c2.TryGetValue<std::string>(keyNotFound, strValue));
   EXPECT_FALSE(c2.TryGetValue<int>(keyNotFound, intValue));
 
+#if GTEST_HAS_DEATH_TEST
 // Type-safe assert requires RTTI build
 #if defined(AZ_CORE_RTTI)
 #if defined(NDEBUG)
@@ -488,12 +489,14 @@ TEST(Context, KeyTypePairPrecondition)
       c2.TryGetValue<std::string>(key, strValue), "Type mismatch for Context::TryGetValue");
 #endif
 #endif
+#endif
 
   EXPECT_TRUE(strValue == "previous value");
 
   EXPECT_TRUE(c2.TryGetValue<int>(key, intValue));
   EXPECT_TRUE(intValue == 123);
 
+#if GTEST_HAS_DEATH_TEST
 // Type-safe assert requires RTTI build
 #if defined(AZ_CORE_RTTI)
 #if defined(NDEBUG)
@@ -501,6 +504,7 @@ TEST(Context, KeyTypePairPrecondition)
   ASSERT_DEATH(c3.TryGetValue<int>(key, intValue), "");
 #else
   ASSERT_DEATH(c3.TryGetValue<int>(key, intValue), "Type mismatch for Context::TryGetValue");
+#endif
 #endif
 #endif
 

--- a/sdk/core/azure-core/test/ut/etag_test.cpp
+++ b/sdk/core/azure-core/test/ut/etag_test.cpp
@@ -259,6 +259,7 @@ TEST(ETag, EqualsWeak)
   EXPECT_FALSE(ETag::Equals(weakTagtwo, weakTagTwo, ETag::ETagComparison::Weak));
 }
 
+#if GTEST_HAS_DEATH_TEST
 TEST(ETag, PreCondition)
 {
   ETag emptyTag;
@@ -270,3 +271,4 @@ TEST(ETag, PreCondition)
   ASSERT_DEATH(emptyTag.ToString(), "Empty ETag");
 #endif
 }
+#endif

--- a/sdk/core/azure-core/test/ut/md5_test.cpp
+++ b/sdk/core/azure-core/test/ut/md5_test.cpp
@@ -103,13 +103,16 @@ TEST(Md5Hash, ExpectThrow)
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data.c_str());
   Md5Hash instance;
 
+#if GTEST_HAS_DEATH_TEST
   ASSERT_DEATH(instance.Final(nullptr, 1), "");
   ASSERT_DEATH(instance.Append(nullptr, 1), "");
+#endif
 
   EXPECT_EQ(
       Azure::Core::Convert::Base64Encode(instance.Final(ptr, data.length())),
       "1B2M2Y8AsgTpgAmY7PhCfg==");
 
+#if GTEST_HAS_DEATH_TEST
 #if defined(NDEBUG)
   // Release build won't provide assert msg
   ASSERT_DEATH(instance.Final(), "");
@@ -119,6 +122,7 @@ TEST(Md5Hash, ExpectThrow)
   ASSERT_DEATH(instance.Final(), "Cannot call Final");
   ASSERT_DEATH(instance.Final(ptr, data.length()), "Cannot call Final");
   ASSERT_DEATH(instance.Append(ptr, data.length()), "Cannot call Append after calling Final");
+#endif
 #endif
 }
 

--- a/sdk/core/azure-core/test/ut/nullable_test.cpp
+++ b/sdk/core/azure-core/test/ut/nullable_test.cpp
@@ -174,6 +174,7 @@ TEST(Nullable, ValueOr)
 
 void Foo(int&& rValue) { (void)rValue; }
 
+#if GTEST_HAS_DEATH_TEST
 TEST(Nullable, PreCondition)
 {
   Nullable<int> emptyNullable;
@@ -207,6 +208,7 @@ TEST(Nullable, PreCondition3)
   ASSERT_DEATH(Foo(Nullable<int>().Value());, "Empty Nullable");
 #endif
 }
+#endif
 
 TEST(Nullable, Operator)
 {

--- a/sdk/storage/azure-storage-common/test/ut/crypt_functions_test.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/crypt_functions_test.cpp
@@ -117,12 +117,15 @@ namespace Azure { namespace Storage { namespace Test {
     const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data.data());
     Crc64Hash instance;
 
+#if GTEST_HAS_DEATH_TEST
     ASSERT_DEATH(instance.Final(nullptr, 1), "");
     ASSERT_DEATH(instance.Append(nullptr, 1), "");
+#endif
 
     EXPECT_EQ(
         Azure::Core::Convert::Base64Encode(instance.Final(ptr, data.length())), "AAAAAAAAAAA=");
 
+#if GTEST_HAS_DEATH_TEST
 #if defined(NDEBUG)
     // Release build won't provide assert msg
     ASSERT_DEATH(instance.Final(), "");
@@ -132,6 +135,7 @@ namespace Azure { namespace Storage { namespace Test {
     ASSERT_DEATH(instance.Final(), "Cannot call Final");
     ASSERT_DEATH(instance.Final(ptr, data.length()), "Cannot call Final");
     ASSERT_DEATH(instance.Append(ptr, data.length()), "Cannot call Append after calling Final");
+#endif
 #endif
   }
 


### PR DESCRIPTION
This is NOT the fix for the missing `VCRUNTIME140D_APP.dll`.
This is to successfully compile all of them before it would get to that point.

Gtest does not support `ASSERT_DEATH()` on UWP: https://github.com/google/googletest/blob/100f6fbf5f81a82d163c1e29735e8a2936eacd4f/googletest/include/gtest/internal/gtest-port.h#L605-L613