### PR TITLE
Run tests on Release mode for Windows CI gates (nightly)

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -245,8 +245,7 @@ jobs:
     condition: and(
       succeeded(),
       ne(variables['RunSamples'], '1'),
-      not(contains(variables['OSVmImage'], 'MMS'))
-    )
+      not(contains(variables['OSVmImage'], 'MMS')))
 
     # Visual Studio generator used in CI is a multi-config generator.
     # As such, it requires the configuration argument for building and invoking ctest
@@ -260,8 +259,7 @@ jobs:
     condition: and(
       succeeded(),
       ne(variables['RunSamples'], '1'),
-      contains(variables['OSVmImage'], 'MMS')
-    )
+      contains(variables['OSVmImage'], 'MMS'))
       
 
   - task: PublishTestResults@2

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -165,6 +165,7 @@ jobs:
     CMOCKA_MESSAGE_OUTPUT: "xml"
     AZURE_ENABLE_STATIC_ANALYSIS: 1
     BuildArgs: ""
+    WindowsCtestConfig: "Release"
     CmakeEnvArg: ""
     CmakeArgs: ""
     AZURE_TEST_MODE: "LIVE"
@@ -232,14 +233,35 @@ jobs:
       Location: ${{ parameters.Location }}
       SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
 
-  - script: ctest -V -C Debug --tests-regex ${{ parameters.CtestRegex }} --no-compress-output -T Test
+    # For non multi-config generator use the same build configuration to run tests
+    # We don't need to set it to invoke ctest 
+  - script: ctest -V --tests-regex ${{ parameters.CtestRegex }} --no-compress-output -T Test
     workingDirectory: build
     displayName: ctest
     # Runs only if test-resources are happly deployed.
     # unit-tests runs for those configs where samples are not ran.
     # This enables to run tests and samples at the same time as different matrix configuration.
     # Then unit-tests runs, samples should not run.
-    condition: and(succeeded(), ne(variables['RunSamples'], '1'))
+    condition: and(
+      succeeded(),
+      ne(variables['RunSamples'], '1'),
+      not(contains(variables['OSVmImage'], 'MMS'))
+    )
+
+    # Visual Studio generator used in CI is a multi-config generator.
+    # As such, it requires the configuration argument for building and invoking ctest
+  - script: ctest -V -C $(WindowsCtestConfig) --tests-regex ${{ parameters.CtestRegex }} --no-compress-output -T Test
+    workingDirectory: build
+    displayName: VisualStudio ctest
+    # Runs only if test-resources are happly deployed.
+    # unit-tests runs for those configs where samples are not ran.
+    # This enables to run tests and samples at the same time as different matrix configuration.
+    # Then unit-tests runs, samples should not run.
+    condition: and(
+      succeeded(),
+      ne(variables['RunSamples'], '1'),
+      contains(variables['OSVmImage'], 'MMS')
+    )
       
 
   - task: PublishTestResults@2

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -88,6 +88,7 @@ jobs:
         CMAKE_GENERATOR_PLATFORM: Win32
         CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_PERFORMANCE_TESTS=ON '
         BuildArgs: '-v --parallel 8 --config Release'
+        WindowsCtestConfig: "-C Release"
       Win_x86_no_rtti_whit_unit_test:
         Pool: azsdk-pool-mms-win-2019-general
         OSVmImage: MMS2019
@@ -97,6 +98,7 @@ jobs:
         CMAKE_GENERATOR_PLATFORM: Win32
         CmakeArgs: ' -DBUILD_RTTI=OFF -DBUILD_TESTING=ON -DBUILD_SAMPLES=ON'
         BuildArgs: '-v --parallel 8 --config Release'
+        WindowsCtestConfig: "-C Release"
       Win_x64_with_unit_test_winHttp:
         Pool: azsdk-pool-mms-win-2019-general
         VcpkgInstall: 'openssl'
@@ -107,6 +109,7 @@ jobs:
         CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_PERFORMANCE_TESTS=ON '
         BuildArgs: '-v --parallel 8 --config Release '
         AZURE_CORE_ENABLE_JSON_TESTS: 1
+        WindowsCtestConfig: "-C Release"
       Win_x64_with_unit_samples_winHttp:
         Pool: azsdk-pool-mms-win-2019-general
         VcpkgInstall: 'openssl'
@@ -117,7 +120,8 @@ jobs:
         CmakeArgs: ' -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_PERFORMANCE_TESTS=ON -DBUILD_SAMPLES=ON '
         BuildArgs: '-v --parallel 8 --config Release '
         AZURE_CORE_ENABLE_JSON_TESTS: 1
-        RunSamples: 1        
+        RunSamples: 1
+        WindowsCtestConfig: "-C Release"
       # specify libcurl to be used on Windows
       Win_x86_with_unit_test_libcurl:
         Pool: azsdk-pool-mms-win-2019-general
@@ -138,6 +142,7 @@ jobs:
         CMAKE_GENERATOR_PLATFORM: x64
         CmakeArgs: ' -DBUILD_TRANSPORT_CURL=ON -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_PERFORMANCE_TESTS=ON '
         BuildArgs: '-v --parallel 8 --config Release '
+        WindowsCtestConfig: "-C Release"
         #AZURE_CORE_ENABLE_JSON_TESTS: 1  # Testing Json lib on Win+WinHttp only, No need to repeat here as it is independent to the http transport adapter.
       Win_x64_with_unit_samples_libcurl:
         Pool: azsdk-pool-mms-win-2019-general
@@ -148,7 +153,8 @@ jobs:
         CMAKE_GENERATOR_PLATFORM: x64
         CmakeArgs: ' -DBUILD_TRANSPORT_CURL=ON -DBUILD_TESTING=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_PERFORMANCE_TESTS=ON  -DBUILD_SAMPLES=ON '
         BuildArgs: '-v --parallel 8 --config Release '
-        RunSamples: 1        
+        RunSamples: 1
+        WindowsCtestConfig: "-C Release"
       MacOS_x64_with_unit_test:
         Pool: Azure Pipelines
         OSVmImage: 'macOS-10.15'
@@ -165,7 +171,7 @@ jobs:
     CMOCKA_MESSAGE_OUTPUT: "xml"
     AZURE_ENABLE_STATIC_ANALYSIS: 1
     BuildArgs: ""
-    WindowsCtestConfig: "Release"
+    WindowsCtestConfig: ""
     CmakeEnvArg: ""
     CmakeArgs: ""
     AZURE_TEST_MODE: "LIVE"
@@ -235,7 +241,9 @@ jobs:
 
     # For non multi-config generator use the same build configuration to run tests
     # We don't need to set it to invoke ctest 
-  - script: ctest -V --tests-regex ${{ parameters.CtestRegex }} --no-compress-output -T Test
+    # Visual Studio generator used in CI is a multi-config generator.
+    # As such, it requires the configuration argument for building and invoking ctest
+  - script: ctest $(WindowsCtestConfig) -V --tests-regex ${{ parameters.CtestRegex }} --no-compress-output -T Test
     workingDirectory: build
     displayName: ctest
     # Runs only if test-resources are happly deployed.
@@ -244,23 +252,7 @@ jobs:
     # Then unit-tests runs, samples should not run.
     condition: and(
       succeeded(),
-      ne(variables['RunSamples'], '1'),
-      not(contains(variables['OSVmImage'], 'MMS')))
-
-    # Visual Studio generator used in CI is a multi-config generator.
-    # As such, it requires the configuration argument for building and invoking ctest
-  - script: ctest -V -C $(WindowsCtestConfig) --tests-regex ${{ parameters.CtestRegex }} --no-compress-output -T Test
-    workingDirectory: build
-    displayName: VisualStudio ctest
-    # Runs only if test-resources are happly deployed.
-    # unit-tests runs for those configs where samples are not ran.
-    # This enables to run tests and samples at the same time as different matrix configuration.
-    # Then unit-tests runs, samples should not run.
-    condition: and(
-      succeeded(),
-      ne(variables['RunSamples'], '1'),
-      contains(variables['OSVmImage'], 'MMS'))
-      
+      ne(variables['RunSamples'], '1'))
 
   - task: PublishTestResults@2
     inputs:


### PR DESCRIPTION
Multi-config generator, like Visual Studio, requires a configuration argument for running ctest.
We are currently using `Debug` everywhere (even for non-multi-config generators)

This PR updates the run tests with `ctest` to provide the configuration step only for multi-config generators.