### PR TITLE
Removed version>= fields for openssl in vcpkg.json files

### DIFF
--- a/sdk/attestation/azure-security-attestation/vcpkg/vcpkg.json
+++ b/sdk/attestation/azure-security-attestation/vcpkg/vcpkg.json
@@ -25,8 +25,7 @@
       "host": true
     },
     {
-      "name": "openssl",
-      "version>=": "1.1.1n"
+      "name": "openssl"
     }
   ]
 }

--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -13,8 +13,7 @@
   "dependencies": [
     {
       "name": "openssl",
-      "platform": "!windows & !uwp",
-      "version>=": "1.1.1n"
+      "platform": "!windows & !uwp"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-common/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg.json
@@ -19,8 +19,7 @@
     },
     {
       "name": "openssl",
-      "platform": "!windows",
-      "version>=": "1.1.1n" 
+      "platform": "!windows"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
@@ -22,8 +22,7 @@
     },
     {
       "name": "openssl",
-      "platform": "!windows",
-      "version>=": "1.1.1n" 
+      "platform": "!windows"
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
# Remove `version>=` fields from vcpkg.json files.

Fixes #3703 

These fields are broken because:

1.  These fields are illegal in the vcpkg schema because `version>=` only works with semver version numbers and 1.1.1n is not a legal semver version number.
2. We rely on the vcpkg baseline to determine which version of openssl we use, currently 3.0.2.

## Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [X] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [X] Doxygen docs
- [X] Unit tests
- [X] No unwanted commits/changes
- [X] Descriptive title/description
  - [X] PR is single purpose
  - [X] Related issue listed
- [X] Comments in source
- [X] No typos
- [X] Update changelog
- [X] Not work-in-progress
- [X] External references or docs updated
- [X] Self review of PR done
- [X] Any breaking changes?
