### PR TITLE
Implemented close correctly

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/websockets/websockets.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/websockets/websockets.hpp
@@ -62,7 +62,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
      * Note: Some of these statistics are not available if the underlying transport supports native
      * websockets.
      */
-    struct WebSocketStatistics
+    struct WebSocketStatistics final
     {
       /** @brief The number of WebSocket frames sent on this WebSocket. */
       uint32_t FramesSent;
@@ -172,10 +172,11 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
           : FrameType{frameType}, IsFinalFrame{isFinalFrame}
       {
       }
+      virtual ~WebSocketFrame() {}
     };
 
     /** @brief Contains the contents of a WebSocket Text frame.*/
-    class WebSocketTextFrame : public WebSocketFrame,
+    class WebSocketTextFrame final : public WebSocketFrame,
                                public std::enable_shared_from_this<WebSocketTextFrame> {
       friend Azure::Core::Http::WebSockets::_detail::WebSocketImplementation;
 
@@ -201,7 +202,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
     };
 
     /** @brief Contains the contents of a WebSocket Binary frame.*/
-    class WebSocketBinaryFrame : public WebSocketFrame,
+    class WebSocketBinaryFrame final : public WebSocketFrame,
                                  public std::enable_shared_from_this<WebSocketBinaryFrame> {
       friend Azure::Core::Http::WebSockets::_detail::WebSocketImplementation;
 
@@ -227,7 +228,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
     };
 
     /** @brief Contains the contents of a WebSocket Close frame.*/
-    class WebSocketPeerCloseFrame : public WebSocketFrame,
+    class WebSocketPeerCloseFrame final : public WebSocketFrame,
                                     public std::enable_shared_from_this<WebSocketPeerCloseFrame> {
       friend Azure::Core::Http::WebSockets::_detail::WebSocketImplementation;
 
@@ -254,7 +255,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
       }
     };
 
-    struct WebSocketOptions : Azure::Core::_internal::ClientOptions
+    struct WebSocketOptions final : Azure::Core::_internal::ClientOptions
     {
       /**
        * @brief The set of protocols which are supported by this client
@@ -290,7 +291,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
       WebSocketOptions() = default;
     };
 
-    class WebSocket {
+    class WebSocket final {
     public:
       /** @brief Constructs a new instance of a WebSocket with the specified WebSocket options.
        *

--- a/sdk/core/azure-core/inc/azure/core/http/websockets/websockets.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/websockets/websockets.hpp
@@ -311,13 +311,12 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
        */
       void Open(Azure::Core::Context const& context = Azure::Core::Context{});
 
-      /** @brief Closes a WebSocket connection to the remote server gracefully.
-       *
-       * @param context Context for the operation.
+      /** @brief Closes a WebSocket connection to the remote server.
        */
-      void Close(Azure::Core::Context const& context = Azure::Core::Context{});
+      void Close();
 
-      /** @brief Closes a WebSocket connection to the remote server with additional context.
+      /** @brief Gracefully closes a WebSocket connection to the remote server with additional
+       * context.
        *
        * @param closeStatus 16 bit WebSocket error code.
        * @param closeReason String describing the reason for closing the socket.

--- a/sdk/core/azure-core/inc/azure/core/http/websockets/websockets.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/websockets/websockets.hpp
@@ -177,7 +177,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
 
     /** @brief Contains the contents of a WebSocket Text frame.*/
     class WebSocketTextFrame final : public WebSocketFrame,
-                               public std::enable_shared_from_this<WebSocketTextFrame> {
+                                     public std::enable_shared_from_this<WebSocketTextFrame> {
       friend Azure::Core::Http::WebSockets::_detail::WebSocketImplementation;
 
     private:
@@ -203,7 +203,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
 
     /** @brief Contains the contents of a WebSocket Binary frame.*/
     class WebSocketBinaryFrame final : public WebSocketFrame,
-                                 public std::enable_shared_from_this<WebSocketBinaryFrame> {
+                                       public std::enable_shared_from_this<WebSocketBinaryFrame> {
       friend Azure::Core::Http::WebSockets::_detail::WebSocketImplementation;
 
     private:
@@ -228,8 +228,9 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets {
     };
 
     /** @brief Contains the contents of a WebSocket Close frame.*/
-    class WebSocketPeerCloseFrame final : public WebSocketFrame,
-                                    public std::enable_shared_from_this<WebSocketPeerCloseFrame> {
+    class WebSocketPeerCloseFrame final
+        : public WebSocketFrame,
+          public std::enable_shared_from_this<WebSocketPeerCloseFrame> {
       friend Azure::Core::Http::WebSockets::_detail::WebSocketImplementation;
 
     public:

--- a/sdk/core/azure-core/src/http/curl/curl_websockets.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl_websockets.cpp
@@ -27,7 +27,13 @@
 
 namespace Azure { namespace Core { namespace Http { namespace WebSockets {
 
-  void CurlWebSocketTransport::Close() { m_upgradedConnection->Shutdown(); }
+  void CurlWebSocketTransport::Close()
+  {
+    if (m_upgradedConnection)
+    {
+      m_upgradedConnection->Shutdown();
+    }
+  }
 
   // Send an HTTP request to the remote server.
   std::unique_ptr<RawResponse> CurlWebSocketTransport::Send(

--- a/sdk/core/azure-core/src/http/websockets/websockets.cpp
+++ b/sdk/core/azure-core/src/http/websockets/websockets.cpp
@@ -21,11 +21,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets { names
   {
     m_socketImplementation->Open(context);
   }
-  void WebSocket::Close(Azure::Core::Context const& context)
-  {
-    m_socketImplementation->Close(
-        static_cast<uint16_t>(WebSocketErrorCode::EndpointDisappearing), {}, context);
-  }
+  void WebSocket::Close() { m_socketImplementation->Close(); }
   void WebSocket::Close(
       uint16_t closeStatus,
       std::string const& closeReason,

--- a/sdk/core/azure-core/src/http/websockets/websockets_impl.hpp
+++ b/sdk/core/azure-core/src/http/websockets/websockets_impl.hpp
@@ -16,7 +16,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets { names
   // Generator for random bytes. Used in WebSocketImplementation and tests.
   std::vector<uint8_t> GenerateRandomBytes(size_t vectorSize);
 
-  class WebSocketImplementation {
+  class WebSocketImplementation final {
     enum class SocketState
     {
       Invalid,

--- a/sdk/core/azure-core/src/http/websockets/websockets_impl.hpp
+++ b/sdk/core/azure-core/src/http/websockets/websockets_impl.hpp
@@ -30,8 +30,10 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets { names
     WebSocketImplementation(
         Azure::Core::Url const& remoteUrl,
         _internal::WebSocketOptions const& options);
+    ~WebSocketImplementation();
 
     void Open(Azure::Core::Context const& context);
+    void Close();
     void Close(
         uint16_t closeStatus,
         std::string const& closeReason,


### PR DESCRIPTION
# Implement the `Close()` method correctly.

The cognitive services team reported that the `Close()` method with no parameters sent data to the server, which is an unexpected behavior. In addition, if you destroyed a `WebSocket` object without calling `Close()`, then the WebSocket  codebase would AV. This fixes both of these issues.


## Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
