### PR TITLE
Fix an issue that reason phrase is missing as expected from HTTP/2 server

### DIFF
--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -624,7 +624,7 @@ std::unique_ptr<RawResponse> WinHttpTransport::SendRequestAndGetResponse(
 
   // HTTP/2 does not support reason phrase, refer to
   // https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.4.
-  if (majorVersion > 1)
+  if (majorVersion == 1)
   {
     if (WinHttpQueryHeaders(
             handleManager->m_requestHandle,

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -622,7 +622,8 @@ std::unique_ptr<RawResponse> WinHttpTransport::SendRequestAndGetResponse(
   std::string reasonPhrase;
   DWORD sizeOfReasonPhrase = sizeOfHeaders;
 
-  // HTTP/2 does not support reason phrase, refer to https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.4.
+  // HTTP/2 does not support reason phrase, refer to
+  // https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.4.
   if (majorVersion == 1)
   {
     if (WinHttpQueryHeaders(
@@ -633,7 +634,8 @@ std::unique_ptr<RawResponse> WinHttpTransport::SendRequestAndGetResponse(
             &sizeOfReasonPhrase,
             WINHTTP_NO_HEADER_INDEX))
     {
-      // even with HTTP/1.1, we cannot assume that reason phrase is set since it is optional according to https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1.
+      // even with HTTP/1.1, we cannot assume that reason phrase is set since it is optional
+      // according to https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1.
       if (sizeOfReasonPhrase > 0)
       {
         start = outputBuffer.begin();

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -622,17 +622,27 @@ std::unique_ptr<RawResponse> WinHttpTransport::SendRequestAndGetResponse(
   std::string reasonPhrase;
   DWORD sizeOfReasonPhrase = sizeOfHeaders;
 
-  if (WinHttpQueryHeaders(
-          handleManager->m_requestHandle,
-          WINHTTP_QUERY_STATUS_TEXT,
-          WINHTTP_HEADER_NAME_BY_INDEX,
-          outputBuffer.data(),
-          &sizeOfReasonPhrase,
-          WINHTTP_NO_HEADER_INDEX))
+  // HTTP/2 does not support reason phrase, refer to
+  // https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.4.
+  if (majorVersion > 1)
   {
-    start = outputBuffer.begin();
-    reasonPhrase
-        = WideStringToString(std::wstring(start, start + sizeOfReasonPhrase / sizeof(WCHAR)));
+    if (WinHttpQueryHeaders(
+            handleManager->m_requestHandle,
+            WINHTTP_QUERY_STATUS_TEXT,
+            WINHTTP_HEADER_NAME_BY_INDEX,
+            outputBuffer.data(),
+            &sizeOfReasonPhrase,
+            WINHTTP_NO_HEADER_INDEX))
+    {
+      // even with HTTP/1.1, we cannot assume that reason phrase is set since it is optional
+      // according to https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1.
+      if (sizeOfReasonPhrase > 0)
+      {
+        start = outputBuffer.begin();
+        reasonPhrase
+            = WideStringToString(std::wstring(start, start + sizeOfReasonPhrase / sizeof(WCHAR)));
+      }
+    }
   }
 
   // Allocate the instance of the response on the heap with a shared ptr so this memory gets

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -622,8 +622,7 @@ std::unique_ptr<RawResponse> WinHttpTransport::SendRequestAndGetResponse(
   std::string reasonPhrase;
   DWORD sizeOfReasonPhrase = sizeOfHeaders;
 
-  // HTTP/2 does not support reason phrase, refer to
-  // https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.4.
+  // HTTP/2 does not support reason phrase, refer to https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.4.
   if (majorVersion == 1)
   {
     if (WinHttpQueryHeaders(
@@ -634,8 +633,7 @@ std::unique_ptr<RawResponse> WinHttpTransport::SendRequestAndGetResponse(
             &sizeOfReasonPhrase,
             WINHTTP_NO_HEADER_INDEX))
     {
-      // even with HTTP/1.1, we cannot assume that reason phrase is set since it is optional
-      // according to https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1.
+      // even with HTTP/1.1, we cannot assume that reason phrase is set since it is optional according to https://www.rfc-editor.org/rfc/rfc2616.html#section-6.1.1.
       if (sizeOfReasonPhrase > 0)
       {
         start = outputBuffer.begin();


### PR DESCRIPTION
Fix an issue that reason phrase is missing as expected from HTTP/2 server

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [ ] Related issue listed
- [x] Comments in source
- [x] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
