### PR TITLE
Include `api-version` to default list of unredacted query params for logging

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -42,7 +42,8 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
 
   namespace _detail {
     std::shared_ptr<HttpTransport> GetTransportAdapter();
-    AZ_CORE_DLLEXPORT extern Azure::Core::CaseInsensitiveSet const g_defaultAllowedHttpHeaders;
+    AZ_CORE_DLLEXPORT extern std::set<std::string> const g_defaultAllowedHttpQueryParameters;
+    AZ_CORE_DLLEXPORT extern CaseInsensitiveSet const g_defaultAllowedHttpHeaders;
   } // namespace _detail
 
   /**
@@ -120,13 +121,13 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * @brief HTTP query parameter names that are allowed to be logged.
      *
      */
-    std::set<std::string> AllowedHttpQueryParameters;
+    std::set<std::string> AllowedHttpQueryParameters = _detail::g_defaultAllowedHttpQueryParameters;
 
     /**
      * @brief HTTP header names that are allowed to be logged.
      *
      */
-    Azure::Core::CaseInsensitiveSet AllowedHttpHeaders = _detail::g_defaultAllowedHttpHeaders;
+    CaseInsensitiveSet AllowedHttpHeaders = _detail::g_defaultAllowedHttpHeaders;
   };
 
   /**

--- a/sdk/core/azure-core/src/http/log_policy.cpp
+++ b/sdk/core/azure-core/src/http/log_policy.cpp
@@ -66,33 +66,35 @@ inline std::string GetResponseLogMessage(
 }
 } // namespace
 
-Azure::Core::CaseInsensitiveSet const
-    Azure::Core::Http::Policies::_detail::g_defaultAllowedHttpHeaders
-    = {
-        "Accept",
-        "Cache-Control",
-        "Connection",
-        "Content-Length",
-        "Content-Type",
-        "Date",
-        "ETag",
-        "Expires",
-        "If-Match",
-        "If-Modified-Since",
-        "If-None-Match",
-        "If-Unmodified-Since",
-        "Last-Modified",
-        "Pragma",
-        "Request-Id",
-        "Retry-After",
-        "Server",
-        "traceparent",
-        "tracestate",
-        "Transfer-Encoding",
-        "User-Agent",
-        "x-ms-client-request-id",
-        "x-ms-request-id",
-        "x-ms-return-client-request-id",
+std::set<std::string> const Policies::_detail::g_defaultAllowedHttpQueryParameters = {
+    "api-version",
+};
+
+CaseInsensitiveSet const Policies::_detail::g_defaultAllowedHttpHeaders = {
+    "Accept",
+    "Cache-Control",
+    "Connection",
+    "Content-Length",
+    "Content-Type",
+    "Date",
+    "ETag",
+    "Expires",
+    "If-Match",
+    "If-Modified-Since",
+    "If-None-Match",
+    "If-Unmodified-Since",
+    "Last-Modified",
+    "Pragma",
+    "Request-Id",
+    "Retry-After",
+    "Server",
+    "traceparent",
+    "tracestate",
+    "Transfer-Encoding",
+    "User-Agent",
+    "x-ms-client-request-id",
+    "x-ms-request-id",
+    "x-ms-return-client-request-id",
 };
 
 std::unique_ptr<RawResponse> LogPolicy::Send(


### PR DESCRIPTION
Closes #3708