### PR TITLE
Update attestation core vcpkg dependency to latest GA version that is required.

### DIFF
--- a/sdk/attestation/azure-security-attestation/vcpkg/Config.cmake.in
+++ b/sdk/attestation/azure-security-attestation/vcpkg/Config.cmake.in
@@ -4,7 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(azure-core-cpp "1.5.0")
+find_dependency(azure-core-cpp "1.7.0")
 find_dependency(OpenSSL)
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-security-attestation-cppTargets.cmake")

--- a/sdk/attestation/azure-security-attestation/vcpkg/vcpkg.json
+++ b/sdk/attestation/azure-security-attestation/vcpkg/vcpkg.json
@@ -14,7 +14,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.7.0-beta.1"
+      "version>=": "1.7.0"
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
Related to:
https://github.com/Azure/azure-sdk-for-cpp/issues/3829
https://github.com/microsoft/vcpkg/pull/25629