### PR TITLE
Remove extra period at ends of exception messages in winhttp transport

### DIFF
--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -355,7 +355,7 @@ void WinHttpTransport::CreateRequestHandle(std::unique_ptr<_detail::HandleManage
             WINHTTP_NO_CLIENT_CERT_CONTEXT,
             0))
     {
-      GetErrorAndThrow("Error while setting client cert context to ignore..");
+      GetErrorAndThrow("Error while setting client cert context to ignore.");
     }
   }
 
@@ -365,7 +365,7 @@ void WinHttpTransport::CreateRequestHandle(std::unique_ptr<_detail::HandleManage
     if (!WinHttpSetOption(
             handleManager->m_requestHandle, WINHTTP_OPTION_SECURITY_FLAGS, &option, sizeof(option)))
     {
-      GetErrorAndThrow("Error while setting ignore unknown server certificate..");
+      GetErrorAndThrow("Error while setting ignore unknown server certificate.");
     }
   }
 }


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk-for-cpp/pull/3366#discussion_r838085031
and:
https://github.com/Azure/azure-sdk-for-cpp/pull/3434/files#diff-939798b5f977387c47f2fb3afc90d4ce2bf40856212ecdae6e503de589c4339bR357