### PR TITLE
Set VCPKG_ROOT

### DIFF
--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -144,6 +144,7 @@ stages:
                         parameters:
                           RepoOwner: Azure
                           RepoName: azure-sdk-vcpkg-betas
+                          SetVcpkgRoot: false
 
                       - template: /eng/pipelines/templates/steps/vcpkg-publish.yml
                         parameters:

--- a/eng/pipelines/templates/steps/vcpkg-clone.yml
+++ b/eng/pipelines/templates/steps/vcpkg-clone.yml
@@ -15,7 +15,7 @@ steps:
       }
     displayName: Clone vcpkg (${{ parameters.RepoOwner }}/${{ parameters.RepoName }})
 
-  - ${{ if eq(parameters.SetVcpkgRoot, 'true') }}:
+  - ${{ if eq(parameters.SetVcpkgRoot, true) }}:
     - pwsh: |
         $vcpkgRoot = Resolve-Path "${{ parameters.Workspace }}/${{ parameters.RepoName }}"
         Write-Host "Set VCPKG_ROOT: $vcpkgRoot"

--- a/eng/pipelines/templates/steps/vcpkg-clone.yml
+++ b/eng/pipelines/templates/steps/vcpkg-clone.yml
@@ -3,6 +3,7 @@ parameters:
   RepoOwner: not-set
   RepoName: vcpkg
   PRBranchName: not-set
+  SetVcpkgRoot: true
 
 steps:
   - pwsh: |
@@ -13,6 +14,13 @@ steps:
         exit $LASTEXITCODE
       }
     displayName: Clone vcpkg (${{ parameters.RepoOwner }}/${{ parameters.RepoName }})
+
+  - ${{ if eq(parameters.SetVcpkgRoot, 'true') }}:
+    - pwsh: |
+        $vcpkgRoot = Resolve-Path "${{ parameters.Workspace }}/${{ parameters.RepoName }}"
+        Write-Host "Set VCPKG_ROOT: $vcpkgRoot"
+        Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$vcpkgRoot"
+      displayName: Set VCPKG_ROOT
 
   # Check out the PR branch if it's already in remote. Ignore failures.
   - pwsh: |


### PR DESCRIPTION
A [recent change to the Windows 2019 image](https://github.com/actions/runner-images/commit/a4b9a513045f0114e987d8b6dd55f6e750e2e892) sets the `VCPKG_ROOT` environment variable explicitly to `c:\vcpkg` (the version of `vcpkg` already baked into the image, not the instance we want to use for publishing). 

`vcpkg.exe` looks at `VCPKG_ROOT` directly to discover which paths to operate. This can break scenarios where it's assumed that `VCPKG_ROOT` is not set. 

This change sets VCPKG_ROOT explicitly at runtime whenever `vcpkg` is cloned. 

Broken behavior: 

* Pipeline run showing error that the port does not exist (the port does exist, but `vcpkg.exe` is looking in `c:\vcpkg` instead of `D:\a\_work\1\vcpkg\`) -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1856228&view=logs&j=db30d5e9-5c21-5d7b-155a-3df6a2f30198&t=71e3fb16-129f-5b82-f69c-5d7e567d5f18&l=116
* PR opened with error describing missing baseline info -- https://github.com/microsoft/vcpkg/pull/26841

Working behavior from this PR: 

* Pipeline run showing updates to port -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1856252&view=logs&j=db30d5e9-5c21-5d7b-155a-3df6a2f30198&t=fd44e9d3-3be0-5017-163f-2cdf78e4aece&l=116
* PR opened without error (files tab shows 4 edited files including the baseline.json and checks passed) -- https://github.com/microsoft/vcpkg/pull/26842

Other options include: 

* Set `VCPKG_ROOT` to an empty value in a `variable: ` section -- Doing this would take the process of setting `VCPKG_ROOT` away from the explicit steps happening in vcpkg. One would have to look at a higher scope (`job`, `stage`) to discover that `VCPKG_ROOT` is being set to an empty value. If one were cloning and manipulating an instance of `vcpkg` in another pipeline, one would have to remember that `VCPKG_ROOT` is supposed to be set to an empty value before manipulations would work. 
* Set `VCPKG_ROOT` to an empty value at runtime whenever cloning -- I'd rather be explicit about the `VCPKG_ROOT` being used because the value is already set on the image. In cases of multiple `vcpkg` instances _in use_ on the same agent, we'd have to consider this course of action.
