### PR TITLE
Add missing license header to http_sanitizer source file

### DIFF
--- a/sdk/core/azure-core/src/http/http_sanitizer.cpp
+++ b/sdk/core/azure-core/src/http/http_sanitizer.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
 
 #include "azure/core/internal/http/http_sanitizer.hpp"
 #include "azure/core/url.hpp"


### PR DESCRIPTION
Resolving https://github.com/Azure/azure-sdk-for-cpp/pull/3736#discussion_r899441456