### PR TITLE
Skip release stage on private repository

### DIFF
--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -12,7 +12,7 @@ stages:
       - stage: Release_${{ replace(artifact.Name, '-', '_') }}
         displayName: 'Release ${{artifact.name}}'
         dependsOn: ${{ parameters.DependsOn }}
-        condition:  and(succeeded(), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-cpp'), ne(variables['Skip.AllRelease'], 'true'))
+        condition:  and(succeeded(), not(endsWith(variables['Build.Repository.Name'], '-pr')), ne(variables['Skip.AllRelease'], 'true'))
 
         jobs:
           - deployment: TagRepository


### PR DESCRIPTION
Fixes situations where the release stage is unintentionally skipped. The code changed here has been this way for a long time but the bug behavior has begun manifesting recently. 

Template releasing correctly with this change -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1347771&view=results