### PR TITLE
Disable warning C6387 coming from wil in win_http_transport due to SAL annotation

### DIFF
--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -17,7 +17,8 @@
 #include <mutex>
 #pragma warning(push)
 #pragma warning(disable : 6553)
-#pragma warning(disable : 6387) // An argument in result_macros.h may be '0', for the function 'GetProcAddress'.
+#pragma warning(disable : 6387) // An argument in result_macros.h may be '0', for the function
+                                // 'GetProcAddress'.
 #include <wil\resource.h>
 #pragma warning(pop)
 #include <winhttp.h>

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -17,6 +17,7 @@
 #include <mutex>
 #pragma warning(push)
 #pragma warning(disable : 6553)
+#pragma warning(disable : 6387) // An argument in result_macros.h may be '0', for the function 'GetProcAddress'.
 #include <wil\resource.h>
 #pragma warning(pop)
 #include <winhttp.h>

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #pragma warning(push)
 #pragma warning(disable : 6553)
+#pragma warning(disable : 6387) // An argument in result_macros.h may be '0', for the function 'GetProcAddress'.
 #include <wil/resource.h> // definitions for wil::unique_cert_chain_context and other RAII type wrappers for Windows types.
 #pragma warning(pop)
 

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -21,7 +21,8 @@
 #include <string>
 #pragma warning(push)
 #pragma warning(disable : 6553)
-#pragma warning(disable : 6387) // An argument in result_macros.h may be '0', for the function 'GetProcAddress'.
+#pragma warning(disable : 6387) // An argument in result_macros.h may be '0', for the function
+                                // 'GetProcAddress'.
 #include <wil/resource.h> // definitions for wil::unique_cert_chain_context and other RAII type wrappers for Windows types.
 #pragma warning(pop)
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/4131

With the vcpkg baseline update of dependencies like `wil` (from https://github.com/Azure/azure-sdk-for-cpp/pull/4100), it introduced this warning (treated as error), which is causing nightly run pipelines to fail on Windows:
https://learn.microsoft.com/en-us/cpp/code-quality/c6387?view=msvc-170

For example:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2013774&view=logs&j=d6204d4c-df7b-58eb-f6e9-300f4a1ec51a&t=9dd83b26-fa53-5361-4278-635b5975bfe8&l=128

Disabling it, similar to https://github.com/Azure/azure-sdk-for-cpp/pull/4054