### PR TITLE
Vcpkg Beta Automation

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -34,25 +34,25 @@ parameters:
     default: []
 
 jobs:
-  - template: /eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
-    parameters:
-      MatrixConfigs:
-        - Name: base
-          Path: eng/pipelines/templates/stages/platform-matrix.json
-          Selection: all
-          GenerateVMJobs: true
-      JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
-      AdditionalParameters:
-        Artifacts: ${{ parameters.Artifacts }}
-        ServiceDirectory: ${{ parameters.ServiceDirectory }}
-        TestPipeline: ${{ parameters.TestPipeline }}
-        CtestRegex: ${{ parameters.CtestRegex }}
-        CtestExcludeRegex: ${{ parameters.CtestExcludeRegex }}
-        CoverageReportPath: ${{ parameters.CoverageReportPath }}
-        CoverageEnabled: ${{ parameters.CoverageEnabled }}
-        LineCoverageTarget: ${{ parameters.LineCoverageTarget }}
-        BranchCoverageTarget: ${{ parameters.BranchCoverageTarget }}
-        TestEnv: ${{ parameters.TestEnv }}
+  # - template: /eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+  #   parameters:
+  #     MatrixConfigs:
+  #       - Name: base
+  #         Path: eng/pipelines/templates/stages/platform-matrix.json
+  #         Selection: all
+  #         GenerateVMJobs: true
+  #     JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
+  #     AdditionalParameters:
+  #       Artifacts: ${{ parameters.Artifacts }}
+  #       ServiceDirectory: ${{ parameters.ServiceDirectory }}
+  #       TestPipeline: ${{ parameters.TestPipeline }}
+  #       CtestRegex: ${{ parameters.CtestRegex }}
+  #       CtestExcludeRegex: ${{ parameters.CtestExcludeRegex }}
+  #       CoverageReportPath: ${{ parameters.CoverageReportPath }}
+  #       CoverageEnabled: ${{ parameters.CoverageEnabled }}
+  #       LineCoverageTarget: ${{ parameters.LineCoverageTarget }}
+  #       BranchCoverageTarget: ${{ parameters.BranchCoverageTarget }}
+  #       TestEnv: ${{ parameters.TestEnv }}
 
   # Disable build for cpp - client
   - ${{ if ne(parameters.ServiceDirectory, 'not-specified' )}}:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -73,6 +73,7 @@ jobs:
           parameters:
             Directory: ''
             CheckLinkGuidance: $true
+            Condition: and(succeeded(), ne(variables['Skip.LinkVerification'], 'true'))
 
         - ${{ each artifact in parameters.Artifacts }}: 
           - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -65,15 +65,15 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         Package.EnableSBOMSigning: true
       steps:
-        - template: /eng/common/pipelines/templates/steps/check-spelling.yml
-          parameters:
-            ContinueOnError: false
+        # - template: /eng/common/pipelines/templates/steps/check-spelling.yml
+        #   parameters:
+        #     ContinueOnError: false
 
-        - template: /eng/common/pipelines/templates/steps/verify-links.yml
-          parameters:
-            Directory: ''
-            CheckLinkGuidance: $true
-            Condition: and(succeeded(), ne(variables['Skip.LinkVerification'], 'true'))
+        # - template: /eng/common/pipelines/templates/steps/verify-links.yml
+        #   parameters:
+        #     Directory: ''
+        #     CheckLinkGuidance: $true
+        #     Condition: and(succeeded(), ne(variables['Skip.LinkVerification'], 'true'))
 
         - ${{ each artifact in parameters.Artifacts }}: 
           - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
@@ -112,8 +112,8 @@ jobs:
               -DBUILD_TRANSPORT_CURL=OFF
               -DBUILD_DOCUMENTATION=YES
 
-        - pwsh: npm install -g moxygen
-          displayName: Install Moxygen to generate markdown for docs.microsoft.com
+        # - pwsh: npm install -g moxygen
+        #   displayName: Install Moxygen to generate markdown for docs.microsoft.com
 
         # Generate package spec JSON files for tagging the repo
         - ${{ each artifact in parameters.Artifacts }}:
@@ -171,17 +171,17 @@ jobs:
               workingDirectory: build
               displayName: Generate docs (${{ artifact.Name }}-docs)
 
-            - task: PowerShell@2
-              inputs:
-                targetType: filePath
-                filePath: eng/scripts/New-DocsMsArtifact.ps1
-                arguments: >-
-                  -ServiceDirectory ${{ parameters.ServiceDirectory }}
-                  -PackageName ${{ artifact.Name }}
-                  -TargetFolder $(Build.ArtifactStagingDirectory)/packages/${{ artifact.Name }}/docs/docs.ms
-                ignoreLASTEXITCODE: true
-                pwsh: true
-              displayName: Generate artifacts for docs.ms
+            # - task: PowerShell@2
+            #   inputs:
+            #     targetType: filePath
+            #     filePath: eng/scripts/New-DocsMsArtifact.ps1
+            #     arguments: >-
+            #       -ServiceDirectory ${{ parameters.ServiceDirectory }}
+            #       -PackageName ${{ artifact.Name }}
+            #       -TargetFolder $(Build.ArtifactStagingDirectory)/packages/${{ artifact.Name }}/docs/docs.ms
+            #     ignoreLASTEXITCODE: true
+            #     pwsh: true
+            #   displayName: Generate artifacts for docs.ms
 
             - pwsh: |
                 New-Item -ItemType directory -Path $(Build.ArtifactStagingDirectory) -Name docs/${{ artifact.Name }}
@@ -211,15 +211,15 @@ jobs:
             artifactName: docs
             path: $(Build.ArtifactStagingDirectory)/docs
 
-        - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
+        # - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
 
-        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-          displayName: 'Generate BOM'
-          condition: succeededOrFailed()
-          inputs:
-            BuildDropPath: $(Build.SourcesDirectory)/build
+        # - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        #   displayName: 'Generate BOM'
+        #   condition: succeededOrFailed()
+        #   inputs:
+        #     BuildDropPath: $(Build.SourcesDirectory)/build
 
-        - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
-          parameters:
-            ArtifactPath: '$(Build.SourcesDirectory)/build/_manifest'
-            ArtifactName: 'release_artifact_manifest'
+        # - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+        #   parameters:
+        #     ArtifactPath: '$(Build.SourcesDirectory)/build/_manifest'
+        #     ArtifactName: 'release_artifact_manifest'

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -144,7 +144,6 @@ stages:
                         parameters:
                           RepoOwner: Azure
                           RepoName: azure-sdk-vcpkg-betas
-                          PRBranchName: djurek/vcpkg-beta-3
 
                       - template: /eng/pipelines/templates/steps/vcpkg-publish.yml
                         parameters:
@@ -157,7 +156,7 @@ stages:
                           WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
                           TargetRepoName: azure-sdk-vcpkg-betas
                           BaseRepoOwner: Azure
-                          BaseRepoBranch: djurek/vcpkg-beta-3
+                          CommitMsg: Update vcpkg-configuration.json
 
                       # Set $(HasChanges) to $true so that
                       # create-pull-request.yml completes the push and PR

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -139,6 +139,35 @@ stages:
                           RepoOwner: azure-sdk
                           PRBranchName: $(PrBranchName)
 
+                      - pwsh: |
+                          Write-Host "git clone https://github.com/Azure/azure-sdk-vcpkg-betas $(Pipeline.Workspace)/azure-sdk-vcpkg-betas"
+                          ggit clone https://github.com/Azure/azure-sdk-vcpkg-betas $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
+                          if ($LASTEXITCODE -ne 0) {
+                            Write-Error "Unable to check out vcpkg fork repo"
+                            exit $LASTEXITCODE
+                          }
+
+                      - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+                        parameters:
+                          WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
+
+                      - pwsh: |
+                          git show-ref --verify --quiet refs/heads/$PRBranchName
+                          if ($LASTEXITCODE -eq 0) {
+                            Write-Host "git checkout $PRBranchName."
+                            git checkout $PRBranchName
+                          }
+                          else {
+                            Write-Host "git checkout -b $PRBranchName."
+                            git checkout -b $PRBranchName
+                          }
+                          if ($LASTEXITCODE -ne 0)
+                          {
+                              Write-Error "Unable to create branch LASTEXITCODE=$($LASTEXITCODE), see command output above."
+                              exit $LASTEXITCODE
+                          }
+                        displayName: Checkout vcpkg betas branch
+
                       # Clone Vcpkg Betas
                       - template: /eng/pipelines/templates/steps/vcpkg-clone.yml
                         parameters:

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -144,7 +144,7 @@ stages:
                         parameters:
                           RepoOwner: Azure
                           RepoName: azure-sdk-vcpkg-betas
-                          PRBranchName: djurek/vcpkg-beta
+                          PRBranchName: djurek/vcpkg-beta-2
 
                       - template: /eng/pipelines/templates/steps/vcpkg-publish.yml
                         parameters:
@@ -153,7 +153,9 @@ stages:
 
                       # Set $(HasChanges) to $true so that
                       # create-pull-request.yml completes the push and PR
-                      # submission steps
+                      # submission steps. This is contegnent upon
+                      # `$(PublishToVcpkg)` being `true`. `$(PublishToVcpkg)` is
+                      # set in `vcpkg-publish.yml`
                       - pwsh: Write-Host "##vso[task.setvariable variable=HasChanges]$true"
                         condition: and(succeeded(), eq(variables['PublishToVcpkg'], 'true'))
                         displayName: Set $(HasChanges) to $true for create-pull-request.yml
@@ -272,5 +274,6 @@ stages:
                 CommitMsg: Daily vcpkg ports for ${{ parameters.ServiceDirectory }}
                 TargetRepoOwner: azure-sdk
                 TargetRepoName: vcpkg
+                PushArgs: --follow-tags
                 WorkingDirectory: $(Pipeline.Workspace)/vcpkg
                 ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -139,48 +139,24 @@ stages:
                           RepoOwner: azure-sdk
                           PRBranchName: $(PrBranchName)
 
-                      - pwsh: |
-                          Write-Host "git clone https://github.com/Azure/azure-sdk-vcpkg-betas $(Pipeline.Workspace)/azure-sdk-vcpkg-betas"
-                          ggit clone https://github.com/Azure/azure-sdk-vcpkg-betas $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
-                          if ($LASTEXITCODE -ne 0) {
-                            Write-Error "Unable to check out vcpkg fork repo"
-                            exit $LASTEXITCODE
-                          }
-
-                      - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
-                        parameters:
-                          WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
-
-                      - pwsh: |
-                          git show-ref --verify --quiet refs/heads/$PRBranchName
-                          if ($LASTEXITCODE -eq 0) {
-                            Write-Host "git checkout $PRBranchName."
-                            git checkout $PRBranchName
-                          }
-                          else {
-                            Write-Host "git checkout -b $PRBranchName."
-                            git checkout -b $PRBranchName
-                          }
-                          if ($LASTEXITCODE -ne 0)
-                          {
-                              Write-Error "Unable to create branch LASTEXITCODE=$($LASTEXITCODE), see command output above."
-                              exit $LASTEXITCODE
-                          }
-                        displayName: Checkout vcpkg betas branch
-
                       # Clone Vcpkg Betas
                       - template: /eng/pipelines/templates/steps/vcpkg-clone.yml
                         parameters:
                           RepoOwner: Azure
                           RepoName: azure-sdk-vcpkg-betas
-                          # TODO: Use default branch, maybe do a normal git
-                          # clone instead of vcpkg-clone...
                           PRBranchName: djurek/vcpkg-beta-3
 
                       - template: /eng/pipelines/templates/steps/vcpkg-publish.yml
                         parameters:
                           ArtifactName: ${{ artifact.Name }}
                           VcpkgPortName: ${{ artifact.VcpkgPortName }}
+
+                      # Push changes to vcpkg betas
+                      - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
+                        parameters:
+                          WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
+                          TargetRepoName: azure-sdk-vcpkg-betas
+                          BaseRepoBranch: djurek/vcpkg-beta-3
 
                       # Set $(HasChanges) to $true so that
                       # create-pull-request.yml completes the push and PR

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -156,6 +156,7 @@ stages:
                         parameters:
                           WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
                           TargetRepoName: azure-sdk-vcpkg-betas
+                          BaseRepoOwner: Azure
                           BaseRepoBranch: djurek/vcpkg-beta-3
 
                       # Set $(HasChanges) to $true so that

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -150,6 +150,11 @@ stages:
                           ArtifactName: ${{ artifact.Name }}
                           VcpkgPortName: ${{ artifact.VcpkgPortName }}
 
+
+                      - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+                        parameters:
+                          WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
+
                       # Push changes to vcpkg betas
                       - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
                         parameters:
@@ -157,6 +162,7 @@ stages:
                           TargetRepoName: azure-sdk-vcpkg-betas
                           BaseRepoOwner: Azure
                           CommitMsg: Update vcpkg-configuration.json
+                          BaseRepoBranch: $(DefaultBranch)
 
                       # Set $(HasChanges) to $true so that
                       # create-pull-request.yml completes the push and PR

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -146,7 +146,7 @@ stages:
                           RepoName: azure-sdk-vcpkg-betas
                           # TODO: Use default branch, maybe do a normal git
                           # clone instead of vcpkg-clone...
-                          PRBranchName: djurek/vcpkg-beta-2
+                          PRBranchName: djurek/vcpkg-beta-3
 
                       - template: /eng/pipelines/templates/steps/vcpkg-publish.yml
                         parameters:

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -144,6 +144,8 @@ stages:
                         parameters:
                           RepoOwner: Azure
                           RepoName: azure-sdk-vcpkg-betas
+                          # TODO: Use default branch, maybe do a normal git
+                          # clone instead of vcpkg-clone...
                           PRBranchName: djurek/vcpkg-beta-2
 
                       - template: /eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -274,6 +276,5 @@ stages:
                 CommitMsg: Daily vcpkg ports for ${{ parameters.ServiceDirectory }}
                 TargetRepoOwner: azure-sdk
                 TargetRepoName: vcpkg
-                PushArgs: --follow-tags
                 WorkingDirectory: $(Pipeline.Workspace)/vcpkg
                 ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -123,7 +123,7 @@ stages:
                       - pwsh: |
                           $title = "[${{ artifact.VcpkgPortName }}] publish version $(PackageVersion)"
 
-                          if ('$(VcpkgPRTitle)') { 
+                          if ('$(VcpkgPRTitle)') {
                             Write-Host "Using queue time PR title"
                             $title = '$(VcpkgPRTitle)'
                           }
@@ -131,22 +131,31 @@ stages:
                         displayName: Set PR title
 
                       # There are potential race conditions if this script runs
-                      # in parallel against the same branch name. Release only 
+                      # in parallel against the same branch name. Release only
                       # one package at a time.
+                      # Clone main vcpkg repo
                       - template: /eng/pipelines/templates/steps/vcpkg-clone.yml
                         parameters:
                           RepoOwner: azure-sdk
                           PRBranchName: $(PrBranchName)
+
+                      # Clone Vcpkg Betas
+                      - template: /eng/pipelines/templates/steps/vcpkg-clone.yml
+                        parameters:
+                          RepoOwner: Azure
+                          RepoName: azure-sdk-vcpkg-betas
+                          PRBranchName: djurek/vcpkg-beta
 
                       - template: /eng/pipelines/templates/steps/vcpkg-publish.yml
                         parameters:
                           ArtifactName: ${{ artifact.Name }}
                           VcpkgPortName: ${{ artifact.VcpkgPortName }}
 
-                      # Set $(HasChanges) to $true so that 
-                      # create-pull-request.yml completes the push and PR 
+                      # Set $(HasChanges) to $true so that
+                      # create-pull-request.yml completes the push and PR
                       # submission steps
                       - pwsh: Write-Host "##vso[task.setvariable variable=HasChanges]$true"
+                        condition: and(succeeded(), eq(variables['PublishToVcpkg'], 'true'))
                         displayName: Set $(HasChanges) to $true for create-pull-request.yml
 
                       - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -186,6 +195,7 @@ stages:
                             -RepoName $(VcpkgPrRepoName) `
                             -IssueNumber "$(Submitted.PullRequest.Number)" `
                             -Comment $prComment
+                        condition: and(succeeded(), eq(variables['PublishToVcpkg'], 'true'))
                         displayName: Comment notification to PR
 
           - ${{if ne(artifact.skipUpdatePackageVersion, 'true')}}:
@@ -244,7 +254,7 @@ stages:
             # can be re-run.
             - ${{ each artifact in parameters.Artifacts }}:
               # Only run vcpkg publish if the artifact has a "VcpkgPortName"
-              # property. Absence of VcpkgPortName implies that the artifact 
+              # property. Absence of VcpkgPortName implies that the artifact
               # does not ship to vcpkg.
               - ${{ if ne(artifact.VcpkgPortName, '') }}:
                 - template: /eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -254,6 +264,7 @@ stages:
                     DisplayNameExtension: ${{ artifact.Name }}
                     DailyRelease: true
                     DailyReleaseRef: $(Build.SourceVersion)
+                    UpdateVcpkgBeta: false
 
             - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
               parameters:

--- a/eng/pipelines/templates/steps/vcpkg-clone.yml
+++ b/eng/pipelines/templates/steps/vcpkg-clone.yml
@@ -4,7 +4,7 @@ parameters:
   RepoName: vcpkg
   PRBranchName: not-set
 
-steps: 
+steps:
   - pwsh: |
       Write-Host "git clone https://github.com/${{ parameters.RepoOwner }}/${{ parameters.RepoName }} ${{ parameters.Workspace }}/vcpkg"
       git clone https://github.com/${{ parameters.RepoOwner }}/${{ parameters.RepoName }} ${{ parameters.Workspace }}/vcpkg
@@ -12,7 +12,7 @@ steps:
         Write-Error "Unable to check out vcpkg fork repo"
         exit $LASTEXITCODE
       }
-    displayName: Clone vcpkg from upstream
+    displayName: Clone vcpkg (${{ params.RepoOwner }}/${{ params.RepoName }})
 
   # Check out the PR branch if it's already in remote. Ignore failures.
   - pwsh: |

--- a/eng/pipelines/templates/steps/vcpkg-clone.yml
+++ b/eng/pipelines/templates/steps/vcpkg-clone.yml
@@ -6,8 +6,8 @@ parameters:
 
 steps:
   - pwsh: |
-      Write-Host "git clone https://github.com/${{ parameters.RepoOwner }}/${{ parameters.RepoName }} ${{ parameters.Workspace }}/vcpkg"
-      git clone https://github.com/${{ parameters.RepoOwner }}/${{ parameters.RepoName }} ${{ parameters.Workspace }}/vcpkg
+      Write-Host "git clone https://github.com/${{ parameters.RepoOwner }}/${{ parameters.RepoName }} ${{ parameters.Workspace }}/${{ parameters.RepoName }}"
+      git clone https://github.com/${{ parameters.RepoOwner }}/${{ parameters.RepoName }} ${{ parameters.Workspace }}/${{ parameters.RepoName }}
       if ($LASTEXITCODE -ne 0) {
         Write-Error "Unable to check out vcpkg fork repo"
         exit $LASTEXITCODE

--- a/eng/pipelines/templates/steps/vcpkg-clone.yml
+++ b/eng/pipelines/templates/steps/vcpkg-clone.yml
@@ -12,7 +12,7 @@ steps:
         Write-Error "Unable to check out vcpkg fork repo"
         exit $LASTEXITCODE
       }
-    displayName: Clone vcpkg (${{ params.RepoOwner }}/${{ params.RepoName }})
+    displayName: Clone vcpkg (${{ parameters.RepoOwner }}/${{ parameters.RepoName }})
 
   # Check out the PR branch if it's already in remote. Ignore failures.
   - pwsh: |

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -62,7 +62,6 @@ steps:
           -ReleaseArtifactSourceDirectory "${{ parameters.Workspace }}/packages/${{ parameters.ArtifactName }}"
           -VcpkgPortName '${{ parameters.VcpkgPortName }}'
           -GitCommitParameters '-c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com"'
-          -TestBuildVcpkg
       displayName: Update Vcpkg Betas port ${{ parameters.DisplayNameExtension }}
 
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -78,7 +77,10 @@ steps:
         TargetRepoName: azure-sdk-vcpkg-betas
         WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
         ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
-        PushArgs: --tags
         SkipCheckingForChanges: true
+
+    - pwsh: git push --tags
+      condition: and(succeeded())
+      displayName: Push tags
 
 

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -62,6 +62,7 @@ steps:
           -ReleaseArtifactSourceDirectory "${{ parameters.Workspace }}/packages/${{ parameters.ArtifactName }}"
           -VcpkgPortName '${{ parameters.VcpkgPortName }}'
           -GitCommitParameters '-c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com"'
+          -TestBuildVcpkg
       displayName: Update Vcpkg Betas port ${{ parameters.DisplayNameExtension }}
 
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -78,5 +79,6 @@ steps:
         WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
         ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
         PushArgs: --atomic --tags
+        SkipCheckingForChanges: true
 
 

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -4,7 +4,7 @@ parameters:
   ArtifactName: not-set
   VcpkgPortName: not-set
   DisplayNameExtension:
-  DailyReleaseRef: 
+  DailyReleaseRef:
   DailyRelease: false
   UpdateVcpkgBeta: true
 
@@ -63,12 +63,3 @@ steps:
           -VcpkgPortName '${{ parameters.VcpkgPortName }}'
           -GitCommitParameters '-c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com"'
       displayName: Update Vcpkg Betas port ${{ parameters.DisplayNameExtension }}
-
-    - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
-      parameters:
-        WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
-
-    - pwsh: |
-        git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/Azure/azure-sdk-vcpkg-betas.git"
-        git push azure-sdk-forkdjurek/vcpkg-beta-3
-      displayName: Push changes back to azure-sdk-vcpkg-betas repo

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -80,7 +80,7 @@ steps:
         ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
         SkipCheckingForChanges: true
 
-    - pwsh: git push --tags
+    - pwsh: git push azure-sdk-fork --tags
       displayName: Push tags
 
 

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -83,6 +83,7 @@ steps:
     - pwsh: |
         git remote -v
         git push azure-sdk-fork --tags
+      workingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
       displayName: Push tags
 
 

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -78,7 +78,7 @@ steps:
         TargetRepoName: azure-sdk-vcpkg-betas
         WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
         ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
-        PushArgs: --atomic --tags
+        PushArgs: --tags
         SkipCheckingForChanges: true
 
 

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -72,6 +72,7 @@ steps:
       parameters:
         # TODO: Use default branch
         BaseRepoBranch: djurek/vcpkg-beta-2
+        BaseRepoOwner: Azure
         CommitMsg: Update vcpkg beta
         TargetRepoOwner: Azure
         TargetRepoName: azure-sdk-vcpkg-betas

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -68,22 +68,7 @@ steps:
       parameters:
         WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
 
-    - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
-      parameters:
-        # TODO: Use default branch
-        BaseRepoBranch: djurek/vcpkg-beta-2
-        BaseRepoOwner: Azure
-        CommitMsg: Update vcpkg beta
-        TargetRepoOwner: Azure
-        TargetRepoName: azure-sdk-vcpkg-betas
-        WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
-        ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
-        SkipCheckingForChanges: true
-
     - pwsh: |
-        git remote -v
-        git push azure-sdk-fork --tags
-      workingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
-      displayName: Push tags
-
-
+        git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/Azure/azure-sdk-vcpkg-betas.git"
+        git push azure-sdk-forkdjurek/vcpkg-beta-3
+      displayName: Push changes back to azure-sdk-vcpkg-betas repo

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -80,7 +80,6 @@ steps:
         SkipCheckingForChanges: true
 
     - pwsh: git push --tags
-      condition: and(succeeded())
       displayName: Push tags
 
 

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -80,7 +80,9 @@ steps:
         ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
         SkipCheckingForChanges: true
 
-    - pwsh: git push azure-sdk-fork --tags
+    - pwsh: |
+        git remote -v
+        git push azure-sdk-fork --tags
       displayName: Push tags
 
 

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -53,6 +53,10 @@ steps:
       pwsh: true
       targetType: filePath
       filePath: eng/scripts/Test-ShouldReleaseToVcpkg.ps1
+      arguments: >-
+        -ReleaseArtifactSourceDirectory "${{ parameters.Workspace }}/packages/${{ parameters.ArtifactName }}"
+        -VcpkgFolder ${{ parameters.Workspace }}/vcpkg
+        -VcpkgPortName '${{ parameters.VcpkgPortName }}'
     displayName: Check whether to release to vcpkg
 
   - task: Powershell@2

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -3,9 +3,10 @@ parameters:
   Workspace: $(Pipeline.Workspace)
   ArtifactName: not-set
   VcpkgPortName: not-set
-  DisplayNameExtension: 
+  DisplayNameExtension:
   DailyReleaseRef: 
   DailyRelease: false
+  UpdateVcpkgBeta: true
 
 steps:
   - task: Powershell@2
@@ -20,6 +21,37 @@ steps:
       pwsh: true
     displayName: Initialize vcpkg release ${{ parameters.DisplayNameExtension }}
 
+  # Always update betas on release
+
+  # Release to vcpkg ONLY if:
+  # - GA release or
+  # - Current version on vcpkg is beta
+
+  - ${{ if eq(parameters.UpdateVcpkgBeta, 'true') }}:
+    - task: Powershell@2
+      inputs:
+        pwsh: true
+        targetType: filePath
+        filePath: eng/scripts/Update-VcpkgBeta.ps1
+        arguments: >-
+          -VcpkgBetaFolder ${{ parameters.Workspace }}/azure-sdk-vcpkg-betas
+          -VcpkgFolder ${{ parameters.Workspace }}/vcpkg
+          -ReleaseArtifactSourceDirectory "${{ parameters.Workspace }}/packages/${{ parameters.ArtifactName }}"
+          -VcpkgPortName '${{ parameters.VcpkgPortName }}'
+          -GitCommitParameters '-c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com"'
+      displayName: Update Vcpkg Betas port ${{ parameters.DisplayNameExtension }}
+
+    - pwsh: git push
+      workingDirectory: ${{ parameters.Workspace }}/azure-sdk-vcpkg-betas
+      displayName: Push changes to vcpkg beta
+
+  - task: Powershell@2
+    inputs:
+      pwsh: true
+      targetType: filePath
+      filePath: eng/scripts/Test-ShouldReleaseToVcpkg.ps1
+    displayName: Check whether to release to vcpkg
+
   - task: Powershell@2
     inputs:
       pwsh: true
@@ -32,4 +64,5 @@ steps:
         -GitCommitParameters '-c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com"'
         -DailyRelease:$${{ parameters.DailyRelease }}
       workingDirectory: ${{ parameters.Workspace }}/vcpkg
+      condition: and(succeeded(), eq(variables['PublishToVcpkg'], 'true'))
     displayName: Update vcpkg port ${{ parameters.DisplayNameExtension }}

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -21,12 +21,7 @@ steps:
       pwsh: true
     displayName: Initialize vcpkg release ${{ parameters.DisplayNameExtension }}
 
-  # Always update betas on release
-
-  # Release to vcpkg ONLY if:
-  # - GA release or
-  # - Current version on vcpkg is beta
-
+  # On package release vcpkg beta should always be updated
   - ${{ if eq(parameters.UpdateVcpkgBeta, 'true') }}:
     - task: Powershell@2
       inputs:
@@ -41,10 +36,18 @@ steps:
           -GitCommitParameters '-c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com"'
       displayName: Update Vcpkg Betas port ${{ parameters.DisplayNameExtension }}
 
-    - pwsh: git push
+    # Single override to push directly to the target branch. Failure in this
+    # step is likely caused by a race condition. Re-running the pipeline will
+    # succeed if another race condition does not arise.
+    - pwsh: |
+        git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/Azure/azure-sdk-vcpkg-betas.git"
+        $currentBranch = git branch --show-current
+        git push -u azure-sdk-fork $currentBranch
       workingDirectory: ${{ parameters.Workspace }}/azure-sdk-vcpkg-betas
       displayName: Push changes to vcpkg beta
 
+  # In some cases there should be no release to vcpkg. If vcpkg should be
+  # released, set "PublishToVcpkg" to "true" so we can make changes.
   - task: Powershell@2
     inputs:
       pwsh: true

--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -21,31 +21,6 @@ steps:
       pwsh: true
     displayName: Initialize vcpkg release ${{ parameters.DisplayNameExtension }}
 
-  # On package release vcpkg beta should always be updated
-  - ${{ if eq(parameters.UpdateVcpkgBeta, 'true') }}:
-    - task: Powershell@2
-      inputs:
-        pwsh: true
-        targetType: filePath
-        filePath: eng/scripts/Update-VcpkgBeta.ps1
-        arguments: >-
-          -VcpkgBetaFolder ${{ parameters.Workspace }}/azure-sdk-vcpkg-betas
-          -VcpkgFolder ${{ parameters.Workspace }}/vcpkg
-          -ReleaseArtifactSourceDirectory "${{ parameters.Workspace }}/packages/${{ parameters.ArtifactName }}"
-          -VcpkgPortName '${{ parameters.VcpkgPortName }}'
-          -GitCommitParameters '-c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com"'
-      displayName: Update Vcpkg Betas port ${{ parameters.DisplayNameExtension }}
-
-    # Single override to push directly to the target branch. Failure in this
-    # step is likely caused by a race condition. Re-running the pipeline will
-    # succeed if another race condition does not arise.
-    - pwsh: |
-        git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/Azure/azure-sdk-vcpkg-betas.git"
-        $currentBranch = git branch --show-current
-        git push -u azure-sdk-fork $currentBranch
-      workingDirectory: ${{ parameters.Workspace }}/azure-sdk-vcpkg-betas
-      displayName: Push changes to vcpkg beta
-
   # In some cases there should be no release to vcpkg. If vcpkg should be
   # released, set "PublishToVcpkg" to "true" so we can make changes.
   - task: Powershell@2
@@ -73,3 +48,35 @@ steps:
       workingDirectory: ${{ parameters.Workspace }}/vcpkg
       condition: and(succeeded(), eq(variables['PublishToVcpkg'], 'true'))
     displayName: Update vcpkg port ${{ parameters.DisplayNameExtension }}
+
+  # On package release vcpkg beta should always be updated
+  - ${{ if eq(parameters.UpdateVcpkgBeta, 'true') }}:
+    - task: Powershell@2
+      inputs:
+        pwsh: true
+        targetType: filePath
+        filePath: eng/scripts/Update-VcpkgBeta.ps1
+        arguments: >-
+          -VcpkgBetaFolder ${{ parameters.Workspace }}/azure-sdk-vcpkg-betas
+          -VcpkgFolder ${{ parameters.Workspace }}/vcpkg
+          -ReleaseArtifactSourceDirectory "${{ parameters.Workspace }}/packages/${{ parameters.ArtifactName }}"
+          -VcpkgPortName '${{ parameters.VcpkgPortName }}'
+          -GitCommitParameters '-c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com"'
+      displayName: Update Vcpkg Betas port ${{ parameters.DisplayNameExtension }}
+
+    - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+      parameters:
+        WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
+
+    - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
+      parameters:
+        # TODO: Use default branch
+        BaseRepoBranch: djurek/vcpkg-beta-2
+        CommitMsg: Update vcpkg beta
+        TargetRepoOwner: Azure
+        TargetRepoName: azure-sdk-vcpkg-betas
+        WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-vcpkg-betas
+        ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
+        PushArgs: --atomic --tags
+
+

--- a/eng/scripts/Test-ShouldReleaseToVcpkg.ps1
+++ b/eng/scripts/Test-ShouldReleaseToVcpkg.ps1
@@ -23,7 +23,7 @@ Write-Host "Released package is preview"
 
 # The package does not exist in vcpkg, publish to vcpkg
 $vcpkgJsonPath = "$VcpkgFolder/ports/$VcpkgPortName/vcpkg.json"
-if (!Test-Path $vcpkgJsonPath) {
+if (!(Test-Path $vcpkgJsonPath)) {
     Write-Host "Package ($VcpkgPortName) has not been published, publish to vcpkg"
     Write-Host "##vso[task.setvariable variable=PublishToVcpkg]true"
     exit 0

--- a/eng/scripts/Test-ShouldReleaseToVcpkg.ps1
+++ b/eng/scripts/Test-ShouldReleaseToVcpkg.ps1
@@ -6,7 +6,7 @@ param(
 
 ."$PSSCriptRoot/../common/scripts/common.ps1"
 
-# TODO: Use strict mode after importing common
+Set-StrictMode -Version 3
 
 if ($Test) {
     Test-Cmdlet

--- a/eng/scripts/Test-ShouldReleaseToVcpkg.ps1
+++ b/eng/scripts/Test-ShouldReleaseToVcpkg.ps1
@@ -1,0 +1,52 @@
+param(
+    [string] $ReleaseArtifactSourceDirectory,
+    [string] $VcpkgFolder,
+    [string] $VcpkgPortName
+)
+
+."$PSSCriptRoot/../common/scripts/common.ps1"
+
+# TODO: Use strict mode after importing common
+
+if ($Test) {
+    Test-Cmdlet
+    exit 0
+}
+
+$packageJsonContents = Get-Content `
+    -Path "$ReleaseArtifactSourceDirectory/package-info.json" `
+    -Raw
+$packageJson = ConvertFrom-Json $packageJsonContents
+$packageVersionSemver = [AzureEngSemanticVersion]::ParseVersionString($packageJson.version)
+
+if (!$packageVersionSemver.IsPrerelease) {
+    Write-Host "Package version is GA ($($packageJson.version)), publish to vcpkg"
+    Write-Host "##vso[task.setvariable variable=PublishToVcpkg]true"
+    exit 0
+}
+Write-Host "Released package is preview"
+
+# The package does not exist in vcpkg, publish to vcpkg
+$vcpkgJsonPath = "$VcpkgFolder/ports/$VcpkgPortName/vcpkg.json"
+if (!Test-Path $vcpkgJsonPath) {
+    Write-Host "Package ($VcpkgPortName) has not been published, publish to vcpkg"
+    Write-Host "##vso[task.setvariable variable=PublishToVcpkg]true"
+    exit 0
+}
+Write-Host "Package has been published before"
+
+$vcpkgJsonContents = Get-Content -Raw -Path $vcpkgJsonPath
+$vcpkgJson = ConvertFrom-Json $vcpkgJsonContents
+
+$existingVersion = [AzureEngSemanticVersion]::ParseVersionString($vcpkgJson.'version-semver')
+
+# Published version is a prerelease
+if ($existingVersion.IsPrerelease) {
+    Write-Host "Existing version ($($vcpkgJson.'version-semver')) is prerelease, publish to vcpkg"
+    Write-Host "##vso[task.setvariable variable=PublishToVcpkg]true"
+    exit 0
+}
+Write-Host "Existing version is GA"
+
+Write-Host "Criteria for publishing not satisifed, do NOT publish to vcpkg"
+Write-Host "##vso[task.setvariable variable=PublishToVcpkg]false"

--- a/eng/scripts/Test-ShouldReleaseToVcpkg.ps1
+++ b/eng/scripts/Test-ShouldReleaseToVcpkg.ps1
@@ -8,11 +8,6 @@ param(
 
 Set-StrictMode -Version 3
 
-if ($Test) {
-    Test-Cmdlet
-    exit 0
-}
-
 $packageJsonContents = Get-Content `
     -Path "$ReleaseArtifactSourceDirectory/package-info.json" `
     -Raw

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -27,6 +27,10 @@ $packageInfo = ConvertFrom-Json $rawPackageInfo
 
 $originalLocation = Get-Location
 try {
+    Set-Location $VcpkgFolder
+    Write-Host "./bootstrap-vcpkg.bat"
+    ./bootstrap-vcpkg.bat
+
     Set-Location $VcpkgBetaFolder
 
     Write-Host "$VcpkgFolder/vcpkg format-manifest --all --vcpkg-root=. --x-scripts-root=$VcpkgFolder/scripts"

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -78,6 +78,7 @@ try {
     "git $GitCommitParameters commit --amend --no-edit"
 
     Write-Host "git tag $tagName"
+    git tag $tagName
 
     # Validate overlay port installs (may only be possible after a push)
     Write-Host "$VcpkgFolder/vcpkg" install $VcpkgPortName --overlay-ports=$VcpkgBetaFolder

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -41,7 +41,7 @@ try {
 
     Write-Host "git add -A"
     git add -A
-    Write-Host "git $GitCommitParameters commit -m \"$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)\""
+    Write-Host "git $GitCommitParameters commit -m `"$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)`""
     git $GitCommitParameters commit -m "$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)"
 
     Write-Host "$VcpkgFolder/vcpkg x-add-version $VcpkgPortName --vcpkg-root=. --x-scripts-root=$VcpkgFolder/scripts"
@@ -78,7 +78,7 @@ try {
 
     Write-Host "git add -A"
     git add -A
-    Write-Host "git $GitCommitParameters commit -m \"Update vcpkg-configuration.json\""
+    Write-Host "git $GitCommitParameters commit -m `"Update vcpkg-configuration.json`""
     git $GitCommitParameters commit -m "Update vcpkg-configuration.json"
 
 } finally {

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -10,6 +10,7 @@ param(
 # This ensures that files no longer present in the build output do not
 # persist in later versions.
 Remove-Item "$VcpkgBetaFolder/ports/$VcpkgPortName" -Recurse -Force
+New-Item -ItemType Directory -Path "$VcpkgBetaFolder/vcpkg/ports/$VcpkgPortName"
 
 Copy-Item `
     -Path "$ReleaseArtifactSourceDirectory/vcpkg/port/*" `

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -43,7 +43,7 @@ try {
     & $VcpkgFolder/vcpkg format-manifest `
         --all `
         --vcpkg-root=. `
-        --x-scripts-root=$VcpkgFolder/scripts  # This param is extra
+        --x-scripts-root=$VcpkgFolder/scripts
 
     Write-Host "git add -A"
     git add -A
@@ -54,7 +54,7 @@ try {
     & $VcpkgFolder/vcpkg x-add-version `
         $VcpkgPortName `
         --vcpkg-root=. `
-        --x-scripts-root=$VcpkgFolder/scripts  # This param is extra
+        --x-scripts-root=$VcpkgFolder/scripts
 
     Write-Host "git add -A"
     git add -A

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -48,7 +48,7 @@ try {
     Write-Host "git add -A"
     git add -A
     Write-Host "git $GitCommitParameters commit -m `"$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)`""
-    "git $GitCommitParameters commit -m '$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)'"
+    git $GitCommitParameters commit -m "$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)"
 
     Write-Host "$VcpkgFolder/vcpkg x-add-version $VcpkgPortName --vcpkg-root=. --x-scripts-root=$VcpkgFolder/scripts"
     & $VcpkgFolder/vcpkg x-add-version `
@@ -75,7 +75,7 @@ try {
     Write-Host "git add -A"
     git add -A
     Write-Host "git $GitCommitParameters commit --amend --no-edit"
-    "git $GitCommitParameters commit --amend --no-edit"
+    git $GitCommitParameters commit --amend --no-edit
 
     Write-Host "git tag $tagName"
     git tag $tagName

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -30,24 +30,26 @@ try {
     & $VcpkgFolder/vcpkg format-manifest `
         --all `
         --vcpkg-root=. `
-        --x-scripts-root=$VcpkgFolder/scripts
+        --x-scripts-root=$VcpkgFolder/scripts  # This param is extra
 
     Write-Host "git add -A"
     git add -A
     Write-Host "git $GitCommitParameters commit -m \"$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)\""
     git $GitCommitParameters commit -m "$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)"
 
-    Write-Host "$VcpkgFolder/vcpkg x-add-version --all --vcpkg-root=. --x-scripts-root=$VcpkgFolder/scripts"
+    Write-Host "$VcpkgFolder/vcpkg x-add-version $VcpkgPortName --vcpkg-root=. --x-scripts-root=$VcpkgFolder/scripts"
     & $VcpkgFolder/vcpkg x-add-version `
-        --all `
+        $VcpkgPortName `
         --vcpkg-root=. `
-        --x-scripts-root=$VcpkgFolder/scripts
+        --x-scripts-root=$VcpkgFolder/scripts  # This param is extra
 
     Write-Host "git add -A"
     git add -A
     Write-Host "git commit --amend --no-edit"
     git commit --amend --no-edit
 
+    # TODO: This hash may not be the same unless we push using a method that
+    # isn't our normal push process in engsys.
     Write-Host "git log -1 --format=format:%H"
     $baseHash = git log -1 --format=format:%H
     Write-Host "New Baseline: $baseHash"

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -1,0 +1,66 @@
+param(
+    [string] $VcpkgBetaFolder,
+    [string] $VcpkgFolder,
+    [string] $ReleaseArtifactSourceDirectory,
+    [string] $GitCommitParameters
+)
+
+$portFolder = "azure-$Service-cpp"
+
+# To ensure a clean synchronization remove all files at the destination.
+# This ensures that files no longer present in the build output do not
+# persist in later versions.
+Remove-Item "$VcpkgBetaFolder/ports/$portFolder" -Recurse -Force
+
+Copy-Item `
+    -Path "$ReleaseArtifactSourceDirectory/vcpkg/port/*" `
+    -Destination "$VcpkgBetaFolder/vcpkg/ports/$portFolder"
+
+$rawPackageInfo = Get-Content -Raw -Path $ReleaseArtifactSourceDirectory/package-info.json
+$packageInfo = ConvertFrom-Json $rawPackageInfo
+
+$portName = "$($packageInfo.name)-cpp"
+
+# TODO: test?
+# vcpkg install azure-core-cpp --overlay-ports=../azure-sdk-vcpkg-betas/ports/
+
+$originalLocation = Get-Location
+try {
+    & $VcpkgFolder/vcpkg format-manifest `
+        --all `
+        --vcpkg-root =. `
+        --x-scripts-root=$VcpkgFolder/scripts
+
+    Write-Host "git add -A"
+    git add -A
+    Write-Host "git $GitCommitParameters commit -m \"$(Get-Date -Format "yyyy-MM-dd" ): $portName $($packageInfo.version)\""
+    git $GitCommitParameters commit -m "$(Get-Date -Format "yyyy-MM-dd" ): $portName $($packageInfo.version)"
+
+    & $VcpkgFolder/vcpkg x-add-version `
+        --all `
+        --vcpkg-root=. `
+        --x-scripts-root=$VcpkgFolder/scripts
+
+    git add -A
+    git commit --amend --no-edit
+
+    $commitHash = git log -1 --format=format:%H
+
+    # Update vcpkg-configuration.json to include this package and set the
+    # baseline
+    $vcpkgConfigPath = "$VcpkgBetaFolder/vcpkg-configuration.json"
+    $rawVcpkgConfig = Get-Content -Raw -Path $vcpkgConfigPath
+    $vcpkgConfig = ConvertFrom-Json $rawVcpkgConfig
+
+
+    $vcpkgConfig.registries[0].baseline = $commitHash
+    if (!($vcpkgConfig.registries[0].packages -contains $portName)) {
+        $vcpkgConfig.registries[0].packages += $portName
+    }
+
+    $vcpkgConfigJson = ConvertTo-Json $vcpkgConfig -Depth 100
+    Set-Content -Path $vcpkgConfigPath -Value $vcpkgConfigJson
+
+} finally {
+    Set-Location $originalLocation
+}

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -2,19 +2,18 @@ param(
     [string] $VcpkgBetaFolder,
     [string] $VcpkgFolder,
     [string] $ReleaseArtifactSourceDirectory,
+    [string] $VcpkgPortName,
     [string] $GitCommitParameters
 )
-
-$portFolder = "azure-$Service-cpp"
 
 # To ensure a clean synchronization remove all files at the destination.
 # This ensures that files no longer present in the build output do not
 # persist in later versions.
-Remove-Item "$VcpkgBetaFolder/ports/$portFolder" -Recurse -Force
+Remove-Item "$VcpkgBetaFolder/ports/$VcpkgPortName" -Recurse -Force
 
 Copy-Item `
     -Path "$ReleaseArtifactSourceDirectory/vcpkg/port/*" `
-    -Destination "$VcpkgBetaFolder/vcpkg/ports/$portFolder"
+    -Destination "$VcpkgBetaFolder/vcpkg/ports/$VcpkgPortName"
 
 $rawPackageInfo = Get-Content -Raw -Path $ReleaseArtifactSourceDirectory/package-info.json
 $packageInfo = ConvertFrom-Json $rawPackageInfo

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -52,8 +52,8 @@ try {
 
     Write-Host "git add -A"
     git add -A
-    Write-Host "git commit --amend --no-edit"
-    git commit --amend --no-edit
+    Write-Host "git $GitCommitParameters commit --amend --no-edit"
+    git $GitCommitParameters commit --amend --no-edit
 
     # TODO: This hash may not be the same unless we push using a method that
     # isn't our normal push process in engsys.
@@ -75,6 +75,11 @@ try {
 
     $vcpkgConfigJson = ConvertTo-Json $vcpkgConfig -Depth 100
     Set-Content -Path $vcpkgConfigPath -Value $vcpkgConfigJson
+
+    Write-Host "git add -A"
+    git add -A
+    Write-Host "git $GitCommitParameters commit -m \"Update vcpkg-configuration.json\""
+    git $GitCommitParameters commit -m "Update vcpkg-configuration.json"
 
 } finally {
     Set-Location $originalLocation

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -48,7 +48,7 @@ try {
     Write-Host "git add -A"
     git add -A
     Write-Host "git $GitCommitParameters commit -m `"$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)`""
-    git $GitCommitParameters commit -m "$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)"
+    Invoke-Expression "git $GitCommitParameters commit -m `"$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)`""
 
     Write-Host "$VcpkgFolder/vcpkg x-add-version $VcpkgPortName --vcpkg-root=. --x-scripts-root=$VcpkgFolder/scripts"
     & $VcpkgFolder/vcpkg x-add-version `
@@ -75,7 +75,7 @@ try {
     Write-Host "git add -A"
     git add -A
     Write-Host "git $GitCommitParameters commit --amend --no-edit"
-    git $GitCommitParameters commit --amend --no-edit
+    Invoke-Expression "git $GitCommitParameters commit --amend --no-edit"
 
     Write-Host "git tag $tagName"
     git tag $tagName

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -4,7 +4,8 @@ param(
     [string] $ReleaseArtifactSourceDirectory,
     [string] $VcpkgPortName,
     [string] $GitCommitParameters,
-    [string] $BuildIdentifier = $env:BUILD_BUILDID
+    [string] $BuildIdentifier = $env:BUILD_BUILDID,
+    [switch] $TestBuildVcpkg
 )
 
 ."$PSSCriptRoot/../common/scripts/common.ps1"
@@ -80,13 +81,15 @@ try {
     Write-Host "git tag $tagName"
     git tag $tagName
 
-    # Validate overlay port installs (may only be possible after a push)
-    Write-Host "$VcpkgFolder/vcpkg" install $VcpkgPortName --overlay-ports=$VcpkgBetaFolder
-    ."$VcpkgFolder/vcpkg" install $VcpkgPortName --overlay-ports=$VcpkgBetaFolder
+    if ($TestBuildVcpkg) {
+        # Validate overlay port installs (may only be possible after a push)
+        Write-Host "$VcpkgFolder/vcpkg" install $VcpkgPortName --overlay-ports=$VcpkgBetaFolder
+        ."$VcpkgFolder/vcpkg" install $VcpkgPortName --overlay-ports=$VcpkgBetaFolder
 
-    if ($LASTEXITCODE) {
-        LogError "Port validation failed. Ensure the port builds properly"
-        exit 1
+        if ($LASTEXITCODE) {
+            LogError "Port validation failed. Ensure the port builds properly"
+            exit 1
+        }
     }
 } finally {
     Set-Location $originalLocation

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -10,41 +10,47 @@ param(
 # This ensures that files no longer present in the build output do not
 # persist in later versions.
 Remove-Item "$VcpkgBetaFolder/ports/$VcpkgPortName" -Recurse -Force
-New-Item -ItemType Directory -Path "$VcpkgBetaFolder/vcpkg/ports/$VcpkgPortName"
+New-Item -ItemType Directory -Path "$VcpkgBetaFolder/ports/$VcpkgPortName"
 
 Copy-Item `
     -Path "$ReleaseArtifactSourceDirectory/vcpkg/port/*" `
-    -Destination "$VcpkgBetaFolder/vcpkg/ports/$VcpkgPortName"
+    -Destination "$VcpkgBetaFolder/ports/$VcpkgPortName"
 
 $rawPackageInfo = Get-Content -Raw -Path $ReleaseArtifactSourceDirectory/package-info.json
 $packageInfo = ConvertFrom-Json $rawPackageInfo
-
-$portName = "$($packageInfo.name)-cpp"
 
 # TODO: test?
 # vcpkg install azure-core-cpp --overlay-ports=../azure-sdk-vcpkg-betas/ports/
 
 $originalLocation = Get-Location
 try {
+    Set-Location $VcpkgBetaFolder
+
+    Write-Host "$VcpkgFolder/vcpkg format-manifest --all --vcpkg-root=. --x-scripts-root=$VcpkgFolder/scripts"
     & $VcpkgFolder/vcpkg format-manifest `
         --all `
-        --vcpkg-root =. `
+        --vcpkg-root=. `
         --x-scripts-root=$VcpkgFolder/scripts
 
     Write-Host "git add -A"
     git add -A
-    Write-Host "git $GitCommitParameters commit -m \"$(Get-Date -Format "yyyy-MM-dd" ): $portName $($packageInfo.version)\""
-    git $GitCommitParameters commit -m "$(Get-Date -Format "yyyy-MM-dd" ): $portName $($packageInfo.version)"
+    Write-Host "git $GitCommitParameters commit -m \"$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)\""
+    git $GitCommitParameters commit -m "$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)"
 
+    Write-Host "$VcpkgFolder/vcpkg x-add-version --all --vcpkg-root=. --x-scripts-root=$VcpkgFolder/scripts"
     & $VcpkgFolder/vcpkg x-add-version `
         --all `
         --vcpkg-root=. `
         --x-scripts-root=$VcpkgFolder/scripts
 
+    Write-Host "git add -A"
     git add -A
+    Write-Host "git commit --amend --no-edit"
     git commit --amend --no-edit
 
-    $commitHash = git log -1 --format=format:%H
+    Write-Host "git log -1 --format=format:%H"
+    $baseHash = git log -1 --format=format:%H
+    Write-Host "New Baseline: $baseHash"
 
     # Update vcpkg-configuration.json to include this package and set the
     # baseline
@@ -53,9 +59,9 @@ try {
     $vcpkgConfig = ConvertFrom-Json $rawVcpkgConfig
 
 
-    $vcpkgConfig.registries[0].baseline = $commitHash
-    if (!($vcpkgConfig.registries[0].packages -contains $portName)) {
-        $vcpkgConfig.registries[0].packages += $portName
+    $vcpkgConfig.registries[0].baseline = $baseHash
+    if (!($vcpkgConfig.registries[0].packages -contains $VcpkgPortName)) {
+        $vcpkgConfig.registries[0].packages += $VcpkgPortName
     }
 
     $vcpkgConfigJson = ConvertTo-Json $vcpkgConfig -Depth 100

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -9,12 +9,15 @@ param(
 # To ensure a clean synchronization remove all files at the destination.
 # This ensures that files no longer present in the build output do not
 # persist in later versions.
-Remove-Item "$VcpkgBetaFolder/ports/$VcpkgPortName" -Recurse -Force
-New-Item -ItemType Directory -Path "$VcpkgBetaFolder/ports/$VcpkgPortName"
+$portFolder = "$VcpkgBetaFolder/ports/$VcpkgPortName"
+if (Test-Path $portFolder) {
+    Remove-Item $portFolder -Recurse -Force
+}
+New-Item -ItemType Directory -Path $portFolder
 
 Copy-Item `
     -Path "$ReleaseArtifactSourceDirectory/vcpkg/port/*" `
-    -Destination "$VcpkgBetaFolder/ports/$VcpkgPortName"
+    -Destination $portFolder
 
 $rawPackageInfo = Get-Content -Raw -Path $ReleaseArtifactSourceDirectory/package-info.json
 $packageInfo = ConvertFrom-Json $rawPackageInfo

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -42,7 +42,7 @@ try {
     Write-Host "git add -A"
     git add -A
     Write-Host "git $GitCommitParameters commit -m `"$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)`""
-    git $GitCommitParameters commit -m "$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)"
+    "git $GitCommitParameters commit -m '$(Get-Date -Format "yyyy-MM-dd" ): $VcpkgPortName $($packageInfo.version)'"
 
     Write-Host "$VcpkgFolder/vcpkg x-add-version $VcpkgPortName --vcpkg-root=. --x-scripts-root=$VcpkgFolder/scripts"
     & $VcpkgFolder/vcpkg x-add-version `
@@ -53,7 +53,7 @@ try {
     Write-Host "git add -A"
     git add -A
     Write-Host "git $GitCommitParameters commit --amend --no-edit"
-    git $GitCommitParameters commit --amend --no-edit
+    "git $GitCommitParameters commit --amend --no-edit"
 
     # TODO: This hash may not be the same unless we push using a method that
     # isn't our normal push process in engsys.
@@ -79,7 +79,7 @@ try {
     Write-Host "git add -A"
     git add -A
     Write-Host "git $GitCommitParameters commit -m `"Update vcpkg-configuration.json`""
-    git $GitCommitParameters commit -m "Update vcpkg-configuration.json"
+    "git $GitCommitParameters commit -m 'Update vcpkg-configuration.json'"
 
 } finally {
     Set-Location $originalLocation

--- a/eng/scripts/Update-VcpkgPort.ps1
+++ b/eng/scripts/Update-VcpkgPort.ps1
@@ -29,7 +29,7 @@ if ((Get-Command git | Measure-Object).Count -eq 0) {
     exit 1
 } 
 
-if (!(Test-Path $ReleaseArtifactSourceDirectory/package-info.json)) { 
+if (!(Test-Path $ReleaseArtifactSourceDirectory/package-info.json)) {
     LogError "Could not locate package-info.json in -ReleaseArtifactSourceDirectory"
     exit 1
 }
@@ -42,7 +42,7 @@ if (!(Test-Path $ReleaseArtifactSourceDirectory/vcpkg/port)) {
     LogError "Could not locate vcpkg/port directory in -ReleaseArtifactSourceDirectory"
 }
 
-# Clean out the folder so that template files removed are not inadvertently 
+# Clean out the folder so that template files removed are not inadvertently
 # re-added
 if (Test-Path $PortDestinationDirectory) {
     Remove-Item -v -r $PortDestinationDirectory
@@ -124,7 +124,7 @@ if (!$DailyRelease) {
         | Invoke-Expression -Verbose `
         | Write-Host
 
-    # Set $(HasChanges) to $true so that create-pull-request.yml completes the 
+    # Set $(HasChanges) to $true so that create-pull-request.yml completes the
     # push and PR submission steps
     Write-Host "##vso[task.setvariable variable=HasChanges]$true"
 }
@@ -137,7 +137,7 @@ Uses release artifacts to update a vcpkg port
 .DESCRIPTION
 This script updates a given vcpkg port using C++ release artifacts. It requires 
 that the GitHub repo is tagged and a release is available at that tag for 
-generating the SHA of the vcpkg artifact. 
+generating the SHA of the vcpkg artifact.
 
 This script also uses the contents of the changelog at the release version in 
 the commit message. 

--- a/sdk/core/CMakeLists.txt
+++ b/sdk/core/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_subdirectory(azure-core)
-if (BUILD_PERFORMANCE_TESTS) 
+if (BUILD_PERFORMANCE_TESTS)
   add_subdirectory(perf)
 endif()
 


### PR DESCRIPTION
This PR is meant as a starting place to discuss this question, @weshaggard:  

* Given that the release process depends on an accurate baseline SHA and `git-branch-push.ps1` may rewrite history, should we bypass `git-branch-push.ps1` in this case? (I think yes)

Plenty of opportunity for refactoring. I wanted to get the question out here with an example that describes the process. 

Example release process: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1435561&view=logs&j=0a110e0c-5ffe-5151-43d9-18cd9ba97648&t=ccf1f0a9-677b-534e-3ff4-96ebeda7ff70 (note: a later step failed but it's not particularly relevant to the architectural discussion) 

Example update to vcpkg beta repo: https://github.com/Azure/azure-sdk-vcpkg-betas/commits/djurek/vcpkg-beta-automation-1