### PR TITLE
Add support for space character instead of 'T' when parsing RFC3339 DateTimes

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for parsing space character in place of 'T' in RFC3339 DateTimes.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -604,7 +604,8 @@ DateTime DateTime::Parse(std::string const& dateTime, DateFormat format)
         day = ParseNumber<decltype(day)>(&cursor, dateTime, DateTimeLength, parsingArea, 2, 2);
       }
 
-      if (cursor < DateTimeLength && (dateTime[cursor] == 'T' || dateTime[cursor] == 't'))
+      if (cursor < DateTimeLength
+          && (dateTime[cursor] == 'T' || dateTime[cursor] == 't' || dateTime[cursor] == ' '))
       {
         ++cursor;
         IncreaseAndCheckMinLength(&minDateTimeLength, DateTimeLength, 7);

--- a/sdk/core/azure-core/test/ut/datetime_test.cpp
+++ b/sdk/core/azure-core/test/ut/datetime_test.cpp
@@ -895,3 +895,10 @@ TEST(DateTime, LeapYear)
   EXPECT_NO_THROW(static_cast<void>(DateTime(2021, 2, 28)));
   EXPECT_THROW(static_cast<void>(DateTime(2021, 2, 29)), std::invalid_argument);
 }
+
+TEST(DateTime, Rfc3339Space)
+{
+  auto const datetime
+      = DateTime::Parse("2022-08-24 00:43:08.0004308Z", DateTime::DateFormat::Rfc3339);
+  EXPECT_EQ(datetime.ToString(DateTime::DateFormat::Rfc3339), "2022-08-24T00:43:08.0004308Z");
+}

--- a/sdk/identity/azure-identity/src/token_credential_impl.cpp
+++ b/sdk/identity/azure-identity/src/token_credential_impl.cpp
@@ -181,17 +181,9 @@ AccessToken TokenCredentialImpl::ParseToken(
     }
     else
     {
-      auto expiresOn = parsedJson[expiresOnPropertyName].get<std::string>();
-      {
-        auto const spacePos = expiresOn.find(' ');
-        if (spacePos != std::string::npos)
-        {
-          expiresOn = expiresOn.replace(spacePos, 1, 1, 'T');
-        }
-      }
-
-      accessToken.ExpiresOn
-          = Azure::DateTime::Parse(expiresOn, Azure::DateTime::DateFormat::Rfc3339);
+      accessToken.ExpiresOn = Azure::DateTime::Parse(
+          parsedJson[expiresOnPropertyName].get<std::string>(),
+          Azure::DateTime::DateFormat::Rfc3339);
     }
 
     return accessToken;


### PR DESCRIPTION
Closes #4171