### PR TITLE
Revert MultipleCrlOperations test to the previous version

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -136,8 +136,8 @@
     {
       "StaticConfigs": {
         "Ubuntu18": {
-          "OSVmImage": "MMSUbuntu18.04",
-          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
+          "OSVmImage": "ubuntu-18.04",
+          "Pool": "Azure Pipelines",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "RunProxyTests": true

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -181,7 +181,7 @@
       "StaticConfigs": {
         "Ubuntu20": {
           "OSVmImage": "MMSUbuntu20.04",
-          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-perf",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "CC": "/usr/bin/clang-11",

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -136,8 +136,8 @@
     {
       "StaticConfigs": {
         "Ubuntu18": {
-          "OSVmImage": "ubuntu-18.04",
-          "Pool": "Azure Pipelines",
+          "OSVmImage": "MMSUbuntu18.04",
+          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "RunProxyTests": true
@@ -181,7 +181,7 @@
       "StaticConfigs": {
         "Ubuntu20": {
           "OSVmImage": "MMSUbuntu20.04",
-          "Pool": "azsdk-pool-mms-ubuntu-2004-perf",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "CC": "/usr/bin/clang-11",

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -180,8 +180,8 @@
     {
       "StaticConfigs": {
         "Ubuntu20": {
-          "OSVmImage": "ubuntu-20.04",
-          "Pool": "azsdk-pool-mms-ubuntu-2004-perf",
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "CC": "/usr/bin/clang-11",

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -180,8 +180,8 @@
     {
       "StaticConfigs": {
         "Ubuntu20": {
-          "OSVmImage": "MMSUbuntu20.04",
-          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+          "OSVmImage": "ubuntu-20.04",
+          "Pool": "Azure Pipelines",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "CC": "/usr/bin/clang-11",

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -181,7 +181,7 @@
       "StaticConfigs": {
         "Ubuntu20": {
           "OSVmImage": "ubuntu-20.04",
-          "Pool": "Azure Pipelines",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-perf",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "CC": "/usr/bin/clang-11",

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -136,8 +136,8 @@
     {
       "StaticConfigs": {
         "Ubuntu18": {
-          "OSVmImage": "MMSUbuntu18.04",
-          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
+          "OSVmImage": "ubuntu-18.04",
+          "Pool": "Azure Pipelines",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "RunProxyTests": true
@@ -180,8 +180,8 @@
     {
       "StaticConfigs": {
         "Ubuntu20": {
-          "OSVmImage": "MMSUbuntu20.04",
-          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+          "OSVmImage": "ubuntu-20.04",
+          "Pool": "Azure Pipelines",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "CC": "/usr/bin/clang-11",

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -136,8 +136,8 @@
     {
       "StaticConfigs": {
         "Ubuntu18": {
-          "OSVmImage": "ubuntu-18.04",
-          "Pool": "Azure Pipelines",
+          "OSVmImage": "MMSUbuntu18.04",
+          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "RunProxyTests": true
@@ -180,8 +180,8 @@
     {
       "StaticConfigs": {
         "Ubuntu20": {
-          "OSVmImage": "ubuntu-20.04",
-          "Pool": "Azure Pipelines",
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "CC": "/usr/bin/clang-11",

--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -524,9 +524,6 @@ namespace Azure { namespace Core { namespace Test {
 #endif
   }
 
-  // This test started to fail consistently in CI on Linux.
-  // It should be fixed, but to unblock CI, there is a workaround below.
-#if !defined(AZ_PLATFORM_LINUX)
   TEST_F(TransportAdapterOptions, MultipleCrlOperations)
   {
     // LetsEncrypt certificates don't contain a distribution point URL extension. While this seems
@@ -630,7 +627,6 @@ namespace Azure { namespace Core { namespace Test {
       }
     }
   }
-#endif
 
   TEST_F(TransportAdapterOptions, TestRootCertificate)
   {

--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -529,12 +529,11 @@ namespace Azure { namespace Core { namespace Test {
     // LetsEncrypt certificates don't contain a distribution point URL extension. While this seems
     // to work when run locally, it fails in the CI pipeline. "https://www.wikipedia.org" uses a
     // LetsEncrypt certificate, so when testing manually, it is important to add it to the list.
-    std::vector<std::pair<std::string, bool>> testUrls{
-        {AzureSdkHttpbinServer::Get(), true}, // Uses a Microsoft/DigiCert certificate.
-        {"https://aws.amazon.com", true}, // Uses a Amazon/Starfield Technologies certificate.
-        //        {"https://www.example.com/", true}, // Uses a DigiCert certificate. Does not work
-        //        correctly from Linux as of 2023-01-09.
-        {"https://www.google.com/", true}, // Uses a google certificate.
+    std::vector<std::string> testUrls{
+        AzureSdkHttpbinServer::Get(), // Uses a Microsoft/DigiCert certificate.
+        "https://aws.amazon.com", // Uses a Amazon/Starfield Technologies certificate.
+        "https://www.example.com/", // Uses a DigiCert certificate.
+        "https://www.google.com/", // Uses a google certificate.
     };
 
     GTEST_LOG_(INFO) << "Basic test calls.";
@@ -545,27 +544,17 @@ namespace Azure { namespace Core { namespace Test {
       transportOptions.EnableCertificateRevocationListCheck = false;
       HttpPipeline pipeline(CreateHttpPipeline(transportOptions));
 
-      for (auto& target : testUrls)
+      for (auto const& target : testUrls)
       {
-        GTEST_LOG_(INFO) << "Test " << target.first;
-        Azure::Core::Url url(target.first);
+        GTEST_LOG_(INFO) << "Test " << target;
+        Azure::Core::Url url(target);
         auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, url);
         std::unique_ptr<Azure::Core::Http::RawResponse> response;
-        try
+        EXPECT_NO_THROW(
+            response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+        if (response && response->GetStatusCode() != Azure::Core::Http::HttpStatusCode::Found)
         {
-          response = pipeline.Send(request, Azure::Core::Context::ApplicationContext);
-        }
-        catch (Azure::Core::Http::TransportException& ex)
-        {
-          GTEST_LOG_(INFO) << "Error " << ex.what() << " accessing site " << target.first;
-          target.second = false;
-        }
-        if (target.second)
-        {
-          if (response && response->GetStatusCode() != Azure::Core::Http::HttpStatusCode::Found)
-          {
-            EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
-          }
+          EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
         }
       }
     }
@@ -582,19 +571,15 @@ namespace Azure { namespace Core { namespace Test {
 
       for (auto const& target : testUrls)
       {
-        // Only try to access the server if we were able to contact it earlier.
-        if (target.second)
+        GTEST_LOG_(INFO) << "Test " << target;
+        Azure::Core::Url url(target);
+        auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, url);
+        std::unique_ptr<Azure::Core::Http::RawResponse> response;
+        EXPECT_NO_THROW(
+            response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+        if (response && response->GetStatusCode() != Azure::Core::Http::HttpStatusCode::Found)
         {
-          GTEST_LOG_(INFO) << "Test " << target.first;
-          Azure::Core::Url url(target.first);
-          auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, url);
-          std::unique_ptr<Azure::Core::Http::RawResponse> response;
-          EXPECT_NO_THROW(
-              response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
-          if (response && response->GetStatusCode() != Azure::Core::Http::HttpStatusCode::Found)
-          {
-            EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
-          }
+          EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
         }
       }
     }
@@ -611,18 +596,15 @@ namespace Azure { namespace Core { namespace Test {
 
       for (auto const& target : testUrls)
       {
-        if (target.second)
+        GTEST_LOG_(INFO) << "Test " << target;
+        Azure::Core::Url url(target);
+        auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, url);
+        std::unique_ptr<Azure::Core::Http::RawResponse> response;
+        EXPECT_NO_THROW(
+            response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+        if (response && response->GetStatusCode() != Azure::Core::Http::HttpStatusCode::Found)
         {
-          GTEST_LOG_(INFO) << "Test " << target.first;
-          Azure::Core::Url url(target.first);
-          auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, url);
-          std::unique_ptr<Azure::Core::Http::RawResponse> response;
-          EXPECT_NO_THROW(
-              response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
-          if (response && response->GetStatusCode() != Azure::Core::Http::HttpStatusCode::Found)
-          {
-            EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
-          }
+          EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
         }
       }
     }
@@ -933,4 +915,5 @@ namespace Azure { namespace Core { namespace Test {
 
     EXPECT_THROW(proxyServer.IsAlive(), Azure::Core::Http::TransportException);
   }
+
 }}} // namespace Azure::Core::Test


### PR DESCRIPTION
Previous version was more fragile, and when we were looking at the ways to work around #4237, @LarryOsterman made some improvements to make test to not fail if some hosts are unreachable.
But we now know that #4237 was an intermittent (although multiple days long) issue, I think it is better to use the previous version.

This PR is effectively this version: https://github.com/Azure/azure-sdk-for-cpp/blob/53c9da155244b72ac90ad27f515d4ea1e7505a01/sdk/core/azure-core/test/ut/transport_policy_options.cpp

Closes #4237.