### PR TITLE
Fixed a bug where text of XML element cannot be empty.

### DIFF
--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where text of XML element cannot be empty.
+
 ### Other Changes
 
 ## 12.2.3 (2022-04-06)

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -19,17 +19,20 @@ namespace Azure { namespace Storage { namespace _internal {
 
   struct XmlNode final
   {
-    explicit XmlNode(
-        XmlNodeType type,
-        std::string name = std::string(),
-        std::string value = std::string())
-        : Type(type), Name(std::move(name)), Value(std::move(value))
+    explicit XmlNode(XmlNodeType type, std::string name = std::string())
+        : Type(type), Name(std::move(name))
+    {
+    }
+
+    explicit XmlNode(XmlNodeType type, std::string name, std::string value)
+        : Type(type), Name(std::move(name)), Value(std::move(value)), HasValue(true)
     {
     }
 
     XmlNodeType Type;
     std::string Name;
     std::string Value;
+    bool HasValue = false;
   };
 
   class XmlReader final {

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -203,7 +203,7 @@ namespace Azure { namespace Storage { namespace _internal {
       }
       case WS_XML_NODE_TYPE_END_ELEMENT:
         moveToNext();
-        return XmlNode{XmlNodeType::EndTag, std::string()};
+        return XmlNode{XmlNodeType::EndTag};
       case WS_XML_NODE_TYPE_EOF:
         return XmlNode{XmlNodeType::End};
       case WS_XML_NODE_TYPE_CDATA:
@@ -288,7 +288,7 @@ namespace Azure { namespace Storage { namespace _internal {
     auto context = static_cast<XmlWriterContext*>(m_context);
     if (node.Type == XmlNodeType::StartTag)
     {
-      if (!node.Value.empty())
+      if (node.HasValue)
       {
         Write(XmlNode{XmlNodeType::StartTag, std::move(node.Name)});
         Write(XmlNode{XmlNodeType::Text, std::string(), std::move(node.Value)});
@@ -576,7 +576,7 @@ namespace Azure { namespace Storage { namespace _internal {
     xmlTextWriterPtr writer = context->writer;
     if (node.Type == XmlNodeType::StartTag)
     {
-      if (node.Value.empty())
+      if (!node.HasValue)
       {
         xmlTextWriterStartElement(writer, BadCast(node.Name.data()));
       }


### PR DESCRIPTION
There's a bug in storage xml generator that text of an XML element cannot be empty. The bug wasn't discovered before because we didn't use empty XML text.

I found it when I was working on Blob Query. In the request body of this API, we need to write something like 

```xml
<DelimitedTextConfiguration>
  <ColumnSeparator>String</ColumnSeparator>
</DelimitedTextConfiguration>
```

if we want to use the default separator, we also need to include the XML tag, like

```xml
<DelimitedTextConfiguration>
  <ColumnSeparator></ColumnSeparator>
</DelimitedTextConfiguration>
```

or 

```xml
<DelimitedTextConfiguration>
  <ColumnSeparator/>
</DelimitedTextConfiguration>
```

This trigged the bug. I fixed in a non-breaking way.

We don't test internal functions. Testing will be covered by public functions (which I'm working on in another branch).

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?