### PR TITLE
Move Request ctor impl to the request.cpp file instead of http.cpp

### DIFF
--- a/sdk/core/azure-core/src/http/http.cpp
+++ b/sdk/core/azure-core/src/http/http.cpp
@@ -9,7 +9,6 @@
 
 using namespace Azure::Core;
 using namespace Azure::Core::Http;
-using namespace Azure::Core::IO::_internal;
 
 char const Azure::Core::Http::_internal::HttpShared::ContentType[] = "content-type";
 char const Azure::Core::Http::_internal::HttpShared::ApplicationJson[] = "application/json";

--- a/sdk/core/azure-core/src/http/http.cpp
+++ b/sdk/core/azure-core/src/http/http.cpp
@@ -3,7 +3,6 @@
 
 #include "azure/core/http/http.hpp"
 #include "azure/core/http/policies/policy.hpp"
-#include "azure/core/internal/io/null_body_stream.hpp"
 #include "azure/core/url.hpp"
 
 #include <utility>

--- a/sdk/core/azure-core/src/http/http.cpp
+++ b/sdk/core/azure-core/src/http/http.cpp
@@ -175,13 +175,3 @@ void Azure::Core::Http::_detail::RawResponseHelpers::InsertHeaderWithValidation(
   // insert (override if duplicated)
   headers[headerName] = headerValue;
 }
-
-Request::Request(HttpMethod httpMethod, Url url, bool shouldBufferResponse)
-    : Request(httpMethod, std::move(url), NullBodyStream::GetNullBodyStream(), shouldBufferResponse)
-{
-}
-
-Request::Request(HttpMethod httpMethod, Url url)
-    : Request(httpMethod, std::move(url), NullBodyStream::GetNullBodyStream(), true)
-{
-}

--- a/sdk/core/azure-core/src/http/request.cpp
+++ b/sdk/core/azure-core/src/http/request.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 using namespace Azure::Core::Http;
+using namespace Azure::Core::IO::_internal;
 
 namespace {
 // returns left map plus all items in right

--- a/sdk/core/azure-core/src/http/request.cpp
+++ b/sdk/core/azure-core/src/http/request.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "azure/core/http/http.hpp"
+#include "azure/core/internal/http/null_body_stream.hpp"
 #include "azure/core/internal/strings.hpp"
 
 #include <map>
@@ -21,6 +22,16 @@ static Azure::Core::CaseInsensitiveMap MergeMaps(
   return left;
 }
 } // namespace
+
+Request::Request(HttpMethod httpMethod, Url url, bool shouldBufferResponse)
+    : Request(httpMethod, std::move(url), NullBodyStream::GetNullBodyStream(), shouldBufferResponse)
+{
+}
+
+Request::Request(HttpMethod httpMethod, Url url)
+    : Request(httpMethod, std::move(url), NullBodyStream::GetNullBodyStream(), true)
+{
+}
 
 Azure::Nullable<std::string> Request::GetHeader(std::string const& name)
 {

--- a/sdk/core/azure-core/src/http/request.cpp
+++ b/sdk/core/azure-core/src/http/request.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "azure/core/http/http.hpp"
-#include "azure/core/internal/http/null_body_stream.hpp"
+#include "azure/core/internal/io/null_body_stream.hpp"
 #include "azure/core/internal/strings.hpp"
 
 #include <map>


### PR DESCRIPTION
We already have a `request.cpp` file, so all method implementations for the `Request` object belong there, rather than in the common `http.cpp`.

These constructors were moved from the `http.hpp` header file to source here: https://github.com/Azure/azure-sdk-for-cpp/pull/1741