### PR TITLE
Update vcpkg baseline to latest released tags/2022.10.19

### DIFF
--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -22,7 +22,7 @@ macro(az_vcpkg_integrate)
       if(NOT DEFINED ENV{AZURE_SDK_DISABLE_AUTO_VCPKG})
         # GET VCPKG FROM SOURCE
         #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
-        set(VCPKG_COMMIT_STRING 6ca56aeb457f033d344a7106cb3f9f1abf8f4e98) # default SDK tested commit
+        set(VCPKG_COMMIT_STRING 94ce0dab56f4d8ba6bd631ba59ed682b02d45c46) # default SDK tested commit
         if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
           set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit
         endif()

--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -5,41 +5,37 @@
 set(AZ_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 
 macro(az_vcpkg_integrate)
+  message("Vcpkg integrate step.")
   # AUTO CMAKE_TOOLCHAIN_FILE:
   #   User can call `cmake -DCMAKE_TOOLCHAIN_FILE="path_to_the_toolchain"` as the most specific scenario.
-  #   An env var VCPKG_ROOT or VCPKG_INSTALLATION_ROOT can be set to let Azure SDK to set the VCPKG toolchain automatically.
   #   As the last alternative (default case), Azure SDK will automatically clone VCPKG folder and set toolchain from there.
   if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-    if(DEFINED ENV{VCPKG_ROOT})
-      set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-          CACHE STRING "")
-    elseif(DEFINED ENV{VCPKG_INSTALLATION_ROOT})
-      set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake"
-          CACHE STRING "")
-    else()
-      # Set AZURE_SDK_DISABLE_AUTO_VCPKG env var to avoid Azure SDK from cloning and setting VCPKG automatically
-      # This option delegate package's dependencies installation to user.
-      if(NOT DEFINED ENV{AZURE_SDK_DISABLE_AUTO_VCPKG})
-        # GET VCPKG FROM SOURCE
-        #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
-        set(VCPKG_COMMIT_STRING 94ce0dab56f4d8ba6bd631ba59ed682b02d45c46) # default SDK tested commit
-        if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
-          set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit
-        endif()
-        include(FetchContent)
-        FetchContent_Declare(
-            vcpkg
-            GIT_REPOSITORY      https://github.com/microsoft/vcpkg.git
-            GIT_TAG             ${VCPKG_COMMIT_STRING}
-            )
-        FetchContent_GetProperties(vcpkg)
-        # make sure to pull vcpkg only once.
-        if(NOT vcpkg_POPULATED) 
-            FetchContent_Populate(vcpkg)
-        endif()
-        # use the vcpkg source path 
-        set(CMAKE_TOOLCHAIN_FILE "${vcpkg_SOURCE_DIR}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
+    message("CMAKE_TOOLCHAIN_FILE is not defined. Define it for the user.")
+    # Set AZURE_SDK_DISABLE_AUTO_VCPKG env var to avoid Azure SDK from cloning and setting VCPKG automatically
+    # This option delegate package's dependencies installation to user.
+    if(NOT DEFINED ENV{AZURE_SDK_DISABLE_AUTO_VCPKG})
+      message("AZURE_SDK_DISABLE_AUTO_VCPKG is not defined. Fetch a local copy of vcpkg.")
+      # GET VCPKG FROM SOURCE
+      #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
+      set(VCPKG_COMMIT_STRING 94ce0dab56f4d8ba6bd631ba59ed682b02d45c46) # default SDK tested commit
+      if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
+        message("AZURE_SDK_VCPKG_COMMIT is defined. Using that instead of the default.")
+        set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit
       endif()
+      message("Vcpkg commit string used: ${VCPKG_COMMIT_STRING}")
+      include(FetchContent)
+      FetchContent_Declare(
+          vcpkg
+          GIT_REPOSITORY      https://github.com/microsoft/vcpkg.git
+          GIT_TAG             ${VCPKG_COMMIT_STRING}
+          )
+      FetchContent_GetProperties(vcpkg)
+      # make sure to pull vcpkg only once.
+      if(NOT vcpkg_POPULATED) 
+          FetchContent_Populate(vcpkg)
+      endif()
+      # use the vcpkg source path 
+      set(CMAKE_TOOLCHAIN_FILE "${vcpkg_SOURCE_DIR}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
     endif()
   endif()
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-sdk-for-cpp",
   "version": "1.5.0",
-  "builtin-baseline": "6ca56aeb457f033d344a7106cb3f9f1abf8f4e98",
+  "builtin-baseline": "94ce0dab56f4d8ba6bd631ba59ed682b02d45c46",
   "dependencies": [
     {
       "name": "curl"


### PR DESCRIPTION
This is now in-sync with Embedded C as well.