### PR TITLE
Revert setting WINHTTP_NO_CLIENT_CERT_CONTEXT

### DIFF
--- a/sdk/attestation/azure-security-attestation/src/attestation_administration_client.cpp
+++ b/sdk/attestation/azure-security-attestation/src/attestation_administration_client.cpp
@@ -57,6 +57,11 @@ AttestationAdministrationClient::AttestationAdministrationClient(
   m_apiVersion = options.Version.ToString();
   std::vector<std::unique_ptr<HttpPolicy>> perCallpolicies;
 
+#if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
+  // This configuration will make winHTTP to disable client certificate for all attestation requests
+  perCallpolicies.emplace_back(std::make_unique<SetNoClientCertificatePolicy>());
+#endif
+
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       options,
       "Attestation",

--- a/sdk/attestation/azure-security-attestation/src/attestation_client.cpp
+++ b/sdk/attestation/azure-security-attestation/src/attestation_client.cpp
@@ -27,25 +27,30 @@ using namespace Azure::Core::Http::Policies::_internal;
 using namespace Azure::Core::Http::_internal;
 
 #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
-// Whenever winHTTP transport is built, create a policy to make request with no client certificate for attestation requests
+// Whenever winHTTP transport is built, create a policy to make request with no client certificate
+// for attestation requests
 #include "azure/core/http/win_http_transport.hpp"
 
 namespace {
-  class SetNoClientCertificatePolicy : public Azure::Core::Http::Policies::HttpPolicy {
-  public:
-    std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override
-    {
-      return std::make_unique<SetNoClientCertificatePolicy>();
-    }
+class SetNoClientCertificatePolicy : public Azure::Core::Http::Policies::HttpPolicy {
+public:
+  std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override
+  {
+    return std::make_unique<SetNoClientCertificatePolicy>();
+  }
 
-    std::unique_ptr<Azure::Core::Http::RawResponse> Send(
-        Azure::Core::Http::Request& request,
-        Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
-        const Azure::Core::Context& ctx) const override {
-          return nextHttpPolicy.Send(request, Azure::Core::Http::_internal::WinHttpTransportContextProvider::GetNoClientCertificateContext(ctx));
-        }
-  };
-}
+  std::unique_ptr<Azure::Core::Http::RawResponse> Send(
+      Azure::Core::Http::Request& request,
+      Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
+      const Azure::Core::Context& ctx) const override
+  {
+    return nextHttpPolicy.Send(
+        request,
+        Azure::Core::Http::_internal::WinHttpTransportContextProvider::
+            GetNoClientCertificateContext(ctx));
+  }
+};
+} // namespace
 #endif
 
 AttestationClient::AttestationClient(
@@ -67,11 +72,11 @@ AttestationClient::AttestationClient(
   }
   m_apiVersion = options.Version.ToString();
   std::vector<std::unique_ptr<HttpPolicy>> perCallpolicies;
-  
-  #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
+
+#if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
   // This configuration will make winHTTP to disable client certificate for all attestation requests
   perCallpolicies.emplace_back(std::make_unique<SetNoClientCertificatePolicy>());
-  #endif
+#endif
 
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       options,

--- a/sdk/attestation/azure-security-attestation/src/attestation_client.cpp
+++ b/sdk/attestation/azure-security-attestation/src/attestation_client.cpp
@@ -26,33 +26,6 @@ using namespace Azure::Core::Http::Policies;
 using namespace Azure::Core::Http::Policies::_internal;
 using namespace Azure::Core::Http::_internal;
 
-#if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
-// Whenever winHTTP transport is built, create a policy to make request with no client certificate
-// for attestation requests
-#include "azure/core/http/win_http_transport.hpp"
-
-namespace {
-class SetNoClientCertificatePolicy : public Azure::Core::Http::Policies::HttpPolicy {
-public:
-  std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override
-  {
-    return std::make_unique<SetNoClientCertificatePolicy>();
-  }
-
-  std::unique_ptr<Azure::Core::Http::RawResponse> Send(
-      Azure::Core::Http::Request& request,
-      Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
-      const Azure::Core::Context& ctx) const override
-  {
-    return nextHttpPolicy.Send(
-        request,
-        Azure::Core::Http::_internal::WinHttpTransportContextProvider::
-            GetNoClientCertificateContext(ctx));
-  }
-};
-} // namespace
-#endif
-
 AttestationClient::AttestationClient(
     std::string const& endpoint,
     std::shared_ptr<Core::Credentials::TokenCredential const> credential,

--- a/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.cpp
+++ b/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.cpp
@@ -8,6 +8,7 @@
  *
  */
 #include "attestation_client_models_private.hpp"
+#include "attestation_client_private.hpp"
 #include "crypto/inc/crypto.hpp"
 #include <azure/core/internal/json/json.hpp>
 #include <chrono>
@@ -18,8 +19,21 @@
 using namespace Azure::Security::Attestation::_detail;
 
 namespace Azure { namespace Security { namespace Attestation { namespace _detail {
+#if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
 
-}}}} // namespace Azure::Security::Attestation::_detail
+  std::unique_ptr<Azure::Core::Http::RawResponse> SetNoClientCertificatePolicy::Send(
+      Azure::Core::Http::Request& request,
+      Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
+      const Azure::Core::Context& ctx) const
+  {
+    return nextHttpPolicy.Send(
+        request,
+        Azure::Core::Http::_internal::WinHttpTransportContextProvider::
+            GetNoClientCertificateContext(ctx));
+  }
+};
+#endif
+}}} // namespace Azure::Security::Attestation::_detail
 
 namespace Azure {
   namespace Security {

--- a/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.cpp
+++ b/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.cpp
@@ -7,8 +7,8 @@
  * This file contains private classes used to support public model types.
  *
  */
-#include "attestation_client_models_private.hpp"
 #include "attestation_client_private.hpp"
+#include "attestation_client_models_private.hpp"
 #include "crypto/inc/crypto.hpp"
 #include <azure/core/internal/json/json.hpp>
 #include <chrono>
@@ -18,22 +18,23 @@
 #include <vector>
 using namespace Azure::Security::Attestation::_detail;
 
-namespace Azure { namespace Security { namespace Attestation { namespace _detail {
+namespace Azure { namespace Security { namespace Attestation {
+  namespace _detail {
 #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
 
-  std::unique_ptr<Azure::Core::Http::RawResponse> SetNoClientCertificatePolicy::Send(
-      Azure::Core::Http::Request& request,
-      Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
-      const Azure::Core::Context& ctx) const
-  {
-    return nextHttpPolicy.Send(
-        request,
-        Azure::Core::Http::_internal::WinHttpTransportContextProvider::
-            GetNoClientCertificateContext(ctx));
-  }
-};
+    std::unique_ptr<Azure::Core::Http::RawResponse> SetNoClientCertificatePolicy::Send(
+        Azure::Core::Http::Request& request,
+        Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
+        const Azure::Core::Context& ctx) const
+    {
+      return nextHttpPolicy.Send(
+          request,
+          Azure::Core::Http::_internal::WinHttpTransportContextProvider::
+              GetNoClientCertificateContext(ctx));
+    }
+  };
 #endif
-}}} // namespace Azure::Security::Attestation::_detail
+}}} // namespace Azure::Security::Attestation
 
 namespace Azure {
   namespace Security {

--- a/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.cpp
+++ b/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.cpp
@@ -18,23 +18,21 @@
 #include <vector>
 using namespace Azure::Security::Attestation::_detail;
 
-namespace Azure { namespace Security { namespace Attestation {
-  namespace _detail {
+namespace Azure { namespace Security { namespace Attestation { namespace _detail {
 #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
 
-    std::unique_ptr<Azure::Core::Http::RawResponse> SetNoClientCertificatePolicy::Send(
-        Azure::Core::Http::Request& request,
-        Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
-        const Azure::Core::Context& ctx) const
-    {
-      return nextHttpPolicy.Send(
-          request,
-          Azure::Core::Http::_internal::WinHttpTransportContextProvider::
-              GetNoClientCertificateContext(ctx));
-    }
-  };
+  std::unique_ptr<Azure::Core::Http::RawResponse> SetNoClientCertificatePolicy::Send(
+      Azure::Core::Http::Request& request,
+      Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
+      const Azure::Core::Context& ctx) const
+  {
+    return nextHttpPolicy.Send(
+        request,
+        Azure::Core::Http::_internal::WinHttpTransportContextProvider::
+            GetNoClientCertificateContext(ctx));
+  }
 #endif
-}}} // namespace Azure::Security::Attestation
+}}}} // namespace Azure::Security::Attestation::_detail
 
 namespace Azure {
   namespace Security {

--- a/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.hpp
+++ b/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.hpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-  #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
+#if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
 // Whenever winHTTP transport is built, create a policy to make request with no client certificate
 // for attestation requests
 #include "azure/core/http/win_http_transport.hpp"
@@ -448,27 +448,27 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
     /**
      * @brief Convert the internal attestation token to a public AttestationToken object.
      */
-    operator Models::AttestationToken<T>&() { return m_token; }
+    operator Models::AttestationToken<T> &() { return m_token; }
     /**
      * @brief Convert the internal attestation token to a public AttestationToken object.
      */
     operator Models::AttestationToken<T> const &() const { return m_token; }
   };
 
-  #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
+#if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
 
-class SetNoClientCertificatePolicy : public Azure::Core::Http::Policies::HttpPolicy {
-public:
-  std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override
-  {
-    return std::make_unique<SetNoClientCertificatePolicy>();
-  }
+  class SetNoClientCertificatePolicy : public Azure::Core::Http::Policies::HttpPolicy {
+  public:
+    std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override
+    {
+      return std::make_unique<SetNoClientCertificatePolicy>();
+    }
 
-  std::unique_ptr<Azure::Core::Http::RawResponse> Send(
-      Azure::Core::Http::Request& request,
-      Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
-      const Azure::Core::Context& ctx) const override;
-};
+    std::unique_ptr<Azure::Core::Http::RawResponse> Send(
+        Azure::Core::Http::Request& request,
+        Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
+        const Azure::Core::Context& ctx) const override;
+  };
 
 #endif
 }}}} // namespace Azure::Security::Attestation::_detail

--- a/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.hpp
+++ b/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.hpp
@@ -26,6 +26,12 @@
 #include <string>
 #include <vector>
 
+  #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
+// Whenever winHTTP transport is built, create a policy to make request with no client certificate
+// for attestation requests
+#include "azure/core/http/win_http_transport.hpp"
+#endif
+
 namespace Azure { namespace Security { namespace Attestation { namespace _detail {
 
   template <class T> class EmptyDeserializer {
@@ -448,4 +454,21 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
      */
     operator Models::AttestationToken<T> const &() const { return m_token; }
   };
+
+  #if defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
+
+class SetNoClientCertificatePolicy : public Azure::Core::Http::Policies::HttpPolicy {
+public:
+  std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override
+  {
+    return std::make_unique<SetNoClientCertificatePolicy>();
+  }
+
+  std::unique_ptr<Azure::Core::Http::RawResponse> Send(
+      Azure::Core::Http::Request& request,
+      Azure::Core::Http::Policies::NextHttpPolicy nextHttpPolicy,
+      const Azure::Core::Context& ctx) const override;
+};
+
+#endif
 }}}} // namespace Azure::Security::Attestation::_detail

--- a/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.hpp
+++ b/sdk/attestation/azure-security-attestation/src/private/attestation_client_private.hpp
@@ -448,7 +448,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
     /**
      * @brief Convert the internal attestation token to a public AttestationToken object.
      */
-    operator Models::AttestationToken<T> &() { return m_token; }
+    operator Models::AttestationToken<T>&() { return m_token; }
     /**
      * @brief Convert the internal attestation token to a public AttestationToken object.
      */

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- [3548](https://github.com/Azure/azure-sdk-for-cpp/issues/3548) Fixed performance regression on Windows.
+
 ### Other Changes
 
 ## 1.5.0 (2022-03-31)

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -146,11 +146,29 @@ namespace Azure { namespace Core { namespace Http {
      */
     class WinHttpTransportContextProvider {
     public:
-      // Factory with no constructor
+      /**
+       * @brief Remove constructor. This is a factory only class. Should not be instantiated.
+       *
+       */
       WinHttpTransportContextProvider() = delete;
 
-      // Creates a set up token to make
+      /**
+       * @brief Creates a context child from \p parent that contains a key and value to override the
+       * default winHTTP transport adapter implementation.
+       *
+       * @param parent The parent context is used to create the child context.
+       * @return Azure::Core::Context
+       */
       static Azure::Core::Context GetNoClientCertificateContext(Azure::Core::Context const& parent);
+
+      /**
+       * @brief Validate if \p context containst a key and value for overriding `no client
+       * certificate` default implementation.
+       *
+       * @param context The context represent a list of nodes, and all nodes are evaluated while
+       * looking for the `no client certificate` key.
+       * @return true when the `no client certificate` key is found within the context.
+       */
       static bool HasNoClientCertificateConfiguration(Azure::Core::Context const& context);
     };
   } // namespace _internal

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -150,10 +150,9 @@ namespace Azure { namespace Core { namespace Http {
         WinHttpTransportContextProvider() = delete;
 
         // Creates a set up token to make 
-        Azure::Core::Context GetNoClientCertContext(Azure::Core::Context const& parent){
-          return parent
-        }
-    }
+        static Azure::Core::Context GetNoClientCertificateContext(Azure::Core::Context const& parent);
+        static bool HasNoClientCertificateConfiguration(Azure::Core::Context const& context);
+    };
   } // namespace _internal
 
   /**

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -145,13 +145,13 @@ namespace Azure { namespace Core { namespace Http {
      *
      */
     class WinHttpTransportContextProvider {
-      public:
-        // Factory with no constructor
-        WinHttpTransportContextProvider() = delete;
+    public:
+      // Factory with no constructor
+      WinHttpTransportContextProvider() = delete;
 
-        // Creates a set up token to make 
-        static Azure::Core::Context GetNoClientCertificateContext(Azure::Core::Context const& parent);
-        static bool HasNoClientCertificateConfiguration(Azure::Core::Context const& context);
+      // Creates a set up token to make
+      static Azure::Core::Context GetNoClientCertificateContext(Azure::Core::Context const& parent);
+      static bool HasNoClientCertificateConfiguration(Azure::Core::Context const& context);
     };
   } // namespace _internal
 

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -176,8 +176,6 @@ namespace Azure { namespace Core { namespace Http {
     std::unique_ptr<RawResponse> SendRequestAndGetResponse(
         std::unique_ptr<_detail::HandleManager> handleManager,
         HttpMethod requestMethod);
-    // This option can be set only using context option
-    bool m_noClientCert = false;
 
   public:
     /**

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -134,6 +134,28 @@ namespace Azure { namespace Core { namespace Http {
     bool IgnoreUnknownCertificateAuthority = false;
   };
 
+  namespace _internal {
+    /**
+     * @brief Factory to produce a context with special settings like no client cert context.
+     *
+     * @details Client SDKs can use this class to create an Azure Context to change the
+     * WinHttpTransport default behavior. This is because a Client SDK doesn't know about the
+     * specifics of a transport adapter. So, on Windows, SDK client can set options and only
+     * WinHTTPTransport will check for those options to be in the context.
+     *
+     */
+    class WinHttpTransportContextProvider {
+      public:
+        // Factory with no constructor
+        WinHttpTransportContextProvider() = delete;
+
+        // Creates a set up token to make 
+        Azure::Core::Context GetNoClientCertContext(Azure::Core::Context const& parent){
+          return parent
+        }
+    }
+  } // namespace _internal
+
   /**
    * @brief Concrete implementation of an HTTP transport that uses WinHTTP when sending and
    * receiving requests and responses over the wire.
@@ -155,6 +177,8 @@ namespace Azure { namespace Core { namespace Http {
     std::unique_ptr<RawResponse> SendRequestAndGetResponse(
         std::unique_ptr<_detail::HandleManager> handleManager,
         HttpMethod requestMethod);
+    // This option can be set only using context option
+    bool m_noClientCert = false;
 
   public:
     /**

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -360,7 +360,11 @@ void WinHttpTransport::CreateRequestHandle(std::unique_ptr<_detail::HandleManage
   }
 
   // Option is set up by context settings only and is only available for SDK clients
-  if (m_noClientCert)
+  using namespace Azure::Core::Http::_internal;
+  auto noClientCert = WinHttpTransportContextProvider::HasNoClientCertificateConfiguration(
+      handleManager->m_context);
+
+  if (noClientCert)
   {
     // If the service requests TLS client certificates, we want to let the WinHTTP APIs know that
     // it's ok to initiate the request without a client certificate.
@@ -672,9 +676,6 @@ std::unique_ptr<RawResponse> WinHttpTransport::SendRequestAndGetResponse(
 
 std::unique_ptr<RawResponse> WinHttpTransport::Send(Request& request, Context const& context)
 {
-  using namespace Azure::Core::Http::_internal;
-  m_noClientCert = WinHttpTransportContextProvider::HasNoClientCertificateConfiguration(context);
-
   auto handleManager = std::make_unique<_detail::HandleManager>(request, context);
 
   CreateSessionHandle(handleManager);

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -342,23 +342,6 @@ void WinHttpTransport::CreateRequestHandle(std::unique_ptr<_detail::HandleManage
     GetErrorAndThrow("Error while getting a request handle.");
   }
 
-  if (requestSecureHttp)
-  {
-    // If the service requests TLS client certificates, we want to let the WinHTTP APIs know that
-    // it's ok to initiate the request without a client certificate.
-    //
-    // Note: If/When TLS client certificate support is added to the pipeline, this line may need to
-    // be revisited.
-    if (!WinHttpSetOption(
-            handleManager->m_requestHandle,
-            WINHTTP_OPTION_CLIENT_CERT_CONTEXT,
-            WINHTTP_NO_CLIENT_CERT_CONTEXT,
-            0))
-    {
-      GetErrorAndThrow("Error while setting client cert context to ignore..");
-    }
-  }
-
   if (m_options.IgnoreUnknownCertificateAuthority)
   {
     auto option = SECURITY_FLAG_IGNORE_UNKNOWN_CA;

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -196,6 +196,11 @@ std::string GetHeadersAsString(Azure::Core::Http::Request const& request)
   return requestHeaderString;
 }
 
+/**
+ * @brief A key used to override the default winHTTP transport behavior when a Service requires a
+ * client certificate.
+ *
+ */
 Azure::Core::Context::Key NoClientCertificateConfiguration;
 
 } // namespace

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -200,11 +200,16 @@ Azure::Core::Context::Key NoClientCertificateConfiguration;
 
 } // namespace
 
-Azure::Core::Context Azure::Core::Http::_internal::WinHttpTransportContextProvider::GetNoClientCertificateContext(Azure::Core::Context const& parent) {
+Azure::Core::Context
+Azure::Core::Http::_internal::WinHttpTransportContextProvider::GetNoClientCertificateContext(
+    Azure::Core::Context const& parent)
+{
   return parent.WithValue(NoClientCertificateConfiguration, true);
 }
 
-bool Azure::Core::Http::_internal::WinHttpTransportContextProvider::HasNoClientCertificateConfiguration(Azure::Core::Context const& context) {
+bool Azure::Core::Http::_internal::WinHttpTransportContextProvider::
+    HasNoClientCertificateConfiguration(Azure::Core::Context const& context)
+{
   bool value = false;
   context.TryGetValue<bool>(NoClientCertificateConfiguration, value);
   return value;
@@ -355,7 +360,8 @@ void WinHttpTransport::CreateRequestHandle(std::unique_ptr<_detail::HandleManage
   }
 
   // Option is set up by context settings only and is only available for SDK clients
-  if(m_noClientCert) {
+  if (m_noClientCert)
+  {
     // If the service requests TLS client certificates, we want to let the WinHTTP APIs know that
     // it's ok to initiate the request without a client certificate.
     //


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-for-cpp/issues/3548