### PR TITLE
Only allow BearerTokenAuthPolicy for HTTPS

### DIFF
--- a/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
+++ b/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
+#include "azure/core/credentials/credentials.hpp"
 #include "azure/core/http/policies/policy.hpp"
 
 #include <chrono>
@@ -9,12 +10,19 @@ using Azure::Core::Context;
 using namespace Azure::Core::Http;
 using namespace Azure::Core::Http::Policies;
 using namespace Azure::Core::Http::Policies::_internal;
+using Azure::Core::Credentials::AuthenticationException;
 
 std::unique_ptr<RawResponse> BearerTokenAuthenticationPolicy::Send(
     Request& request,
     NextHttpPolicy nextPolicy,
     Context const& context) const
 {
+  if (request.GetUrl().GetScheme() != "https")
+  {
+    throw AuthenticationException(
+        "Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
+  }
+
   {
     std::lock_guard<std::mutex> lock(m_accessTokenMutex);
 

--- a/sdk/core/azure-core/test/ut/bearer_token_authentication_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/bearer_token_authentication_policy_test.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <azure/core/http/policies/policy.hpp>
+
+#include <azure/core/credentials/credentials.hpp>
 #include <azure/core/internal/http/pipeline.hpp>
 
 #include <gtest/gtest.h>
@@ -201,4 +203,32 @@ TEST(BearerTokenAuthenticationPolicy, RefreshAfterExpiry)
       EXPECT_EQ(authHeader->second, "Bearer ACCESSTOKEN2");
     }
   }
+}
+
+TEST(BearerTokenAuthenticationPolicy, HttpEndpoint)
+{
+  using namespace std::chrono_literals;
+  auto accessToken = std::make_shared<Azure::Core::Credentials::AccessToken>();
+
+  std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+
+  Azure::Core::Credentials::TokenRequestContext tokenRequestContext;
+  tokenRequestContext.Scopes = {"https://microsoft.com/.default"};
+
+  policies.emplace_back(
+      std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
+          std::make_shared<TestTokenCredential>(accessToken), tokenRequestContext));
+
+  policies.emplace_back(std::make_unique<TestTransportPolicy>());
+
+  Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+  Azure::Core::Http::Request request(
+      Azure::Core::Http::HttpMethod::Get, Azure::Core::Url("http://www.azure.com"));
+
+  *accessToken = {"ACCESSTOKEN1", std::chrono::system_clock::now()};
+
+  EXPECT_THROW(
+      static_cast<void>(pipeline.Send(request, Azure::Core::Context())),
+      Azure::Core::Credentials::AuthenticationException);
 }


### PR DESCRIPTION
Other SDKs have the same restriction.