### PR TITLE
Add back azure_assert.hpp to core CMakeLists

### DIFF
--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -78,6 +78,7 @@ set(
     inc/azure/core/internal/json/json.hpp
     inc/azure/core/internal/strings.hpp
     inc/azure/core/io/body_stream.hpp
+    inc/azure/core/azure_assert.hpp
     inc/azure/core/rtti.hpp
     inc/azure/core/base64.hpp
     inc/azure/core/case_insensitive_containers.hpp


### PR DESCRIPTION
Follow-up to https://github.com/Azure/azure-sdk-for-cpp/pull/3186, to add back the hpp file that was there previously, before https://github.com/Azure/azure-sdk-for-cpp/pull/3059.