### PR TITLE
Remove winhttp

### DIFF
--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -204,7 +204,10 @@ if(BUILD_TESTING)
     add_subdirectory(test/nlohmann-json-test)
   endif()
   add_subdirectory(test/fault-injector)
-  add_subdirectory(test/libcurl-stress-test)
+  
+  if(BUILD_TRANSPORT_CURL)
+    add_subdirectory(test/libcurl-stress-test)
+  endif()
 endif()
 
 if (BUILD_PERFORMANCE_TESTS)

--- a/sdk/core/azure-core/test/libcurl-stress-test/libcurl_stress_test.cpp
+++ b/sdk/core/azure-core/test/libcurl-stress-test/libcurl_stress_test.cpp
@@ -27,16 +27,12 @@ void SendRequest(std::string target)
 {
   std::cout << target << std::endl;
   /* The transport adapter must allow insecure SSL certs.
-  If both curl and winHttp are available, curl is preferred for this test.for*/
-#if defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
+  If both curl and winHttp are available, curl is preferred for this test*/
+
   Azure::Core::Http::CurlTransportOptions curlOptions;
   curlOptions.SslVerifyPeer = false;
   auto implementationClient = std::make_shared<Azure::Core::Http::CurlTransport>(curlOptions);
 
-#elif (BUILD_TRANSPORT_WINHTTP_ADAPTER)
-  Azure::Core::Http::WinHttpTransportOptions winHttpOptions;
-  auto implementationClient = std::make_shared<Azure::Core::Http::WinHttpTransport>(winHttpOptions);
-#endif
   try
   {
 


### PR DESCRIPTION
This test is only for libcurl ( being a pretotype and all that for the stress test scafolding) thus remove the winhttp refs in the code and checking for curl in the cmake file
# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
