### PR TITLE
Use non-template-template parameter in UniqueHandle

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/internal/unique_handle.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/unique_handle.hpp
@@ -62,6 +62,5 @@ namespace Azure { namespace Core { namespace _internal {
   template <typename T> struct UniqueHandleHelper;
 
   // *** Now users can say UniqueHandle<T> if they want:
-  template <typename T, template <typename> class U = UniqueHandleHelper>
-  using UniqueHandle = typename U<T>::type;
+  template <typename T, typename U = UniqueHandleHelper<T>> using UniqueHandle = typename U::type;
 }}} // namespace Azure::Core::_internal

--- a/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
@@ -25,8 +25,7 @@ namespace Azure { namespace Identity {
 
     void FreePkeyImpl(void* pkey);
 
-    template <typename> struct UniquePkeyHelper;
-    template <> struct UniquePkeyHelper<void*>
+    struct UniquePkeyHelper
     {
       static void FreePkey(void* pkey) { FreePkeyImpl(pkey); }
       using type = Azure::Core::_internal::BasicUniqueHandle<void, FreePkey>;

--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -154,15 +154,14 @@ AccessToken AzureCliCredential::GetToken(
 
 namespace {
 #if defined(AZ_PLATFORM_WINDOWS)
-template <typename> struct UniqueHandleHelper;
-template <> struct UniqueHandleHelper<HANDLE>
+struct UniqueWin32HandleHelper
 {
   static void CloseWin32Handle(HANDLE handle) { static_cast<void>(CloseHandle(handle)); }
   using type = Azure::Core::_internal::BasicUniqueHandle<void, CloseWin32Handle>;
 };
 
 template <typename T>
-using UniqueHandle = Azure::Core::_internal::UniqueHandle<T, UniqueHandleHelper>;
+using UniqueHandle = Azure::Core::_internal::UniqueHandle<T, UniqueWin32HandleHelper>;
 #endif
 
 class ShellProcess;

--- a/sdk/identity/azure-identity/src/client_certificate_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_certificate_credential.cpp
@@ -66,7 +66,7 @@ template <> struct UniqueHandleHelper<EVP_MD_CTX>
 };
 
 template <typename T>
-using UniqueHandle = Azure::Core::_internal::UniqueHandle<T, UniqueHandleHelper>;
+using UniqueHandle = Azure::Core::_internal::UniqueHandle<T, UniqueHandleHelper<T>>;
 } // namespace
 
 void Azure::Identity::_detail::FreePkeyImpl(void* pkey)


### PR DESCRIPTION
If needed, UniqueHandle's template-template argument can be rewritten as regular typed argument. There could be subjective pros and cons to each, but in the end same things are possible using either of two semantics.

We can change it while both changes are in betas (Identity and Core, Identity depends on Core).
But the Core Beta has already shipped, while Identity Beta ships tomorrow, so don't merge this until tomorrow after the Identity release.

Regular template parameters are supported by current ApiView parser implementation, while for template-template parameters, ApiView needs to be updated.