### PR TITLE
Unblock Core CI

### DIFF
--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -529,7 +529,7 @@ namespace Azure { namespace Core { namespace Test {
 #if !defined(AZ_PLATFORM_LINUX)
   TEST_F(TransportAdapterOptions, MultipleCrlOperations)
 #else
-  TEST_F(TransportAdapterOptions, DISABLED_MultipleCrlOperations)
+  TEST_F(TransportAdapterOptions, MultipleCrlOperations_LIVEONLY_)
 #endif
   {
     // LetsEncrypt certificates don't contain a distribution point URL extension. While this seems

--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -524,7 +524,7 @@ namespace Azure { namespace Core { namespace Test {
 #endif
   }
 
-  TEST_F(TransportAdapterOptions, MultipleCrlOperations)
+  TEST_F(TransportAdapterOptions, MultipleCrlOperations_LIVEONLY_)
   {
     // LetsEncrypt certificates don't contain a distribution point URL extension. While this seems
     // to work when run locally, it fails in the CI pipeline. "https://www.wikipedia.org" uses a

--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -529,7 +529,7 @@ namespace Azure { namespace Core { namespace Test {
 #if !defined(AZ_PLATFORM_LINUX)
   TEST_F(TransportAdapterOptions, MultipleCrlOperations)
 #else
-  TEST_F(TransportAdapterOptions, MultipleCrlOperations_LIVEONLY_)
+  TEST_F(TransportAdapterOptions, DISABLED_MultipleCrlOperations)
 #endif
   {
     // LetsEncrypt certificates don't contain a distribution point URL extension. While this seems

--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -524,13 +524,16 @@ namespace Azure { namespace Core { namespace Test {
 #endif
   }
 
-// This test started to fail consistently in CI on Linux.
-// It should be fixed, but to unblock CI, there is a workaround below.
+  // This test started to fail consistently in CI on Linux.
+  // It should be fixed, but to unblock CI, there is a workaround below.
+  TEST_F(
+      TransportAdapterOptions,
 #if !defined(AZ_PLATFORM_LINUX)
-  TEST_F(TransportAdapterOptions, MultipleCrlOperations)
+      MultipleCrlOperations
 #else
-  TEST_F(TransportAdapterOptions, DISABLED_MultipleCrlOperations)
+      DISABLED_MultipleCrlOperations
 #endif
+  )
   {
     // LetsEncrypt certificates don't contain a distribution point URL extension. While this seems
     // to work when run locally, it fails in the CI pipeline. "https://www.wikipedia.org" uses a

--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -526,14 +526,8 @@ namespace Azure { namespace Core { namespace Test {
 
   // This test started to fail consistently in CI on Linux.
   // It should be fixed, but to unblock CI, there is a workaround below.
-  TEST_F(
-      TransportAdapterOptions,
 #if !defined(AZ_PLATFORM_LINUX)
-      MultipleCrlOperations
-#else
-      DISABLED_MultipleCrlOperations
-#endif
-  )
+  TEST_F(TransportAdapterOptions, MultipleCrlOperations)
   {
     // LetsEncrypt certificates don't contain a distribution point URL extension. While this seems
     // to work when run locally, it fails in the CI pipeline. "https://www.wikipedia.org" uses a
@@ -618,6 +612,7 @@ namespace Azure { namespace Core { namespace Test {
       }
     }
   }
+#endif
 
   TEST_F(TransportAdapterOptions, TestRootCertificate)
   {

--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -524,7 +524,13 @@ namespace Azure { namespace Core { namespace Test {
 #endif
   }
 
+// This test started to fail consistently in CI on Linux.
+// It should be fixed, but to unblock CI, there is a workaround below.
+#if !defined(AZ_PLATFORM_LINUX)
+  TEST_F(TransportAdapterOptions, MultipleCrlOperations)
+#else
   TEST_F(TransportAdapterOptions, MultipleCrlOperations_LIVEONLY_)
+#endif
   {
     // LetsEncrypt certificates don't contain a distribution point URL extension. While this seems
     // to work when run locally, it fails in the CI pipeline. "https://www.wikipedia.org" uses a


### PR DESCRIPTION
This test started to fail around Jan 9th, it fails consistently, but on Linux only.
Further investigations should be made, but CI needs to be unblocked sooner, and this is what this PR does.

More info:
I compiled with Curl transport on Windows, it does not repro.
CI failure logs:
first,
```
[  INFO ] /mnt/vss/_work/1/s/sdk/core/azure-core/test/ut/transport_policy_options.cpp:549:: Test https://www.example.com/
231: [2023-01-10T19:34:34.6835347Z] DEBUG : [CURL Transport Adapter]: Creating a new session.
231: [2023-01-10T19:34:34.6835697Z] DEBUG : [CURL Transport Adapter]: Spawn new connection.
231: [2023-01-10T19:35:38.7378656Z] DEBUG : [CURL Transport Adapter]: No Host in request headers. Adding it
231: [2023-01-10T19:35:38.7379044Z] DEBUG : [CURL Transport Adapter]: No content-length in headers. Adding it
231: [2023-01-10T19:35:38.7379310Z] DEBUG : [CURL Transport Adapter]: Send request without payload
231: [2023-01-10T19:35:38.7384886Z] DEBUG : [CURL Transport Adapter]: Parse server response
231: [2023-01-10T19:35:38.7459252Z] DEBUG : [CURL Transport Adapter]: Request completed. Moving response out of session and session to response.
231: [2023-01-10T19:35:38.7459741Z] DEBUG : Moving connection to pool...
231: [2023-01-10T19:35:38.7460087Z] DEBUG : Clean thread running. Won't start a new one.
```

then,
```
231:   Actual: it throws Azure::Core::Http::TransportException with description "Fail to get a new connection for: https://www.example.com. Timeout was reached".
```

Place in the test code where it fails:
https://github.com/Azure/azure-sdk-for-cpp/blob/01af6783b1ffa4be1717fd8d413e874dcee5620d/sdk/core/azure-core/test/ut/transport_policy_options.cpp#L578-L579