### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/sdk/attestation/azure-security-attestation/cgmanifest.json
+++ b/sdk/attestation/azure-security-attestation/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/sdk/core/azure-core-test/cgmanifest.json
+++ b/sdk/core/azure-core-test/cgmanifest.json
@@ -1,25 +1,26 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/google/googletest",
-                    "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "clang-format",
-                    "Version": "9.0.0-2",
-                    "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
-                }
-            },
-            "DevelopmentDependency": true
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/google/googletest",
+          "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
         }
-    ]
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "clang-format",
+          "Version": "9.0.0-2",
+          "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
+        }
+      },
+      "DevelopmentDependency": true
+    }
+  ]
 }

--- a/sdk/core/azure-core-tracing-opentelemetry/cgmanifest.json
+++ b/sdk/core/azure-core-tracing-opentelemetry/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/sdk/core/azure-core/cgmanifest.json
+++ b/sdk/core/azure-core/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/sdk/core/perf/cgmanifest.json
+++ b/sdk/core/perf/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/sdk/identity/azure-identity/cgmanifest.json
+++ b/sdk/identity/azure-identity/cgmanifest.json
@@ -1,4 +1,4 @@
 {
-  "Registrations": [
-  ]
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": []
 }

--- a/sdk/keyvault/azure-security-keyvault-certificates/cgmanifest.json
+++ b/sdk/keyvault/azure-security-keyvault-certificates/cgmanifest.json
@@ -1,36 +1,37 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/google/googletest",
-                    "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "clang-format",
-                    "Version": "9.0.0-2",
-                    "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "doxygen",
-                    "Version": "1.8.20",
-                    "DownloadUrl": "http://doxygen.nl/files/doxygen-1.8.20-setup.exe"
-                }
-            },
-            "DevelopmentDependency": true
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/google/googletest",
+          "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
         }
-    ]
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "clang-format",
+          "Version": "9.0.0-2",
+          "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "doxygen",
+          "Version": "1.8.20",
+          "DownloadUrl": "http://doxygen.nl/files/doxygen-1.8.20-setup.exe"
+        }
+      },
+      "DevelopmentDependency": true
+    }
+  ]
 }

--- a/sdk/keyvault/azure-security-keyvault-keys/cgmanifest.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/cgmanifest.json
@@ -1,36 +1,37 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/google/googletest",
-                    "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "clang-format",
-                    "Version": "9.0.0-2",
-                    "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "doxygen",
-                    "Version": "1.8.20",
-                    "DownloadUrl": "http://doxygen.nl/files/doxygen-1.8.20-setup.exe"
-                }
-            },
-            "DevelopmentDependency": true
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/google/googletest",
+          "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
         }
-    ]
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "clang-format",
+          "Version": "9.0.0-2",
+          "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "doxygen",
+          "Version": "1.8.20",
+          "DownloadUrl": "http://doxygen.nl/files/doxygen-1.8.20-setup.exe"
+        }
+      },
+      "DevelopmentDependency": true
+    }
+  ]
 }

--- a/sdk/keyvault/azure-security-keyvault-secrets/cgmanifest.json
+++ b/sdk/keyvault/azure-security-keyvault-secrets/cgmanifest.json
@@ -1,36 +1,37 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/google/googletest",
-                    "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "clang-format",
-                    "Version": "9.0.0-2",
-                    "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "doxygen",
-                    "Version": "1.8.20",
-                    "DownloadUrl": "http://doxygen.nl/files/doxygen-1.8.20-setup.exe"
-                }
-            },
-            "DevelopmentDependency": true
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/google/googletest",
+          "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
         }
-    ]
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "clang-format",
+          "Version": "9.0.0-2",
+          "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "doxygen",
+          "Version": "1.8.20",
+          "DownloadUrl": "http://doxygen.nl/files/doxygen-1.8.20-setup.exe"
+        }
+      },
+      "DevelopmentDependency": true
+    }
+  ]
 }

--- a/sdk/storage/azure-storage-blobs/cgmanifest.json
+++ b/sdk/storage/azure-storage-blobs/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/sdk/storage/azure-storage-common/cgmanifest.json
+++ b/sdk/storage/azure-storage-common/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/sdk/storage/azure-storage-files-datalake/cgmanifest.json
+++ b/sdk/storage/azure-storage-files-datalake/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/sdk/storage/azure-storage-files-shares/cgmanifest.json
+++ b/sdk/storage/azure-storage-files-shares/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/sdk/storage/azure-storage-queues/cgmanifest.json
+++ b/sdk/storage/azure-storage-queues/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/sdk/template/azure-template/cgmanifest.json
+++ b/sdk/template/azure-template/cgmanifest.json
@@ -1,36 +1,37 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/google/googletest",
-                    "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "clang-format",
-                    "Version": "9.0.0-2",
-                    "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "other",
-                "Other": {
-                    "Name": "doxygen",
-                    "Version": "1.8.20",
-                    "DownloadUrl": "http://doxygen.nl/files/doxygen-1.8.20-setup.exe"
-                }
-            },
-            "DevelopmentDependency": true
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/google/googletest",
+          "CommitHash": "703bd9caab50b139428cea1aaff9974ebee5742e"
         }
-    ]
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "clang-format",
+          "Version": "9.0.0-2",
+          "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "other",
+        "Other": {
+          "Name": "doxygen",
+          "Version": "1.8.20",
+          "DownloadUrl": "http://doxygen.nl/files/doxygen-1.8.20-setup.exe"
+        }
+      },
+      "DevelopmentDependency": true
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.