### PR TITLE
Improve the quality of the WinHTTP transport error message.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ endif()
 
 # sub-projects
 add_subdirectory(sdk/core)
-add_subdirectory(sdk/attestation)
 add_subdirectory(sdk/identity)
 add_subdirectory(sdk/keyvault)
 add_subdirectory(sdk/storage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ endif()
 
 # sub-projects
 add_subdirectory(sdk/core)
+add_subdirectory(sdk/attestation)
 add_subdirectory(sdk/identity)
 add_subdirectory(sdk/keyvault)
 add_subdirectory(sdk/storage)


### PR DESCRIPTION
# Improve the quality of the WinHTTP exception error message.

The WInHTTP error message used to simply report the Win32 error code returned by WinHTTP. This change updates the error generation logic in WinHTTP to add the error text from WIndows using the `FormatMessage` API.

