### PR TITLE
Cherry-pick MSVC 19.34 fix for the feature/storage-dec-release feature branch

### DIFF
--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
@@ -63,8 +63,8 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
     void Run(Azure::Core::Context const& context) override
     {
       // Loop each page
-      for (auto page = m_containerClient->ListBlobs({}, context); page.HasPage();
-           page.MoveToNextPage(context))
+      auto page = m_containerClient->ListBlobs({}, context);
+      for (; page.HasPage(); page.MoveToNextPage(context))
       {
         // loop each blob
         for (auto blob : page.Blobs)


### PR DESCRIPTION
Cherry-pick commit 760126502a79a08c51f787cd3a2a5a785bd90464 for the `feature/storage-dec-release` feature branch.
This should fix CI failure in #4173.