### PR TITLE
Tab vcpkg publishing condition in to apply to the task

### DIFF
--- a/eng/pipelines/templates/steps/vcpkg-publish.yml
+++ b/eng/pipelines/templates/steps/vcpkg-publish.yml
@@ -46,7 +46,7 @@ steps:
         -GitCommitParameters '-c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com"'
         -DailyRelease:$${{ parameters.DailyRelease }}
       workingDirectory: ${{ parameters.Workspace }}/vcpkg
-      condition: and(succeeded(), eq(variables['PublishToVcpkg'], 'true'))
+    condition: and(succeeded(), eq(variables['PublishToVcpkg'], 'true'))
     displayName: Update vcpkg port ${{ parameters.DisplayNameExtension }}
 
   # On package release vcpkg beta should always be updated


### PR DESCRIPTION
Fixes #3700

Examples: 
* Example template pipeline running: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1620790&view=results
* Template pipeline evaluating `PublishToVcpkg`: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1620790&view=logs&j=db30d5e9-5c21-5d7b-155a-3df6a2f30198&t=71e3fb16-129f-5b82-f69c-5d7e567d5f18&l=2 (this was not being done previously) 

The `condition` was initially tabbed under the task's `input` section. This PR moves the `condition` to its correct placement at the level of the task. 

Of note: `condition` is not a documented valid item in the `input` section in the [PowerShell@2](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/powershell?view=azure-devops) task. The task does not fail from the presence of an unusable input. 