### PR TITLE
Removed uwp-x86 from platform matrix.

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -89,9 +89,6 @@
                 }
             },
             "TargetArchitecture": {
-                "x86": {
-                    "CMAKE_GENERATOR_PLATFORM": "Win32"
-                },
                 "x64": {
                     "CMAKE_GENERATOR_PLATFORM": "x64",
                     "VCPKG_DEFAULT_TRIPLET": "x64-uwp"


### PR DESCRIPTION
# Removes uwp-x86 from the platform CI matrix.

VCPKG's support for uwp-x86 is community contributed and they do not appear to run uwp-x86 as a part of their CI pipelines, so removing uwp-x86 support from the platform CI matrix until official vcpkg support for uwp-x86 is added.

