### PR TITLE
Remove noexcept specification from Azure::DateTime::clock::now()

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Breaking Changes
 
+- Removed `noexcept` specification from `Azure::DateTime::clock::now()`.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/core/azure-core/inc/azure/core/datetime.hpp
+++ b/sdk/core/azure-core/inc/azure/core/datetime.hpp
@@ -39,7 +39,7 @@ namespace _detail {
     // this clock's time_point), and add that duration to steady clock's time_point to get a new
     // time_point in the steady clock's "coordinate system".
     static constexpr bool is_steady = std::chrono::system_clock::is_steady;
-    static time_point now() noexcept;
+    static time_point now();
   };
 } // namespace _detail
 
@@ -202,7 +202,7 @@ public:
   std::string ToString(DateFormat format, TimeFractionFormat fractionFormat) const;
 };
 
-inline _detail::Clock::time_point _detail::Clock::now() noexcept
+inline _detail::Clock::time_point _detail::Clock::now()
 {
   return DateTime(std::chrono::system_clock::now());
 }
@@ -268,49 +268,49 @@ inline bool operator>=(std::chrono::system_clock::time_point const& tp, DateTime
 }
 
 namespace Core { namespace _internal {
-  /**
-   * @brief Provides convertion methods for POSIX time to an #Azure::DateTime.
-   *
-   */
-  class PosixTimeConverter final {
-  public:
     /**
-     * @brief Converts POSIX time to an #Azure::DateTime.
+     * @brief Provides convertion methods for POSIX time to an #Azure::DateTime.
      *
-     * @param posixTime The number of seconds since 1970.
-     * @return Calculated #Azure::DateTime.
      */
-    static DateTime PosixTimeToDateTime(int64_t posixTime)
-    {
-      return {DateTime(1970) + std::chrono::seconds(posixTime)};
-    }
+    class PosixTimeConverter final {
+    public:
+      /**
+       * @brief Converts POSIX time to an #Azure::DateTime.
+       *
+       * @param posixTime The number of seconds since 1970.
+       * @return Calculated #Azure::DateTime.
+       */
+      static DateTime PosixTimeToDateTime(int64_t posixTime)
+      {
+        return {DateTime(1970) + std::chrono::seconds(posixTime)};
+      }
 
-    /**
-     * @brief Converts a DateTime to POSIX time.
-     *
-     * @param dateTime The `%DateTime` to convert.
-     * @return The number of seconds since 1970.
-     */
-    static int64_t DateTimeToPosixTime(DateTime const& dateTime)
-    {
-      //  This count starts at the POSIX epoch which is January 1st, 1970 UTC.
-      return std::chrono::duration_cast<std::chrono::seconds>(dateTime - DateTime(1970)).count();
-    }
+      /**
+       * @brief Converts a DateTime to POSIX time.
+       *
+       * @param dateTime The `%DateTime` to convert.
+       * @return The number of seconds since 1970.
+       */
+      static int64_t DateTimeToPosixTime(DateTime const& dateTime)
+      {
+        //  This count starts at the POSIX epoch which is January 1st, 1970 UTC.
+        return std::chrono::duration_cast<std::chrono::seconds>(dateTime - DateTime(1970)).count();
+      }
 
-  private:
-    /**
-     * @brief An instance of `%PosixTimeConverter` class cannot be created.
-     *
-     */
-    PosixTimeConverter() = delete;
+    private:
+      /**
+       * @brief An instance of `%PosixTimeConverter` class cannot be created.
+       *
+       */
+      PosixTimeConverter() = delete;
 
-    /**
-     * @brief An instance of `%PosixTimeConverter` class cannot be destructed, because no instance
-     * can be created.
-     *
-     */
-    ~PosixTimeConverter() = delete;
-  };
+      /**
+       * @brief An instance of `%PosixTimeConverter` class cannot be destructed, because no instance
+       * can be created.
+       *
+       */
+      ~PosixTimeConverter() = delete;
+    };
 }} // namespace Core::_internal
 
 } // namespace Azure

--- a/sdk/core/azure-core/inc/azure/core/datetime.hpp
+++ b/sdk/core/azure-core/inc/azure/core/datetime.hpp
@@ -268,49 +268,49 @@ inline bool operator>=(std::chrono::system_clock::time_point const& tp, DateTime
 }
 
 namespace Core { namespace _internal {
+  /**
+   * @brief Provides convertion methods for POSIX time to an #Azure::DateTime.
+   *
+   */
+  class PosixTimeConverter final {
+  public:
     /**
-     * @brief Provides convertion methods for POSIX time to an #Azure::DateTime.
+     * @brief Converts POSIX time to an #Azure::DateTime.
+     *
+     * @param posixTime The number of seconds since 1970.
+     * @return Calculated #Azure::DateTime.
+     */
+    static DateTime PosixTimeToDateTime(int64_t posixTime)
+    {
+      return {DateTime(1970) + std::chrono::seconds(posixTime)};
+    }
+
+    /**
+     * @brief Converts a DateTime to POSIX time.
+     *
+     * @param dateTime The `%DateTime` to convert.
+     * @return The number of seconds since 1970.
+     */
+    static int64_t DateTimeToPosixTime(DateTime const& dateTime)
+    {
+      //  This count starts at the POSIX epoch which is January 1st, 1970 UTC.
+      return std::chrono::duration_cast<std::chrono::seconds>(dateTime - DateTime(1970)).count();
+    }
+
+  private:
+    /**
+     * @brief An instance of `%PosixTimeConverter` class cannot be created.
      *
      */
-    class PosixTimeConverter final {
-    public:
-      /**
-       * @brief Converts POSIX time to an #Azure::DateTime.
-       *
-       * @param posixTime The number of seconds since 1970.
-       * @return Calculated #Azure::DateTime.
-       */
-      static DateTime PosixTimeToDateTime(int64_t posixTime)
-      {
-        return {DateTime(1970) + std::chrono::seconds(posixTime)};
-      }
+    PosixTimeConverter() = delete;
 
-      /**
-       * @brief Converts a DateTime to POSIX time.
-       *
-       * @param dateTime The `%DateTime` to convert.
-       * @return The number of seconds since 1970.
-       */
-      static int64_t DateTimeToPosixTime(DateTime const& dateTime)
-      {
-        //  This count starts at the POSIX epoch which is January 1st, 1970 UTC.
-        return std::chrono::duration_cast<std::chrono::seconds>(dateTime - DateTime(1970)).count();
-      }
-
-    private:
-      /**
-       * @brief An instance of `%PosixTimeConverter` class cannot be created.
-       *
-       */
-      PosixTimeConverter() = delete;
-
-      /**
-       * @brief An instance of `%PosixTimeConverter` class cannot be destructed, because no instance
-       * can be created.
-       *
-       */
-      ~PosixTimeConverter() = delete;
-    };
+    /**
+     * @brief An instance of `%PosixTimeConverter` class cannot be destructed, because no instance
+     * can be created.
+     *
+     */
+    ~PosixTimeConverter() = delete;
+  };
 }} // namespace Core::_internal
 
 } // namespace Azure


### PR DESCRIPTION
Part of the work for the #3674 effort

`time_point Azure::_detail::Clock::now()`:
* `std::chrono::<Clock>::now()` is `noexcept`, but we don't have to be, but would be nice to be if possible;
* Returns `DateTime(std::chrono::system_clock::now())`;
* `std::chrono::system_clock::now()` is `noexcept`;
* `DateTime(std::chrono::system_clock::time_point const& systemTime)` calls `DateTime(SystemClockEpoch + std::chrono::duration_cast<duration>(systemTime.time_since_epoch()))`;
  * `std::chrono::system_clock::time_point::time_since_epoch()` is **NOT** `noexcept`;
  * `std::chrono::duration_cast` is **NOT** `noexcept`;
  * `std::chrono::duration::operator+()` is **NOT** `noexcept`;
  * `DateTime(time_point const& timePoint)` invokes `std::chrono::time_point()` which is **NOT** `noexcept`.

Verdict: **REMOVE** - practically it is unlikely to throw, but still too many functions that are not `noexcept`. We could've tried to use conditional `noexcept()`, but unless users need it, we should not. After all, one may rely on the fact that it does not throw, but the same code compiled on the other platform may not be `noexcept` - it would really be dependent on the stdlib implementation.