### PR TITLE
Vcpkg Binary Cache Cleanup

### DIFF
--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -21,7 +21,7 @@ steps:
       filePath: eng/scripts/Set-VcpkgWriteModeCache.ps1
       arguments: -StorageAccountKey '$(cpp-vcpkg-cache-storage-key)'
     displayName: Set Vcpkg Write-mode Cache
-    condition: eq(variables['System.TeamProject'], 'internal')
+    condition: and(succeeded(), eq(variables['System.TeamProject'], 'internal'))
 
   - task: PowerShell@2
     inputs:

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -2,7 +2,11 @@ param(
     [string] $StorageAccountKey
 )
 
+Get-Command Start-CopyAzureStorageBlob
+
+
 if(Test-Path "function:Uninstall-AzureRm") {
+    Write-Host ""
     Uninstall-AzureRm
 }
 ."$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -11,18 +11,18 @@ Write-Host "`$env:PSModulePath = $($env:PSModulePath)"
 if ($IsWindows) {
     $hostedAgentModulePath = $env:SystemDrive + "\\Modules"
     $moduleSeperator = ";"
-  } else {
+} else {
     $hostedAgentModulePath = "/usr/share"
     $moduleSeperator = ":"
-  }
-  $modulePaths = $env:PSModulePath -split $moduleSeperator
-  $modulePaths = $modulePaths.Where({ !$_.StartsWith($hostedAgentModulePath) })
-  $AzModuleCachPath = (Get-ChildItem "$hostedAgentModulePath/az_*" -Attributes Directory) -join $moduleSeperator
-  if ($AzModuleCachPath -and $env.PSModulePath -notcontains $AzModuleCachPath) {
+}
+$modulePaths = $env:PSModulePath -split $moduleSeperator
+$modulePaths = $modulePaths.Where({ !$_.StartsWith($hostedAgentModulePath) })
+$AzModuleCachPath = (Get-ChildItem "$hostedAgentModulePath/az_*" -Attributes Directory) -join $moduleSeperator
+if ($AzModuleCachPath -and $env.PSModulePath -notcontains $AzModuleCachPath) {
     $modulePaths += $AzModuleCachPath
-  }
+}
 
-  $env:PSModulePath = $modulePaths -join $moduleSeperator
+$env:PSModulePath = $modulePaths -join $moduleSeperator
 
 try {
     Write-Host "Get-Command Start-CopyAzureStorageBlob | Format-List"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -6,9 +6,9 @@ param(
 try {
     Write-Host "Get-Command Start-CopyAzureStorageBlob | Format-List"
     Get-Command "Start-CopyAzureStorageBlob" | Format-List
-    # It's an alias to Start-AzStorageBlobCopy
-    Write-Host "Get-Command Start-AzStorageBlobCopy | Format-List"
-    Get-Command "Start-AzStorageBlobCopy" | Format-List
+    # It's an alias to Start-AzureStorageBlobCopy
+    Write-Host "Get-Command Start-AzureStorageBlobCopy | Format-List"
+    Get-Command "Start-AzureStorageBlobCopy" | Format-List
 
 } catch {
     Write-Host "Start-CopyAzureStorageBlob does not exist"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -2,12 +2,12 @@ param(
     [string] $StorageAccountKey
 )
 
-Write-Host "Get-Command Start-CopyAzureStorageBlob"
-Get-Command "Start-CopyAzureStorageBlob"
+Write-Host "Get-Command Start-CopyAzureStorageBlob | Format-List"
+try {
+    Get-Command "Start-CopyAzureStorageBlob" | Format-List
 
-if (Get-Module "Azure.Storage") {
-    Write-Host "Uninstalling Azure.Storage"
-    Uninstall-Module "Azure.Storage"
+} catch {
+    Write-Host "Start-CopyAzureStorageBlob does not exist"
 }
 
 ."$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -2,13 +2,10 @@ param(
     [string] $StorageAccountKey
 )
 
-Get-Command Start-CopyAzureStorageBlob
-
-
-if(Test-Path "function:Uninstall-AzureRm") {
-    Write-Host ""
-    Uninstall-AzureRm
+if (Get-Module Azure.Storage) {
+    Uninstall-Module Azure.Storage
 }
+
 ."$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"
 Install-ModuleIfNotInstalled "Az.Storage" "4.3.0" | Import-Module
 

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -24,18 +24,6 @@ if ($AzModuleCachPath -and $env.PSModulePath -notcontains $AzModuleCachPath) {
 
 $env:PSModulePath = $modulePaths -join $moduleSeperator
 
-try {
-    Write-Host "Get-Command Start-CopyAzureStorageBlob | Format-List"
-    Get-Command "Start-CopyAzureStorageBlob" | Format-List
-    # It's an alias to Start-AzureStorageBlobCopy
-    Write-Host "Get-Command Start-AzureStorageBlobCopy | Format-List"
-    Get-Command "Start-AzureStorageBlobCopy" | Format-List
-
-} catch {
-    Write-Host "Start-CopyAzureStorageBlob does not exist"
-}
-
-
 Install-ModuleIfNotInstalled "Az.Storage" "4.3.0" | Import-Module
 
 $ctx = New-AzStorageContext `

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -7,6 +7,23 @@ param(
 
 Write-Host "`$env:PSModulePath = $($env:PSModulePath)"
 
+# Work around double backslash
+if ($IsWindows) {
+    $hostedAgentModulePath = $env:SystemDrive + "\\Modules"
+    $moduleSeperator = ";"
+  } else {
+    $hostedAgentModulePath = "/usr/share"
+    $moduleSeperator = ":"
+  }
+  $modulePaths = $env:PSModulePath -split $moduleSeperator
+  $modulePaths = $modulePaths.Where({ !$_.StartsWith($hostedAgentModulePath) })
+  $AzModuleCachPath = (Get-ChildItem "$hostedAgentModulePath/az_*" -Attributes Directory) -join $moduleSeperator
+  if ($AzModuleCachPath -and $env.PSModulePath -notcontains $AzModuleCachPath) {
+    $modulePaths += $AzModuleCachPath
+  }
+
+  $env:PSModulePath = $modulePaths -join $moduleSeperator
+
 try {
     Write-Host "Get-Command Start-CopyAzureStorageBlob | Format-List"
     Get-Command "Start-CopyAzureStorageBlob" | Format-List

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -1,6 +1,7 @@
 param(
     [string] $StorageAccountKey
 )
+Uninstall-AzureRm
 Install-Module "Az.Storage" -AllowClobber -Force
 
 $ctx = New-AzStorageContext `
@@ -10,7 +11,8 @@ $token = New-AzStorageAccountSASToken `
     -Service Blob `
     -ResourceType Object `
     -Permission "rwc" `
-    -Context $ctx
+    -Context $ctx `
+    -ExpiryTime (Get-Date).AddDay(1)
 $vcpkgBinarySourceSas = $token.Substring(1)
 
 Write-Host "Setting vcpkg binary cache to read and write"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -2,7 +2,7 @@ param(
     [string] $StorageAccountKey
 )
 Uninstall-AzureRm
-Install-Module "Az.Storage" -AllowClobber -Force
+Install-ModuleIfNotInstalled "Az.Storage" "4.3.0" | Import-Module
 
 $ctx = New-AzStorageContext `
     -StorageAccountName 'cppvcpkgcache' `
@@ -12,7 +12,7 @@ $token = New-AzStorageAccountSASToken `
     -ResourceType Object `
     -Permission "rwc" `
     -Context $ctx `
-    -ExpiryTime (Get-Date).AddDay(1)
+    -ExpiryTime (Get-Date).AddDays(1)
 $vcpkgBinarySourceSas = $token.Substring(1)
 
 Write-Host "Setting vcpkg binary cache to read and write"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -2,6 +2,9 @@ param(
     [string] $StorageAccountKey
 )
 
+Write-Host "Get-Command Start-CopyAzureStorageBlob"
+Get-Command "Start-CopyAzureStorageBlob"
+
 if (Get-Module "Azure.Storage") {
     Write-Host "Uninstalling Azure.Storage"
     Uninstall-Module "Azure.Storage"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -2,9 +2,13 @@ param(
     [string] $StorageAccountKey
 )
 
-Write-Host "Get-Command Start-CopyAzureStorageBlob | Format-List"
+
 try {
+    Write-Host "Get-Command Start-CopyAzureStorageBlob | Format-List"
     Get-Command "Start-CopyAzureStorageBlob" | Format-List
+    # It's an alias to Start-AzStorageBlobCopy
+    Write-Host "Get-Command Start-AzStorageBlobCopy | Format-List"
+    Get-Command "Start-AzStorageBlobCopy" | Format-List
 
 } catch {
     Write-Host "Start-CopyAzureStorageBlob does not exist"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -2,6 +2,7 @@ param(
     [string] $StorageAccountKey
 )
 Uninstall-AzureRm
+."$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"
 Install-ModuleIfNotInstalled "Az.Storage" "4.3.0" | Import-Module
 
 $ctx = New-AzStorageContext `

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -3,6 +3,10 @@ param(
 )
 
 
+."$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"
+
+Write-Host "`$env:PSModulePath = $($env:PSModulePath)"
+
 try {
     Write-Host "Get-Command Start-CopyAzureStorageBlob | Format-List"
     Get-Command "Start-CopyAzureStorageBlob" | Format-List
@@ -14,7 +18,7 @@ try {
     Write-Host "Start-CopyAzureStorageBlob does not exist"
 }
 
-."$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"
+
 Install-ModuleIfNotInstalled "Az.Storage" "4.3.0" | Import-Module
 
 $ctx = New-AzStorageContext `

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -3,6 +3,7 @@ param(
 )
 
 if (Get-Module Azure.Storage) {
+    Write-Host "Uninstalling Azure.Storage"
     Uninstall-Module Azure.Storage
 }
 

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -17,9 +17,9 @@ if ($IsWindows) {
 }
 $modulePaths = $env:PSModulePath -split $moduleSeperator
 $modulePaths = $modulePaths.Where({ !$_.StartsWith($hostedAgentModulePath) })
-$AzModuleCachPath = (Get-ChildItem "$hostedAgentModulePath/az_*" -Attributes Directory) -join $moduleSeperator
-if ($AzModuleCachPath -and $env.PSModulePath -notcontains $AzModuleCachPath) {
-    $modulePaths += $AzModuleCachPath
+$AzModuleCachePath = (Get-ChildItem "$hostedAgentModulePath/az_*" -Attributes Directory) -join $moduleSeperator
+if ($AzModuleCachePath -and $env.PSModulePath -notcontains $AzModuleCachePath) {
+    $modulePaths += $AzModuleCachePath
 }
 
 $env:PSModulePath = $modulePaths -join $moduleSeperator

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -1,7 +1,10 @@
 param(
     [string] $StorageAccountKey
 )
-Uninstall-AzureRm
+
+if(Test-Path "function:Uninstall-AzureRm") {
+    Uninstall-AzureRm
+}
 ."$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"
 Install-ModuleIfNotInstalled "Az.Storage" "4.3.0" | Import-Module
 

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -2,9 +2,9 @@ param(
     [string] $StorageAccountKey
 )
 
-if (Get-Module Azure.Storage) {
+if (Get-Module "Azure.Storage") {
     Write-Host "Uninstalling Azure.Storage"
-    Uninstall-Module Azure.Storage
+    Uninstall-Module "Azure.Storage"
 }
 
 ."$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"


### PR DESCRIPTION
* Set expiration time
* Clean up condition for running `Set-VcpkgWriteModeCache.ps1` which takes a long time to run on account of `Install-Module` 
* Clean up warning

Example core run -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1465280&view=results