### PR TITLE
Better TokenRequestContext initialization

### DIFF
--- a/sdk/attestation/azure-security-attestation/src/attestation_administration_client.cpp
+++ b/sdk/attestation/azure-security-attestation/src/attestation_administration_client.cpp
@@ -49,8 +49,8 @@ AttestationAdministrationClient::AttestationAdministrationClient(
   std::vector<std::unique_ptr<HttpPolicy>> perRetrypolicies;
   if (credential)
   {
-    Azure::Core::Credentials::TokenRequestContext const tokenContext
-        = {{"https://attest.azure.net/.default"}};
+    Azure::Core::Credentials::TokenRequestContext tokenContext;
+    tokenContext.Scopes = {"https://attest.azure.net/.default"};
 
     perRetrypolicies.emplace_back(
         std::make_unique<BearerTokenAuthenticationPolicy>(credential, tokenContext));

--- a/sdk/attestation/azure-security-attestation/src/attestation_client.cpp
+++ b/sdk/attestation/azure-security-attestation/src/attestation_client.cpp
@@ -38,8 +38,8 @@ AttestationClient::AttestationClient(
   std::vector<std::unique_ptr<HttpPolicy>> perRetrypolicies;
   if (credential)
   {
-    Azure::Core::Credentials::TokenRequestContext const tokenContext
-        = {{"https://attest.azure.net/.default"}};
+    Azure::Core::Credentials::TokenRequestContext tokenContext;
+    tokenContext.Scopes = {"https://attest.azure.net/.default"};
 
     perRetrypolicies.emplace_back(
         std::make_unique<BearerTokenAuthenticationPolicy>(credential, tokenContext));

--- a/sdk/core/azure-core/test/ut/bearer_token_authentication_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/bearer_token_authentication_policy_test.cpp
@@ -51,10 +51,12 @@ TEST(BearerTokenAuthenticationPolicy, InitialGet)
 
   std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
 
+  Azure::Core::Credentials::TokenRequestContext tokenRequestContext;
+  tokenRequestContext.Scopes = {"https://microsoft.com/.default"};
+
   policies.emplace_back(
       std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
-          std::make_shared<TestTokenCredential>(accessToken),
-          Azure::Core::Credentials::TokenRequestContext{{"https://microsoft.com/.default"}}));
+          std::make_shared<TestTokenCredential>(accessToken), tokenRequestContext));
 
   policies.emplace_back(std::make_unique<TestTransportPolicy>());
 
@@ -84,10 +86,12 @@ TEST(BearerTokenAuthenticationPolicy, ReuseWhileValid)
 
   std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
 
+  Azure::Core::Credentials::TokenRequestContext tokenRequestContext;
+  tokenRequestContext.Scopes = {"https://microsoft.com/.default"};
+
   policies.emplace_back(
       std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
-          std::make_shared<TestTokenCredential>(accessToken),
-          Azure::Core::Credentials::TokenRequestContext{{"https://microsoft.com/.default"}}));
+          std::make_shared<TestTokenCredential>(accessToken), tokenRequestContext));
 
   policies.emplace_back(std::make_unique<TestTransportPolicy>());
 
@@ -126,10 +130,12 @@ TEST(BearerTokenAuthenticationPolicy, RefreshNearExpiry)
 
   std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
 
+  Azure::Core::Credentials::TokenRequestContext tokenRequestContext;
+  tokenRequestContext.Scopes = {"https://microsoft.com/.default"};
+
   policies.emplace_back(
       std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
-          std::make_shared<TestTokenCredential>(accessToken),
-          Azure::Core::Credentials::TokenRequestContext{{"https://microsoft.com/.default"}}));
+          std::make_shared<TestTokenCredential>(accessToken), tokenRequestContext));
 
   policies.emplace_back(std::make_unique<TestTransportPolicy>());
 
@@ -168,10 +174,12 @@ TEST(BearerTokenAuthenticationPolicy, RefreshAfterExpiry)
 
   std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
 
+  Azure::Core::Credentials::TokenRequestContext tokenRequestContext;
+  tokenRequestContext.Scopes = {"https://microsoft.com/.default"};
+
   policies.emplace_back(
       std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
-          std::make_shared<TestTokenCredential>(accessToken),
-          Azure::Core::Credentials::TokenRequestContext{{"https://microsoft.com/.default"}}));
+          std::make_shared<TestTokenCredential>(accessToken), tokenRequestContext));
 
   policies.emplace_back(std::make_unique<TestTransportPolicy>());
 

--- a/sdk/identity/azure-identity/test/e2e/azure_identity_e2e_test.cpp
+++ b/sdk/identity/azure-identity/test/e2e/azure_identity_e2e_test.cpp
@@ -61,6 +61,7 @@ int main(int argc, char** argv)
     using Azure::Core::Context;
     using Azure::Core::Credentials::TokenCredentialOptions;
     using Azure::Identity::ManagedIdentityCredential;
+    using Azure::Core::Credentials::TokenRequestContext;
 
     constexpr char const* resourceUrlEnvVarName = "AZURE_IDENTITY_TEST_VAULT_URL";
     std::string const defaultResourceUrl = "https://management.azure.com/";
@@ -94,7 +95,10 @@ int main(int argc, char** argv)
     ManagedIdentityCredential credential(
         Environment::GetVariable("AZURE_IDENTITY_TEST_MANAGED_IDENTITY_CLIENT_ID"), options);
 
-    auto const token = credential.GetToken({{resourceUrl}}, Context());
+    TokenRequestContext tokenRequestContext;
+    tokenRequestContext.Scopes = {resourceUrl};
+
+    auto const token = credential.GetToken(tokenRequestContext, Context());
 
     std::string tokenPreview;
     {

--- a/sdk/identity/azure-identity/test/e2e/azure_identity_e2e_test.cpp
+++ b/sdk/identity/azure-identity/test/e2e/azure_identity_e2e_test.cpp
@@ -60,8 +60,8 @@ int main(int argc, char** argv)
     using Azure::DateTime;
     using Azure::Core::Context;
     using Azure::Core::Credentials::TokenCredentialOptions;
-    using Azure::Identity::ManagedIdentityCredential;
     using Azure::Core::Credentials::TokenRequestContext;
+    using Azure::Identity::ManagedIdentityCredential;
 
     constexpr char const* resourceUrlEnvVarName = "AZURE_IDENTITY_TEST_VAULT_URL";
     std::string const defaultResourceUrl = "https://management.azure.com/";

--- a/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
@@ -272,11 +272,11 @@ TEST(TokenCredentialImpl, FormatScopes)
   // Spaces inside scopes get encoded, but the spaces separating scopes are not
   EXPECT_EQ(TokenCredentialImpl::FormatScopes({"a b", "c d", "e f"}, false), "a%20b c%20d e%20f");
 
-  // 1 scope, './default' only, gets removed when treated as single resource
+  // 1 scope, '/.default' only, gets removed when treated as single resource
   EXPECT_EQ(TokenCredentialImpl::FormatScopes({"/.default"}, false), "%2F.default");
   EXPECT_EQ(TokenCredentialImpl::FormatScopes({"/.default"}, true), "");
 
-  // 2 scopes, './default' only
+  // 2 scopes, '/.default' only
   EXPECT_EQ(
       TokenCredentialImpl::FormatScopes({"/.default", "/.default"}, false),
       "%2F.default %2F.default");

--- a/sdk/keyvault/azure-security-keyvault-certificates/src/certificate_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/src/certificate_client.cpp
@@ -72,8 +72,8 @@ CertificateClient::CertificateClient(
 
   std::vector<std::unique_ptr<HttpPolicy>> perRetrypolicies;
   {
-    Azure::Core::Credentials::TokenRequestContext const tokenContext
-        = {{_internal::UrlScope::GetScopeFromUrl(m_vaultUrl)}};
+    Azure::Core::Credentials::TokenRequestContext tokenContext;
+    tokenContext.Scopes = {_internal::UrlScope::GetScopeFromUrl(m_vaultUrl)};
 
     perRetrypolicies.emplace_back(
         std::make_unique<BearerTokenAuthenticationPolicy>(credential, std::move(tokenContext)));

--- a/sdk/keyvault/azure-security-keyvault-keys/src/cryptography/cryptography_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/cryptography/cryptography_client.cpp
@@ -101,8 +101,8 @@ CryptographyClient::CryptographyClient(
 {
   std::vector<std::unique_ptr<HttpPolicy>> perRetrypolicies;
   {
-    Azure::Core::Credentials::TokenRequestContext const tokenContext
-        = {{_internal::UrlScope::GetScopeFromUrl(m_keyId)}};
+    Azure::Core::Credentials::TokenRequestContext tokenContext;
+    tokenContext.Scopes = {_internal::UrlScope::GetScopeFromUrl(m_keyId)};
 
     perRetrypolicies.emplace_back(
         std::make_unique<BearerTokenAuthenticationPolicy>(credential, tokenContext));

--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -72,8 +72,8 @@ KeyClient::KeyClient(
 {
   std::vector<std::unique_ptr<HttpPolicy>> perRetrypolicies;
   {
-    Azure::Core::Credentials::TokenRequestContext const tokenContext
-        = {{_internal::UrlScope::GetScopeFromUrl(m_vaultUrl)}};
+    Azure::Core::Credentials::TokenRequestContext tokenContext;
+    tokenContext.Scopes = {_internal::UrlScope::GetScopeFromUrl(m_vaultUrl)};
 
     perRetrypolicies.emplace_back(
         std::make_unique<BearerTokenAuthenticationPolicy>(credential, std::move(tokenContext)));

--- a/sdk/keyvault/azure-security-keyvault-secrets/src/secret_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/src/secret_client.cpp
@@ -68,8 +68,8 @@ SecretClient::SecretClient(
 
   std::vector<std::unique_ptr<HttpPolicy>> perRetrypolicies;
   {
-    Azure::Core::Credentials::TokenRequestContext const tokenContext
-        = {{_internal::UrlScope::GetScopeFromUrl(url)}};
+    Azure::Core::Credentials::TokenRequestContext tokenContext;
+    tokenContext.Scopes = {_internal::UrlScope::GetScopeFromUrl(url)};
 
     perRetrypolicies.emplace_back(
         std::make_unique<BearerTokenAuthenticationPolicy>(credential, tokenContext));


### PR DESCRIPTION
`TokenRequestContext` may have new fields, and if we use `{}` initialization, some compilers may generate warnings.