### PR TITLE
Revert "Override live test location default to westus (#3696)"

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -49,14 +49,8 @@ parameters:
   default:
     Public:
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-      # TODO: Migrate location override into azure-sdk-tools eng/common
-      # See https://github.com/Azure/azure-sdk-tools/issues/3398
-      Location: 'westus'
     Preview:
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-      # TODO: Migrate location override into azure-sdk-tools eng/common
-      # See https://github.com/Azure/azure-sdk-tools/issues/3398
-      Location: 'westus'
     Canary:
       SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
       Location: 'eastus2euap'


### PR DESCRIPTION
This reverts commit d4192609d5af237bad1f662c1af74290841c3bee.

This change was undone by https://github.com/Azure/azure-sdk-for-cpp/commit/31ddec2076d9e3d571ecf62c46b26fdca182e49b
