### PR TITLE
Workaround for the MSVC 19.34 bug

### DIFF
--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
@@ -63,8 +63,16 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
     void Run(Azure::Core::Context const& context) override
     {
       // Loop each page
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER == 193431931
+// Workaround for MSVC bug that was introduced in version 19.34 (Visual Studio 2022 version 17.4):
+// https://developercommunity.visualstudio.com/t/Bogus-C2143-brace-initializing-temporary/10218087
+      auto page = m_containerClient->ListBlobs({}, context);
+      for (; page.HasPage(); page.MoveToNextPage(context))
+#else
       for (auto page = m_containerClient->ListBlobs({}, context); page.HasPage();
            page.MoveToNextPage(context))
+#endif
+
       {
         // loop each blob
         for (auto blob : page.Blobs)

--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
@@ -63,7 +63,7 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
     void Run(Azure::Core::Context const& context) override
     {
       // Loop each page
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER == 193431931
+#if defined(_MSC_VER) && _MSC_VER == 1934
 // Workaround for MSVC bug that was introduced in version 19.34 (Visual Studio 2022 version 17.4):
 // https://developercommunity.visualstudio.com/t/Bogus-C2143-brace-initializing-temporary/10218087
       auto page = m_containerClient->ListBlobs({}, context);

--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
@@ -72,7 +72,6 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
       for (auto page = m_containerClient->ListBlobs({}, context); page.HasPage();
            page.MoveToNextPage(context))
 #endif
-
       {
         // loop each blob
         for (auto blob : page.Blobs)

--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
@@ -63,15 +63,8 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
     void Run(Azure::Core::Context const& context) override
     {
       // Loop each page
-#if defined(_MSC_VER) && _MSC_VER == 1934
-// Workaround for MSVC bug that was introduced in version 19.34 (Visual Studio 2022 version 17.4):
-// https://developercommunity.visualstudio.com/t/Bogus-C2143-brace-initializing-temporary/10218087
       auto page = m_containerClient->ListBlobs({}, context);
       for (; page.HasPage(); page.MoveToNextPage(context))
-#else
-      for (auto page = m_containerClient->ListBlobs({}, context); page.HasPage();
-           page.MoveToNextPage(context))
-#endif
       {
         // loop each blob
         for (auto blob : page.Blobs)


### PR DESCRIPTION
This is for the but that was introduced with the most recent MSVC version 19.34 (Visual Studio 2022 version 17.4):
https://developercommunity.visualstudio.com/t/Bogus-C2143-brace-initializing-temporary/10218087

Without this, CI fails:
```
blob_options.hpp(371,35): error C2143: syntax error: missing ';' before 'member initializer'

test/list_blob_test.hpp(67,12): error C2146: syntax error: missing ')' before identifier 'page'
test/list_blob_test.hpp(67,1): error C2059: syntax error: ';'
test/list_blob_test.hpp(67,1): error C2059: syntax error: ')'
test/list_blob_test.hpp(70,30): error C2062: type 'auto' unexpected
test/list_blob_test.hpp(70,30): error C2065: '<range>$L0': undeclared identifier
test/list_blob_test.hpp(71,1): error C3536: '<begin>$L0': cannot be used before it is initialized
test/list_blob_test.hpp(71,1): error C3536: '<end>$L0': cannot be used before it is initialized
test/list_blob_test.hpp(70,36): error C2100: illegal indirection
test/list_blob_test.hpp(101,3): error C2059: syntax error: '}'
test/list_blob_test.hpp(101,3): error C2143: syntax error: missing ';' before '}'

VC\Tools\MSVC\14.34.31933\include\random(33,1): error C2143: syntax error: missing ';' before '{' 
VC\Tools\MSVC\14.34.31933\include\random(33,1): error C2447: '{': missing function header (old-style formal list?)
```

I am glad we don't have to fix anything in `blob_options.hpp` - fix in `test/list_blob_test.hpp` is enough.

If you want to try this code in different compiler versions, here is the link - https://godbolt.org/z/96s5d65cb