### PR TITLE
Fix typo for llong -> long in doc comment for Key Vault Certificates

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client_operations.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client_operations.hpp
@@ -4,7 +4,7 @@
 
 /**
  * @file
- * @brief Defines the Key Vault Certificate llong running operations.
+ * @brief Defines the Key Vault Certificate long running operations.
  *
  */
 


### PR DESCRIPTION
@danieljurek I am assuming cspell didn't catch this because of a C++ language exceptions for a long long int.