### PR TITLE
Fix the SDK Beta Vcpkg Registry information to use stable instead of GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ You can reference this [vcpkg Quick Start](https://github.com/microsoft/vcpkg#qu
 
 #### Getting Beta Releases in Vcpkg
 
-Official vcpkg registry may have beta versions of Azure SDK client libraries, up until a given library gets released as General Availability (GA) version. After that, we don't publish post-GA beta releases of that library in the official registry.
+Official vcpkg registry may have beta versions of Azure SDK client libraries, up until a given library gets released as stable. After that, we don't publish post-first-stable beta releases of that library in the official registry.
 
-If you are interested in both GA releases and post-GA beta releases, see [Azure SDK Beta Vcpkg Registry](https://github.com/azure-sdk/vcpkg-betas).
+If you are interested in both stable releases and post-first-stable beta releases, see [Azure SDK Beta Vcpkg Registry](https://github.com/azure-sdk/vcpkg-betas).
 
 ### Building your Application
 


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk-for-cpp/pull/3306#discussion_r799029065