### PR TITLE
Rename winhttp transport option

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - When a `RequestFailedException` exception is thrown, the `what()` method now includes information about the HTTP request which failed.
-- Adding option `WinHttpTransportOptions.IgnoreUnknownServerCert`. It can be used to disable verifying server certificate for the `WinHttpTransport`.
+- Adding option `WinHttpTransportOptions.IgnoreUnknownServerCertificate`. It can be used to disable verifying server certificate for the `WinHttpTransport`.
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - When a `RequestFailedException` exception is thrown, the `what()` method now includes information about the HTTP request which failed.
-- Adding option `WinHttpTransportOptions.IgnoreUnknownServerCertificate`. It can be used to disable verifying server certificate for the `WinHttpTransport`.
+- Adding option `WinHttpTransportOptions.IgnoreUnknownCertificateAuthority`. It can be used to disable verifying server certificate for the `WinHttpTransport`.
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -132,7 +132,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief When `true`, allows an invalid certificate authority. If this flag is set, the
      * application does not receive a WINHTTP_CALLBACK_STATUS_FLAG_INVALID_CA callback.
      */
-    bool IgnoreUnknownServerCertificate = false;
+    bool IgnoreUnknownCertificateAuthority = false;
   };
 
   /**

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -132,7 +132,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief When `true`, allows an invalid certificate authority. If this flag is set, the
      * application does not receive a WINHTTP_CALLBACK_STATUS_FLAG_INVALID_CA callback.
      */
-    bool IgnoreUnknownServerCert = false;
+    bool IgnoreUnknownServerCertificate = false;
   };
 
   /**

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -359,7 +359,7 @@ void WinHttpTransport::CreateRequestHandle(std::unique_ptr<_detail::HandleManage
     }
   }
 
-  if (m_options.IgnoreUnknownServerCertificate)
+  if (m_options.IgnoreUnknownCertificateAuthority)
   {
     auto option = SECURITY_FLAG_IGNORE_UNKNOWN_CA;
     if (!WinHttpSetOption(

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -359,7 +359,7 @@ void WinHttpTransport::CreateRequestHandle(std::unique_ptr<_detail::HandleManage
     }
   }
 
-  if (m_options.IgnoreUnknownServerCert)
+  if (m_options.IgnoreUnknownServerCertificate)
   {
     auto option = SECURITY_FLAG_IGNORE_UNKNOWN_CA;
     if (!WinHttpSetOption(

--- a/sdk/core/perf/src/base_test.cpp
+++ b/sdk/core/perf/src/base_test.cpp
@@ -116,7 +116,7 @@ namespace Azure { namespace Perf {
           = std::make_shared<Azure::Core::Http::CurlTransport>(curlOptions);
 #elif defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
       Azure::Core::Http::WinHttpTransportOptions winHttpOptions;
-      winHttpOptions.IgnoreUnknownServerCertificate = true;
+      winHttpOptions.IgnoreUnknownCertificateAuthority = true;
       clientOptions.Transport.Transport
           = std::make_shared<Azure::Core::Http::WinHttpTransport>(winHttpOptions);
 #else

--- a/sdk/core/perf/src/base_test.cpp
+++ b/sdk/core/perf/src/base_test.cpp
@@ -116,7 +116,7 @@ namespace Azure { namespace Perf {
           = std::make_shared<Azure::Core::Http::CurlTransport>(curlOptions);
 #elif defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
       Azure::Core::Http::WinHttpTransportOptions winHttpOptions;
-      winHttpOptions.IgnoreUnknownServerCert = true;
+      winHttpOptions.IgnoreUnknownServerCertificate = true;
       clientOptions.Transport.Transport
           = std::make_shared<Azure::Core::Http::WinHttpTransport>(winHttpOptions);
 #else


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/3486