### PR TITLE
Log binary sizes (excl. UWP changes)

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -141,7 +141,8 @@
     {
       "filename": "**/eng/**",
       "words": [
-        "TEAMPROJECTID"
+        "TEAMPROJECTID",
+        "issecret"
       ]
     },
     {

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -139,6 +139,12 @@
       ]
     },
     {
+      "filename": "**/eng/**",
+      "words": [
+        "TEAMPROJECTID"
+      ]
+    },
+    {
       "filename": "**/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client_models.hpp",
       "words": [
         "SECG",

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -213,7 +213,12 @@ jobs:
               Job = '$(Agent.JobName)';
               BuildReason = '$(Build.Reason)';
               SourceBranchName = '$(Build.SourceBranchName)';
-              TestVersion = 1;
+              TargetOs = '$(METRIC_TARGET_OS)';
+              Toolchain = '$(METRIC_TOOLCHAIN)';
+              BuildConfig = '$(METRIC_BUILD_CONFIG)';
+              TargetArchitecture = '$(METRIC_TARGET_ARCHITECTURE)';
+              TargetPlatform = '$(METRIC_TARGET_PLATFORM)';
+              MetricVersion = 1;
             }
           pwsh: true
           workingDirectory: $(Pipeline.Workspace)

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -212,7 +212,7 @@ jobs:
             -ExtraLabels @{
               Job = '$(Agent.JobName)';
               BuildReason = '$(Build.Reason)';
-              SourceBranchName = '$(Build.SourceBranchName)';
+              SourceBranch = '$(Build.SourceBranch)';
               TargetOs = '$(METRIC_TARGET_OS)';
               Toolchain = '$(METRIC_TOOLCHAIN)';
               BuildConfig = '$(METRIC_BUILD_CONFIG)';

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -209,15 +209,13 @@ jobs:
           filePath: $(Build.SourcesDirectory)/eng/scripts/Get-BinarySizes.ps1
           arguments: >-
             -ServiceDirectory ${{parameters.ServiceDirectory}}
+            -OsVMImage '$(OSVmImage)'
+            -CmakeEnvArg '$(CmakeEnvArg)'
+            -BuildArgs '$(BuildArgs)'
+            -Job = '$(Agent.JobName)'
+            -BuildReason = '$(Build.Reason)'
+            -SourceBranch = '$(Build.SourceBranch)'
             -ExtraLabels @{
-              Job = '$(Agent.JobName)';
-              BuildReason = '$(Build.Reason)';
-              SourceBranch = '$(Build.SourceBranch)';
-              TargetOs = '$(METRIC_TARGET_OS)';
-              Toolchain = '$(METRIC_TOOLCHAIN)';
-              BuildConfig = '$(METRIC_BUILD_CONFIG)';
-              TargetArchitecture = '$(METRIC_TARGET_ARCHITECTURE)';
-              TargetPlatform = '$(METRIC_TARGET_PLATFORM)';
               MetricVersion = 1;
             }
           pwsh: true

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -207,7 +207,14 @@ jobs:
       - task: Powershell@2
         inputs:
           filePath: $(Build.SourcesDirectory)/eng/scripts/Get-BinarySizes.ps1
-          arguments: -ServiceDirectory ${{parameters.ServiceDirectory}}
+          arguments: >-
+            -ServiceDirectory ${{parameters.ServiceDirectory}}
+            -ExtraLabels @{
+              Job = '$(Agent.JobName)';
+              BuildReason = '$(Build.Reason)';
+              SourceBranchName = '$(Build.SourceBranchName)';
+              TestVersion = 1;
+            }
           pwsh: true
           workingDirectory: $(Pipeline.Workspace)
         displayName: Report Binary Sizes

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -204,6 +204,14 @@ jobs:
             coverageThreshold: ${{ parameters.BranchCoverageTarget }}
           condition: and(succeededOrFailed(), eq(variables['CODE_COVERAGE'], 'enabled'), eq(variables['Skip.BranchCoverageEnforcement'], ''))
 
+      - task: Powershell@2
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/scripts/Get-BinarySizes.ps1
+          arguments: -ServiceDirectory ${{parameters.ServiceDirectory}}
+          pwsh: true
+          workingDirectory: $(Pipeline.Workspace)
+        displayName: Report Binary Sizes
+
       # Use the job name to create the artifact name for MAP file publishing.
       # Attempts are also noted starting with 1
       # "Validate Windows2019_UWP_debug_x86" -> "Windows2019_UWP_debug_x86_attempt_1"

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -212,9 +212,9 @@ jobs:
             -OsVMImage '$(OSVmImage)'
             -CmakeEnvArg '$(CmakeEnvArg)'
             -BuildArgs '$(BuildArgs)'
-            -Job = '$(Agent.JobName)'
-            -BuildReason = '$(Build.Reason)'
-            -SourceBranch = '$(Build.SourceBranch)'
+            -Job '$(Agent.JobName)'
+            -BuildReason '$(Build.Reason)'
+            -SourceBranch '$(Build.SourceBranch)'
             -ExtraLabels @{
               MetricVersion = 1;
             }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -37,24 +37,25 @@
                 "Windows2019": {
                     "OSVmImage": "MMS2019",
                     "Pool": "azsdk-pool-mms-win-2019-general",
-                    "BuildArgs": "--parallel 8",
                     "CMAKE_GENERATOR": "Visual Studio 16 2019"
                 }
             },
             "TargetPlatform": {
                 "Win32Api_curl": {
-                    "VcpkgInstall": "curl[winssl] openssl",
-                    "CmakeArgs": " -DBUILD_TRANSPORT_CURL=ON"
+                    "VcpkgInstall": "curl[winssl]",
+                    "CmakeArgs": " -DBUILD_TRANSPORT_CURL=ON",
+                    "BuildArgs": "--parallel 8"
                 },
                 "Win32Api_release_curl": {
                     "VcpkgInstall": "curl[winssl] openssl",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON",
-                    "CMAKE_BUILD_TYPE": "Release",
+                    "BuildArgs": "--parallel 8 --config Release",
                     "PublishMapFiles": "true"
                 },
                 "Win32Api_debug_tests": {
                     "VcpkgInstall": "curl[winssl] openssl",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON",
+                    "BuildArgs": "--parallel 8 --config Debug",
                     "PublishMapFiles": "true"
                 }
             },
@@ -74,7 +75,6 @@
                 "Windows2019": {
                     "OSVmImage": "MMS2019",
                     "Pool": "azsdk-pool-mms-win-2019-general",
-                    "BuildArgs": "--parallel 8",
                     "CMAKE_GENERATOR": "Visual Studio 16 2019",
                     "CmakeArgs": " -DBUILD_TRANSPORT_WINHTTP=ON ",
                     "PublishMapFiles": "true"
@@ -84,22 +84,25 @@
                 "UWP_debug": {
                     "VcpkgInstall": "openssl",
                     "CMAKE_SYSTEM_NAME": "WindowsStore",
-                    "CMAKE_SYSTEM_VERSION": "10.0"
+                    "CMAKE_SYSTEM_VERSION": "10.0",
+                    "BuildArgs": "--parallel 8 --config Debug"
                 },
                 "UWP_release": {
                     "VcpkgInstall": "openssl",
                     "CMAKE_SYSTEM_NAME": "WindowsStore",
                     "CMAKE_SYSTEM_VERSION": "10.0",
-                    "CMAKE_BUILD_TYPE": "Release"
+                    "BuildArgs": "--parallel 8 --config Release"
                 }
             },
             "TargetArchitecture": {
                 "x86": {
-                    "CMAKE_GENERATOR_PLATFORM": "Win32"
+                    "CMAKE_GENERATOR_PLATFORM": "Win32",
+                    "BuildArgs": "--parallel 8"
                 },
                 "x64": {
                     "CMAKE_GENERATOR_PLATFORM": "x64",
-                    "VCPKG_DEFAULT_TRIPLET": "x64-uwp"
+                    "VCPKG_DEFAULT_TRIPLET": "x64-uwp",
+                    "BuildArgs": "--parallel 8"
                 }
             }
         },

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -169,6 +169,10 @@
                     "METRIC_TOOLCHAIN": "g++-7",
                     "METRIC_BUILD_CONFIG": "Debug"
                 },
+                "included": {
+                    "METRIC_TOOLCHAIN": "g++-7",
+                    "METRIC_BUILD_CONFIG": "Debug"
+                },
                 "included_release": {
                     "CMAKE_BUILD_TYPE": "Release",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON",

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -169,7 +169,6 @@
                     "METRIC_TOOLCHAIN": "g++-7",
                     "METRIC_BUILD_CONFIG": "Debug"
                 },
-                "included": {},
                 "included_release": {
                     "CMAKE_BUILD_TYPE": "Release",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON",
@@ -181,7 +180,7 @@
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_SAMPLES=ON ",
                     "PublishMapFiles": "true",
                     "METRIC_TOOLCHAIN": "g++-7",
-                    "METRIC_BUILD_CONFIG": "Release"
+                    "METRIC_BUILD_CONFIG": "Debug"
                 }
             }
         },

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -96,13 +96,11 @@
             },
             "TargetArchitecture": {
                 "x86": {
-                    "CMAKE_GENERATOR_PLATFORM": "Win32",
-                    "BuildArgs": "--parallel 8"
+                    "CMAKE_GENERATOR_PLATFORM": "Win32"
                 },
                 "x64": {
                     "CMAKE_GENERATOR_PLATFORM": "x64",
-                    "VCPKG_DEFAULT_TRIPLET": "x64-uwp",
-                    "BuildArgs": "--parallel 8"
+                    "VCPKG_DEFAULT_TRIPLET": "x64-uwp"
                 }
             }
         },

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -52,7 +52,7 @@
             },
             "TargetPlatform": {
                 "Win32Api_curl": {
-                    "VcpkgInstall": "curl[winssl]",
+                    "VcpkgInstall": "curl[winssl] openssl",
                     "CmakeArgs": " -DBUILD_TRANSPORT_CURL=ON",
                     "BuildArgs": "--parallel 8",
                     "METRIC_BUILD_CONFIG": "Debug"

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -6,11 +6,13 @@
         {
             "OSConfiguration": {
                 "macOS-10.15": {
-                    "OSVmImage": "macOS-10.15"
+                    "OSVmImage": "macOS-10.15",
+                    "METRIC_TARGET_OS": "macOS-10.15"
                 },
                 "macOS-11": {
                     "OSVmImage": "macOS-11",
-                    "XCODE_VERSION": "12.5.1"
+                    "XCODE_VERSION": "12.5.1",
+                    "METRIC_TARGET_OS": "macOS-11"
                 }
             },
             "StaticConfigs": {
@@ -20,15 +22,20 @@
                     "BuildArgs": "-j 10",
                     "VCPKG_DEFAULT_TRIPLET": "x64-osx",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON",
-                    "PublishMapFiles": "true"
+                    "PublishMapFiles": "true",
+                    "METRIC_TARGET_ARCHITECTURE": "x64",
+                    "METRIC_TOOLCHAIN": "AppleClang 12",
+                    "METRIC_TARGET_PLATFORM": "macos"
                 }
             },
             "BuildConfig": {
                 "debug": {
-                    "CMAKE_BUILD_TYPE": "Debug"
+                    "CMAKE_BUILD_TYPE": "Debug",
+                    "METRIC_BUILD_CONFIG": "Debug"
                 },
                 "release": {
-                    "CMAKE_BUILD_TYPE": "Release"
+                    "CMAKE_BUILD_TYPE": "Release",
+                    "METRIC_BUILD_CONFIG": "Release"
                 }
             }
         },
@@ -37,36 +44,44 @@
                 "Windows2019": {
                     "OSVmImage": "MMS2019",
                     "Pool": "azsdk-pool-mms-win-2019-general",
-                    "CMAKE_GENERATOR": "Visual Studio 16 2019"
+                    "CMAKE_GENERATOR": "Visual Studio 16 2019",
+                    "METRIC_TARGET_OS": "win-2019",
+                    "METRIC_TOOLCHAIN": "MSVC",
+                    "METRIC_TARGET_PLATFORM": "win32"
                 }
             },
             "TargetPlatform": {
                 "Win32Api_curl": {
                     "VcpkgInstall": "curl[winssl]",
                     "CmakeArgs": " -DBUILD_TRANSPORT_CURL=ON",
-                    "BuildArgs": "--parallel 8"
+                    "BuildArgs": "--parallel 8",
+                    "METRIC_BUILD_CONFIG": "Debug"
                 },
                 "Win32Api_release_curl": {
                     "VcpkgInstall": "curl[winssl] openssl",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON",
                     "BuildArgs": "--parallel 8 --config Release",
-                    "PublishMapFiles": "true"
+                    "PublishMapFiles": "true",
+                    "METRIC_BUILD_CONFIG": "Release"
                 },
                 "Win32Api_debug_tests": {
                     "VcpkgInstall": "curl[winssl] openssl",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON",
                     "BuildArgs": "--parallel 8 --config Debug",
-                    "PublishMapFiles": "true"
+                    "PublishMapFiles": "true",
+                    "METRIC_BUILD_CONFIG": "Debug"
                 }
             },
             "TargetArchitecture": {
                 "x86": {
                     "CMAKE_GENERATOR_PLATFORM": "Win32",
-                    "VCPKG_DEFAULT_TRIPLET": "x86-windows-static"
+                    "VCPKG_DEFAULT_TRIPLET": "x86-windows-static",
+                    "METRIC_TARGET_ARCHITECTURE": "x86"
                 },
                 "x64": {
                     "CMAKE_GENERATOR_PLATFORM": "x64",
-                    "VCPKG_DEFAULT_TRIPLET": "x64-windows-static"
+                    "VCPKG_DEFAULT_TRIPLET": "x64-windows-static",
+                    "METRIC_TARGET_ARCHITECTURE": "x64"
                 }
             }
         },
@@ -77,7 +92,10 @@
                     "Pool": "azsdk-pool-mms-win-2019-general",
                     "CMAKE_GENERATOR": "Visual Studio 16 2019",
                     "CmakeArgs": " -DBUILD_TRANSPORT_WINHTTP=ON ",
-                    "PublishMapFiles": "true"
+                    "PublishMapFiles": "true",
+                    "METRIC_TARGET_OS": "win-2019",
+                    "METRIC_TOOLCHAIN": "MSVC",
+                    "METRIC_TARGET_PLATFORM": "uwp"
                 }
             },
             "TargetPlatform": {
@@ -85,22 +103,26 @@
                     "VcpkgInstall": "openssl",
                     "CMAKE_SYSTEM_NAME": "WindowsStore",
                     "CMAKE_SYSTEM_VERSION": "10.0",
-                    "BuildArgs": "--parallel 8 --config Debug"
+                    "BuildArgs": "--parallel 8 --config Debug",
+                    "METRIC_BUILD_CONFIG": "Debug"
                 },
                 "UWP_release": {
                     "VcpkgInstall": "openssl",
                     "CMAKE_SYSTEM_NAME": "WindowsStore",
                     "CMAKE_SYSTEM_VERSION": "10.0",
-                    "BuildArgs": "--parallel 8 --config Release"
+                    "BuildArgs": "--parallel 8 --config Release",
+                    "METRIC_BUILD_CONFIG": "Release"
                 }
             },
             "TargetArchitecture": {
                 "x86": {
-                    "CMAKE_GENERATOR_PLATFORM": "Win32"
+                    "CMAKE_GENERATOR_PLATFORM": "Win32",
+                    "METRIC_TARGET_ARCHITECTURE": "x86"
                 },
                 "x64": {
                     "CMAKE_GENERATOR_PLATFORM": "x64",
-                    "VCPKG_DEFAULT_TRIPLET": "x64-uwp"
+                    "VCPKG_DEFAULT_TRIPLET": "x64-uwp",
+                    "METRIC_TARGET_ARCHITECTURE": "x64"
                 }
             }
         },
@@ -111,40 +133,55 @@
                     "Pool": "azsdk-pool-mms-ubuntu-1804-general",
                     "VcpkgInstall": "curl[ssl] libxml2 openssl",
                     "VCPKG_DEFAULT_TRIPLET": "x64-linux",
-                    "BuildArgs": "-j 10"
+                    "BuildArgs": "-j 10",
+                    "METRIC_TARGET_OS": "ubuntu-18.04",
+                    "METRIC_TARGET_ARCHITECTURE": "x64",
+                    "METRIC_TARGET_PLATFORM": "linux"
                 }
             },
             "BuildSettings": {
                 "gpp-5": {
                     "AptDependencies": "g++-5",
-                    "CmakeEnvArg": "CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 "
+                    "CmakeEnvArg": "CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 ",
+                    "METRIC_TOOLCHAIN": "g++-5",
+                    "METRIC_BUILD_CONFIG": "Debug"
                 },
                 "gpp-8": {
                     "AptDependencies": "g++-8",
                     "CC": "/usr/bin/gcc-8",
-                    "CXX": "/usr/bin/g++-8"
+                    "CXX": "/usr/bin/g++-8",
+                    "METRIC_TOOLCHAIN": "g++-8",
+                    "METRIC_BUILD_CONFIG": "Debug"
                 },
                 "gpp-9": {
                     "AptDependencies": "g++-9",
                     "CC": "/usr/bin/gcc-9",
-                    "CXX": "/usr/bin/g++-9"
+                    "CXX": "/usr/bin/g++-9",
+                    "METRIC_TOOLCHAIN": "g++-9",
+                    "METRIC_BUILD_CONFIG": "Debug"
                 },
                 "included_coverage": {
                     "AptDependencies": "gcovr lcov",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_CODE_COVERAGE=ON -DCMAKE_VERBOSE_MAKEFILE=ON",
                     "CODE_COVERAGE_COLLECT_ONLY": "1",
                     "CODE_COVERAGE": "enabled",
-                    "PublishMapFiles": "true"
+                    "PublishMapFiles": "true",
+                    "METRIC_TOOLCHAIN": "g++-7",
+                    "METRIC_BUILD_CONFIG": "Debug"
                 },
                 "included": {},
                 "included_release": {
                     "CMAKE_BUILD_TYPE": "Release",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON",
-                    "PublishMapFiles": "true"
+                    "PublishMapFiles": "true",
+                    "METRIC_TOOLCHAIN": "g++-7",
+                    "METRIC_BUILD_CONFIG": "Release"
                 },
                 "included_samples": {
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_SAMPLES=ON ",
-                    "PublishMapFiles": "true"
+                    "PublishMapFiles": "true",
+                    "METRIC_TOOLCHAIN": "g++-7",
+                    "METRIC_BUILD_CONFIG": "Release"
                 }
             }
         },
@@ -159,15 +196,21 @@
                     "CC": "/usr/bin/clang-11",
                     "CXX": "/usr/bin/clang++-11",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON",
-                    "PublishMapFiles": "true"
+                    "PublishMapFiles": "true",
+                    "METRIC_TARGET_PLATFORM": "linux",
+                    "METRIC_TOOLCHAIN": "clang-11",
+                    "METRIC_TARGET_ARCHITECTURE": "x64",
+                    "METRIC_TARGET_OS": "ubuntu-20.04"
                 }
             },
             "BuildSettings": {
                 "clang-11": {
-                    "CHECK_CLANG_FORMAT": "1"
+                    "CHECK_CLANG_FORMAT": "1",
+                    "METRIC_BUILD_CONFIG": "Debug"
                 },
                 "included_release": {
-                    "CMAKE_BUILD_TYPE": "Release"
+                    "CMAKE_BUILD_TYPE": "Release",
+                    "METRIC_BUILD_CONFIG": "Release"
                 }
             }
         }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -6,13 +6,11 @@
         {
             "OSConfiguration": {
                 "macOS-10.15": {
-                    "OSVmImage": "macOS-10.15",
-                    "METRIC_TARGET_OS": "macOS-10.15"
+                    "OSVmImage": "macOS-10.15"
                 },
                 "macOS-11": {
                     "OSVmImage": "macOS-11",
-                    "XCODE_VERSION": "12.5.1",
-                    "METRIC_TARGET_OS": "macOS-11"
+                    "XCODE_VERSION": "12.5.1"
                 }
             },
             "StaticConfigs": {
@@ -22,20 +20,15 @@
                     "BuildArgs": "-j 10",
                     "VCPKG_DEFAULT_TRIPLET": "x64-osx",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON",
-                    "PublishMapFiles": "true",
-                    "METRIC_TARGET_ARCHITECTURE": "x64",
-                    "METRIC_TOOLCHAIN": "AppleClang 12",
-                    "METRIC_TARGET_PLATFORM": "macos"
+                    "PublishMapFiles": "true"
                 }
             },
             "BuildConfig": {
                 "debug": {
-                    "CMAKE_BUILD_TYPE": "Debug",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "CMAKE_BUILD_TYPE": "Debug"
                 },
                 "release": {
-                    "CMAKE_BUILD_TYPE": "Release",
-                    "METRIC_BUILD_CONFIG": "Release"
+                    "CMAKE_BUILD_TYPE": "Release"
                 }
             }
         },
@@ -44,44 +37,36 @@
                 "Windows2019": {
                     "OSVmImage": "MMS2019",
                     "Pool": "azsdk-pool-mms-win-2019-general",
-                    "CMAKE_GENERATOR": "Visual Studio 16 2019",
-                    "METRIC_TARGET_OS": "win-2019",
-                    "METRIC_TOOLCHAIN": "MSVC",
-                    "METRIC_TARGET_PLATFORM": "win32"
+                    "CMAKE_GENERATOR": "Visual Studio 16 2019"
                 }
             },
             "TargetPlatform": {
                 "Win32Api_curl": {
                     "VcpkgInstall": "curl[winssl] openssl",
                     "CmakeArgs": " -DBUILD_TRANSPORT_CURL=ON",
-                    "BuildArgs": "--parallel 8",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "BuildArgs": "--parallel 8"
                 },
                 "Win32Api_release_curl": {
                     "VcpkgInstall": "curl[winssl] openssl",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON",
                     "BuildArgs": "--parallel 8 --config Release",
-                    "PublishMapFiles": "true",
-                    "METRIC_BUILD_CONFIG": "Release"
+                    "PublishMapFiles": "true"
                 },
                 "Win32Api_debug_tests": {
                     "VcpkgInstall": "curl[winssl] openssl",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON -DBUILD_TRANSPORT_WINHTTP=ON",
                     "BuildArgs": "--parallel 8 --config Debug",
-                    "PublishMapFiles": "true",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "PublishMapFiles": "true"
                 }
             },
             "TargetArchitecture": {
                 "x86": {
                     "CMAKE_GENERATOR_PLATFORM": "Win32",
-                    "VCPKG_DEFAULT_TRIPLET": "x86-windows-static",
-                    "METRIC_TARGET_ARCHITECTURE": "x86"
+                    "VCPKG_DEFAULT_TRIPLET": "x86-windows-static"
                 },
                 "x64": {
                     "CMAKE_GENERATOR_PLATFORM": "x64",
-                    "VCPKG_DEFAULT_TRIPLET": "x64-windows-static",
-                    "METRIC_TARGET_ARCHITECTURE": "x64"
+                    "VCPKG_DEFAULT_TRIPLET": "x64-windows-static"
                 }
             }
         },
@@ -92,10 +77,7 @@
                     "Pool": "azsdk-pool-mms-win-2019-general",
                     "CMAKE_GENERATOR": "Visual Studio 16 2019",
                     "CmakeArgs": " -DBUILD_TRANSPORT_WINHTTP=ON ",
-                    "PublishMapFiles": "true",
-                    "METRIC_TARGET_OS": "win-2019",
-                    "METRIC_TOOLCHAIN": "MSVC",
-                    "METRIC_TARGET_PLATFORM": "uwp"
+                    "PublishMapFiles": "true"
                 }
             },
             "TargetPlatform": {
@@ -103,26 +85,22 @@
                     "VcpkgInstall": "openssl",
                     "CMAKE_SYSTEM_NAME": "WindowsStore",
                     "CMAKE_SYSTEM_VERSION": "10.0",
-                    "BuildArgs": "--parallel 8 --config Debug",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "BuildArgs": "--parallel 8 --config Debug"
                 },
                 "UWP_release": {
                     "VcpkgInstall": "openssl",
                     "CMAKE_SYSTEM_NAME": "WindowsStore",
                     "CMAKE_SYSTEM_VERSION": "10.0",
-                    "BuildArgs": "--parallel 8 --config Release",
-                    "METRIC_BUILD_CONFIG": "Release"
+                    "BuildArgs": "--parallel 8 --config Release"
                 }
             },
             "TargetArchitecture": {
                 "x86": {
-                    "CMAKE_GENERATOR_PLATFORM": "Win32",
-                    "METRIC_TARGET_ARCHITECTURE": "x86"
+                    "CMAKE_GENERATOR_PLATFORM": "Win32"
                 },
                 "x64": {
                     "CMAKE_GENERATOR_PLATFORM": "x64",
-                    "VCPKG_DEFAULT_TRIPLET": "x64-uwp",
-                    "METRIC_TARGET_ARCHITECTURE": "x64"
+                    "VCPKG_DEFAULT_TRIPLET": "x64-uwp"
                 }
             }
         },
@@ -133,58 +111,41 @@
                     "Pool": "azsdk-pool-mms-ubuntu-1804-general",
                     "VcpkgInstall": "curl[ssl] libxml2 openssl",
                     "VCPKG_DEFAULT_TRIPLET": "x64-linux",
-                    "BuildArgs": "-j 10",
-                    "METRIC_TARGET_OS": "ubuntu-18.04",
-                    "METRIC_TARGET_ARCHITECTURE": "x64",
-                    "METRIC_TARGET_PLATFORM": "linux"
+                    "BuildArgs": "-j 10"
                 }
             },
             "BuildSettings": {
                 "gpp-5": {
                     "AptDependencies": "g++-5",
-                    "CmakeEnvArg": "CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 ",
-                    "METRIC_TOOLCHAIN": "g++-5",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "CmakeEnvArg": "CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 "
                 },
                 "gpp-8": {
                     "AptDependencies": "g++-8",
                     "CC": "/usr/bin/gcc-8",
-                    "CXX": "/usr/bin/g++-8",
-                    "METRIC_TOOLCHAIN": "g++-8",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "CXX": "/usr/bin/g++-8"
                 },
                 "gpp-9": {
                     "AptDependencies": "g++-9",
                     "CC": "/usr/bin/gcc-9",
-                    "CXX": "/usr/bin/g++-9",
-                    "METRIC_TOOLCHAIN": "g++-9",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "CXX": "/usr/bin/g++-9"
                 },
                 "included_coverage": {
                     "AptDependencies": "gcovr lcov",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_CODE_COVERAGE=ON -DCMAKE_VERBOSE_MAKEFILE=ON",
                     "CODE_COVERAGE_COLLECT_ONLY": "1",
                     "CODE_COVERAGE": "enabled",
-                    "PublishMapFiles": "true",
-                    "METRIC_TOOLCHAIN": "g++-7",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "PublishMapFiles": "true"
                 },
                 "included": {
-                    "METRIC_TOOLCHAIN": "g++-7",
-                    "METRIC_BUILD_CONFIG": "Debug"
                 },
                 "included_release": {
                     "CMAKE_BUILD_TYPE": "Release",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON",
-                    "PublishMapFiles": "true",
-                    "METRIC_TOOLCHAIN": "g++-7",
-                    "METRIC_BUILD_CONFIG": "Release"
+                    "PublishMapFiles": "true"
                 },
                 "included_samples": {
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_SAMPLES=ON ",
-                    "PublishMapFiles": "true",
-                    "METRIC_TOOLCHAIN": "g++-7",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "PublishMapFiles": "true"
                 }
             }
         },
@@ -199,21 +160,15 @@
                     "CC": "/usr/bin/clang-11",
                     "CXX": "/usr/bin/clang++-11",
                     "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON",
-                    "PublishMapFiles": "true",
-                    "METRIC_TARGET_PLATFORM": "linux",
-                    "METRIC_TOOLCHAIN": "clang-11",
-                    "METRIC_TARGET_ARCHITECTURE": "x64",
-                    "METRIC_TARGET_OS": "ubuntu-20.04"
+                    "PublishMapFiles": "true"
                 }
             },
             "BuildSettings": {
                 "clang-11": {
-                    "CHECK_CLANG_FORMAT": "1",
-                    "METRIC_BUILD_CONFIG": "Debug"
+                    "CHECK_CLANG_FORMAT": "1"
                 },
                 "included_release": {
-                    "CMAKE_BUILD_TYPE": "Release",
-                    "METRIC_BUILD_CONFIG": "Release"
+                    "CMAKE_BUILD_TYPE": "Release"
                 }
             }
         }

--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string] $BuildDirectory = "$PSScriptRoot../../../build/",
+
+    [Parameter()]
+    [string] $ServiceDirectory = "*",
+
+    [Parameter()]
+    [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID)
+)
+
+$targetExtension = "lib"
+if ($IsLinux -or $IsMacOS) {
+    $targetExtension = "a"
+}
+
+$binaries = Get-ChildItem `
+    -Path "$BuildDirectory/sdk/$ServiceDirectory/*/*.$targetExtension" `
+
+if ($CI) {
+    foreach ($binary in $binaries) {
+        $metricLogObject = @{
+            name = "TestBinarySize";
+            value = $binary.Length
+            timestamp = (Get-Date -AsUTC).ToString()
+            labels = @{ 
+                BinaryName = $binary.Name
+            }
+        }
+
+        $metricLogJson = ConvertTo-Json $metricLogObject -Depth 2 -Compress
+        Write-Host "logmetric: $metricLogJson"
+    }
+    
+}
+$bins `
+    | Format-Table -Property Name, @{Name="SizeInKB"; Expression={"{0:N2}" -f ($_.Length / 1KB)}; Alignment='right'} `
+    | Out-String ` 
+    | Write-Host 
+
+return $binaries

--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -7,7 +7,10 @@ param(
     [string] $ServiceDirectory = "*",
 
     [Parameter()]
-    [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID)
+    [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
+
+    [Parameter()]
+    [hashtable]$ExtraLabels = @{}
 )
 
 $searchPath = "$BuildDirectory/sdk/$ServiceDirectory/*/*.a"
@@ -24,8 +27,8 @@ if ($CI) {
             value = $binary.Length
             timestamp = (Get-Date -AsUTC).ToString()
             labels = @{ 
-                BinaryName = $binary.Name
-            }
+                BinaryName = $binary.Name;
+            } + $ExtraLabels
         }
 
         $metricLogJson = ConvertTo-Json $metricLogObject -Depth 2 -Compress

--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -23,10 +23,10 @@ $binaries = Get-ChildItem -Path $searchPath
 if ($CI) {
     foreach ($binary in $binaries) {
         $metricLogObject = @{
-            name = "TestBinarySize";
+            name = "BinarySize";
             value = $binary.Length
             timestamp = (Get-Date -AsUTC).ToString()
-            labels = @{ 
+            labels = @{
                 BinaryName = $binary.Name;
             } + $ExtraLabels
         }

--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -41,7 +41,7 @@ function setEnvVar($key, $value) {
 }
 
 function getTargetOs {
-    if ($OsVMImage.StartsWith('macos')) {
+    if ($OsVMImage.StartsWith('macOS')) {
         return $OsVMImage
     }
 

--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter()]
-    [string] $BuildDirectory = "$PSScriptRoot../../../build/",
+    [string] $BuildDirectory = "$PSScriptRoot/../../../build/",
 
     [Parameter()]
     [string] $ServiceDirectory = "*",
@@ -25,13 +25,13 @@ if ($CI) {
         $metricLogObject = @{
             name = "BinarySize";
             value = $binary.Length
-            timestamp = (Get-Date -AsUTC).ToString()
+            timestamp = (Get-Date -AsUTC).ToString("o")
             labels = @{
                 BinaryName = $binary.Name;
             } + $ExtraLabels
         }
 
-        $metricLogJson = ConvertTo-Json $metricLogObject -Depth 2 -Compress
+        $metricLogJson = ConvertTo-Json $metricLogObject -Compress
         Write-Host "logmetric: $metricLogJson"
     }
 }

--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -10,13 +10,12 @@ param(
     [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID)
 )
 
-$targetExtension = "lib"
-if ($IsLinux -or $IsMacOS) {
-    $targetExtension = "a"
+$searchPath = "$BuildDirectory/sdk/$ServiceDirectory/*/*.a"
+if ($IsWindows) {
+    $searchPath = "$BuildDirectory/sdk/$ServiceDirectory/*/*/*.lib"
 }
 
-$binaries = Get-ChildItem `
-    -Path "$BuildDirectory/sdk/$ServiceDirectory/*/*.$targetExtension" `
+$binaries = Get-ChildItem -Path $searchPath
 
 if ($CI) {
     foreach ($binary in $binaries) {
@@ -32,11 +31,10 @@ if ($CI) {
         $metricLogJson = ConvertTo-Json $metricLogObject -Depth 2 -Compress
         Write-Host "logmetric: $metricLogJson"
     }
-    
 }
-$bins `
+$binaries `
     | Format-Table -Property Name, @{Name="SizeInKB"; Expression={"{0:N2}" -f ($_.Length / 1KB)}; Alignment='right'} `
-    | Out-String ` 
+    | Out-String `
     | Write-Host 
 
 return $binaries

--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter()]
-    [string] $BuildDirectory = "$PSScriptRoot/../../../build/",
+    [string] $BuildDirectory = "$PSScriptRoot/../../build/",
 
     [Parameter()]
     [string] $ServiceDirectory = "*",

--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -38,6 +38,6 @@ if ($CI) {
 $binaries `
     | Format-Table -Property Name, @{Name="SizeInKB"; Expression={"{0:N2}" -f ($_.Length / 1KB)}; Alignment='right'} `
     | Out-String `
-    | Write-Host 
+    | Write-Host
 
 return $binaries

--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -7,11 +7,136 @@ param(
     [string] $ServiceDirectory = "*",
 
     [Parameter()]
+    [string] $OsVMImage,
+
+    [Parameter()]
+    [string] $CmakeArgs,
+
+    [Parameter()]
+    [string] $CmakeEnvArg,
+
+    [Parameter()]
+    [string] $BuildArgs,
+
+    [Parameter()]
+    [string] $Job,
+
+    [Parameter()]
+    [string] $BuildReason,
+
+    [Parameter()]
+    [string] $SourceBranch,
+
+    [Parameter()]
     [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
 
     [Parameter()]
     [hashtable]$ExtraLabels = @{}
 )
+
+. $PSScriptRoot/../common/scripts/common.ps1
+
+function setEnvVar($key, $value) {
+    Write-Host "##vso[task.setvariable variable=_$key;issecret=true;]$value"
+}
+
+function getTargetOs {
+    if ($OsVMImage.StartsWith('macos')) {
+        return $OsVMImage
+    }
+
+    if ($OsVMImage -eq "MMS2019") {
+        return "win-2019"
+    }
+
+    if ($OsVMImage -eq "MMSUbuntu18.04") {
+        return "ubuntu-18.04"
+    }
+
+    if ($OsVMImage -eq "MMSUbuntu20.04") {
+        return "ubuntu-20.04"
+    }
+
+    LogError "Could not infer target OS"
+}
+
+function getTargetArchitecture {
+    if ($OSVmImage.StartsWith('macOS')) {
+        return "x64"
+    }
+
+    if ($env:CMAKE_GENERATOR_PLATFORM -and $env:CMAKE_GENERATOR_PLATFORM -eq "Win32") {
+        return "x86"
+    }
+
+    if ($env:CMAKE_GENERATOR_PLATFORM -and $env:CMAKE_GENERATOR_PLATFORM -eq "x64") {
+        return "x64"
+    }
+
+    # Most builds target x64 by default
+    return "x64"
+}
+
+function getToolChain {
+    if ($OSVmImage.StartsWith('macOS')) {
+        return "AppleClang 12"
+    }
+
+    if ($OSVmImage -eq "MMS2019") {
+        return "MSVC"
+    }
+
+    if ($OSVmImage.Contains("Ubuntu")) {
+        if ($CmakeEnvArg.Contains('g++-5')) {
+            return 'g++-5'
+        } elseif ($env:CXX -and $env:CXX.Contains("g++8")) {
+            return 'g++-8'
+        } elseif ($env:CXX -and $env:CXX.Contains("g++-9")) {
+            return 'g++-9'
+        } elseif ($env:CXX -and $env:CXX.Contains("clang-11")) {
+            return 'clang-11'
+        }
+        return "g++-7"
+    }
+    LogError "Could not infer toolchain"
+}
+
+function getTargetPlatform {
+    if ($OSVmImage.StartsWith('macOS')) {
+        return "macos"
+    }
+
+    if ($OSVmImage -eq 'MMS2019') {
+        if (!$env:CMAKE_SYSTEM_NAME -and !$CmakeArgs.Contains('WindowsStore')) {
+            return 'win32'
+        } elseif ($env:CMAKE_SYSTEM_NAME -eq 'WindowsStore' -or $CmakeArgs.Contains('WindowsStore')) {
+            return 'uwp'
+        }
+    }
+
+    if ($OSVmImage.Contains("Ubuntu")) {
+        return 'linux'
+    }
+
+    LogError "Could not infer target platform"
+}
+
+function getBuildConfiguration {
+    if ($env:CMAKE_BUILD_TYPE) {
+        return $env:CMAKE_BUILD_TYPE
+    }
+
+    if ($BuildArgs.Contains("--config Debug")) {
+        return "Debug"
+    }
+
+    if ($BuildArgs.Contains("--config Release")) {
+        return "Release"
+    }
+
+    # Most builds default to Debug unless overridden by configuration variables
+    return "Debug"
+}
 
 $searchPath = "$BuildDirectory/sdk/$ServiceDirectory/*/*.a"
 if ($IsWindows) {
@@ -20,6 +145,14 @@ if ($IsWindows) {
 
 $binaries = Get-ChildItem -Path $searchPath
 
+$buildLabels = @{
+    TargetOs = getTargetOs;
+    Toolchain = getToolChain;
+    BuildConfig = getBuildConfiguration;
+    TargetArchitecture = getTargetArchitecture;
+    TargetPlatform = getTargetPlatform;
+}
+
 if ($CI) {
     foreach ($binary in $binaries) {
         $metricLogObject = @{
@@ -27,8 +160,11 @@ if ($CI) {
             value = $binary.Length
             timestamp = (Get-Date -AsUTC).ToString("o")
             labels = @{
+                Job = $Job;
+                BuildReason = $BuildReason;
+                SourceBranch = $SourceBranch;
                 BinaryName = $binary.Name;
-            } + $ExtraLabels
+            } + $buildLabels + $ExtraLabels
         }
 
         $metricLogJson = ConvertTo-Json $metricLogObject -Compress


### PR DESCRIPTION
Log the sizes of binaries that the builds produce. Do not make UWP related changes. 