### PR TITLE
Remove version pin for OpenSSL

### DIFF
--- a/sdk/attestation/azure-security-attestation/CMakeLists.txt
+++ b/sdk/attestation/azure-security-attestation/CMakeLists.txt
@@ -107,3 +107,4 @@ endif()
 if(BUILD_SAMPLES)
    add_subdirectory(samples)
 endif()
+

--- a/sdk/core/CMakeLists.txt
+++ b/sdk/core/CMakeLists.txt
@@ -17,3 +17,4 @@ endif()
 if (BUILD_TESTING)
   add_subdirectory(azure-core-test)
 endif()
+

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "azure-sdk-for-cpp",
   "version": "1.5.0",
-  "builtin-baseline": "f0aa678b7471497f1adedcc99f40e1599ad22f69",
   "dependencies": [
     {
       "name": "curl"
@@ -12,12 +11,6 @@
     },
     {
       "name": "openssl"
-    }
-  ],
-  "overrides": [
-    {
-      "name": "openssl",
-      "version-string": "1.1.1n"
     }
   ]
 }


### PR DESCRIPTION
# Remove the version pin for OpenSSL and let the version used to build the SDKs float.
