### PR TITLE
Use Azure Pipelines and workaround for WSL installation

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -79,7 +79,7 @@
       "StaticConfigs": {
         "Win2022": {
           "OSVmImage": "windows-2022",
-          "Pool": "azsdk-pool-mms-win-2022-general",
+          "Pool": "Azure Pipelines",
           "RunProxyTests": true,
           "CMAKE_GENERATOR": "Visual Studio 17 2022"
         }

--- a/eng/scripts/Install-WSL.ps1
+++ b/eng/scripts/Install-WSL.ps1
@@ -1,8 +1,22 @@
+[console]::OutputEncoding = New-Object System.Text.UnicodeEncoding
+
+# Workaround from https://github.com/actions/runner-images/issues/6844#issuecomment-1367225048
+# At the time of this comment (30-12-2022) this only works on Azure DevOps hosted
+# agents and doesn't work on 1ES images
+Write-Host "wsl --update --web-download"
+wsl --update --web-download | Out-String
+
+# Out-String waits for the process to finish
+Write-Host "wsl --update --web-download | Out-String"
+wsl --update --web-download | Out-String
+
+Write-Host "wsl --version" 
+wsl --version
+
 write-host "WSL install of ubuntu."
-wsl --install -d Ubuntu-20.04
+wsl --install -d Ubuntu-20.04 --web-download
 
 write-host "Launch WSL."
-[console]::OutputEncoding = New-Object System.Text.UnicodeEncoding
 $wsl = wsl -l -v | out-string
 
 write-host $wsl

--- a/eng/scripts/Install-WSL.ps1
+++ b/eng/scripts/Install-WSL.ps1
@@ -6,10 +6,6 @@
 Write-Host "wsl --update --web-download"
 wsl --update --web-download | Out-String
 
-# Out-String waits for the process to finish
-Write-Host "wsl --update --web-download | Out-String"
-wsl --update --web-download | Out-String
-
 Write-Host "wsl --version" 
 wsl --version
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/4214 ... We had to fall back to the `Azure Pipelines` pool because the version of WSL in the 1ES image is behind the version in Azure Pipelines for which this workaround succeeds ([example](https://dev.azure.com/azure-sdk/playground/_build/results?buildId=2084637&view=logs&j=03087da8-5232-5b41-9f62-6cda8795c0f1&t=6cdc73ea-717d-5e17-6dcc-57dbaf1c633a))

Workaround based on advice from https://github.com/actions/runner-images/issues/6844

We might want to consider a different approach that isn't going to involve discovering and accommodating changes to the image and wsl.exe. @mikeharder 