### PR TITLE
Increment gTest version to get rid of warning during cmake-configure

### DIFF
--- a/cmake-modules/AddGoogleTest.cmake
+++ b/cmake-modules/AddGoogleTest.cmake
@@ -15,7 +15,7 @@ if(CMAKE_VERSION VERSION_LESS 3.11)
     download_project(
         PROJ                googletest
 		GIT_REPOSITORY      https://github.com/google/googletest.git
-		GIT_TAG             release-1.10.0
+		GIT_TAG             release-1.11.0
 		UPDATE_DISCONNECTED 1
 		QUIET
     )
@@ -29,7 +29,7 @@ else()
     FetchContent_Declare(
         googletest
         GIT_REPOSITORY      https://github.com/google/googletest.git
-        GIT_TAG             release-1.10.0
+        GIT_TAG             release-1.11.0
         )
     FetchContent_GetProperties(googletest)
     if(NOT googletest_POPULATED)

--- a/sdk/core/azure-core/cgmanifest.json
+++ b/sdk/core/azure-core/cgmanifest.json
@@ -12,11 +12,11 @@
         },
         {
             "Component": {
-              "Type": "git",
-              "git": {
-                "RepositoryUrl": "https://github.com/nlohmann/json",
-                "CommitHash": "db78ac1d7716f56fc9f1b030b715f872f93964e4"
-              }
+                "Type": "git",
+                "git": {
+                    "RepositoryUrl": "https://github.com/nlohmann/json",
+                    "CommitHash": "db78ac1d7716f56fc9f1b030b715f872f93964e4"
+                }
             },
             "DevelopmentDependency": false
         },
@@ -25,7 +25,7 @@
                 "Type": "git",
                 "git": {
                     "RepositoryUrl": "https://github.com/google/googletest",
-                    "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
+                    "CommitHash": "e2239ee6043f73722e7aa812a459f54a28552929"
                 }
             },
             "DevelopmentDependency": true
@@ -54,24 +54,24 @@
         },
         {
             "Component": {
-              "Type": "git",
-              "git": {
-                "RepositoryUrl": "https://github.com/CLIUtils/cmake",
-                "CommitHash": "4e52e4d0bc2e9fd27171926d0b5d9f396dd8637c"
-              }
+                "Type": "git",
+                "git": {
+                    "RepositoryUrl": "https://github.com/CLIUtils/cmake",
+                    "CommitHash": "4e52e4d0bc2e9fd27171926d0b5d9f396dd8637c"
+                }
             },
             "DevelopmentDependency": true
         },
         {
-          "Component": {
-            "Type": "other",
-            "Other": {
-              "Name": "gcovr",
-              "Version": "3.4-1",
-              "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-universe-amd64/gcovr_3.4-1_all.deb.html"
-            }
-          },
-          "DevelopmentDependency": true
+            "Component": {
+                "Type": "other",
+                "Other": {
+                    "Name": "gcovr",
+                    "Version": "3.4-1",
+                    "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-universe-amd64/gcovr_3.4-1_all.deb.html"
+                }
+            },
+            "DevelopmentDependency": true
         },
         {
             "Component": {

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
@@ -530,7 +530,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_P(DowloadShare, fromBuffer)
   {
-    auto const p = GetParam();
+    ShareConcurrentDownloadParameter const& p(GetParam());
     m_fileContent = std::vector<uint8_t>(static_cast<size_t>(8_MB), 'x');
     m_fileClient->UploadFrom(m_fileContent.data(), m_fileContent.size());
 
@@ -605,7 +605,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_P(DowloadShare, fromFile)
   {
-    auto const p = GetParam();
+    ShareConcurrentDownloadParameter const& p(GetParam());
     m_fileContent = std::vector<uint8_t>(static_cast<size_t>(8_MB), 'x');
     m_fileClient->UploadFrom(m_fileContent.data(), m_fileContent.size());
 


### PR DESCRIPTION
fix: https://github.com/Azure/azure-sdk-for-cpp/issues/3352

Removes warning :


  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.

