### PR TITLE
live test guard

### DIFF
--- a/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
@@ -392,7 +392,7 @@ namespace Azure { namespace Core { namespace Test {
       m_testContext.RecordingPath = recordingPath;
       m_testContext.AssetsPath = GetAssetsPath();
 
-      if (!m_wasSkipped)
+      if (!m_wasSkipped && !m_testContext.IsLiveMode())
       {
         m_testProxy = std::make_unique<Azure::Core::Test::TestProxyManager>(m_testContext);
       }

--- a/sdk/core/azure-core-test/src/test_base.cpp
+++ b/sdk/core/azure-core-test/src/test_base.cpp
@@ -13,7 +13,7 @@ using namespace Azure::Core::Json::_internal;
 
 void Azure::Core::Test::TestBase::TearDown()
 {
-  if (m_wasSkipped)
+  if (m_wasSkipped || m_testContext.IsLiveMode())
   {
     return;
   }


### PR DESCRIPTION
Properly guard for live tests , no need to init tear down test proxy.
The internal check for IsAlive for the test proxy then fails which gets the test to fail ., 

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?