### PR TITLE
Add default .assets directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,3 +343,6 @@ build/
 # vscode
 .vscode/
 .factorypath
+
+# Default Assets restore directory
+.assets


### PR DESCRIPTION
The default assets restore is a `.assets` directory in the repository root. This directory needs to be ignored by each individual langue.