### PR TITLE
Add auto apiview review creation

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -56,6 +56,49 @@ jobs:
 
   # Disable build for cpp - client
   - ${{ if ne(parameters.ServiceDirectory, 'not-specified' )}}:
+    - ${{ each artifact in parameters.Artifacts }}:
+      - job:
+        displayName: Create API Review for ${{ artifact.name }}
+        pool:
+          name: azsdk-pool-mms-win-2019-general
+          vmImage: MMS2019
+        steps:
+          - task: Powershell@2
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/common/scripts/Save-Package-Properties.ps1
+              arguments: >
+                -ServiceDirectory ${{ parameters.ServiceDirectory }}
+                -OutDirectory $(Build.ArtifactStagingDirectory)/PackageInfo
+              pwsh: true
+              workingDirectory: $(Pipeline.Workspace)
+            displayName: Dump Package properties
+            condition: succeeded()
+
+          - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+
+          - task: Powershell@2
+            inputs:
+              filePath: $(System.DefaultWorkingDirectory)/eng/scripts/Create-APIReview.ps1
+              arguments: >
+                -ArtifactName ${{ artifact.name }}
+                -OutPath $(Build.ArtifactStagingDirectory)
+                -ApiviewUri "$(azuresdk-apiview-uri)"
+                -ApiKey "$(azuresdk-apiview-apikey)"
+                -ApiLabel "Auto Review - $(Build.SourceVersion)"
+                -SourceBranch $(Build.SourceBranchName)
+                -DefaultBranch $(DefaultBranch)
+                -ConfigFileDir $(Build.ArtifactStagingDirectory)/PackageInfo
+              pwsh: true
+              workingDirectory: $(Pipeline.Workspace)
+            displayName: Create API Review for ${{ artifact.name }}
+            condition: >-
+              and(
+                succeeded(),
+                ne(variables['Skip.CreateApiReview'], 'true'),
+                ne(variables['Build.Reason'],'PullRequest'),
+                eq(variables['System.TeamProject'], 'internal')
+              )
+
     - job: GenerateReleaseArtifacts
       pool:
         name: azsdk-pool-mms-win-2019-general
@@ -73,7 +116,7 @@ jobs:
             Directory: ''
             CheckLinkGuidance: $true
 
-        - ${{ each artifact in parameters.Artifacts }}: 
+        - ${{ each artifact in parameters.Artifacts }}:
           - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
             parameters:
               PackageName: ${{ artifact.Name }}
@@ -145,7 +188,7 @@ jobs:
 
                   Copy-Item -Recurse `
                     build/vcpkg/ports/${{ artifact.VcpkgPortName }}/. `
-                    $(Build.ArtifactStagingDirectory)/packages/${{ artifact.Name }}/vcpkg/port 
+                    $(Build.ArtifactStagingDirectory)/packages/${{ artifact.Name }}/vcpkg/port
                 pwsh: true
               displayName: Copy vcpkg port files from build
 
@@ -192,7 +235,7 @@ jobs:
                 sourceFolder: build/sdk/${{ parameters.ServiceDirectory }}/${{ artifact.Path }}/docs/html
                 targetFolder: $(Build.ArtifactStagingDirectory)/docs/${{ artifact.Name }}
               displayName: Copy documentation to artifact staging directory
-             
+
             - task: Powershell@2
               inputs:
                 filePath: $(Build.SourcesDirectory)/eng/common/scripts/Verify-ChangeLog.ps1

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -91,6 +91,7 @@ jobs:
               pwsh: true
               workingDirectory: $(Pipeline.Workspace)
             displayName: Create API Review for ${{ artifact.name }}
+            continueOnError: true
             condition: >-
               and(
                 succeeded(),

--- a/eng/scripts/Create-APIReview.ps1
+++ b/eng/scripts/Create-APIReview.ps1
@@ -1,0 +1,40 @@
+Param(
+    [Parameter(Mandatory=$True)]
+    [string] $ArtifactName,
+    [Parameter(Mandatory=$True)]
+    [string] $OutPath,
+    [Parameter(Mandatory=$True)]
+    [string] $ApiviewUri,
+    [Parameter(Mandatory=$True)]
+    [string] $ApiKey,
+    [Parameter(Mandatory=$True)]
+    [string] $ApiLabel,
+    [Parameter(Mandatory=$True)]
+    [string] $SourceBranch,
+    [Parameter(Mandatory=$True)]
+    [string] $DefaultBranch,
+    [Parameter(Mandatory=$True)]
+    [string] $ConfigFileDir
+)
+
+Write-Host "$PSScriptRoot"
+. (Join-Path $PSScriptRoot .. common scripts common.ps1)
+$createReviewScript = (Join-Path $PSScriptRoot .. common scripts Create-APIReview.ps1)
+Set-Location $PSScriptRoot
+
+Write-Host "Creating API review artifact for $ArtifactName"
+New-Item -ItemType Directory -Path $OutPath/$ArtifactName -force
+
+$gitroot = Join-Path $PSScriptRoot .. ..
+Write-Host "Get-ApiViewCommandLine.ps1 $gitroot $ArtifactName"
+$cmdLine = & $PSScriptRoot/Get-ApiViewCommandLine.ps1 $gitroot $ArtifactName
+Write-Host "Executing clang++ command:"
+Write-Host $cmdLine
+$cmd, $cmdArgs = $cmdLine -split ' '
+& $cmd $cmdArgs > artifact
+
+Compress-Archive -Path artifact -DestinationPath $OutPath/$ArtifactName/$ArtifactName
+Rename-Item $OutPath/$ArtifactName/$ArtifactName.zip -NewName "$ArtifactName.cppast"
+
+Write-Host "Send request to APIView to create review for $ArtifactName"
+&($createReviewScript) -ArtifactPath $OutPath -APIViewUri $ApiviewUri -APIKey $ApiKey -APILabel $ApiLabel -PackageName $ArtifactName -SourceBranch $SourceBranch -DefaultBranch $DefaultBranch -ConfigFileDir $ConfigFileDir

--- a/eng/scripts/Create-APIReview.ps1
+++ b/eng/scripts/Create-APIReview.ps1
@@ -31,9 +31,12 @@ $cmdLine = & $PSScriptRoot/Get-ApiViewCommandLine.ps1 $gitroot $ArtifactName
 Write-Host "Executing clang++ command:"
 Write-Host $cmdLine
 $cmd, $cmdArgs = $cmdLine -split ' '
-& $cmd $cmdArgs > artifact
+# Get-ApiViewCommandLine.ps1 returns a string representing a clang++ command that needs to be run, e.g.
+# clang++ <space separated list of header files> -Xclang -ast-dump -I <space separated list of header files>
+# ApiView expects a zip of this ast as the format for a C++ language artifact.
+& $cmd $cmdArgs > clangAstOutput
 
-Compress-Archive -Path artifact -DestinationPath $OutPath/$ArtifactName/$ArtifactName
+Compress-Archive -Path clangAstOutput -DestinationPath $OutPath/$ArtifactName/$ArtifactName
 Rename-Item $OutPath/$ArtifactName/$ArtifactName.zip -NewName "$ArtifactName.cppast"
 
 Write-Host "Send request to APIView to create review for $ArtifactName"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -98,3 +98,16 @@ function SetPackageVersion ($PackageName, $Version, $ServiceDirectory, $ReleaseD
     -ReleaseDate $ReleaseDate `
     -ReplaceLatestEntryTitle $ReplaceLatestEntryTitle
 }
+
+function Find-cpp-Artifacts-For-Apireview($ArtifactPath, $PackageName)
+{
+  $artifact = Get-ChildItem -Path (Join-Path $ArtifactPath $PackageName) -Filter "*.cppast"
+  if ($artifact)
+  {
+    $packages = @{
+      $artifact.FullName = $artifact.FullName
+    }
+    return $packages
+  }
+  return $null
+}

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -49,14 +49,14 @@ stages:
         - Name: azure-core-tracing-opentelemetry
           Path: azure-core-tracing-opentelemetry
           VcpkgPortName: azure-core-tracing-opentelemetry-cpp
-# Since Azure Core will run all service's tests, it requires all the expected env vars from services          
+# Since Azure Core will run all service's tests, it requires all the expected env vars from services
       TestEnv:
 # Key Vault
         - Name: AZURE_KEYVAULT_URL
           Value: "https://non-real-account.vault.azure.net"
         - Name: AZURE_KEYVAULT_HSM_URL
           Value: "https://non-real-account.vault.azure.net"
-# Key Vault & Identity 
+# Key Vault & Identity
         - Name: AZURE_TENANT_ID
           Value: "33333333-3333-3333-3333-333333333333"
         - Name: AZURE_CLIENT_ID


### PR DESCRIPTION
This PR adds a new pipeline job to generate the ast and upload an apiview artifact to generate a new review for the
commit if one does not exist. Currently it will not gate on failure, but after it proves reliable, we can enable the
gate as the script will fail on release if there is not an approval for the version.

FYI @antkmsft @RickWinter 