### PR TITLE
Test proxy & storage tests improvements

### DIFF
--- a/sdk/attestation/assets.json
+++ b/sdk/attestation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "cpp",
   "TagPrefix": "cpp/attestation",
-  "Tag": "cpp/attestation_10abfdc3e0"
+  "Tag": "cpp/attestation_6398169251"
 }

--- a/sdk/attestation/azure-security-attestation/test/ut/policycertmgmt_test.cpp
+++ b/sdk/attestation/azure-security-attestation/test/ut/policycertmgmt_test.cpp
@@ -171,8 +171,6 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
 
   TEST_F(CertificateTests, AddPolicyManagementCertificate_LIVEONLY_)
   {
-    CHECK_SKIP_TEST()
-
     auto adminClient(CreateClient(ServiceInstanceType::Isolated));
 
     auto isolatedCertificateBase64(GetEnv("ISOLATED_SIGNING_CERTIFICATE"));
@@ -233,8 +231,6 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
 
   TEST_F(CertificateTests, RemovePolicyManagementCertificate_LIVEONLY_)
   {
-    CHECK_SKIP_TEST()
-
     auto adminClient(CreateClient(ServiceInstanceType::Isolated));
 
     auto isolatedCertificateBase64(GetEnv("ISOLATED_SIGNING_CERTIFICATE"));

--- a/sdk/core/azure-core-test/inc/azure/core/test/network_models.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/network_models.hpp
@@ -8,14 +8,6 @@
 
 #pragma once
 
-#include <azure/core/http/policies/policy.hpp>
-#include <azure/core/io/body_stream.hpp>
-
-#include <list>
-#include <map>
-#include <string>
-#include <vector>
-
 namespace Azure { namespace Core { namespace Test {
 
   /**
@@ -27,111 +19,6 @@ namespace Azure { namespace Core { namespace Test {
     PLAYBACK,
     RECORD,
     LIVE,
-  };
-
-  /**
-   * @brief Keeps track of network call records from each unit test session.
-   *
-   */
-  struct NetworkCallRecord
-  {
-    std::string Method;
-    std::string Url;
-    std::map<std::string, std::string> Headers;
-    std::map<std::string, std::string> Response;
-  };
-
-  /**
-   * @brief Keeps track of the network calls and variable names that were made in a test
-   * session.
-   *
-   */
-  class RecordedData {
-  public:
-    std::list<NetworkCallRecord> NetworkCallRecords;
-    std::list<std::string> Variables;
-  };
-
-  /**
-   * @brief A body stream which holds the memory inside.
-   *
-   * @remark The playback http uses this body stream to be returned as part of the raw response so
-   * the transport policy can read from it.
-   *
-   */
-  class WithMemoryBodyStream : public Azure::Core::IO::BodyStream {
-  private:
-    std::vector<uint8_t> m_memory;
-    Azure::Core::IO::MemoryBodyStream m_streamer;
-
-    size_t OnRead(uint8_t* buffer, size_t count, Azure::Core::Context const& context) override
-    {
-      return m_streamer.Read(buffer, count, context);
-    }
-
-  public:
-    // Forbid constructor for rval so we don't end up storing dangling ptr
-    WithMemoryBodyStream(std::vector<uint8_t> const&&) = delete;
-
-    /**
-     * @brief Construct using vector of bytes.
-     *
-     * @param buffer Vector of bytes with the contents to provide the data from to the readers.
-     */
-    WithMemoryBodyStream(std::vector<uint8_t> const& buffer)
-        : m_memory(buffer), m_streamer(m_memory)
-    {
-    }
-
-    int64_t Length() const override { return m_streamer.Length(); }
-
-    void Rewind() override { m_streamer.Rewind(); }
-  };
-
-  /**
-   * @brief Wraps a stream and keep reading bytes from it by rewinding it until some length.
-   *
-   * @note Enables to create a stream with huge size by re-using a small buffer (1Mb).
-   *
-   */
-  class CircularBodyStream : public Azure::Core::IO::BodyStream {
-  private:
-    std::unique_ptr<std::vector<uint8_t>> m_buffer;
-    size_t m_length;
-    size_t m_totalRead = 0;
-    Azure::Core::IO::MemoryBodyStream m_memoryStream;
-
-    size_t OnRead(uint8_t* buffer, size_t count, Azure::Core::Context const& context) override
-    {
-      auto available = m_length - m_totalRead;
-      if (available == 0)
-      {
-        return 0;
-      }
-
-      auto toRead = std::min(count, available);
-      auto read = m_memoryStream.Read(buffer, toRead, context);
-
-      // Circurlar implementation. Rewind the stream every time we reach the end
-      if (read == 0) // No more bytes to read from.
-      {
-        m_memoryStream.Rewind();
-        read = m_memoryStream.Read(buffer, toRead, context);
-      }
-
-      m_totalRead += read;
-      return read;
-    }
-
-  public:
-    CircularBodyStream(size_t size, uint8_t fillWith)
-        : m_buffer(std::make_unique<std::vector<uint8_t>>(1024 * 1024, fillWith)), m_length(size),
-          m_memoryStream(*m_buffer)
-    {
-    }
-
-    int64_t Length() const override { return m_length; }
-    void Rewind() override { m_totalRead = 0; }
   };
 
 }}} // namespace Azure::Core::Test

--- a/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
@@ -22,13 +22,6 @@
 #include <regex>
 #include <thread>
 
-#define CHECK_SKIP_TEST() \
-  std::string const readTestNameAndUpdateTestContext = GetTestName(); \
-  if (shouldSkipTest()) \
-  { \
-    GTEST_SKIP(); \
-  }
-
 using namespace std::chrono_literals;
 
 namespace Azure { namespace Core { namespace Test {
@@ -374,6 +367,12 @@ namespace Azure { namespace Core { namespace Test {
       if (!m_wasSkipped && !m_testContext.IsLiveMode())
       {
         m_testProxy = std::make_unique<Azure::Core::Test::TestProxyManager>(m_testContext);
+      }
+
+      std::string const readTestNameAndUpdateTestContext = GetTestName();
+      if (shouldSkipTest())
+      {
+        GTEST_SKIP();
       }
     }
 

--- a/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
@@ -134,6 +134,15 @@ namespace Azure { namespace Core { namespace Test {
 
     bool shouldSkipTest() { return m_wasSkipped; }
 
+    void SkipTest()
+    {
+      if (!m_wasSkipped)
+      {
+        m_wasSkipped = true;
+        GTEST_SKIP();
+      }
+    }
+
     // Reads the current test instance name.
     // Name gets also sanitized (special chars are removed) to avoid issues when recording or
     // creating

--- a/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
@@ -134,37 +134,6 @@ namespace Azure { namespace Core { namespace Test {
 
     bool shouldSkipTest() { return m_wasSkipped; }
 
-    void SkipTest()
-    {
-      if (!m_wasSkipped)
-      {
-        m_wasSkipped = true;
-        GTEST_SKIP();
-      }
-    }
-
-    inline void ValidateSkippingTest()
-    {
-      if (m_wasSkipped)
-      {
-        GTEST_SKIP();
-      }
-    }
-
-    bool IsValidTime(const Azure::DateTime& datetime)
-    {
-      // Playback won't check dates
-      if (m_testContext.IsPlaybackMode())
-      {
-        return true;
-      }
-
-      // We assume datetime within a week is valid.
-      const auto minTime = std::chrono::system_clock::now() - std::chrono::hours(24 * 7);
-      const auto maxTime = std::chrono::system_clock::now() + std::chrono::hours(24 * 7);
-      return datetime > minTime && datetime < maxTime;
-    }
-
     // Reads the current test instance name.
     // Name gets also sanitized (special chars are removed) to avoid issues when recording or
     // creating
@@ -236,11 +205,13 @@ namespace Azure { namespace Core { namespace Test {
       return std::make_unique<T>(url, credential, options);
     }
 
+    template <class T> void InitClientOptions(T& options) { PrepareOptions(options); }
+
     template <class T> T InitClientOptions()
     {
       // Run instrumentation before creating the client
       T options;
-      PrepareOptions(options);
+      InitClientOptions(options);
       return options;
     }
 

--- a/sdk/core/azure-core-test/inc/azure/core/test/test_proxy_manager.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_proxy_manager.hpp
@@ -140,18 +140,6 @@ namespace Azure { namespace Core { namespace Test {
     }
 
     /**
-     * Sets proxy to stop RECORD test and save the recording file.
-     *
-     */
-    void SetStopRecordMode();
-
-    /**
-     * Sets proxy to stop PLAYBACK test.
-     *
-     */
-    void SetStopPlaybackMode();
-
-    /**
      * Gets the test recording ID
      *
      * @returns recording ID

--- a/sdk/core/azure-core-test/src/test_base.cpp
+++ b/sdk/core/azure-core-test/src/test_base.cpp
@@ -3,7 +3,6 @@
 
 #include <azure/core/internal/json/json.hpp>
 
-#include "azure/core/test/network_models.hpp"
 #include "azure/core/test/test_base.hpp"
 
 #include <fstream>

--- a/sdk/core/azure-core-test/src/test_proxy_manager.cpp
+++ b/sdk/core/azure-core-test/src/test_proxy_manager.cpp
@@ -94,7 +94,6 @@ void TestProxyManager::StartPlaybackRecord(TestMode testMode)
 {
   if (IsPlaybackMode() || IsRecordMode())
   {
-    std::string mode = (IsPlaybackMode() ? "playback" : "record");
     return;
   }
 

--- a/sdk/core/azure-core-test/src/test_proxy_policy.cpp
+++ b/sdk/core/azure-core-test/src/test_proxy_policy.cpp
@@ -53,11 +53,10 @@ std::unique_ptr<RawResponse> TestProxyPolicy::Send(
   // Copy all headers
   for (auto& header : request.GetHeaders())
   {
-    if (header.first == "host")
+    if (header.first != "host")
     {
-      continue;
+      redirectRequest.SetHeader(header.first, header.second);
     }
-    redirectRequest.SetHeader(header.first, header.second);
   }
   // QP
   for (auto const& qp : request.GetUrl().GetQueryParameters())

--- a/sdk/core/azure-core-test/src/test_proxy_policy.cpp
+++ b/sdk/core/azure-core-test/src/test_proxy_policy.cpp
@@ -42,7 +42,10 @@ std::unique_ptr<RawResponse> TestProxyPolicy::Send(
   {
     // This is a download with keep connection open. Let's switch the request
     redirectRequest = Azure::Core::Http::Request(
-        request.GetMethod(), Azure::Core::Url(m_testProxy->GetTestProxy()), false);
+        request.GetMethod(),
+        Azure::Core::Url(m_testProxy->GetTestProxy()),
+        request.GetBodyStream(),
+        false);
   }
 
   redirectRequest.GetUrl().SetPath(request.GetUrl().GetPath());

--- a/sdk/core/azure-core-test/src/test_proxy_policy.cpp
+++ b/sdk/core/azure-core-test/src/test_proxy_policy.cpp
@@ -53,6 +53,10 @@ std::unique_ptr<RawResponse> TestProxyPolicy::Send(
   // Copy all headers
   for (auto& header : request.GetHeaders())
   {
+    if (header.first == "host")
+    {
+      continue;
+    }
     redirectRequest.SetHeader(header.first, header.second);
   }
   // QP

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,9 +8,12 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where `Host` request header is not set for non-default port (80, 443).
+
 ### Other Changes
 
 - [[#4352]](https://github.com/Azure/azure-sdk-for-cpp/pull/4352) Fixed compilation error on Visual Studio 2017.
+- Libcurl transport doesn't add `Content-Length` request header for GET/HEAD/DELETE requests anymore.
 
 ### Acknowledgments
 

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -413,10 +413,18 @@ CURLcode CurlSession::Perform(Context const& context)
     if (hostHeader == headers.end())
     {
       Log::Write(Logger::Level::Verbose, LogMsgPrefix + "No Host in request headers. Adding it");
-      this->m_request.SetHeader("Host", this->m_request.GetUrl().GetHost());
+      std::string headerValue = this->m_request.GetUrl().GetHost();
+      auto port = this->m_request.GetUrl().GetPort();
+      if (port != 0)
+      {
+        headerValue += ":" + std::to_string(port);
+      }
+      this->m_request.SetHeader("Host", headerValue);
     }
-    auto isContentLengthHeaderInRequest = headers.find("content-length");
-    if (isContentLengthHeaderInRequest == headers.end())
+    if (this->m_request.GetMethod() != HttpMethod::Get
+        && this->m_request.GetMethod() != HttpMethod::Head
+        && this->m_request.GetMethod() != HttpMethod::Delete
+        && headers.find("content-length") == headers.end())
     {
       Log::Write(Logger::Level::Verbose, LogMsgPrefix + "No content-length in headers. Adding it");
       this->m_request.SetHeader(

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -413,13 +413,13 @@ CURLcode CurlSession::Perform(Context const& context)
     if (hostHeader == headers.end())
     {
       Log::Write(Logger::Level::Verbose, LogMsgPrefix + "No Host in request headers. Adding it");
-      std::string headerValue = this->m_request.GetUrl().GetHost();
+      std::string hostName = this->m_request.GetUrl().GetHost();
       auto port = this->m_request.GetUrl().GetPort();
       if (port != 0)
       {
-        headerValue += ":" + std::to_string(port);
+        hostName += ":" + std::to_string(port);
       }
-      this->m_request.SetHeader("Host", headerValue);
+      this->m_request.SetHeader("Host", hostName);
     }
     if (this->m_request.GetMethod() != HttpMethod::Get
         && this->m_request.GetMethod() != HttpMethod::Head

--- a/sdk/storage/assets.json
+++ b/sdk/storage/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "cpp",
   "TagPrefix": "cpp/storage",
-  "Tag": "cpp/storage_69dfdddd50"
+  "Tag": "cpp/storage_fc079eacac"
 }

--- a/sdk/storage/assets.json
+++ b/sdk/storage/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "cpp",
   "TagPrefix": "cpp/storage",
-  "Tag": "cpp/storage_2aba016213"
+  "Tag": "cpp/storage_69dfdddd50"
 }

--- a/sdk/storage/assets.json
+++ b/sdk/storage/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "cpp",
   "TagPrefix": "cpp/storage",
-  "Tag": "cpp/storage_90ac51538b"
+  "Tag": "cpp/storage_2aba016213"
 }

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
@@ -924,6 +924,8 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     /**
      * @brief Optional conditions that source must meet to perform this operation.
+     * @remarks Azure storage service doesn't support tags access condition for this operation.
+     * Don't use it.
      */
     struct : public Azure::ModifiedConditions,
              public Azure::MatchConditions,

--- a/sdk/storage/azure-storage-blobs/test/ut/CMakeLists.txt
+++ b/sdk/storage/azure-storage-blobs/test/ut/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable (
     blob_container_client_test.hpp
     blob_query_test.cpp
     blob_sas_test.cpp
+    blob_service_client_test.hpp
     blob_service_client_test.cpp
     block_blob_client_test.cpp
     block_blob_client_test.hpp

--- a/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
@@ -7,32 +7,47 @@
 #include <azure/storage/blobs/blob_lease_client.hpp>
 #include <azure/storage/common/crypt.hpp>
 
+namespace Azure { namespace Storage { namespace Blobs { namespace Models {
+
+  bool operator==(const BlobHttpHeaders& lhs, const BlobHttpHeaders& rhs);
+
+}}}} // namespace Azure::Storage::Blobs::Models
+
 namespace Azure { namespace Storage { namespace Test {
 
-  void AppendBlobClientTest::SetUp() { BlobContainerClientTest::SetUp(); }
-
-  void AppendBlobClientTest::TearDown()
+  void AppendBlobClientTest::SetUp()
   {
-    if (m_appendBlobClient)
-    {
-      m_appendBlobClient->Delete();
-    }
-    // Delete container
-    BlobContainerClientTest::TearDown();
+    BlobContainerClientTest::SetUp();
+    m_blobName = RandomString();
+    m_appendBlobClient = std::make_shared<Blobs::AppendBlobClient>(
+        m_blobContainerClient->GetAppendBlobClient(m_blobName));
+    m_appendBlobClient->Create();
+    std::vector<uint8_t> blobContent1(static_cast<size_t>(1_KB), 'x');
+    std::vector<uint8_t> blobContent2(static_cast<size_t>(512), 'a');
+    auto blobContent = Azure::Core::IO::MemoryBodyStream(blobContent1.data(), blobContent1.size());
+    m_appendBlobClient->AppendBlock(blobContent);
+    blobContent = Azure::Core::IO::MemoryBodyStream(blobContent2.data(), blobContent2.size());
+    m_appendBlobClient->AppendBlock(blobContent);
+    m_blobContent = blobContent1;
+    m_blobContent.insert(m_blobContent.end(), blobContent2.begin(), blobContent2.end());
   }
 
   // Requires blob versioning?
   TEST_F(AppendBlobClientTest, CreateAppendDelete)
   {
-    auto const testName(GetTestName());
-    auto client = GetAppendBlobClient(testName);
-    auto appendBlobClient = Blobs::AppendBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        testName + "1",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+    auto blobClient = *m_appendBlobClient;
 
-    auto blobContentInfo = appendBlobClient.Create(m_blobUploadOptions);
+    Blobs::CreateAppendBlobOptions createOptions;
+    createOptions.HttpHeaders.ContentType = "application/x-binary";
+    createOptions.HttpHeaders.ContentLanguage = "en-US";
+    createOptions.HttpHeaders.ContentDisposition = "attachment";
+    createOptions.HttpHeaders.CacheControl = "no-cache";
+    createOptions.HttpHeaders.ContentEncoding = "identify";
+    createOptions.Metadata = RandomMetadata();
+    createOptions.Tags["key1"] = "value1";
+    createOptions.Tags["key2"] = "value2";
+    createOptions.Tags["key3 +-./:=_"] = "v1 +-./:=_";
+    auto blobContentInfo = blobClient.Create(createOptions);
     EXPECT_TRUE(blobContentInfo.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(blobContentInfo.Value.LastModified));
     EXPECT_TRUE(blobContentInfo.Value.VersionId.HasValue());
@@ -40,70 +55,53 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(blobContentInfo.Value.EncryptionScope.HasValue());
     EXPECT_FALSE(blobContentInfo.Value.EncryptionKeySha256.HasValue());
 
-    auto properties = appendBlobClient.GetProperties().Value;
+    auto properties = blobClient.GetProperties().Value;
     EXPECT_TRUE(properties.CommittedBlockCount.HasValue());
     EXPECT_EQ(properties.CommittedBlockCount.Value(), 0);
     EXPECT_EQ(properties.BlobSize, 0);
+    EXPECT_EQ(properties.Metadata, createOptions.Metadata);
+    EXPECT_EQ(properties.HttpHeaders, createOptions.HttpHeaders);
+    EXPECT_EQ(blobClient.GetTags().Value, createOptions.Tags);
 
     auto blockContent
         = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-    auto appendResponse = appendBlobClient.AppendBlock(blockContent);
-    properties = appendBlobClient.GetProperties().Value;
+    auto appendResponse = blobClient.AppendBlock(blockContent);
+    properties = blobClient.GetProperties().Value;
     EXPECT_EQ(properties.CommittedBlockCount.Value(), 1);
     EXPECT_EQ(properties.BlobSize, static_cast<int64_t>(m_blobContent.size()));
 
     Azure::Storage::Blobs::AppendBlockOptions options;
     options.AccessConditions.IfAppendPositionEqual = 1_MB;
     blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-    EXPECT_THROW(appendBlobClient.AppendBlock(blockContent, options), StorageException);
+    EXPECT_THROW(blobClient.AppendBlock(blockContent, options), StorageException);
     options.AccessConditions.IfAppendPositionEqual = properties.BlobSize;
     blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-    appendBlobClient.AppendBlock(blockContent, options);
+    blobClient.AppendBlock(blockContent, options);
 
-    properties = appendBlobClient.GetProperties().Value;
+    properties = blobClient.GetProperties().Value;
     options = Azure::Storage::Blobs::AppendBlockOptions();
     options.AccessConditions.IfMaxSizeLessThanOrEqual
         = properties.BlobSize + m_blobContent.size() - 1;
     blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-    EXPECT_THROW(appendBlobClient.AppendBlock(blockContent, options), StorageException);
+    EXPECT_THROW(blobClient.AppendBlock(blockContent, options), StorageException);
     options.AccessConditions.IfMaxSizeLessThanOrEqual = properties.BlobSize + m_blobContent.size();
     blockContent = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-    appendBlobClient.AppendBlock(blockContent, options);
+    blobClient.AppendBlock(blockContent, options);
 
-    properties = appendBlobClient.GetProperties().Value;
+    properties = blobClient.GetProperties().Value;
     int64_t originalLength = properties.BlobSize;
-    appendBlobClient.AppendBlockFromUri(client.GetUrl() + GetSas());
-    properties = appendBlobClient.GetProperties().Value;
-    EXPECT_EQ(properties.BlobSize, static_cast<int64_t>(originalLength + m_blobContent.size()));
+    blobClient.AppendBlockFromUri(blobClient.GetUrl() + GetSas());
+    properties = blobClient.GetProperties().Value;
+    EXPECT_EQ(properties.BlobSize, 2 * originalLength);
 
-    auto deleteResponse = appendBlobClient.Delete();
+    auto deleteResponse = blobClient.Delete();
     EXPECT_TRUE(deleteResponse.Value.Deleted);
-    EXPECT_THROW(appendBlobClient.Delete(), StorageException);
-  }
-
-  TEST_F(AppendBlobClientTest, CreateWithTags)
-  {
-    auto const testName(GetTestName());
-    auto client = GetAppendBlobClient(testName);
-    auto appendBlobClient = Blobs::AppendBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        testName + "1",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
-
-    Blobs::CreateAppendBlobOptions options;
-    options.Tags["key1"] = "value1";
-    options.Tags["key2"] = "value2";
-    options.Tags["key3 +-./:=_"] = "v1 +-./:=_";
-    appendBlobClient.Create(options);
-
-    EXPECT_EQ(appendBlobClient.GetTags().Value, options.Tags);
+    EXPECT_THROW(blobClient.Delete(), StorageException);
   }
 
   TEST_F(AppendBlobClientTest, AccessConditionLastModifiedTime)
   {
-    auto const testName(GetTestName());
-    auto appendBlobClient = GetAppendBlobClient(testName);
+    auto blobClient = *m_appendBlobClient;
 
     enum class TimePoint
     {
@@ -118,7 +116,7 @@ namespace Azure { namespace Storage { namespace Test {
       UnmodifiedSince,
     };
 
-    auto lastModifiedTime = appendBlobClient.GetProperties().Value.LastModified;
+    auto lastModifiedTime = blobClient.GetProperties().Value.LastModified;
     auto timeBeforeStr = lastModifiedTime - std::chrono::seconds(1);
     auto timeAfterStr = lastModifiedTime + std::chrono::seconds(1);
     for (auto condition : {Condition::ModifiedSince, Condition::UnmodifiedSince})
@@ -141,11 +139,11 @@ namespace Azure { namespace Storage { namespace Test {
             || (condition == Condition::UnmodifiedSince && sinceTime == TimePoint::TimeBefore);
         if (shouldThrow)
         {
-          EXPECT_THROW(appendBlobClient.GetProperties(options), StorageException);
+          EXPECT_THROW(blobClient.GetProperties(options), StorageException);
         }
         else
         {
-          EXPECT_NO_THROW(appendBlobClient.GetProperties(options));
+          EXPECT_NO_THROW(blobClient.GetProperties(options));
         }
       }
     }
@@ -153,20 +151,14 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(AppendBlobClientTest, AccessConditionETag)
   {
-    auto const testName(GetTestName());
-    auto client = GetAppendBlobClient(testName);
-    auto appendBlobClient = Blobs::AppendBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        testName + "1",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+    auto blobClient = GetAppendBlobClientForTest(RandomString());
 
     Blobs::CreateAppendBlobOptions createOptions;
     createOptions.AccessConditions.IfNoneMatch = Azure::ETag::Any();
-    EXPECT_NO_THROW(appendBlobClient.Create(createOptions));
-    EXPECT_THROW(appendBlobClient.Create(createOptions), StorageException);
+    EXPECT_NO_THROW(blobClient.Create(createOptions));
+    EXPECT_THROW(blobClient.Create(createOptions), StorageException);
 
-    Azure::ETag eTag = appendBlobClient.GetProperties().Value.ETag;
+    Azure::ETag eTag = blobClient.GetProperties().Value.ETag;
     for (Azure::ETag match : {eTag, DummyETag, Azure::ETag()})
     {
       for (Azure::ETag noneMatch : {eTag, DummyETag, Azure::ETag()})
@@ -183,11 +175,11 @@ namespace Azure { namespace Storage { namespace Test {
         bool shouldThrow = (match.HasValue() && match != eTag) || noneMatch == eTag;
         if (shouldThrow)
         {
-          EXPECT_THROW(appendBlobClient.GetProperties(options), StorageException);
+          EXPECT_THROW(blobClient.GetProperties(options), StorageException);
         }
         else
         {
-          EXPECT_NO_THROW(appendBlobClient.GetProperties(options));
+          EXPECT_NO_THROW(blobClient.GetProperties(options));
         }
       }
     }
@@ -195,39 +187,21 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(AppendBlobClientTest, AccessConditionLeaseId)
   {
-    auto const testName(GetTestName());
-    auto client = GetAppendBlobClient(testName);
-    auto appendBlobClient = Blobs::AppendBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        testName + "leaseId",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
-    appendBlobClient.Create();
+    auto blobClient = GetAppendBlobClientForTest(RandomString());
+    blobClient.Create();
 
-    std::string leaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
-    Blobs::BlobLeaseClient leaseClient(appendBlobClient, leaseId);
+    std::string leaseId = RandomUUID();
+    Blobs::BlobLeaseClient leaseClient(blobClient, leaseId);
     leaseClient.Acquire(std::chrono::seconds(30));
-    EXPECT_THROW(appendBlobClient.Delete(), StorageException);
+    EXPECT_THROW(blobClient.Delete(), StorageException);
     Blobs::DeleteBlobOptions options;
     options.AccessConditions.LeaseId = leaseId;
-    EXPECT_NO_THROW(appendBlobClient.Delete(options));
+    EXPECT_NO_THROW(blobClient.Delete(options));
   }
 
   TEST_F(AppendBlobClientTest, Seal)
   {
-    auto const testName(GetTestName());
-    auto client = GetAppendBlobClient(testName);
-    auto const extraBlobName = testName + "1";
-    auto blobClient = Blobs::AppendBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        extraBlobName,
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
-    blobClient.Create();
-
-    auto blockContent
-        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-    blobClient.AppendBlock(blockContent);
+    auto blobClient = *m_appendBlobClient;
 
     auto downloadResult = blobClient.Download();
     EXPECT_TRUE(downloadResult.Value.Details.IsSealed.HasValue());
@@ -237,7 +211,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_TRUE(getPropertiesResult.Value.IsSealed.HasValue());
     EXPECT_FALSE(getPropertiesResult.Value.IsSealed.Value());
 
-    auto blobItem = GetBlobItem(extraBlobName);
+    auto blobItem = GetBlobItem(m_blobName);
     EXPECT_TRUE(blobItem.Details.IsSealed.HasValue());
     EXPECT_FALSE(blobItem.Details.IsSealed.Value());
 
@@ -259,16 +233,11 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_TRUE(getPropertiesResult.Value.IsSealed.HasValue());
     EXPECT_TRUE(getPropertiesResult.Value.IsSealed.Value());
 
-    blobItem = GetBlobItem(extraBlobName);
+    blobItem = GetBlobItem(m_blobName);
     EXPECT_TRUE(blobItem.Details.IsSealed.HasValue());
     EXPECT_TRUE(blobItem.Details.IsSealed.Value());
 
-    auto const extraBlobName2 = testName + "2";
-    auto blobClient2 = Blobs::AppendBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        extraBlobName2,
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+    auto blobClient2 = GetAppendBlobClientForTest(RandomString());
 
     Blobs::StartBlobCopyFromUriOptions copyOptions;
     copyOptions.ShouldSealDestination = false;
@@ -289,13 +258,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(AppendBlobClientTest, CreateIfNotExists)
   {
-    auto const testName(GetTestName());
-    auto client = GetAppendBlobClient(testName);
-    auto blobClient = Blobs::AppendBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        testName + "test",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+    auto blobClient = GetAppendBlobClientForTest(RandomString());
 
     auto blobClientWithoutAuth = Azure::Storage::Blobs::AppendBlobClient(
         blobClient.GetUrl(), InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
@@ -317,8 +280,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(AppendBlobClientTest, ContentHash)
   {
-    auto const testName(GetTestName());
-    auto appendBlobClient = GetAppendBlobClient(testName);
+    auto appendBlobClient = GetAppendBlobClientForTest(RandomString());
 
     const std::vector<uint8_t> blobContent = RandomBuffer(10);
     const std::vector<uint8_t> contentMd5
@@ -330,7 +292,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto contentStream = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
     appendBlobClient.AppendBlock(contentStream);
 
-    auto appendBlobClient2 = GetAppendBlobClient(testName + "2");
+    auto appendBlobClient2 = GetAppendBlobClientForTest(RandomString());
     appendBlobClient2.Create();
 
     Blobs::AppendBlockOptions options1;

--- a/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.cpp
@@ -18,6 +18,10 @@ namespace Azure { namespace Storage { namespace Test {
   void AppendBlobClientTest::SetUp()
   {
     BlobContainerClientTest::SetUp();
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_blobName = RandomString();
     m_appendBlobClient = std::make_shared<Blobs::AppendBlobClient>(
         m_blobContainerClient->GetAppendBlobClient(m_blobName));

--- a/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/append_blob_client_test.hpp
@@ -9,42 +9,21 @@
 namespace Azure { namespace Storage { namespace Test {
 
   class AppendBlobClientTest : public BlobContainerClientTest {
-  private:
-    std::shared_ptr<Azure::Storage::Blobs::AppendBlobClient> m_appendBlobClient;
+  protected:
+    void SetUp() override;
+
+    Blobs::AppendBlobClient GetAppendBlobClientForTest(
+        const std::string& blobName,
+        Blobs::BlobClientOptions clientOptions = Blobs::BlobClientOptions())
+    {
+      auto containerClient = GetBlobContainerClientForTest(m_containerName, clientOptions);
+      return containerClient.GetAppendBlobClient(blobName);
+    }
 
   protected:
-    Azure::Storage::Blobs::CreateAppendBlobOptions m_blobUploadOptions;
+    std::shared_ptr<Azure::Storage::Blobs::AppendBlobClient> m_appendBlobClient;
+    std::string m_blobName;
     std::vector<uint8_t> m_blobContent;
-
-    virtual void SetUp() override;
-    virtual void TearDown() override;
-
-    Azure::Storage::Blobs::AppendBlobClient const& GetAppendBlobClient(std::string const& blobName)
-    {
-      // Create container
-      auto containerClient = GetBlobContainerTestClient();
-      containerClient.CreateIfNotExists();
-
-      m_appendBlobClient = std::make_unique<Azure::Storage::Blobs::AppendBlobClient>(
-          containerClient.GetAppendBlobClient(blobName));
-
-      m_blobContent = std::vector<uint8_t>(100, 'x');
-      m_blobUploadOptions.Metadata = {{"key1", "V1"}, {"key2", "Value2"}};
-      m_blobUploadOptions.HttpHeaders.ContentType = "application/x-binary";
-      m_blobUploadOptions.HttpHeaders.ContentLanguage = "en-US";
-      m_blobUploadOptions.HttpHeaders.ContentDisposition = "attachment";
-      m_blobUploadOptions.HttpHeaders.CacheControl = "no-cache";
-      m_blobUploadOptions.HttpHeaders.ContentEncoding = "identify";
-      m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
-      m_appendBlobClient->Create(m_blobUploadOptions);
-      auto blockContent
-          = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-      m_appendBlobClient->AppendBlock(blockContent);
-      m_blobUploadOptions.HttpHeaders.ContentHash
-          = m_appendBlobClient->GetProperties().Value.HttpHeaders.ContentHash;
-
-      return *m_appendBlobClient;
-    }
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_batch_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_batch_client_test.cpp
@@ -9,7 +9,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, BatchSubmitDelete_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
     const std::string containerNamePrefix = LowercaseRandomString();
 
     const std::string containerName1 = containerNamePrefix + "1";
@@ -49,7 +48,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, BatchSnapshotVersion_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
     const std::string containerNamePrefix = LowercaseRandomString();
 
     const std::string containerName1 = containerNamePrefix + "1";
@@ -133,7 +131,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, BatchTokenAuthorization_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
     std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
         = std::make_shared<Azure::Identity::ClientSecretCredential>(
             AadTenantId(), AadClientId(), AadClientSecret());
@@ -160,7 +157,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, BatchExceptions_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
     const std::string containerName = LowercaseRandomString();
     const std::string blobName = "b1";
 

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_batch_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_batch_client_test.cpp
@@ -3,49 +3,25 @@
 
 #include <azure/storage/blobs.hpp>
 
-#include "test/ut/test_base.hpp"
+#include "blob_container_client_test.hpp"
 
 namespace Azure { namespace Storage { namespace Test {
 
-  class BlobBatchClientTest : public StorageTest {
-  private:
-    std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient> m_client;
-
-  protected:
-    // Required to rename the test propertly once the test is started.
-    // We can only know the test instance name until the test instance is run.
-    Azure::Storage::Blobs::BlobServiceClient const& GetClientForTest(std::string const& testName)
-    {
-      // set the interceptor for the current test
-      m_testContext.RenameTest(testName);
-      return *m_client;
-    }
-
-    void SetUp() override
-    {
-      StorageTest::SetUp();
-
-      auto options = InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>();
-      m_client = std::make_unique<Azure::Storage::Blobs::BlobServiceClient>(
-          Azure::Storage::Blobs::BlobServiceClient::CreateFromConnectionString(
-              StandardStorageConnectionString(), options));
-    }
-  };
-
-  TEST_F(BlobBatchClientTest, DISABLED_SubmitDeleteBatch)
+  TEST_F(BlobContainerClientTest, BatchSubmitDelete_LIVEONLY_)
   {
-    const std::string testName = GetTestNameLowerCase();
+    CHECK_SKIP_TEST();
+    const std::string containerNamePrefix = LowercaseRandomString();
 
-    const std::string containerName1 = testName + "1";
+    const std::string containerName1 = containerNamePrefix + "1";
     const std::string blob1Name = "b1";
     const std::string blob2Name = "b2";
-    const std::string containerName2 = testName + "2";
+    const std::string containerName2 = containerNamePrefix + "2";
     const std::string blob3Name = "b3";
 
-    auto serviceClient = GetClientForTest(testName);
-    auto container1Client = serviceClient.GetBlobContainerClient(containerName1);
+    auto serviceClient = *m_blobServiceClient;
+    auto container1Client = GetBlobContainerClientForTest(containerName1);
     container1Client.CreateIfNotExists();
-    auto container2Client = serviceClient.GetBlobContainerClient(containerName2);
+    auto container2Client = GetBlobContainerClientForTest(containerName2);
     container2Client.CreateIfNotExists();
     auto blob1Client = container1Client.GetAppendBlobClient(blob1Name);
     blob1Client.Create();
@@ -69,19 +45,17 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_THROW(blob1Client.GetProperties(), StorageException);
     EXPECT_THROW(blob2Client.GetProperties(), StorageException);
     EXPECT_NO_THROW(blob3Client.GetProperties());
-
-    container1Client.Delete();
-    container2Client.Delete();
   }
 
-  TEST_F(BlobBatchClientTest, DISABLED_SnapshotVersion)
+  TEST_F(BlobContainerClientTest, BatchSnapshotVersion_LIVEONLY_)
   {
-    const std::string testName = GetTestNameLowerCase();
+    CHECK_SKIP_TEST();
+    const std::string containerNamePrefix = LowercaseRandomString();
 
-    const std::string containerName1 = testName + "1";
+    const std::string containerName1 = containerNamePrefix + "1";
     const std::string blob1Name = "blockblob1";
-    auto serviceClient = GetClientForTest(testName);
-    auto container1Client = serviceClient.GetBlobContainerClient(containerName1);
+    auto serviceClient = *m_blobServiceClient;
+    auto container1Client = GetBlobContainerClientForTest(containerName1);
     container1Client.CreateIfNotExists();
     auto blob1Client = container1Client.GetBlockBlobClient(blob1Name);
     auto versionId = blob1Client.UploadFrom(nullptr, 0).Value.VersionId.Value();
@@ -113,15 +87,11 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_NO_THROW(r4.GetResponse());
     EXPECT_THROW(blob1Client.WithVersionId(versionId).GetProperties(), StorageException);
     EXPECT_THROW(blob1Client.WithSnapshot(snapshotId).GetProperties(), StorageException);
-
-    container1Client.DeleteIfExists();
   }
 
-  TEST_F(BlobBatchClientTest, SubmitSetTierBatch_LIVEONLY_)
+  TEST_F(BlobContainerClientTest, BatchSubmitSetTier_LIVEONLY_)
   {
-    const std::string testName = GetTestNameLowerCase();
-
-    const std::string containerName = testName;
+    const std::string containerName = LowercaseRandomString();
     const std::string blob1Name = "b1";
     const std::string blob2Name = "b2";
 
@@ -136,11 +106,13 @@ namespace Azure { namespace Storage { namespace Test {
           *_internal::ParseConnectionString(StandardStorageConnectionString()).KeyCredential);
     }();
 
-    auto serviceClient = GetClientForTest(testName);
-    serviceClient.GetBlobContainerClient(containerName).CreateIfNotExists();
+    auto serviceClient = *m_blobServiceClient;
+    GetBlobContainerClientForTest(containerName).CreateIfNotExists();
+    Blobs::BlobClientOptions clientOptions;
+    InitClientOptions(clientOptions);
     auto containerClient = Blobs::BlobContainerClient(
         serviceClient.GetBlobContainerClient(containerName).GetUrl() + containerSasToken,
-        InitClientOptions<Blobs::BlobClientOptions>());
+        clientOptions);
     auto blob1Client = containerClient.GetBlockBlobClient(blob1Name);
     blob1Client.UploadFrom(nullptr, 0);
     auto blob2Client = containerClient.GetBlockBlobClient(blob2Name);
@@ -157,26 +129,24 @@ namespace Azure { namespace Storage { namespace Test {
         blob1Client.GetProperties().Value.AccessTier.Value(), Blobs::Models::AccessTier::Cool);
     EXPECT_EQ(
         blob2Client.GetProperties().Value.AccessTier.Value(), Blobs::Models::AccessTier::Archive);
-
-    serviceClient.DeleteBlobContainer(containerName);
   }
 
-  TEST_F(BlobBatchClientTest, DISABLED_TokenAuthorization)
+  TEST_F(BlobContainerClientTest, BatchTokenAuthorization_LIVEONLY_)
   {
-    const std::string testName = GetTestNameLowerCase();
-
+    CHECK_SKIP_TEST();
     std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
         = std::make_shared<Azure::Identity::ClientSecretCredential>(
             AadTenantId(), AadClientId(), AadClientSecret());
-    Blobs::BlobClientOptions options;
+    Blobs::BlobClientOptions clientOptions;
+    InitClientOptions(clientOptions);
 
-    auto serviceClient = InitTestClient<Blobs::BlobServiceClient, Blobs::BlobClientOptions>(
-        GetClientForTest(testName).GetUrl(), credential, options);
+    auto serviceClient
+        = Blobs::BlobServiceClient(m_blobServiceClient->GetUrl(), credential, clientOptions);
 
-    const std::string containerName = testName;
+    const std::string containerName = LowercaseRandomString();
     const std::string blobName = "b1";
 
-    auto containerClient = serviceClient->GetBlobContainerClient(containerName);
+    auto containerClient = serviceClient.GetBlobContainerClient(containerName);
     containerClient.CreateIfNotExists();
     auto blobClient = containerClient.GetAppendBlobClient(blobName);
     blobClient.Create();
@@ -186,19 +156,16 @@ namespace Azure { namespace Storage { namespace Test {
     auto submitBatchResponse = containerClient.SubmitBatch(batch);
 
     EXPECT_TRUE(delete1Response.GetResponse().Value.Deleted);
-
-    containerClient.Delete();
   }
 
-  TEST_F(BlobBatchClientTest, Exceptions_LIVEONLY_)
+  TEST_F(BlobContainerClientTest, BatchExceptions_LIVEONLY_)
   {
-    const std::string testName = GetTestNameLowerCase();
-
-    const std::string containerName = testName;
+    CHECK_SKIP_TEST();
+    const std::string containerName = LowercaseRandomString();
     const std::string blobName = "b1";
 
-    auto serviceClient = GetClientForTest(testName);
-    auto containerClient = serviceClient.GetBlobContainerClient(containerName);
+    auto serviceClient = *m_blobServiceClient;
+    auto containerClient = GetBlobContainerClientForTest(containerName);
     containerClient.CreateIfNotExists();
     auto blobClient = containerClient.GetBlockBlobClient(blobName);
     blobClient.UploadFrom(nullptr, 0);

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
@@ -22,7 +22,10 @@ namespace Azure { namespace Storage { namespace Test {
   void BlobContainerClientTest::SetUp()
   {
     BlobServiceClientTest::SetUp();
-
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_containerName = GetLowercaseIdentifier();
     m_blobContainerClient = std::make_shared<Blobs::BlobContainerClient>(
         m_blobServiceClient->GetBlobContainerClient(m_containerName));
@@ -403,9 +406,6 @@ namespace Azure { namespace Storage { namespace Test {
   // Hence, the test can't be recorded and need to run on live mode always.
   TEST_F(BlobContainerClientTest, AccessControlList)
   {
-    // will skip test under some cased where test can't run (usually LIVE only tests)
-    CHECK_SKIP_TEST()
-
     auto containerClient = *m_blobContainerClient;
     containerClient.CreateIfNotExists();
 
@@ -611,9 +611,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, CustomerProvidedKey)
   {
-    // will skip test under some cased where test can't run (usually LIVE only tests)
-    CHECK_SKIP_TEST()
-
     auto sourceContainerClient = *m_blobContainerClient;
 
     auto getRandomCustomerProvidedKey = [&]() {

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
@@ -39,7 +39,7 @@ namespace Azure { namespace Storage { namespace Test {
         {
           throw;
         }
-        SUCCEED() << "Cotnainer is being deleted. Will try again after 3 seconds.";
+        SUCCEED() << "Container is being deleted. Will try again after 3 seconds.";
         std::this_thread::sleep_for(std::chrono::seconds(3));
       }
     }

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.cpp
@@ -19,6 +19,48 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Models {
 
 namespace Azure { namespace Storage { namespace Test {
 
+  void BlobContainerClientTest::SetUp()
+  {
+    BlobServiceClientTest::SetUp();
+
+    m_containerName = GetLowercaseIdentifier();
+    m_blobContainerClient = std::make_shared<Blobs::BlobContainerClient>(
+        m_blobServiceClient->GetBlobContainerClient(m_containerName));
+    while (true)
+    {
+      try
+      {
+        m_blobContainerClient->CreateIfNotExists();
+        break;
+      }
+      catch (StorageException& e)
+      {
+        if (e.ErrorCode != "ContainerBeingDeleted")
+        {
+          throw;
+        }
+        SUCCEED() << "Cotnainer is being deleted. Will try again after 3 seconds.";
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+      }
+    }
+
+    m_resourceCleanupFunctions.push_back(
+        [blobContainerClient = *m_blobContainerClient]() { blobContainerClient.DeleteIfExists(); });
+  }
+
+  Blobs::BlobContainerClient BlobContainerClientTest::GetBlobContainerClientForTest(
+      const std::string& containerName,
+      Blobs::BlobClientOptions clientOptions)
+  {
+    InitClientOptions(clientOptions);
+    auto blobContainerClient = Blobs::BlobContainerClient::CreateFromConnectionString(
+        StandardStorageConnectionString(), containerName, clientOptions);
+    m_resourceCleanupFunctions.push_back(
+        [blobContainerClient]() { blobContainerClient.DeleteIfExists(); });
+
+    return blobContainerClient;
+  }
+
   std::string BlobContainerClientTest::GetSas()
   {
     Sas::BlobSasBuilder sasBuilder;
@@ -54,61 +96,60 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, CreateDelete)
   {
-    auto container_client = GetBlobContainerTestClient();
+    auto containerClient = GetBlobContainerClientForTest(LowercaseRandomString());
     Azure::Storage::Blobs::CreateBlobContainerOptions options;
     Azure::Storage::Metadata metadata;
     metadata["key1"] = "one";
     metadata["key2"] = "TWO";
     options.Metadata = metadata;
-    auto res = container_client.Create(options);
+    auto res = containerClient.Create(options);
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderDate).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderXMsVersion).empty());
     EXPECT_TRUE(res.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(res.Value.LastModified));
-    EXPECT_THROW(container_client.Create(), StorageException);
+    EXPECT_THROW(containerClient.Create(), StorageException);
 
-    auto res2 = container_client.Delete();
+    auto res2 = containerClient.Delete();
     EXPECT_FALSE(res2.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
     EXPECT_FALSE(res2.RawResponse->GetHeaders().at(_internal::HttpHeaderDate).empty());
     EXPECT_FALSE(res2.RawResponse->GetHeaders().at(_internal::HttpHeaderXMsVersion).empty());
 
-    container_client = GetBlobContainerTestClient("UPPERCASE");
-    EXPECT_THROW(container_client.CreateIfNotExists(), StorageException);
-    container_client = GetBlobContainerTestClient("2");
+    containerClient = GetBlobContainerClientForTest("UPPERCASE");
+    EXPECT_THROW(containerClient.CreateIfNotExists(), StorageException);
+    containerClient = GetBlobContainerClientForTest(LowercaseRandomString());
     {
-      auto response = container_client.DeleteIfExists();
+      auto response = containerClient.DeleteIfExists();
       EXPECT_FALSE(response.Value.Deleted);
     }
     {
-      auto response = container_client.CreateIfNotExists();
+      auto response = containerClient.CreateIfNotExists();
       EXPECT_TRUE(response.Value.Created);
     }
     {
-      auto response = container_client.CreateIfNotExists();
+      auto response = containerClient.CreateIfNotExists();
       EXPECT_FALSE(response.Value.Created);
     }
     {
-      auto response = container_client.DeleteIfExists();
+      auto response = containerClient.DeleteIfExists();
       EXPECT_TRUE(response.Value.Deleted);
     }
   }
 
   TEST_F(BlobContainerClientTest, Metadata)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
     Azure::Storage::Metadata metadata;
     metadata["key1"] = "one";
     metadata["key2"] = "TWO";
-    auto res = client.SetMetadata(metadata);
+    auto res = containerClient.SetMetadata(metadata);
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderDate).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderXMsVersion).empty());
     EXPECT_TRUE(res.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(res.Value.LastModified));
 
-    auto res2 = client.GetProperties();
+    auto res2 = containerClient.GetProperties();
     EXPECT_FALSE(res2.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
     EXPECT_FALSE(res2.RawResponse->GetHeaders().at(_internal::HttpHeaderDate).empty());
     EXPECT_FALSE(res2.RawResponse->GetHeaders().at(_internal::HttpHeaderXMsVersion).empty());
@@ -118,15 +159,14 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(properties.Metadata, metadata);
 
     metadata.clear();
-    client.SetMetadata(metadata);
-    properties = client.GetProperties().Value;
+    containerClient.SetMetadata(metadata);
+    properties = containerClient.GetProperties().Value;
     EXPECT_TRUE(properties.Metadata.empty());
   }
 
   TEST_F(BlobContainerClientTest, ListBlobsFlat)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
 
     const std::string prefix1 = "prefix1-";
     const std::string prefix2 = "prefix2-";
@@ -139,22 +179,22 @@ namespace Azure { namespace Storage { namespace Test {
     for (int i = 0; i < 5; ++i)
     {
       std::string blobName = prefix1 + baseName + std::to_string(i);
-      auto blobClient = client.GetBlockBlobClient(blobName);
+      auto blobClient = containerClient.GetBlockBlobClient(blobName);
       auto emptyContent = Azure::Core::IO::MemoryBodyStream(nullptr, 0);
       blobClient.Upload(emptyContent);
       p1Blobs.insert(blobName);
       p1p2Blobs.insert(blobName);
     }
     {
-      auto appendBlobClient = client.GetAppendBlobClient(m_containerName + "-appendblob");
+      auto appendBlobClient = containerClient.GetAppendBlobClient(RandomString() + "-appendblob");
       appendBlobClient.Create();
-      auto pageBlobClient = client.GetPageBlobClient(m_containerName + "-pageblob");
+      auto pageBlobClient = containerClient.GetPageBlobClient(RandomString() + "-pageblob");
       pageBlobClient.Create(4096);
     }
     for (int i = 0; i < 5; ++i)
     {
       std::string blobName = prefix2 + baseName + std::to_string(i);
-      auto blobClient = client.GetBlockBlobClient(blobName);
+      auto blobClient = containerClient.GetBlockBlobClient(blobName);
       auto emptyContent = Azure::Core::IO::MemoryBodyStream(nullptr, 0);
       blobClient.Upload(emptyContent);
       p2Blobs.insert(blobName);
@@ -164,7 +204,7 @@ namespace Azure { namespace Storage { namespace Test {
     Azure::Storage::Blobs::ListBlobsOptions options;
     options.PageSizeHint = 4;
     std::set<std::string> listBlobs;
-    for (auto pageResult = client.ListBlobs(options); pageResult.HasPage();
+    for (auto pageResult = containerClient.ListBlobs(options); pageResult.HasPage();
          pageResult.MoveToNextPage())
     {
       EXPECT_FALSE(pageResult.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
@@ -216,7 +256,7 @@ namespace Azure { namespace Storage { namespace Test {
 
     options.Prefix = prefix1;
     listBlobs.clear();
-    for (auto pageResult = client.ListBlobs(options); pageResult.HasPage();
+    for (auto pageResult = containerClient.ListBlobs(options); pageResult.HasPage();
          pageResult.MoveToNextPage())
     {
       for (const auto& blob : pageResult.Blobs)
@@ -229,20 +269,19 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, ListBlobsByHierarchy)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
 
     const std::string delimiter = "/";
-    const std::string prefix = m_containerName;
-    const std::string prefix1 = prefix + "-" + m_containerName;
-    const std::string prefix2 = prefix + "-" + m_containerName;
+    const std::string prefix = RandomString();
+    const std::string prefix1 = prefix + "-" + RandomString();
+    const std::string prefix2 = prefix + "-" + RandomString();
     std::set<std::string> blobs;
     for (const auto& blobNamePrefix : {prefix1, prefix2})
     {
       for (int i = 0; i < 3; ++i)
       {
-        std::string blobName = blobNamePrefix + delimiter + m_containerName + std::to_string(i);
-        auto blobClient = client.GetBlockBlobClient(blobName);
+        std::string blobName = blobNamePrefix + delimiter + RandomString() + std::to_string(i);
+        auto blobClient = containerClient.GetBlockBlobClient(blobName);
         auto emptyContent = Azure::Core::IO::MemoryBodyStream(nullptr, 0);
         blobClient.Upload(emptyContent);
         blobs.insert(blobName);
@@ -252,7 +291,8 @@ namespace Azure { namespace Storage { namespace Test {
     Azure::Storage::Blobs::ListBlobsOptions options;
     options.Prefix = prefix;
     std::set<std::string> items;
-    for (auto pageResult = client.ListBlobsByHierarchy(delimiter, options); pageResult.HasPage();
+    for (auto pageResult = containerClient.ListBlobsByHierarchy(delimiter, options);
+         pageResult.HasPage();
          pageResult.MoveToNextPage())
     {
       EXPECT_EQ(pageResult.Delimiter, delimiter);
@@ -269,7 +309,8 @@ namespace Azure { namespace Storage { namespace Test {
     for (const auto& p : {prefix1, prefix2})
     {
       options.Prefix = p + delimiter;
-      for (auto pageResult = client.ListBlobsByHierarchy(delimiter, options); pageResult.HasPage();
+      for (auto pageResult = containerClient.ListBlobsByHierarchy(delimiter, options);
+           pageResult.HasPage();
            pageResult.MoveToNextPage())
       {
         EXPECT_EQ(pageResult.Delimiter, delimiter);
@@ -284,15 +325,14 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(items, blobs);
   }
 
-  // NOTE: This test Requires storage account with versioning enabled!
-  // https://docs.microsoft.com/en-us/azure/storage/blobs/versioning-enable?tabs=portal
   TEST_F(BlobContainerClientTest, ListBlobsOtherStuff)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    // NOTE: This test Requires storage account with versioning enabled!
+    // https://docs.microsoft.com/en-us/azure/storage/blobs/versioning-enable?tabs=portal
+    auto containerClient = *m_blobContainerClient;
 
     std::string blobName = "blob" + m_containerName;
-    auto blobClient = client.GetAppendBlobClient(blobName);
+    auto blobClient = containerClient.GetAppendBlobClient(blobName);
     blobClient.Create();
     blobClient.Delete();
     blobClient.Create();
@@ -315,7 +355,7 @@ namespace Azure { namespace Storage { namespace Test {
     bool foundDeleted = false;
     bool foundMetadata = false;
 
-    for (auto pageResult = client.ListBlobs(options); pageResult.HasPage();
+    for (auto pageResult = containerClient.ListBlobs(options); pageResult.HasPage();
          pageResult.MoveToNextPage())
     {
       for (const auto& blob : pageResult.Blobs)
@@ -361,19 +401,19 @@ namespace Azure { namespace Storage { namespace Test {
 
   // Test uses StartsOn and ExpiresOn values based on time now() + minutes
   // Hence, the test can't be recorded and need to run on live mode always.
-  TEST_F(BlobContainerClientTest, AccessControlList_LIVEONLY_)
+  TEST_F(BlobContainerClientTest, AccessControlList)
   {
     // will skip test under some cased where test can't run (usually LIVE only tests)
     CHECK_SKIP_TEST()
 
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
+    containerClient.CreateIfNotExists();
 
     Blobs::SetBlobContainerAccessPolicyOptions options;
     options.AccessType = Blobs::Models::PublicAccessType::Blob;
     {
       Blobs::Models::SignedIdentifier identifier;
-      identifier.Id = GetStringOfSize(63) + "1";
+      identifier.Id = RandomString(63) + "1";
       identifier.StartsOn = std::chrono::system_clock::now() - std::chrono::minutes(1);
       identifier.ExpiresOn = std::chrono::system_clock::now() + std::chrono::minutes(1);
       identifier.Permissions = "r";
@@ -381,7 +421,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
     {
       Blobs::Models::SignedIdentifier identifier;
-      identifier.Id = GetStringOfSize(63) + "2";
+      identifier.Id = RandomString(63) + "2";
       identifier.StartsOn = std::chrono::system_clock::now() - std::chrono::minutes(2);
       identifier.ExpiresOn.Reset();
       /* cspell:disable-next-line */
@@ -390,36 +430,45 @@ namespace Azure { namespace Storage { namespace Test {
     }
     {
       Blobs::Models::SignedIdentifier identifier;
-      identifier.Id = GetStringOfSize(63) + "3";
+      identifier.Id = RandomString(63) + "3";
       identifier.Permissions = "r";
       options.SignedIdentifiers.emplace_back(identifier);
     }
     {
       Blobs::Models::SignedIdentifier identifier;
-      identifier.Id = GetStringOfSize(63) + "4";
+      identifier.Id = RandomString(63) + "4";
       identifier.StartsOn = std::chrono::system_clock::now() - std::chrono::minutes(1);
       identifier.ExpiresOn = std::chrono::system_clock::now() + std::chrono::minutes(1);
       options.SignedIdentifiers.emplace_back(identifier);
     }
 
-    auto ret = client.SetAccessPolicy(options);
+    auto ret = containerClient.SetAccessPolicy(options);
     EXPECT_TRUE(ret.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(ret.Value.LastModified));
 
-    auto ret2 = client.GetAccessPolicy();
+    auto ret2 = containerClient.GetAccessPolicy();
     EXPECT_EQ(ret2.Value.AccessType, options.AccessType);
-    EXPECT_EQ(ret2.Value.SignedIdentifiers, options.SignedIdentifiers);
+    if (m_testContext.IsLiveMode())
+    {
+      EXPECT_EQ(ret2.Value.SignedIdentifiers, options.SignedIdentifiers);
+    }
+    containerClient.DeleteIfExists();
   }
 
-  TEST_F(BlobContainerClientTest, Lease_LIVEONLY_)
+  TEST_F(BlobContainerClientTest, Lease)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
 
     {
       std::string leaseId1 = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
+      std::string leaseId2 = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
+      EXPECT_EQ(leaseId1.length(), leaseId2.length());
+      EXPECT_NE(leaseId1, leaseId2);
+    }
+    {
+      std::string leaseId1 = RandomUUID();
       auto leaseDuration = std::chrono::seconds(20);
-      Blobs::BlobLeaseClient leaseClient(client, leaseId1);
+      Blobs::BlobLeaseClient leaseClient(containerClient, leaseId1);
       auto aLease = leaseClient.Acquire(leaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
       EXPECT_TRUE(IsValidTime(aLease.LastModified));
@@ -430,7 +479,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(IsValidTime(aLease.LastModified));
       EXPECT_EQ(aLease.LeaseId, leaseId1);
 
-      auto properties = client.GetProperties().Value;
+      auto properties = containerClient.GetProperties().Value;
       EXPECT_EQ(properties.LeaseState, Blobs::Models::LeaseState::Leased);
       EXPECT_EQ(properties.LeaseStatus, Blobs::Models::LeaseStatus::Locked);
       EXPECT_EQ(properties.LeaseDuration.Value(), Blobs::Models::LeaseDurationType::Fixed);
@@ -440,7 +489,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(IsValidTime(rLease.LastModified));
       EXPECT_EQ(rLease.LeaseId, leaseId1);
 
-      std::string leaseId2 = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
+      std::string leaseId2 = RandomUUID();
       EXPECT_NE(leaseId1, leaseId2);
       auto cLease = leaseClient.Change(leaseId2).Value;
       EXPECT_TRUE(cLease.ETag.HasValue());
@@ -454,9 +503,9 @@ namespace Azure { namespace Storage { namespace Test {
     }
 
     {
-      Blobs::BlobLeaseClient leaseClient(client, Blobs::BlobLeaseClient::CreateUniqueLeaseId());
+      Blobs::BlobLeaseClient leaseClient(containerClient, RandomUUID());
       auto aLease = leaseClient.Acquire(Blobs::BlobLeaseClient::InfiniteLeaseDuration).Value;
-      auto properties = client.GetProperties().Value;
+      auto properties = containerClient.GetProperties().Value;
       EXPECT_EQ(properties.LeaseDuration.Value(), Blobs::Models::LeaseDurationType::Infinite);
       auto brokenLease = leaseClient.Break().Value;
       EXPECT_TRUE(brokenLease.ETag.HasValue());
@@ -464,7 +513,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
 
     {
-      Blobs::BlobLeaseClient leaseClient(client, Blobs::BlobLeaseClient::CreateUniqueLeaseId());
+      Blobs::BlobLeaseClient leaseClient(containerClient, RandomUUID());
       auto leaseDuration = std::chrono::seconds(20);
       auto aLease = leaseClient.Acquire(leaseDuration).Value;
       auto brokenLease = leaseClient.Break().Value;
@@ -479,37 +528,35 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, EncryptionScope)
   {
-    auto blobContainerClient = GetBlobContainerTestClient();
-    blobContainerClient.CreateIfNotExists();
-    auto const& testEncryptionScope = GetTestEncryptionScope();
+    auto containerClient = *m_blobContainerClient;
+    const auto& testEncryptionScope = GetTestEncryptionScope();
 
     {
-      auto properties = blobContainerClient.GetProperties().Value;
+      auto properties = containerClient.GetProperties().Value;
       EXPECT_EQ(properties.DefaultEncryptionScope, AccountEncryptionKey);
       EXPECT_EQ(properties.PreventEncryptionScopeOverride, false);
     }
     {
-      std::string containerName = GetContainerValidName() + "1";
+      std::string containerName = GetLowercaseIdentifier() + "1";
       std::string blobName = GetTestName() + "1";
-      Blobs::BlobClientOptions options = InitClientOptions<Blobs::BlobClientOptions>();
+      Blobs::BlobClientOptions options;
       options.EncryptionScope = testEncryptionScope;
-      auto containerClient = Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
-          StandardStorageConnectionString(), containerName, options);
+      auto containerClient2 = GetBlobContainerClientForTest(containerName, options);
       Blobs::CreateBlobContainerOptions createOptions;
       createOptions.DefaultEncryptionScope = testEncryptionScope;
       createOptions.PreventEncryptionScopeOverride = true;
-      EXPECT_NO_THROW(containerClient.Create(createOptions));
-      auto properties = containerClient.GetProperties().Value;
+      EXPECT_NO_THROW(containerClient2.Create(createOptions));
+      auto properties = containerClient2.GetProperties().Value;
       EXPECT_EQ(properties.DefaultEncryptionScope, createOptions.DefaultEncryptionScope.Value());
       EXPECT_EQ(
           properties.PreventEncryptionScopeOverride,
           createOptions.PreventEncryptionScopeOverride.Value());
-      auto appendBlobClient = containerClient.GetAppendBlobClient(blobName);
+      auto appendBlobClient = containerClient2.GetAppendBlobClient(blobName);
       auto blobContentInfo = appendBlobClient.Create();
       {
         Blobs::ListBlobsOptions listOptions;
         listOptions.Prefix = blobName;
-        for (auto page = containerClient.ListBlobs(listOptions); page.HasPage();
+        for (auto page = containerClient2.ListBlobs(listOptions); page.HasPage();
              page.MoveToNextPage())
         {
           for (auto& blob : page.Blobs)
@@ -526,19 +573,19 @@ namespace Azure { namespace Storage { namespace Test {
       appendBlobClient.Delete();
       EXPECT_TRUE(blobContentInfo.Value.EncryptionScope.HasValue());
       EXPECT_EQ(blobContentInfo.Value.EncryptionScope.Value(), testEncryptionScope);
-      auto appendBlobClientWithoutEncryptionScope = containerClient.GetAppendBlobClient(blobName);
+      auto appendBlobClientWithoutEncryptionScope = containerClient2.GetAppendBlobClient(blobName);
       blobContentInfo = appendBlobClientWithoutEncryptionScope.Create();
       appendBlobClientWithoutEncryptionScope.Delete();
       EXPECT_TRUE(blobContentInfo.Value.EncryptionScope.HasValue());
       EXPECT_EQ(blobContentInfo.Value.EncryptionScope.Value(), testEncryptionScope);
-      containerClient.Delete();
+      containerClient2.Delete();
     }
     {
       std::string blobName = GetTestName() + "2";
-      Blobs::BlobClientOptions options = InitClientOptions<Blobs::BlobClientOptions>();
+      Blobs::BlobClientOptions options;
       options.EncryptionScope = testEncryptionScope;
-      auto appendBlobClient = Azure::Storage::Blobs::AppendBlobClient::CreateFromConnectionString(
-          StandardStorageConnectionString(), m_containerName, blobName, options);
+      auto appendBlobClient
+          = GetBlobContainerClientForTest(m_containerName, options).GetAppendBlobClient(blobName);
       auto blobContentInfo = appendBlobClient.Create();
       EXPECT_TRUE(blobContentInfo.Value.EncryptionScope.HasValue());
       EXPECT_EQ(blobContentInfo.Value.EncryptionScope.Value(), testEncryptionScope);
@@ -554,8 +601,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(appendBlobClient.AppendBlock(bodyStream));
 
       bodyStream.Rewind();
-      auto appendBlobClientWithoutEncryptionScope
-          = blobContainerClient.GetAppendBlobClient(blobName);
+      auto appendBlobClientWithoutEncryptionScope = containerClient.GetAppendBlobClient(blobName);
       EXPECT_THROW(
           appendBlobClientWithoutEncryptionScope.AppendBlock(bodyStream), StorageException);
       EXPECT_THROW(appendBlobClientWithoutEncryptionScope.CreateSnapshot(), StorageException);
@@ -563,19 +609,16 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
-  TEST_F(BlobContainerClientTest, CustomerProvidedKey_LIVEONLY_)
+  TEST_F(BlobContainerClientTest, CustomerProvidedKey)
   {
     // will skip test under some cased where test can't run (usually LIVE only tests)
     CHECK_SKIP_TEST()
 
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto sourceContainerClient = *m_blobContainerClient;
 
     auto getRandomCustomerProvidedKey = [&]() {
       Blobs::EncryptionKey key;
-      std::vector<uint8_t> aes256Key;
-      aes256Key.resize(32);
-      RandomBuffer(&aes256Key[0], aes256Key.size());
+      std::vector<uint8_t> aes256Key = RandomBuffer(32);
       key.Key = Azure::Core::Convert::Base64Encode(aes256Key);
       key.KeyHash = Azure::Core::Cryptography::_internal::Sha256Hash().Final(
           aes256Key.data(), aes256Key.size());
@@ -585,17 +628,16 @@ namespace Azure { namespace Storage { namespace Test {
 
     Blobs::BlobClientOptions options;
     options.CustomerProvidedKey = getRandomCustomerProvidedKey();
-    auto containerClient = Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_containerName, options);
+    auto destContainerClient = GetBlobContainerClientForTest(m_containerName, options);
 
     std::vector<uint8_t> blobContent(512);
     Azure::Core::IO::MemoryBodyStream bodyStream(blobContent.data(), blobContent.size());
-    auto copySourceBlob = client.GetBlockBlobClient(RandomString());
+    auto copySourceBlob = sourceContainerClient.GetBlockBlobClient(RandomString());
     copySourceBlob.UploadFrom(blobContent.data(), blobContent.size());
 
     {
       std::string blockBlobName = RandomString();
-      auto blockBlob = containerClient.GetBlockBlobClient(blockBlobName);
+      auto blockBlob = destContainerClient.GetBlockBlobClient(blockBlobName);
       bodyStream.Rewind();
       EXPECT_NO_THROW(blockBlob.Upload(bodyStream));
       std::string blockId1 = Base64EncodeText("1");
@@ -606,18 +648,17 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(blockBlob.CommitBlockList({blockId1, blockId2}));
       EXPECT_THROW(blockBlob.SetAccessTier(Blobs::Models::AccessTier::Cool), StorageException);
 
-      auto appendBlobClientWithoutEncryptionKey
-          = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
-              StandardStorageConnectionString(), m_containerName, blockBlobName);
+      auto blockBlobClientWithoutEncryptionKey
+          = m_blobContainerClient->GetBlockBlobClient(blockBlobName);
       EXPECT_THROW(
-          appendBlobClientWithoutEncryptionKey.SetAccessTier(Blobs::Models::AccessTier::Cool),
+          blockBlobClientWithoutEncryptionKey.SetAccessTier(Blobs::Models::AccessTier::Cool),
           StorageException);
-      EXPECT_NO_THROW(appendBlobClientWithoutEncryptionKey.GetBlockList());
+      EXPECT_NO_THROW(blockBlobClientWithoutEncryptionKey.GetBlockList());
     }
 
     {
       std::string appendBlobName = RandomString();
-      auto appendBlob = containerClient.GetAppendBlobClient(appendBlobName);
+      auto appendBlob = destContainerClient.GetAppendBlobClient(appendBlobName);
       auto blobContentInfo = appendBlob.Create().Value;
       EXPECT_TRUE(blobContentInfo.IsServerEncrypted);
       EXPECT_TRUE(blobContentInfo.EncryptionKeySha256.HasValue());
@@ -644,8 +685,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(appendBlob.CreateSnapshot());
 
       auto appendBlobClientWithoutEncryptionKey
-          = Azure::Storage::Blobs::AppendBlobClient::CreateFromConnectionString(
-              StandardStorageConnectionString(), m_containerName, appendBlobName);
+          = m_blobContainerClient->GetAppendBlobClient(appendBlobName);
       bodyStream.Rewind();
       EXPECT_THROW(appendBlobClientWithoutEncryptionKey.AppendBlock(bodyStream), StorageException);
       EXPECT_THROW(
@@ -665,7 +705,7 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       std::string pageBlobName = RandomString();
-      auto pageBlob = containerClient.GetPageBlobClient(pageBlobName);
+      auto pageBlob = destContainerClient.GetPageBlobClient(pageBlobName);
       auto blobContentInfo = pageBlob.Create(0).Value;
       EXPECT_TRUE(blobContentInfo.IsServerEncrypted);
       EXPECT_TRUE(blobContentInfo.EncryptionKeySha256.HasValue());
@@ -679,8 +719,7 @@ namespace Azure { namespace Storage { namespace Test {
           0, copySourceBlob.GetUrl() + GetSas(), {0, static_cast<int64_t>(blobContent.size())}));
 
       auto pageBlobClientWithoutEncryptionKey
-          = Azure::Storage::Blobs::PageBlobClient::CreateFromConnectionString(
-              StandardStorageConnectionString(), m_containerName, pageBlobName);
+          = m_blobContainerClient->GetPageBlobClient(pageBlobName);
       EXPECT_NO_THROW(pageBlobClientWithoutEncryptionKey.GetPageRanges());
       EXPECT_NO_THROW(pageBlobClientWithoutEncryptionKey.Resize(blobContent.size() + 512));
     }
@@ -688,8 +727,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, AccessConditionLastModifiedTime)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
 
     enum class TimePoint
     {
@@ -708,7 +746,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       for (auto sinceTime : {TimePoint::TimeBefore, TimePoint::TimeAfter})
       {
-        auto lastModifiedTime = client.GetProperties().Value.LastModified;
+        auto lastModifiedTime = containerClient.GetProperties().Value.LastModified;
         auto timeBefore = lastModifiedTime - std::chrono::seconds(1);
         auto timeAfter = lastModifiedTime + std::chrono::seconds(1);
 
@@ -729,68 +767,65 @@ namespace Azure { namespace Storage { namespace Test {
             || (condition == Condition::UnmodifiedSince && sinceTime == TimePoint::TimeBefore);
         if (shouldThrow)
         {
-          EXPECT_THROW(client.SetAccessPolicy(options), StorageException);
+          EXPECT_THROW(containerClient.SetAccessPolicy(options), StorageException);
         }
         else
         {
-          EXPECT_NO_THROW(client.SetAccessPolicy(options));
+          EXPECT_NO_THROW(containerClient.SetAccessPolicy(options));
         }
       }
     }
-    client.Delete();
   }
 
   TEST_F(BlobContainerClientTest, AccessConditionLeaseId)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
 
-    const std::string leaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
-    const std::string dummyLeaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
-    Blobs::BlobLeaseClient leaseClient(client, leaseId);
+    const std::string leaseId = RandomUUID();
+    const std::string dummyLeaseId = RandomUUID();
+    Blobs::BlobLeaseClient leaseClient(containerClient, leaseId);
     leaseClient.Acquire(std::chrono::seconds(30));
     {
       Blobs::GetBlobContainerPropertiesOptions options;
       options.AccessConditions.LeaseId = dummyLeaseId;
-      EXPECT_THROW(client.GetProperties(options), StorageException);
+      EXPECT_THROW(containerClient.GetProperties(options), StorageException);
       options.AccessConditions.LeaseId = leaseId;
-      EXPECT_NO_THROW(client.GetProperties(options));
+      EXPECT_NO_THROW(containerClient.GetProperties(options));
     }
     {
       Blobs::SetBlobContainerMetadataOptions options;
       options.AccessConditions.LeaseId = dummyLeaseId;
-      EXPECT_THROW(client.SetMetadata({}, options), StorageException);
+      EXPECT_THROW(containerClient.SetMetadata({}, options), StorageException);
       options.AccessConditions.LeaseId = leaseId;
-      EXPECT_NO_THROW(client.SetMetadata({}, options));
+      EXPECT_NO_THROW(containerClient.SetMetadata({}, options));
     }
     {
       Blobs::GetBlobContainerAccessPolicyOptions options;
       options.AccessConditions.LeaseId = dummyLeaseId;
-      EXPECT_THROW(client.GetAccessPolicy(options), StorageException);
+      EXPECT_THROW(containerClient.GetAccessPolicy(options), StorageException);
       options.AccessConditions.LeaseId = leaseId;
-      EXPECT_NO_THROW(client.GetAccessPolicy(options));
+      EXPECT_NO_THROW(containerClient.GetAccessPolicy(options));
     }
     {
       Blobs::SetBlobContainerAccessPolicyOptions options;
       options.AccessConditions.LeaseId = dummyLeaseId;
-      EXPECT_THROW(client.SetAccessPolicy(options), StorageException);
+      EXPECT_THROW(containerClient.SetAccessPolicy(options), StorageException);
       options.AccessConditions.LeaseId = leaseId;
-      EXPECT_NO_THROW(client.SetAccessPolicy(options));
+      EXPECT_NO_THROW(containerClient.SetAccessPolicy(options));
     }
     {
-      EXPECT_THROW(client.Delete(), StorageException);
+      EXPECT_THROW(containerClient.Delete(), StorageException);
       Blobs::DeleteBlobContainerOptions options;
       options.AccessConditions.LeaseId = leaseId;
-      EXPECT_NO_THROW(client.Delete(options));
+      EXPECT_NO_THROW(containerClient.Delete(options));
     }
   }
 
   TEST_F(BlobContainerClientTest, Tags)
   {
-    auto containerClient = GetBlobContainerTestClient();
-    containerClient.Create();
+    auto containerClient = *m_blobContainerClient;
 
-    std::string blobName = "blob" + m_containerName;
+    std::string blobName = "blob" + RandomString();
     auto blobClient = containerClient.GetAppendBlobClient(blobName);
     blobClient.Create();
 
@@ -801,12 +836,12 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(downloadRet.Value.Details.TagCount.HasValue());
 
     std::map<std::string, std::string> tags;
-    std::string c1 = "k" + m_containerName + "1";
-    std::string v1 = m_containerName + "2";
-    std::string c2 = "k" + m_containerName + "3";
-    std::string v2 = m_containerName + "4";
-    std::string c3 = "k" + m_containerName + "5";
-    std::string v3 = m_containerName + "6";
+    std::string c1 = "k" + RandomString() + "1";
+    std::string v1 = RandomString() + "2";
+    std::string c2 = "k" + RandomString() + "3";
+    std::string v2 = RandomString() + "4";
+    std::string c3 = "k" + RandomString() + "5";
+    std::string v3 = RandomString() + "6";
     std::string c4 = "key3 +-./:=_";
     std::string v4 = "v1 +-./:=_";
     tags[c1] = v1;
@@ -841,9 +876,6 @@ namespace Azure { namespace Storage { namespace Test {
       blobClient1.SetTags(tags);
     }
 
-    auto blobServiceClient = Azure::Storage::Blobs::BlobServiceClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
     std::string whereExpression
         = c1 + " = '" + v1 + "' AND " + c2 + " >= '" + v2 + "' AND " + c3 + " <= '" + v3 + "'";
     std::vector<std::string> findResults;
@@ -867,7 +899,7 @@ namespace Azure { namespace Storage { namespace Test {
           findResults2.emplace_back(item.BlobName);
         }
       }
-      for (auto pageResult = blobServiceClient.FindBlobsByTags(whereExpression);
+      for (auto pageResult = m_blobContainerClient->FindBlobsByTags(whereExpression);
            pageResult.HasPage();
            pageResult.MoveToNextPage())
       {
@@ -901,12 +933,11 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, AccessConditionTags)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
 
     std::map<std::string, std::string> tags;
-    std::string c1 = "k" + m_containerName + "1";
-    std::string v1 = m_containerName + "2";
+    std::string c1 = "k" + RandomString() + "1";
+    std::string v1 = RandomString() + "2";
     tags[c1] = v1;
 
     std::string successWhereExpression = c1 + " = '" + v1 + "'";
@@ -916,12 +947,8 @@ namespace Azure { namespace Storage { namespace Test {
     int64_t contentSize = static_cast<int64_t>(contentData.size());
     auto content = Azure::Core::IO::MemoryBodyStream(contentData.data(), contentData.size());
 
-    std::string blobName = m_containerName;
-    auto appendBlobClient = Azure::Storage::Blobs::AppendBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        blobName,
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+    std::string blobName = RandomString();
+    auto appendBlobClient = m_blobContainerClient->GetAppendBlobClient(blobName);
     appendBlobClient.Create();
     appendBlobClient.SetTags(tags);
 
@@ -997,11 +1024,7 @@ namespace Azure { namespace Storage { namespace Test {
       std::string url = appendBlobClient.GetUrl() + GetSas();
 
       Blobs::StartBlobCopyFromUriOptions options;
-      auto blobClient2 = Azure::Storage::Blobs::AppendBlobClient::CreateFromConnectionString(
-          StandardStorageConnectionString(),
-          m_containerName,
-          m_containerName + "blobClient2",
-          InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+      auto blobClient2 = m_blobContainerClient->GetAppendBlobClient(RandomString());
       options.SourceAccessConditions.TagConditions = failWhereExpression;
       EXPECT_THROW(blobClient2.StartCopyFromUri(url, options), StorageException);
       options.SourceAccessConditions.TagConditions = successWhereExpression;
@@ -1017,7 +1040,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
 
     {
-      std::string leaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
+      std::string leaseId = RandomUUID();
       Blobs::AcquireLeaseOptions options;
       options.AccessConditions.TagConditions = failWhereExpression;
       Blobs::BlobLeaseClient leaseClient(appendBlobClient, leaseId);
@@ -1040,12 +1063,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_THROW(appendBlobClient.Delete(options3), StorageException);
     }
 
-    blobName = m_containerName;
-    auto pageBlobClient = Azure::Storage::Blobs::PageBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        blobName + "blob",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+    auto pageBlobClient = m_blobContainerClient->GetPageBlobClient(RandomString());
     pageBlobClient.Create(contentSize);
     pageBlobClient.SetTags(tags);
 
@@ -1115,12 +1133,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(pageBlobClient.GetPageRanges(options));
     }
 
-    blobName = m_containerName;
-    auto blockBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        blobName + "blockBlobClient",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+    auto blockBlobClient = m_blobContainerClient->GetBlockBlobClient(RandomString());
     blockBlobClient.UploadFrom(contentData.data(), contentData.size());
     blockBlobClient.SetTags(tags);
 
@@ -1167,11 +1180,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
 
     {
-      auto sourceBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
-          StandardStorageConnectionString(),
-          m_containerName,
-          m_containerName + "sourceBlobClient",
-          InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+      auto sourceBlobClient = m_blobContainerClient->GetBlockBlobClient(RandomString());
       std::vector<uint8_t> buffer;
       buffer.resize(1024);
       sourceBlobClient.UploadFrom(buffer.data(), buffer.size());
@@ -1186,11 +1195,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
 
     {
-      auto sourceBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
-          StandardStorageConnectionString(),
-          m_containerName,
-          m_containerName + "sourceBlobClient2",
-          InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+      auto sourceBlobClient = m_blobContainerClient->GetBlockBlobClient(RandomString());
       std::vector<uint8_t> buffer;
       buffer.resize(1024);
       sourceBlobClient.UploadFrom(buffer.data(), buffer.size());
@@ -1207,8 +1212,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, SpecialBlobName)
   {
-    auto client = GetBlobContainerTestClient();
-    client.CreateIfNotExists();
+    auto containerClient = *m_blobContainerClient;
 
     const std::string non_ascii_word = "\xE6\xB5\x8B\xE8\xAF\x95";
     const std::string encoded_non_ascii_word = "%E6%B5%8B%E8%AF%95";
@@ -1217,60 +1221,56 @@ namespace Azure { namespace Storage { namespace Test {
     const std::string baseBlobName = "a b c / !@#$%^&*(?/<>,.;:'\"[]{}|`~) def" + non_ascii_word;
 
     {
-      const std::string blobName = baseBlobName + m_containerName;
-      auto blobClient = client.GetAppendBlobClient(blobName);
+      const std::string blobName = baseBlobName + RandomString();
+      auto blobClient = containerClient.GetAppendBlobClient(blobName);
       EXPECT_NO_THROW(blobClient.Create());
       auto blobUrl = blobClient.GetUrl();
-      EXPECT_EQ(blobUrl, client.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
+      EXPECT_EQ(blobUrl, containerClient.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
       auto blobItem = GetBlobItem(blobName);
       EXPECT_EQ(blobItem.Name, blobName);
     }
     {
-      const std::string blobName = baseBlobName + m_containerName + "1";
-      auto blobClient = client.GetPageBlobClient(blobName);
+      const std::string blobName = baseBlobName + RandomString() + "1";
+      auto blobClient = containerClient.GetPageBlobClient(blobName);
       EXPECT_NO_THROW(blobClient.Create(1024));
       auto blobUrl = blobClient.GetUrl();
-      EXPECT_EQ(blobUrl, client.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
+      EXPECT_EQ(blobUrl, containerClient.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
       auto blobItem = GetBlobItem(blobName);
       EXPECT_EQ(blobItem.Name, blobName);
     }
     {
-      const std::string blobName = baseBlobName + m_containerName + "2";
-      auto blobClient = client.GetBlockBlobClient(blobName);
+      const std::string blobName = baseBlobName + RandomString() + "2";
+      auto blobClient = containerClient.GetBlockBlobClient(blobName);
       EXPECT_NO_THROW(blobClient.UploadFrom(nullptr, 0));
       auto blobUrl = blobClient.GetUrl();
-      EXPECT_EQ(blobUrl, client.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
+      EXPECT_EQ(blobUrl, containerClient.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
       auto blobItem = GetBlobItem(blobName);
       EXPECT_EQ(blobItem.Name, blobName);
     }
-    auto clientOptions = InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>();
     {
-      const std::string blobName = baseBlobName + m_containerName + "3";
-      auto blobClient = Blobs::AppendBlobClient::CreateFromConnectionString(
-          StandardStorageConnectionString(), m_containerName, blobName, clientOptions);
+      const std::string blobName = baseBlobName + RandomString() + "3";
+      auto blobClient = m_blobContainerClient->GetAppendBlobClient(blobName);
       EXPECT_NO_THROW(blobClient.Create());
       auto blobUrl = blobClient.GetUrl();
-      EXPECT_EQ(blobUrl, client.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
+      EXPECT_EQ(blobUrl, containerClient.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
       auto blobItem = GetBlobItem(blobName);
       EXPECT_EQ(blobItem.Name, blobName);
     }
     {
-      const std::string blobName = baseBlobName + m_containerName + "4";
-      auto blobClient = Blobs::PageBlobClient::CreateFromConnectionString(
-          StandardStorageConnectionString(), m_containerName, blobName, clientOptions);
+      const std::string blobName = baseBlobName + RandomString() + "4";
+      auto blobClient = m_blobContainerClient->GetPageBlobClient(blobName);
       EXPECT_NO_THROW(blobClient.Create(1024));
       auto blobUrl = blobClient.GetUrl();
-      EXPECT_EQ(blobUrl, client.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
+      EXPECT_EQ(blobUrl, containerClient.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
       auto blobItem = GetBlobItem(blobName);
       EXPECT_EQ(blobItem.Name, blobName);
     }
     {
-      const std::string blobName = baseBlobName + m_containerName + "5";
-      auto blobClient = Blobs::BlockBlobClient::CreateFromConnectionString(
-          StandardStorageConnectionString(), m_containerName, blobName, clientOptions);
+      const std::string blobName = baseBlobName + RandomString() + "5";
+      auto blobClient = m_blobContainerClient->GetBlockBlobClient(blobName);
       EXPECT_NO_THROW(blobClient.UploadFrom(nullptr, 0));
       auto blobUrl = blobClient.GetUrl();
-      EXPECT_EQ(blobUrl, client.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
+      EXPECT_EQ(blobUrl, containerClient.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
       auto blobItem = GetBlobItem(blobName);
       EXPECT_EQ(blobItem.Name, blobName);
     }
@@ -1282,15 +1282,14 @@ namespace Azure { namespace Storage { namespace Test {
       const std::string blobPrefix
           = std::string("aaaaa\xEF\xBF\xBF") + "bbb/"; // UTF-8 0xEF, 0xBF, 0xBF is UTF-16 0xFFFF
       const std::string blobName = blobPrefix + "ccc";
-      auto blobClient = Blobs::BlockBlobClient::CreateFromConnectionString(
-          StandardStorageConnectionString(), m_containerName, blobName, clientOptions);
+      auto blobClient = m_blobContainerClient->GetBlockBlobClient(blobName);
       EXPECT_NO_THROW(blobClient.UploadFrom(nullptr, 0));
       auto blobUrl = blobClient.GetUrl();
-      EXPECT_EQ(blobUrl, client.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
+      EXPECT_EQ(blobUrl, containerClient.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
       Blobs::Models::BlobItem blobItem;
       Blobs::ListBlobsOptions options;
       options.Prefix = "aaaaa";
-      for (auto page = client.ListBlobs(options); page.HasPage(); page.MoveToNextPage())
+      for (auto page = containerClient.ListBlobs(options); page.HasPage(); page.MoveToNextPage())
       {
         for (auto& blob : page.Blobs)
         {
@@ -1302,7 +1301,8 @@ namespace Azure { namespace Storage { namespace Test {
       }
       EXPECT_EQ(blobItem.Name, blobName);
       bool found = false;
-      for (auto page = client.ListBlobsByHierarchy("/"); page.HasPage(); page.MoveToNextPage())
+      for (auto page = containerClient.ListBlobsByHierarchy("/"); page.HasPage();
+           page.MoveToNextPage())
       {
         for (auto& p : page.BlobPrefixes)
         {
@@ -1318,23 +1318,21 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, QuestionMarkBlobName)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
 
     std::string blobName = "?";
-    auto blobClient = client.GetAppendBlobClient(blobName);
+    auto blobClient = containerClient.GetAppendBlobClient(blobName);
     EXPECT_NO_THROW(blobClient.Create());
     auto blobUrl = blobClient.GetUrl();
-    EXPECT_EQ(blobUrl, client.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
+    EXPECT_EQ(blobUrl, containerClient.GetUrl() + "/" + _internal::UrlEncodePath(blobName));
   }
 
   TEST_F(BlobContainerClientTest, DeleteBlob)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
 
-    std::string blobName = m_containerName;
-    auto blobClient = client.GetAppendBlobClient(blobName);
+    std::string blobName = RandomString();
+    auto blobClient = containerClient.GetAppendBlobClient(blobName);
     blobClient.Create();
     EXPECT_NO_THROW(blobClient.GetProperties());
     blobClient.Delete();
@@ -1343,11 +1341,10 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, ListBlobsDeletedWithActiveVersions)
   {
-    auto client = GetBlobContainerTestClient();
-    client.Create();
+    auto containerClient = *m_blobContainerClient;
 
-    std::string blobName = "blob" + m_containerName;
-    auto blobClient = client.GetAppendBlobClient(blobName);
+    std::string blobName = "blob" + RandomString();
+    auto blobClient = containerClient.GetAppendBlobClient(blobName);
     blobClient.Create();
 
     auto blobItem

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_container_client_test.hpp
@@ -3,54 +3,26 @@
 
 #include <azure/storage/blobs.hpp>
 
-#include "test/ut/test_base.hpp"
+#include "blob_service_client_test.hpp"
 
 namespace Azure { namespace Storage { namespace Test {
 
-  class BlobContainerClientTest : public StorageTest {
-  private:
-    std::shared_ptr<Azure::Storage::Blobs::BlobContainerClient> m_blobContainerClient;
-
+  class BlobContainerClientTest : public BlobServiceClientTest {
   protected:
-    std::string m_testName;
-    std::string m_containerName;
+    void SetUp() override;
 
-    virtual void SetUp() override { StorageTest::SetUp(); }
-
-    virtual void TearDown() override
-    {
-      if (m_blobContainerClient)
-      {
-        m_blobContainerClient->Delete();
-      }
-
-      StorageTest::TearDown();
-    }
-
-    Azure::Storage::Blobs::BlobContainerClient const& GetBlobContainerTestClient(
-        std::string const& prefix = std::string(""))
-    {
-      // set the interceptor for the current test
-      if (m_testName.empty())
-      {
-        // Internal state for the test name allows a test to create new container client with any
-        // name but just the first name is used as the test name for recordings.
-        m_testName = GetTestName(true);
-        m_testContext.RenameTest(m_testName);
-      }
-      m_containerName = prefix + GetContainerValidName();
-      auto options = InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>();
-      m_blobContainerClient = std::make_unique<Azure::Storage::Blobs::BlobContainerClient>(
-          Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
-              StandardStorageConnectionString(), m_containerName, options));
-
-      return *m_blobContainerClient;
-    }
+    Blobs::BlobContainerClient GetBlobContainerClientForTest(
+        const std::string& containerName,
+        Blobs::BlobClientOptions clientOptions = Blobs::BlobClientOptions());
 
     std::string GetSas();
     Blobs::Models::BlobItem GetBlobItem(
         const std::string& blobName,
         Blobs::Models::ListBlobsIncludeFlags include = Blobs::Models::ListBlobsIncludeFlags::None);
+
+  protected:
+    std::string m_containerName;
+    std::shared_ptr<Blobs::BlobContainerClient> m_blobContainerClient;
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
@@ -14,7 +14,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     CHECK_SKIP_TEST();
 
-    auto blobContainerClient = GetBlobContainerTestClient();
+    auto blobContainerClient = GetBlobContainerClientForTest(LowercaseRandomString());
     blobContainerClient.CreateIfNotExists();
 
     auto sasStartsOn = std::chrono::system_clock::now() - std::chrono::minutes(5);

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_sas_test.cpp
@@ -12,8 +12,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobContainerClientTest, BlobSasTest_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
-
     auto blobContainerClient = GetBlobContainerClientForTest(LowercaseRandomString());
     blobContainerClient.CreateIfNotExists();
 

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
@@ -6,7 +6,7 @@
 #include <azure/identity/client_secret_credential.hpp>
 #include <azure/storage/blobs.hpp>
 
-#include "test/ut/test_base.hpp"
+#include "blob_service_client_test.hpp"
 
 namespace Azure { namespace Storage { namespace Blobs { namespace Models {
 
@@ -70,49 +70,13 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Models {
 
 namespace Azure { namespace Storage { namespace Test {
 
-  class BlobServiceClientTest : public Azure::Storage::Test::StorageTest {
-
-  private:
-    std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient> m_client;
-
-  protected:
-    // Required to rename the test propertly once the test is started.
-    // We can only know the test instance name until the test instance is run.
-    Azure::Storage::Blobs::BlobServiceClient const& GetClientForTest(std::string const& testName)
-    {
-      // set the interceptor for the current test
-      m_testContext.RenameTest(testName);
-      return *m_client;
-    }
-
-    Azure::Storage::Blobs::BlobServiceClient const& GetDataLakeClientService()
-    {
-      // set the interceptor for the current test
-      auto options = InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>();
-      m_client = std::make_unique<Azure::Storage::Blobs::BlobServiceClient>(
-          Azure::Storage::Blobs::BlobServiceClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), options));
-      return *m_client;
-    }
-
-    virtual void SetUp() override
-    {
-      StorageTest::SetUp();
-
-      auto options = InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>();
-      m_client = std::make_unique<Azure::Storage::Blobs::BlobServiceClient>(
-          Azure::Storage::Blobs::BlobServiceClient::CreateFromConnectionString(
-              StandardStorageConnectionString(), options));
-    }
-  };
-
   TEST_F(BlobServiceClientTest, ListContainers)
   {
-    const std::string testName = GetTestNameLowerCase();
-    auto client = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
 
-    const std::string prefix1 = testName + "-prefix1-";
-    const std::string prefix2 = testName + "-prefix2-";
+    const std::string prefix = LowercaseRandomString();
+    const std::string prefix1 = prefix + "-prefix1-";
+    const std::string prefix2 = prefix + "-prefix2-";
 
     std::set<std::string> p1Containers;
     std::set<std::string> p2Containers;
@@ -121,7 +85,7 @@ namespace Azure { namespace Storage { namespace Test {
     for (int i = 0; i < 5; ++i)
     {
       std::string containerName = prefix1 + std::to_string(i);
-      auto containerClient = client.GetBlobContainerClient(containerName);
+      auto containerClient = serviceClient.GetBlobContainerClient(containerName);
       containerClient.Create();
       p1Containers.insert(containerName);
       p1p2Containers.insert(containerName);
@@ -129,7 +93,7 @@ namespace Azure { namespace Storage { namespace Test {
     for (int i = 0; i < 5; ++i)
     {
       std::string containerName = prefix2 + std::to_string(i);
-      auto containerClient = client.GetBlobContainerClient(containerName);
+      auto containerClient = serviceClient.GetBlobContainerClient(containerName);
       containerClient.Create();
       p2Containers.insert(containerName);
       p1p2Containers.insert(containerName);
@@ -138,7 +102,7 @@ namespace Azure { namespace Storage { namespace Test {
     Azure::Storage::Blobs::ListBlobContainersOptions options;
     options.PageSizeHint = 4;
     std::set<std::string> listContainers;
-    for (auto pageResult = client.ListBlobContainers(options); pageResult.HasPage();
+    for (auto pageResult = serviceClient.ListBlobContainers(options); pageResult.HasPage();
          pageResult.MoveToNextPage())
     {
       EXPECT_FALSE(pageResult.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
@@ -160,7 +124,7 @@ namespace Azure { namespace Storage { namespace Test {
     // List with prefix
     options.Prefix = prefix1;
     listContainers.clear();
-    for (auto pageResult = client.ListBlobContainers(options); pageResult.HasPage();
+    for (auto pageResult = serviceClient.ListBlobContainers(options); pageResult.HasPage();
          pageResult.MoveToNextPage())
     {
       EXPECT_FALSE(pageResult.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
@@ -188,19 +152,18 @@ namespace Azure { namespace Storage { namespace Test {
     // Remove all containers
     for (const auto& container : p1p2Containers)
     {
-      auto container_client = client.GetBlobContainerClient(container);
+      auto container_client = serviceClient.GetBlobContainerClient(container);
       container_client.Delete();
     }
   }
 
   TEST_F(BlobServiceClientTest, ListSystemContainers)
   {
-    const std::string testName = GetTestNameLowerCase();
-    auto client = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
     Azure::Storage::Blobs::ListBlobContainersOptions options;
     options.Include = Blobs::Models::ListBlobContainersIncludeFlags::System;
     std::vector<std::string> containers;
-    for (auto pageResult = client.ListBlobContainers(options); pageResult.HasPage();
+    for (auto pageResult = serviceClient.ListBlobContainers(options); pageResult.HasPage();
          pageResult.MoveToNextPage())
     {
       for (const auto& c : pageResult.BlobContainers)
@@ -217,10 +180,9 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobServiceClientTest, GetProperties)
   {
-    const std::string testName = GetTestName();
-    auto client = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
 
-    auto ret = client.GetProperties();
+    auto ret = serviceClient.GetProperties();
     auto properties = ret.Value;
     auto logging = properties.Logging;
     EXPECT_FALSE(logging.Version.empty());
@@ -255,10 +217,9 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobServiceClientTest, SetProperties)
   {
-    const std::string testName = GetTestName();
-    auto client = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
 
-    auto getServicePropertiesResult = client.GetProperties().Value;
+    auto getServicePropertiesResult = serviceClient.GetProperties().Value;
     Blobs::Models::BlobServiceProperties properties;
     properties.Logging = getServicePropertiesResult.Logging;
     properties.HourMetrics = getServicePropertiesResult.HourMetrics;
@@ -311,12 +272,12 @@ namespace Azure { namespace Storage { namespace Test {
     properties.DeleteRetentionPolicy.IsEnabled = true;
     properties.DeleteRetentionPolicy.Days = 7;
 
-    EXPECT_NO_THROW(client.SetProperties(properties));
+    EXPECT_NO_THROW(serviceClient.SetProperties(properties));
 
     // It takes some time before the new properties comes into effect.
     using namespace std::chrono_literals;
     TestSleep(10s);
-    auto downloadedProperties = client.GetProperties().Value;
+    auto downloadedProperties = serviceClient.GetProperties().Value;
     EXPECT_EQ(downloadedProperties.Logging.Version, properties.Logging.Version);
     EXPECT_EQ(downloadedProperties.Logging.Delete, properties.Logging.Delete);
     EXPECT_EQ(downloadedProperties.Logging.Read, properties.Logging.Read);
@@ -369,36 +330,30 @@ namespace Azure { namespace Storage { namespace Test {
 
     EXPECT_EQ(downloadedProperties.DeleteRetentionPolicy, properties.DeleteRetentionPolicy);
 
-    auto res = client.SetProperties(originalProperties);
+    auto res = serviceClient.SetProperties(originalProperties);
   }
 
   TEST_F(BlobServiceClientTest, AccountInfo)
   {
-    const std::string testName = GetTestName();
-    auto client = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
 
-    auto accountInfo = client.GetAccountInfo().Value;
+    auto accountInfo = serviceClient.GetAccountInfo().Value;
     EXPECT_FALSE(accountInfo.SkuName.ToString().empty());
     EXPECT_FALSE(accountInfo.AccountKind.ToString().empty());
     EXPECT_FALSE(accountInfo.IsHierarchicalNamespaceEnabled);
-
-    auto dataLakeServiceClient = GetDataLakeClientService();
-    accountInfo = dataLakeServiceClient.GetAccountInfo().Value;
-    EXPECT_TRUE(accountInfo.IsHierarchicalNamespaceEnabled);
   }
 
   TEST_F(BlobServiceClientTest, Statistics)
   {
-    const std::string testName = GetTestName();
-    auto client = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
 
-    EXPECT_THROW(client.GetStatistics(), StorageException);
+    EXPECT_THROW(serviceClient.GetStatistics(), StorageException);
 
     auto keyCredential
         = _internal::ParseConnectionString(StandardStorageConnectionString()).KeyCredential;
 
     auto secondaryServiceClient = Blobs::BlobServiceClient(
-        InferSecondaryUrl(client.GetUrl()),
+        InferSecondaryUrl(serviceClient.GetUrl()),
         keyCredential,
         InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
 
@@ -412,24 +367,22 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobServiceClientTest, CreateDeleteBlobContainer)
   {
-    const std::string testName = GetTestNameLowerCase();
-    auto client = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
 
-    std::string containerName = testName;
-    auto containerClient = client.CreateBlobContainer(containerName);
+    const std::string containerName = LowercaseRandomString();
+    auto containerClient = serviceClient.CreateBlobContainer(containerName);
     EXPECT_NO_THROW(containerClient.Value.GetProperties());
 
-    client.DeleteBlobContainer(containerName);
+    serviceClient.DeleteBlobContainer(containerName);
     EXPECT_THROW(containerClient.Value.GetProperties(), StorageException);
   }
 
   TEST_F(BlobServiceClientTest, UndeleteBlobContainer)
   {
-    const std::string testName = GetTestNameLowerCase();
-    auto client = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
 
-    std::string containerName = testName;
-    auto containerClient = client.GetBlobContainerClient(containerName);
+    const std::string containerName = LowercaseRandomString();
+    auto containerClient = serviceClient.GetBlobContainerClient(containerName);
     containerClient.Create();
     containerClient.Delete();
 
@@ -438,7 +391,7 @@ namespace Azure { namespace Storage { namespace Test {
       Azure::Storage::Blobs::ListBlobContainersOptions options;
       options.Prefix = containerName;
       options.Include = Blobs::Models::ListBlobContainersIncludeFlags::Deleted;
-      for (auto pageResult = client.ListBlobContainers(options); pageResult.HasPage();
+      for (auto pageResult = serviceClient.ListBlobContainers(options); pageResult.HasPage();
            pageResult.MoveToNextPage())
       {
         for (const auto& container : pageResult.BlobContainers)
@@ -464,7 +417,7 @@ namespace Azure { namespace Storage { namespace Test {
     {
       try
       {
-        client.UndeleteBlobContainer(
+        serviceClient.UndeleteBlobContainer(
             deletedContainerItem.Name, deletedContainerItem.VersionId.Value());
         break;
       }
@@ -482,12 +435,12 @@ namespace Azure { namespace Storage { namespace Test {
       }
     }
     EXPECT_NO_THROW(containerClient.GetProperties());
+    containerClient.DeleteIfExists();
   }
 
   TEST_F(BlobServiceClientTest, UserDelegationKey)
   {
-    const std::string testName = GetTestName();
-    auto client = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
 
     auto sasExpiresOn = std::chrono::system_clock::now() + std::chrono::minutes(60);
 
@@ -495,11 +448,11 @@ namespace Azure { namespace Storage { namespace Test {
         = std::make_shared<Azure::Identity::ClientSecretCredential>(
             AadTenantId(), AadClientId(), AadClientSecret());
     Blobs::BlobClientOptions options;
+    InitClientOptions(options);
 
-    auto blobServiceClient1 = InitTestClient<Blobs::BlobServiceClient, Blobs::BlobClientOptions>(
-        client.GetUrl(), credential, options);
+    auto blobServiceClient1 = Blobs::BlobServiceClient(serviceClient.GetUrl(), credential, options);
 
-    auto userDelegationKey = blobServiceClient1->GetUserDelegationKey(sasExpiresOn).Value;
+    auto userDelegationKey = blobServiceClient1.GetUserDelegationKey(sasExpiresOn).Value;
 
     EXPECT_FALSE(userDelegationKey.SignedObjectId.empty());
     EXPECT_FALSE(userDelegationKey.SignedTenantId.empty());
@@ -512,13 +465,13 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlobServiceClientTest, DISABLED_RenameBlobContainer)
   {
-    const std::string testName = GetTestNameLowerCase();
-    auto serviceClient = GetClientForTest(testName);
+    auto serviceClient = *m_blobServiceClient;
+    const std::string prefix = RandomString();
 
-    const std::string srcContainerName = testName + "src";
+    const std::string srcContainerName = prefix + "src";
     auto srcContainerClient = serviceClient.CreateBlobContainer(srcContainerName).Value;
 
-    const std::string destContainerName = testName + "dest1";
+    const std::string destContainerName = prefix + "dest1";
     auto destContainerClient
         = serviceClient.RenameBlobContainer(srcContainerName, destContainerName).Value;
 
@@ -529,7 +482,7 @@ namespace Azure { namespace Storage { namespace Test {
         destContainerClient, Blobs::BlobLeaseClient::CreateUniqueLeaseId());
     leaseClient.Acquire(std::chrono::seconds(60));
 
-    const std::string destContainerName2 = testName + "dest2";
+    const std::string destContainerName2 = prefix + "dest2";
     Blobs::RenameBlobContainerOptions renameOptions;
     renameOptions.SourceAccessConditions.LeaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
     EXPECT_THROW(

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.cpp
@@ -438,7 +438,7 @@ namespace Azure { namespace Storage { namespace Test {
     containerClient.DeleteIfExists();
   }
 
-  TEST_F(BlobServiceClientTest, UserDelegationKey)
+  TEST_F(BlobServiceClientTest, UserDelegationKey_LIVEONLY_)
   {
     auto serviceClient = *m_blobServiceClient;
 

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_service_client_test.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <azure/storage/blobs.hpp>
+
+#include "test/ut/test_base.hpp"
+
+namespace Azure { namespace Storage { namespace Test {
+
+  class BlobServiceClientTest : public StorageTest {
+  protected:
+    std::shared_ptr<Blobs::BlobServiceClient> m_blobServiceClient;
+
+    void SetUp() override
+    {
+      StorageTest::SetUp();
+
+      auto options = InitClientOptions<Blobs::BlobClientOptions>();
+      m_blobServiceClient = std::make_shared<Blobs::BlobServiceClient>(
+          Blobs::BlobServiceClient::CreateFromConnectionString(
+              StandardStorageConnectionString(), options));
+    }
+  };
+
+}}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -1735,9 +1735,9 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(downloadBuffer, expectedData);
     };
 
-    std::vector<std::future<void>> futures;
     for (int c : {1, 2, 4})
     {
+      std::vector<std::future<void>> futures;
       // random range
       for (int i = 0; i < 16; ++i)
       {
@@ -1751,10 +1751,10 @@ namespace Azure { namespace Storage { namespace Test {
         futures.emplace_back(
             std::async(std::launch::async, testUploadFromFile, c, fileSize, 0, 25_KB));
       }
-    }
-    for (auto& f : futures)
-    {
-      f.get();
+      for (auto& f : futures)
+      {
+        f.get();
+      }
     }
   }
 

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -795,17 +795,8 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, DISABLED_SetTierCold)
   {
-
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-
-    std::vector<uint8_t> emptyContent;
-    std::string blobName(testName);
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-
-    // set to cold
-    blobClient.SetAccessTier(Blobs::Models::AccessTier::Cold);
-    auto properties = blobClient.GetProperties().Value;
+    m_blockBlobClient->SetAccessTier(Blobs::Models::AccessTier::Cold);
+    auto properties = m_blockBlobClient->GetProperties().Value;
     EXPECT_EQ(properties.AccessTier.Value(), Blobs::Models::AccessTier::Cold);
   }
 

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -30,22 +30,35 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Models {
 
 namespace Azure { namespace Storage { namespace Test {
 
-  void BlockBlobClientTest::SetUp() { BlobContainerClientTest::SetUp(); }
-
-  void BlockBlobClientTest::TearDown()
+  void BlockBlobClientTest::SetUp()
   {
-    // Deleting the container with any blobs in it
-    BlobContainerClientTest::TearDown();
+    BlobContainerClientTest::SetUp();
+    m_blobName = RandomString();
+    m_blockBlobClient = std::make_shared<Blobs::BlockBlobClient>(
+        m_blobContainerClient->GetBlockBlobClient(m_blobName));
+    m_blobUploadOptions.Metadata = {{"key1", "V1"}, {"key2", "Value2"}};
+    m_blobUploadOptions.HttpHeaders.ContentType = "application/x-binary";
+    m_blobUploadOptions.HttpHeaders.ContentLanguage = "en-US";
+    m_blobUploadOptions.HttpHeaders.ContentDisposition = "attachment";
+    m_blobUploadOptions.HttpHeaders.CacheControl = "no-cache";
+    m_blobUploadOptions.HttpHeaders.ContentEncoding = "identity";
+    m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
+    m_blobUploadOptions.AccessTier = Azure::Storage::Blobs::Models::AccessTier::Hot;
+    m_blobContent = std::vector<uint8_t>(static_cast<size_t>(1_KB), 'x');
+    auto blobContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    m_blockBlobClient->Upload(blobContent, m_blobUploadOptions);
+    m_blobUploadOptions.HttpHeaders.ContentHash
+        = m_blockBlobClient->GetProperties().Value.HttpHeaders.ContentHash;
   }
 
   TEST_F(BlockBlobClientTest, CreateDelete)
   {
-    auto const testName(GetTestName());
-    auto client = GetBlockBlobClient(testName);
+    auto blobClient = *m_blockBlobClient;
 
     auto blobContent
         = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-    auto blobContentInfo = client.Upload(blobContent, m_blobUploadOptions);
+    auto blobContentInfo = blobClient.Upload(blobContent, m_blobUploadOptions);
     EXPECT_TRUE(blobContentInfo.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(blobContentInfo.Value.LastModified));
     EXPECT_TRUE(blobContentInfo.Value.VersionId.HasValue());
@@ -53,26 +66,25 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(blobContentInfo.Value.EncryptionScope.HasValue());
     EXPECT_FALSE(blobContentInfo.Value.EncryptionKeySha256.HasValue());
 
-    client.Delete();
-    EXPECT_THROW(client.Delete(), StorageException);
+    blobClient.Delete();
+    EXPECT_THROW(blobClient.Delete(), StorageException);
   }
 
   TEST_F(BlockBlobClientTest, SoftDelete)
   {
-    auto const testName(GetTestName());
-    auto client = GetBlockBlobClient(testName);
+    const std::string blobName = m_blobName;
+    auto blobClient = *m_blockBlobClient;
 
-    const std::string blobName(testName);
     std::vector<uint8_t> emptyContent;
     auto blobContent = Azure::Core::IO::MemoryBodyStream(emptyContent.data(), emptyContent.size());
-    client.Upload(blobContent);
+    blobClient.Upload(blobContent);
 
     auto blobItem = GetBlobItem(blobName);
     EXPECT_FALSE(blobItem.IsDeleted);
     EXPECT_FALSE(blobItem.Details.DeletedOn.HasValue());
     EXPECT_FALSE(blobItem.Details.RemainingRetentionDays.HasValue());
 
-    client.Delete();
+    blobClient.Delete();
 
     /*
     // Soft delete doesn't work in storage account with versioning enabled.
@@ -84,14 +96,12 @@ namespace Azure { namespace Storage { namespace Test {
     */
   }
 
-  // small default 1Kb upload/download
   TEST_F(BlockBlobClientTest, SmallUploadDownload)
   {
-    auto const testName(GetTestName());
-    auto client = GetBlockBlobClient(testName);
-    UploadBlockBlob();
+    // small default 1Kb upload/download
+    auto blobClient = *m_blockBlobClient;
 
-    auto res = client.Download();
+    auto res = blobClient.Download();
     EXPECT_EQ(res.Value.BlobSize, static_cast<int64_t>(m_blobContent.size()));
     EXPECT_EQ(res.Value.ContentRange.Offset, 0);
     EXPECT_EQ(res.Value.ContentRange.Length.Value(), static_cast<int64_t>(m_blobContent.size()));
@@ -107,7 +117,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(res.Value.BlobType, Azure::Storage::Blobs::Models::BlobType::BlockBlob);
     Azure::Storage::Blobs::DownloadBlobOptions options;
     options.Range = {100, 200};
-    res = client.Download(options);
+    res = blobClient.Download(options);
     EXPECT_EQ(
         ReadBodyStream(res.Value.BodyStream),
         std::vector<uint8_t>(
@@ -120,15 +130,22 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(res.Value.BlobSize, static_cast<int64_t>(m_blobContent.size()));
   }
 
-  // big 8Mb upload/download should be LIVE only to avoid big recording files
-  TEST_F(BlockBlobClientTest, UploadDownload_LIVEONLY_)
+  TEST_F(BlockBlobClientTest, UploadDownload)
   {
-    CHECK_SKIP_TEST();
-    auto const testName(GetTestName());
-    auto client = GetBlockBlobClient(testName);
-    UploadBlockBlob(8_MB);
+    auto blobClient = *m_blockBlobClient;
+    m_blobContent = RandomBuffer(100);
+    {
+      Azure::Core::Cryptography::Md5Hash md5hash;
+      md5hash.Append(m_blobContent.data(), m_blobContent.size());
+      m_blobUploadOptions.HttpHeaders.ContentHash.Value = md5hash.Final();
+      Blobs::UploadBlockBlobOptions options;
+      options.HttpHeaders = m_blobUploadOptions.HttpHeaders;
+      options.Metadata = m_blobUploadOptions.Metadata;
+      Core::IO::MemoryBodyStream bodyStream(m_blobContent.data(), m_blobContent.size());
+      blobClient.Upload(bodyStream, options);
+    }
 
-    auto res = client.Download();
+    auto res = blobClient.Download();
     EXPECT_EQ(res.Value.BlobSize, static_cast<int64_t>(m_blobContent.size()));
     EXPECT_EQ(res.Value.ContentRange.Offset, 0);
     EXPECT_EQ(res.Value.ContentRange.Length.Value(), static_cast<int64_t>(m_blobContent.size()));
@@ -143,8 +160,8 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(res.Value.Details.Metadata, m_blobUploadOptions.Metadata);
     EXPECT_EQ(res.Value.BlobType, Azure::Storage::Blobs::Models::BlobType::BlockBlob);
     Azure::Storage::Blobs::DownloadBlobOptions options;
-    options.Range = {1_MB, 2_MB};
-    res = client.Download(options);
+    options.Range = {10, 20};
+    res = blobClient.Download(options);
     EXPECT_EQ(
         ReadBodyStream(res.Value.BodyStream),
         std::vector<uint8_t>(
@@ -159,22 +176,21 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, UploadWithTags)
   {
-    auto const testName(GetTestName());
-    auto client = GetBlockBlobClient(testName);
+    auto blobClient = *m_blockBlobClient;
 
     std::map<std::string, std::string> tags;
     tags["key1"] = "value1";
     tags["key2"] = "value2";
     tags["key3 +-./:=_"] = "v1 +-./:=_";
 
-    std::vector<uint8_t> blobContent(100, 'a');
+    std::vector<uint8_t> blobContent(10, 'a');
     {
       Blobs::UploadBlockBlobOptions options;
       options.Tags = tags;
       auto stream = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
-      client.Upload(stream, options);
-      EXPECT_EQ(client.GetTags().Value, tags);
-      client.Delete();
+      blobClient.Upload(stream, options);
+      EXPECT_EQ(blobClient.GetTags().Value, tags);
+      blobClient.Delete();
     }
 
     {
@@ -184,27 +200,26 @@ namespace Azure { namespace Storage { namespace Test {
       options.Tags = tags;
 
       {
-        client.UploadFrom(blobContent.data(), blobContent.size(), options);
-        EXPECT_EQ(client.GetTags().Value, tags);
-        client.Delete();
+        blobClient.UploadFrom(blobContent.data(), blobContent.size(), options);
+        EXPECT_EQ(blobClient.GetTags().Value, tags);
+        blobClient.Delete();
       }
       {
-        const std::string tempFilename = "file" + testName;
+        const std::string tempFilename = "file" + RandomString();
         WriteFile(tempFilename, blobContent);
-        client.UploadFrom(tempFilename, options);
-        EXPECT_EQ(client.GetTags().Value, tags);
-        client.Delete();
+        blobClient.UploadFrom(tempFilename, options);
+        EXPECT_EQ(blobClient.GetTags().Value, tags);
+        blobClient.Delete();
       }
     }
   }
 
   TEST_F(BlockBlobClientTest, DownloadTransactionalHash)
   {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
+    auto blobClient = *m_blockBlobClient;
 
-    const std::vector<uint8_t> dataPart1(static_cast<size_t>(4_MB + 1), 'a');
-    const std::vector<uint8_t> dataPart2(static_cast<size_t>(4_MB + 1), 'b');
+    const std::vector<uint8_t> dataPart1 = RandomBuffer(10);
+    const std::vector<uint8_t> dataPart2 = RandomBuffer(20);
 
     const std::string blockId1 = Base64EncodeText("0");
     const std::string blockId2 = Base64EncodeText("1");
@@ -285,8 +300,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, DISABLED_LastAccessTime)
   {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
+    auto blobClient = *m_blockBlobClient;
 
     {
       auto res = blobClient.Download();
@@ -299,22 +313,21 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(IsValidTime(res.Value.LastAccessedOn.Value()));
     }
     {
-      EXPECT_TRUE(IsValidTime(GetBlobItem(testName).Details.LastAccessedOn.Value()));
+      EXPECT_TRUE(IsValidTime(GetBlobItem(m_blobName).Details.LastAccessedOn.Value()));
     }
   }
 
   TEST_F(BlockBlobClientTest, DownloadEmpty)
   {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
+    auto blobClient = *m_blockBlobClient;
 
     std::vector<uint8_t> emptyContent;
     auto blobContent = Azure::Core::IO::MemoryBodyStream(emptyContent.data(), emptyContent.size());
-    blockBlobClient.Upload(blobContent);
-    blockBlobClient.SetHttpHeaders(m_blobUploadOptions.HttpHeaders);
-    blockBlobClient.SetMetadata(m_blobUploadOptions.Metadata);
+    blobClient.Upload(blobContent);
+    blobClient.SetHttpHeaders(m_blobUploadOptions.HttpHeaders);
+    blobClient.SetMetadata(m_blobUploadOptions.Metadata);
 
-    auto res = blockBlobClient.Download();
+    auto res = blobClient.Download();
     EXPECT_EQ(res.Value.BodyStream->Length(), 0);
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderDate).empty());
@@ -325,39 +338,38 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(res.Value.Details.Metadata, m_blobUploadOptions.Metadata);
     EXPECT_EQ(res.Value.BlobType, Azure::Storage::Blobs::Models::BlobType::BlockBlob);
 
-    std::string tempFilename = testName;
-    EXPECT_NO_THROW(blockBlobClient.DownloadTo(tempFilename));
+    std::string tempFilename = RandomString();
+    EXPECT_NO_THROW(blobClient.DownloadTo(tempFilename));
     EXPECT_TRUE(ReadFile(tempFilename).empty());
     DeleteFile(tempFilename);
 
     std::vector<uint8_t> buff;
-    EXPECT_NO_THROW(blockBlobClient.DownloadTo(buff.data(), 0));
+    EXPECT_NO_THROW(blobClient.DownloadTo(buff.data(), 0));
 
     Azure::Storage::Blobs::DownloadBlobOptions options;
     options.Range = Core::Http::HttpRange();
     options.Range.Value().Offset = 0;
-    EXPECT_THROW(blockBlobClient.Download(options), StorageException);
+    EXPECT_THROW(blobClient.Download(options), StorageException);
     options.Range.Value().Length = 1;
-    EXPECT_THROW(blockBlobClient.Download(options), StorageException);
+    EXPECT_THROW(blobClient.Download(options), StorageException);
   }
 
   TEST_F(BlockBlobClientTest, SyncCopyFromUri)
   {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
-    UploadBlockBlob(8_MB);
+    auto sourceBlobClient = m_blobContainerClient->GetBlockBlobClient("source" + RandomString());
+    sourceBlobClient.UploadFrom(m_blobContent.data(), m_blobContent.size());
 
-    const std::string blobName = testName + "blob";
-    auto blobClient = GetBlobClient(blobName);
+    const std::string blobName = "dest" + RandomString();
+    auto destBlobClient = m_blobContainerClient->GetBlockBlobClient(blobName);
 
-    auto res = blobClient->CopyFromUri(blockBlobClient.GetUrl() + GetSas());
+    auto res = destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas());
     EXPECT_EQ(res.RawResponse->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Accepted);
     EXPECT_TRUE(res.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(res.Value.LastModified));
     EXPECT_FALSE(res.Value.CopyId.empty());
     EXPECT_EQ(res.Value.CopyStatus, Azure::Storage::Blobs::Models::CopyStatus::Success);
 
-    auto downloadResult = blobClient->Download();
+    auto downloadResult = destBlobClient.Download();
     EXPECT_FALSE(downloadResult.Value.Details.CopyId.Value().empty());
     EXPECT_FALSE(downloadResult.Value.Details.CopySource.Value().empty());
     EXPECT_TRUE(
@@ -380,13 +392,12 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, SyncCopyFromUriEncryptionScope)
   {
-    auto clientOptions = InitClientOptions<Blobs::BlobClientOptions>();
+    Blobs::BlobClientOptions clientOptions;
     const auto encryptionScope = GetTestEncryptionScope();
     clientOptions.EncryptionScope = encryptionScope;
-    const auto containerName = GetContainerValidName();
+    const auto containerName = LowercaseRandomString();
     const auto blobName = "b";
-    auto containerClient = Blobs::BlobContainerClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), containerName, clientOptions);
+    auto containerClient = GetBlobContainerClientForTest(containerName, clientOptions);
     containerClient.CreateIfNotExists();
     auto srcBlobClient = containerClient.GetBlockBlobClient(blobName);
     uint8_t data;
@@ -408,14 +419,14 @@ namespace Azure { namespace Storage { namespace Test {
           = _internal::ParseConnectionString(StandardStorageConnectionString()).KeyCredential;
       auto sasToken = builder.GenerateSasToken(*keyCredential);
 
-      auto destBlobClient = GetBlockBlobClient(GetTestName());
+      auto destBlobClient = *m_blockBlobClient;
       auto response = destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + sasToken);
       EXPECT_FALSE(response.Value.EncryptionScope.HasValue());
       properties = destBlobClient.GetProperties().Value;
       EXPECT_FALSE(properties.EncryptionScope.HasValue());
 
-      destBlobClient = containerClient.GetBlockBlobClient(GetTestName());
-      response = destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + GetSas());
+      destBlobClient = containerClient.GetBlockBlobClient(RandomString());
+      response = destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + sasToken);
       ASSERT_TRUE(response.Value.EncryptionScope.HasValue());
       EXPECT_EQ(response.Value.EncryptionScope.Value(), encryptionScope);
       properties = destBlobClient.GetProperties().Value;
@@ -426,18 +437,15 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, AsyncCopyFromUri)
   {
+    auto sourceBlobClient = *m_blockBlobClient;
 
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
-    UploadBlockBlob(8_MB);
+    const std::string blobName = RandomString();
+    auto destBlobClient = GetBlockBlobClientForTest(blobName);
 
-    const std::string blobName = testName + "blob";
-    auto blobClient = GetBlobClient(blobName);
-
-    auto res = blobClient->StartCopyFromUri(blockBlobClient.GetUrl());
+    auto res = destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl());
     EXPECT_EQ(res.GetRawResponse().GetStatusCode(), Azure::Core::Http::HttpStatusCode::Accepted);
     res.PollUntilDone(PollInterval());
-    auto properties = blobClient->GetProperties().Value;
+    auto properties = destBlobClient.GetProperties().Value;
     EXPECT_FALSE(properties.CopyId.Value().empty());
     EXPECT_FALSE(properties.CopySource.Value().empty());
     EXPECT_TRUE(
@@ -448,7 +456,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(properties.IsIncrementalCopy.Value());
     EXPECT_FALSE(properties.IncrementalCopyDestinationSnapshot.HasValue());
 
-    auto downloadResult = blobClient->Download();
+    auto downloadResult = destBlobClient.Download();
     EXPECT_FALSE(downloadResult.Value.Details.CopyId.Value().empty());
     EXPECT_FALSE(downloadResult.Value.Details.CopySource.Value().empty());
     EXPECT_TRUE(
@@ -471,12 +479,10 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, CopyWithTagsMetadataTier)
   {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
-    UploadBlockBlob(8_MB);
+    auto sourceBlobClient = *m_blockBlobClient;
 
-    const std::string blobName = testName + "blob";
-    auto blobClient = GetBlobClient(blobName);
+    const std::string blobName = "dest" + RandomString();
+    auto destBlobClient = GetBlockBlobClientForTest(blobName);
 
     Blobs::StartBlobCopyFromUriOptions options;
     options.Tags["key1"] = "value1";
@@ -485,10 +491,10 @@ namespace Azure { namespace Storage { namespace Test {
     options.Metadata["key1"] = "value1";
     options.Metadata["key2"] = "value2";
     options.AccessTier = Blobs::Models::AccessTier::Cool;
-    auto operation = blobClient->StartCopyFromUri(blockBlobClient.GetUrl(), options);
+    auto operation = destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options);
     operation.PollUntilDone(std::chrono::seconds(1));
-    EXPECT_EQ(blobClient->GetTags().Value, options.Tags);
-    auto properties = blobClient->GetProperties().Value;
+    EXPECT_EQ(destBlobClient.GetTags().Value, options.Tags);
+    auto properties = destBlobClient.GetProperties().Value;
     EXPECT_EQ(properties.Metadata, options.Metadata);
     EXPECT_EQ(properties.AccessTier.Value(), options.AccessTier.Value());
 
@@ -496,26 +502,23 @@ namespace Azure { namespace Storage { namespace Test {
     options2.Tags = options.Tags;
     options2.Metadata = options.Metadata;
     options2.AccessTier = options.AccessTier;
-    blobClient->CopyFromUri(blockBlobClient.GetUrl() + GetSas(), options2);
-    EXPECT_EQ(blobClient->GetTags().Value, options2.Tags);
-    properties = blobClient->GetProperties().Value;
+    destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2);
+    EXPECT_EQ(destBlobClient.GetTags().Value, options2.Tags);
+    properties = destBlobClient.GetProperties().Value;
     EXPECT_EQ(properties.Metadata, options2.Metadata);
     EXPECT_EQ(properties.AccessTier.Value(), options2.AccessTier.Value());
 
     options2.CopySourceTagsMode = Blobs::Models::BlobCopySourceTagsMode::Copy;
     options2.Tags.clear();
-    blobClient->CopyFromUri(blockBlobClient.GetUrl() + GetSas(), options2);
-    EXPECT_TRUE(blobClient->GetTags().Value.empty());
+    destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2);
+    EXPECT_TRUE(destBlobClient.GetTags().Value.empty());
   }
 
   TEST_F(BlockBlobClientTest, SnapShotVersions)
   {
+    auto blobClient = *m_blockBlobClient;
 
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
-    UploadBlockBlob(8_MB);
-
-    auto res = blockBlobClient.CreateSnapshot();
+    auto res = blobClient.CreateSnapshot();
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderDate).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderXMsVersion).empty());
@@ -524,11 +527,11 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(res.Value.Snapshot.empty());
     EXPECT_TRUE(res.Value.VersionId.HasValue());
     EXPECT_FALSE(res.Value.VersionId.Value().empty());
-    auto snapshotClient = blockBlobClient.WithSnapshot(res.Value.Snapshot);
+    auto snapshotClient = blobClient.WithSnapshot(res.Value.Snapshot);
     EXPECT_EQ(ReadBodyStream(snapshotClient.Download().Value.BodyStream), m_blobContent);
     EXPECT_EQ(snapshotClient.GetProperties().Value.Metadata, m_blobUploadOptions.Metadata);
     EXPECT_TRUE(snapshotClient.GetProperties().Value.IsServerEncrypted);
-    auto versionClient = blockBlobClient.WithVersionId(res.Value.VersionId.Value());
+    auto versionClient = blobClient.WithVersionId(res.Value.VersionId.Value());
     EXPECT_EQ(ReadBodyStream(versionClient.Download().Value.BodyStream), m_blobContent);
     EXPECT_EQ(versionClient.GetProperties().Value.Metadata, m_blobUploadOptions.Metadata);
     EXPECT_TRUE(versionClient.GetProperties().Value.IsServerEncrypted);
@@ -548,21 +551,20 @@ namespace Azure { namespace Storage { namespace Test {
 
     Azure::Storage::Blobs::CreateBlobSnapshotOptions options;
     options.Metadata = {{"snapshotkey1", "snapshotvalue1"}, {"snapshotkey2", "SNAPSHOTVALUE2"}};
-    res = blockBlobClient.CreateSnapshot(options);
+    res = blobClient.CreateSnapshot(options);
     EXPECT_FALSE(res.Value.Snapshot.empty());
-    auto snapshotClient2 = blockBlobClient.WithSnapshot(res.Value.Snapshot);
+    auto snapshotClient2 = blobClient.WithSnapshot(res.Value.Snapshot);
     EXPECT_EQ(snapshotClient2.GetProperties().Value.Metadata, options.Metadata);
 
     EXPECT_NO_THROW(snapshotClient.Delete());
     EXPECT_NO_THROW(snapshotClient2.Delete());
     EXPECT_NO_THROW(versionClient.Delete());
-    EXPECT_NO_THROW(blockBlobClient.GetProperties());
+    EXPECT_NO_THROW(blobClient.GetProperties());
   }
 
   TEST_F(BlockBlobClientTest, IsCurrentVersion)
   {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
+    auto blobClient = *m_blockBlobClient;
 
     std::vector<uint8_t> emptyContent;
     blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
@@ -600,7 +602,7 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(downloadResponse.Value.Details.IsCurrentVersion.Value());
     EXPECT_EQ(version1, downloadResponse.Value.Details.VersionId.Value());
 
-    auto blobItem = GetBlobItem(testName, Blobs::Models::ListBlobsIncludeFlags::Versions);
+    auto blobItem = GetBlobItem(m_blobName, Blobs::Models::ListBlobsIncludeFlags::Versions);
     ASSERT_TRUE(blobItem.VersionId.HasValue());
     ASSERT_TRUE(blobItem.IsCurrentVersion.HasValue());
     if (blobItem.VersionId.Value() == latestVersion)
@@ -615,17 +617,11 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, Properties)
   {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
+    auto blobClient = *m_blockBlobClient;
 
-    auto blobContent
-        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-    blockBlobClient.Upload(blobContent);
-    blockBlobClient.SetMetadata(m_blobUploadOptions.Metadata);
-    blockBlobClient.SetAccessTier(Azure::Storage::Blobs::Models::AccessTier::Cool);
-    blockBlobClient.SetHttpHeaders(m_blobUploadOptions.HttpHeaders);
+    blobClient.SetAccessTier(Azure::Storage::Blobs::Models::AccessTier::Cool);
 
-    auto res = blockBlobClient.GetProperties();
+    auto res = blobClient.GetProperties();
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderDate).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderXMsVersion).empty());
@@ -642,32 +638,25 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, StageBlock)
   {
-    auto const testName(GetTestName());
-    auto client = GetBlockBlobClient(testName);
-    UploadBlockBlob(8_MB);
+    auto srcBlobClient = *m_blockBlobClient;
+
+    auto blobClient = GetBlockBlobClientForTest(RandomString());
 
     const std::string blockId1 = Base64EncodeText("0");
     const std::string blockId2 = Base64EncodeText("1");
-    auto blockBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        testName + "extra",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
-    std::vector<uint8_t> block1Content;
-    block1Content.resize(100);
-    RandomBuffer(reinterpret_cast<char*>(&block1Content[0]), block1Content.size());
+    std::vector<uint8_t> block1Content = RandomBuffer(100);
     auto blockContent
         = Azure::Core::IO::MemoryBodyStream(block1Content.data(), block1Content.size());
-    blockBlobClient.StageBlock(blockId1, blockContent);
+    blobClient.StageBlock(blockId1, blockContent);
     Azure::Storage::Blobs::CommitBlockListOptions options;
     options.HttpHeaders = m_blobUploadOptions.HttpHeaders;
     options.Metadata = m_blobUploadOptions.Metadata;
-    auto blobContentInfo = blockBlobClient.CommitBlockList({blockId1}, options);
+    auto blobContentInfo = blobClient.CommitBlockList({blockId1}, options);
     EXPECT_TRUE(blobContentInfo.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(blobContentInfo.Value.LastModified));
     EXPECT_TRUE(blobContentInfo.Value.VersionId.HasValue());
     EXPECT_FALSE(blobContentInfo.Value.VersionId.Value().empty());
-    auto res = blockBlobClient.GetBlockList();
+    auto res = blobClient.GetBlockList();
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderDate).empty());
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderXMsVersion).empty());
@@ -679,496 +668,720 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(res.Value.CommittedBlocks[0].Size, static_cast<int64_t>(block1Content.size()));
     EXPECT_TRUE(res.Value.UncommittedBlocks.empty());
 
-    blockBlobClient.StageBlockFromUri(blockId2, client.GetUrl() + GetSas());
+    blobClient.StageBlockFromUri(blockId2, srcBlobClient.GetUrl() + GetSas());
     Blobs::GetBlockListOptions options2;
     options2.ListType = Blobs::Models::BlockListType::All;
-    res = blockBlobClient.GetBlockList(options2);
+    res = blobClient.GetBlockList(options2);
     EXPECT_EQ(res.Value.BlobSize, static_cast<int64_t>(block1Content.size()));
     ASSERT_FALSE(res.Value.UncommittedBlocks.empty());
     EXPECT_EQ(res.Value.UncommittedBlocks[0].Name, blockId2);
     EXPECT_EQ(res.Value.UncommittedBlocks[0].Size, static_cast<int64_t>(m_blobContent.size()));
 
-    blockBlobClient.CommitBlockList({blockId1, blockId2});
-    res = blockBlobClient.GetBlockList(options2);
+    blobClient.CommitBlockList({blockId1, blockId2});
+    res = blobClient.GetBlockList(options2);
     EXPECT_EQ(
         res.Value.BlobSize, static_cast<int64_t>(block1Content.size() + m_blobContent.size()));
     EXPECT_TRUE(res.Value.UncommittedBlocks.empty());
   }
 
-  namespace {
+  TEST_F(BlockBlobClientTest, DeleteIfExists)
+  {
+    auto blobClient = GetBlockBlobClientForTest(RandomString());
 
-    struct BlobConcurrentDownloadParameter
+    auto blobClientWithoutAuth = Azure::Storage::Blobs::BlockBlobClient(
+        blobClient.GetUrl(), InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
     {
-      int Concurrency;
-      int64_t DownloadSize;
-      Azure::Nullable<int64_t> Offset = {};
-      Azure::Nullable<int64_t> Length = {};
-      Azure::Nullable<int64_t> InitialChunkSize = {};
-      Azure::Nullable<int64_t> ChunkSize = {};
-    };
-
-    struct BlobConcurrentUploadParameter
+      auto response = blobClient.DeleteIfExists();
+      EXPECT_FALSE(response.Value.Deleted);
+    }
+    std::vector<uint8_t> emptyContent;
+    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+    EXPECT_THROW(blobClientWithoutAuth.DeleteIfExists(), StorageException);
     {
-      int Concurrency;
-      int64_t Size;
-    };
+      auto response = blobClient.DeleteIfExists();
+      EXPECT_TRUE(response.Value.Deleted);
+    }
 
-    class DownloadBlockBlob
-        : public BlockBlobClientTest,
-          public ::testing::WithParamInterface<BlobConcurrentDownloadParameter> {
-    };
-
-    class UploadBlockBlob : public BlockBlobClientTest,
-                            public ::testing::WithParamInterface<BlobConcurrentUploadParameter> {
-    };
-
-#define APPEND_IF_NOT_NULL(value, suffix, destination) \
-  if (value) \
-  { \
-    destination.append(suffix + std::to_string(value.Value())); \
+    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+    auto snapshot = blobClient.CreateSnapshot().Value.Snapshot;
+    auto blobClientWithSnapshot = blobClient.WithSnapshot(snapshot);
+    {
+      auto response = blobClientWithSnapshot.DeleteIfExists();
+      EXPECT_TRUE(response.Value.Deleted);
+    }
+    {
+      auto response = blobClientWithSnapshot.DeleteIfExists();
+      EXPECT_FALSE(response.Value.Deleted);
+    }
   }
 
-    std::string GetDownloadSuffix(const testing::TestParamInfo<DownloadBlockBlob::ParamType>& info)
-    {
-      // Can't use empty spaces or underscores (_) as per google test documentation
-      // http://google.github.io/googletest/advanced.html#specifying-names-for-value-parameterized-test-parameters
-      auto const& p = info.param;
-      std::string suffix(
-          "c" + std::to_string(p.Concurrency) + "s" + std::to_string(p.DownloadSize));
-      APPEND_IF_NOT_NULL(p.Offset, "o", suffix)
-      APPEND_IF_NOT_NULL(p.Length, "l", suffix)
-      APPEND_IF_NOT_NULL(p.InitialChunkSize, "ics", suffix)
-      APPEND_IF_NOT_NULL(p.ChunkSize, "cs", suffix)
-      return suffix;
-    }
-
-    std::string GetUploadSuffix(const testing::TestParamInfo<UploadBlockBlob::ParamType>& info)
-    {
-      // Can't use empty spaces or underscores (_) as per google test documentation
-      // http://google.github.io/googletest/advanced.html#specifying-names-for-value-parameterized-test-parameters
-      auto const& p = info.param;
-      std::string suffix("c" + std::to_string(p.Concurrency) + "s" + std::to_string(p.Size));
-      return suffix;
-    }
-
-    std::vector<BlobConcurrentDownloadParameter> GetDownloadParameters(int64_t const blobSize)
-    {
-      std::vector<BlobConcurrentDownloadParameter> testParametes;
-      for (int c : {1, 2, 4})
-      {
-        // download whole blob
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize}));
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize, 0}));
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize, 0, blobSize}));
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize, 0, blobSize * 2}));
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize * 2}));
-
-        // Do offset
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize, 0, 1}));
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize, 1, 1}));
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize, blobSize - 1, 1}));
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize, blobSize - 1, 2}));
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize, blobSize, 1}));
-        testParametes.emplace_back(BlobConcurrentDownloadParameter({c, blobSize, blobSize + 1, 2}));
-
-        // // initial chunk size
-        testParametes.emplace_back(
-            BlobConcurrentDownloadParameter({c, blobSize, 0, 1024, 512, 1024}));
-        testParametes.emplace_back(
-            BlobConcurrentDownloadParameter({c, blobSize, 0, 1024, 1024, 1024}));
-        testParametes.emplace_back(
-            BlobConcurrentDownloadParameter({c, blobSize, 0, 1024, 2048, 1024}));
-      }
-      return testParametes;
-    }
-
-    std::vector<BlobConcurrentUploadParameter> GetUploadParameters()
-    {
-      std::vector<BlobConcurrentUploadParameter> testParametes;
-      for (int c : {1, 2, 4})
-      {
-        for (int64_t l :
-             {0ULL, 1ULL, 2ULL, 2_KB, 4_KB, 999_KB, 1_MB, 2_MB - 1, 3_MB, 5_MB, 8_MB - 1234, 8_MB})
-        {
-          testParametes.emplace_back(BlobConcurrentUploadParameter({c, l}));
-        }
-      }
-      return testParametes;
-    }
-
-  } // namespace
-
-  TEST_P(DownloadBlockBlob, downloadToBuffer)
+  TEST_F(BlockBlobClientTest, DeleteSnapshots)
   {
-    BlobConcurrentDownloadParameter const& p(GetParam());
-    auto const testName(GetTestName(true));
-    auto client = GetBlockBlobClient(testName);
-    UploadBlockBlob(8_MB);
+    auto blobClient = *m_blockBlobClient;
 
-    std::vector<uint8_t> downloadBuffer;
-    std::vector<uint8_t> expectedData = m_blobContent;
-    int64_t blobSize = m_blobContent.size();
-    int64_t actualDownloadSize = std::min(p.DownloadSize, blobSize);
-    if (p.Offset.HasValue() && p.Length.HasValue())
+    std::vector<uint8_t> emptyContent;
+    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+    auto s1 = blobClient.CreateSnapshot().Value.Snapshot;
+    Blobs::DeleteBlobOptions deleteOptions;
+    EXPECT_THROW(blobClient.Delete(deleteOptions), StorageException);
+    deleteOptions.DeleteSnapshots = Blobs::Models::DeleteSnapshotsOption::OnlySnapshots;
+    EXPECT_NO_THROW(blobClient.Delete(deleteOptions));
+    EXPECT_NO_THROW(blobClient.GetProperties());
+    EXPECT_THROW(blobClient.WithSnapshot(s1).GetProperties(), StorageException);
+    auto s2 = blobClient.CreateSnapshot().Value.Snapshot;
+    deleteOptions.DeleteSnapshots = Blobs::Models::DeleteSnapshotsOption::IncludeSnapshots;
+    EXPECT_NO_THROW(blobClient.Delete(deleteOptions));
+    EXPECT_THROW(blobClient.GetProperties(), StorageException);
+    EXPECT_THROW(blobClient.WithSnapshot(s2).GetProperties(), StorageException);
+  }
+
+  TEST_F(BlockBlobClientTest, SetTier)
+  {
+    const std::string blobName = RandomString();
+    auto blobClient = GetBlockBlobClientForTest(blobName);
+
+    std::vector<uint8_t> emptyContent;
+    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+
+    auto properties = blobClient.GetProperties().Value;
+    ASSERT_TRUE(properties.AccessTier.HasValue());
+    ASSERT_TRUE(properties.IsAccessTierInferred.HasValue());
+    EXPECT_TRUE(properties.IsAccessTierInferred.Value());
+    EXPECT_FALSE(properties.AccessTierChangedOn.HasValue());
+
+    auto blobItem = GetBlobItem(blobName);
+    ASSERT_TRUE(blobItem.Details.AccessTier.HasValue());
+    ASSERT_TRUE(blobItem.Details.IsAccessTierInferred.HasValue());
+    EXPECT_TRUE(blobItem.Details.IsAccessTierInferred.Value());
+    EXPECT_FALSE(blobItem.Details.AccessTierChangedOn.HasValue());
+
+    // choose a different tier
+    auto targetTier = properties.AccessTier.Value() == Blobs::Models::AccessTier::Hot
+        ? Blobs::Models::AccessTier::Cool
+        : Blobs::Models::AccessTier::Hot;
+    blobClient.SetAccessTier(targetTier);
+
+    properties = blobClient.GetProperties().Value;
+    ASSERT_TRUE(properties.AccessTier.HasValue());
+    ASSERT_TRUE(properties.IsAccessTierInferred.HasValue());
+    EXPECT_FALSE(properties.IsAccessTierInferred.Value());
+    EXPECT_TRUE(properties.AccessTierChangedOn.HasValue());
+
+    blobItem = GetBlobItem(blobName);
+    ASSERT_TRUE(blobItem.Details.AccessTier.HasValue());
+    ASSERT_TRUE(blobItem.Details.IsAccessTierInferred.HasValue());
+    EXPECT_FALSE(blobItem.Details.IsAccessTierInferred.Value());
+    EXPECT_TRUE(blobItem.Details.AccessTierChangedOn.HasValue());
+
+    // set to archive, then rehydrate
+    blobClient.SetAccessTier(Blobs::Models::AccessTier::Archive);
+    blobClient.SetAccessTier(Blobs::Models::AccessTier::Hot);
+    properties = blobClient.GetProperties().Value;
+    ASSERT_TRUE(properties.ArchiveStatus.HasValue());
+    EXPECT_EQ(
+        properties.ArchiveStatus.Value(), Blobs::Models::ArchiveStatus::RehydratePendingToHot);
+    ASSERT_TRUE(properties.RehydratePriority.HasValue());
+    EXPECT_EQ(properties.RehydratePriority.Value(), Blobs::Models::RehydratePriority::Standard);
+
+    blobItem = GetBlobItem(blobName);
+    ASSERT_TRUE(blobItem.Details.ArchiveStatus.HasValue());
+    EXPECT_EQ(
+        blobItem.Details.ArchiveStatus.Value(),
+        Blobs::Models::ArchiveStatus::RehydratePendingToHot);
+    ASSERT_TRUE(blobItem.Details.RehydratePriority.HasValue());
+    EXPECT_EQ(
+        blobItem.Details.RehydratePriority.Value(), Blobs::Models::RehydratePriority::Standard);
+  }
+
+  TEST_F(BlockBlobClientTest, DISABLED_SetTierCold)
+  {
+
+    auto const testName(GetTestName());
+    auto blobClient = GetBlockBlobClient(testName);
+
+    std::vector<uint8_t> emptyContent;
+    std::string blobName(testName);
+    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+
+    // set to cold
+    blobClient.SetAccessTier(Blobs::Models::AccessTier::Cold);
+    auto properties = blobClient.GetProperties().Value;
+    EXPECT_EQ(properties.AccessTier.Value(), Blobs::Models::AccessTier::Cold);
+  }
+
+  TEST_F(BlockBlobClientTest, SetTierWithLeaseId)
+  {
+    auto blobClient = *m_blockBlobClient;
+
+    std::vector<uint8_t> emptyContent;
+    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+
+    const std::string leaseId = RandomUUID();
+    Blobs::BlobLeaseClient leaseClient(blobClient, leaseId);
+    leaseClient.Acquire(std::chrono::seconds(30));
+
+    EXPECT_THROW(blobClient.SetAccessTier(Blobs::Models::AccessTier::Cool), StorageException);
+
+    Blobs::SetBlobAccessTierOptions options;
+    options.AccessConditions.LeaseId = leaseId;
+    EXPECT_NO_THROW(blobClient.SetAccessTier(Blobs::Models::AccessTier::Cool, options));
+  }
+
+  TEST_F(BlockBlobClientTest, UncommittedBlob)
+  {
+    const std::string blobName = RandomString();
+    auto blobClient = GetBlockBlobClientForTest(blobName);
+
+    std::vector<uint8_t> buffer(100);
+    Azure::Core::IO::MemoryBodyStream stream(buffer.data(), buffer.size());
+    blobClient.StageBlock("YWJjZA==", stream);
+
+    Blobs::GetBlockListOptions getBlockListOptions;
+    getBlockListOptions.ListType = Blobs::Models::BlockListType::All;
+    auto res = blobClient.GetBlockList(getBlockListOptions).Value;
+    EXPECT_FALSE(res.ETag.HasValue());
+    EXPECT_EQ(res.BlobSize, 0);
+    EXPECT_TRUE(res.CommittedBlocks.empty());
+    EXPECT_FALSE(res.UncommittedBlocks.empty());
+
+    auto blobItem = GetBlobItem(blobName, Blobs::Models::ListBlobsIncludeFlags::UncomittedBlobs);
+    EXPECT_EQ(blobItem.BlobSize, 0);
+  }
+
+  TEST_F(BlockBlobClientTest, SourceTagsConditions)
+  {
+    auto containerClient = *m_blobContainerClient;
+
+    auto sourceBlobClient = *m_blockBlobClient;
+    std::map<std::string, std::string> tags;
+    tags["key1"] = "value1";
+    sourceBlobClient.SetTags(tags);
+
+    const std::string successfulTagConditions = "key1 = 'value1'";
+    const std::string failedTagConditions = "key1 != 'value1'";
+
+    auto destBlobClient = containerClient.GetBlockBlobClient("dest" + RandomString());
     {
-      actualDownloadSize = std::min(p.Length.Value(), blobSize - p.Offset.Value());
-      if (actualDownloadSize >= 0)
-      {
-        expectedData.assign(
-            m_blobContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value()),
-            m_blobContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value() + actualDownloadSize));
-      }
-      else
-      {
-        expectedData.clear();
-      }
-    }
-    else if (p.Offset.HasValue())
-    {
-      actualDownloadSize = blobSize - p.Offset.Value();
-      if (actualDownloadSize >= 0)
-      {
-        expectedData.assign(
-            m_blobContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value()), m_blobContent.end());
-      }
-      else
-      {
-        expectedData.clear();
-      }
-    }
-    downloadBuffer.resize(static_cast<size_t>(p.DownloadSize), '\x00');
-    Blobs::DownloadBlobToOptions options;
-    options.TransferOptions.Concurrency = p.Concurrency;
-    if (p.Offset.HasValue() || p.Length.HasValue())
-    {
-      options.Range = Core::Http::HttpRange();
-      options.Range.Value().Offset = p.Offset.Value();
-      options.Range.Value().Length = p.Length;
-    }
-    if (p.InitialChunkSize.HasValue())
-    {
-      options.TransferOptions.InitialChunkSize = p.InitialChunkSize.Value();
-    }
-    if (p.ChunkSize.HasValue())
-    {
-      options.TransferOptions.ChunkSize = p.ChunkSize.Value();
-    }
-    if (actualDownloadSize > 0)
-    {
-      auto res = client.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options);
-      EXPECT_EQ(res.Value.BlobSize, blobSize);
-      EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
-      EXPECT_EQ(res.Value.ContentRange.Offset, p.Offset.HasValue() ? p.Offset.Value() : 0);
-      downloadBuffer.resize(static_cast<size_t>(res.Value.ContentRange.Length.Value()));
-      EXPECT_EQ(downloadBuffer, expectedData);
-    }
-    else
-    {
+      Blobs::StartBlobCopyFromUriOptions options;
+      options.SourceAccessConditions.TagConditions = successfulTagConditions;
+      EXPECT_NO_THROW(destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options));
+      options.SourceAccessConditions.TagConditions = failedTagConditions;
       EXPECT_THROW(
-          client.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options),
+          destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options), StorageException);
+
+      Blobs::UploadBlockBlobFromUriOptions options2;
+      options2.SourceAccessConditions.TagConditions = successfulTagConditions;
+      EXPECT_NO_THROW(destBlobClient.UploadFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
+      options2.SourceAccessConditions.TagConditions = failedTagConditions;
+      EXPECT_NO_THROW(destBlobClient.UploadFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
+    }
+  }
+
+  TEST_F(BlockBlobClientTest, SourceBlobAccessConditions)
+  {
+    auto containerClient = *m_blobContainerClient;
+
+    auto sourceBlobClient = containerClient.GetBlockBlobClient("source" + RandomString());
+
+    std::vector<uint8_t> buffer;
+    buffer.resize(1024);
+    auto createResponse = sourceBlobClient.UploadFrom(buffer.data(), buffer.size());
+    Azure::ETag eTag = createResponse.Value.ETag;
+    auto lastModifiedTime = createResponse.Value.LastModified;
+    auto timeBeforeStr = lastModifiedTime - std::chrono::seconds(2);
+    auto timeAfterStr = lastModifiedTime + std::chrono::seconds(2);
+
+    auto destBlobClient = containerClient.GetBlockBlobClient("dest" + RandomString());
+
+    {
+      Blobs::StartBlobCopyFromUriOptions options;
+      options.SourceAccessConditions.IfMatch = eTag;
+      EXPECT_NO_THROW(destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options));
+      options.SourceAccessConditions.IfMatch = DummyETag;
+      EXPECT_THROW(
+          destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options), StorageException);
+
+      Blobs::CopyBlobFromUriOptions options2;
+      options2.SourceAccessConditions.IfMatch = eTag;
+      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
+      options2.SourceAccessConditions.IfMatch = DummyETag;
+      EXPECT_THROW(
+          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2),
           StorageException);
     }
+    {
+      Blobs::StartBlobCopyFromUriOptions options;
+      options.SourceAccessConditions.IfNoneMatch = DummyETag;
+      EXPECT_NO_THROW(destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options));
+      options.SourceAccessConditions.IfNoneMatch = eTag;
+      EXPECT_THROW(
+          destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options), StorageException);
+
+      Blobs::CopyBlobFromUriOptions options2;
+      options2.SourceAccessConditions.IfNoneMatch = DummyETag;
+      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
+      options2.SourceAccessConditions.IfNoneMatch = eTag;
+      EXPECT_THROW(
+          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2),
+          StorageException);
+    }
+    {
+      Blobs::StartBlobCopyFromUriOptions options;
+      options.SourceAccessConditions.IfModifiedSince = timeBeforeStr;
+      EXPECT_NO_THROW(destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options));
+      options.SourceAccessConditions.IfModifiedSince = timeAfterStr;
+      EXPECT_THROW(
+          destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options), StorageException);
+
+      sourceBlobClient.GetProperties();
+      Blobs::CopyBlobFromUriOptions options2;
+      options2.SourceAccessConditions.IfModifiedSince = timeBeforeStr;
+      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
+      options2.SourceAccessConditions.IfModifiedSince = timeAfterStr;
+      EXPECT_THROW(
+          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2),
+          StorageException);
+    }
+    {
+      Blobs::StartBlobCopyFromUriOptions options;
+      options.SourceAccessConditions.IfUnmodifiedSince = timeAfterStr;
+      EXPECT_NO_THROW(destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options));
+      options.SourceAccessConditions.IfUnmodifiedSince = timeBeforeStr;
+      EXPECT_THROW(
+          destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options), StorageException);
+
+      Blobs::CopyBlobFromUriOptions options2;
+      options2.SourceAccessConditions.IfUnmodifiedSince = timeAfterStr;
+      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
+      options2.SourceAccessConditions.IfUnmodifiedSince = timeBeforeStr;
+      EXPECT_THROW(
+          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2),
+          StorageException);
+    }
+
+    // lease
+    {
+      const std::string leaseId = RandomUUID();
+      const std::string dummyLeaseId = RandomUUID();
+      Blobs::BlobLeaseClient leaseClient(destBlobClient, leaseId);
+
+      leaseClient.Acquire(std::chrono::seconds(60));
+
+      Blobs::CopyBlobFromUriOptions options;
+      options.AccessConditions.LeaseId = dummyLeaseId;
+      EXPECT_THROW(
+          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options),
+          StorageException);
+      options.AccessConditions.LeaseId = leaseId;
+      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options));
+      leaseClient.Release();
+    }
   }
 
-  TEST_P(DownloadBlockBlob, downloadToFile)
+  TEST_F(BlockBlobClientTest, DISABLED_Immutability)
   {
-    BlobConcurrentDownloadParameter const& p(GetParam());
-    auto const testName(GetTestName(true));
-    auto client = GetBlockBlobClient(testName);
-    UploadBlockBlob(8_MB);
+    const auto ImmutabilityMaxLength = std::chrono::seconds(5);
+    const std::string blobName = m_blobName;
+    auto blobClient = *m_blockBlobClient;
 
-    std::string tempFilename(testName);
-    std::vector<uint8_t> expectedData = m_blobContent;
-    int64_t blobSize = m_blobContent.size();
-    int64_t actualDownloadSize = std::min(p.DownloadSize, blobSize);
-    if (p.Offset.HasValue() && p.Length.HasValue())
+    std::vector<uint8_t> emptyContent;
+    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+
+    auto blobContainerClient = *m_blobContainerClient;
+    ASSERT_TRUE(blobContainerClient.GetProperties().Value.HasImmutableStorageWithVersioning);
+
+    Blobs::Models::BlobImmutabilityPolicy policy;
+    policy.ExpiresOn = Azure::DateTime::Parse(
+        Azure::DateTime(std::chrono::system_clock::now() + ImmutabilityMaxLength)
+            .ToString(Azure::DateTime::DateFormat::Rfc1123),
+        Azure::DateTime::DateFormat::Rfc1123);
+    policy.PolicyMode = Blobs::Models::BlobImmutabilityPolicyMode::Unlocked;
+    auto setPolicyResponse = blobClient.SetImmutabilityPolicy(policy);
+    EXPECT_EQ(setPolicyResponse.Value.ImmutabilityPolicy, policy);
+    auto blobProperties = blobClient.GetProperties().Value;
+    ASSERT_TRUE(blobProperties.ImmutabilityPolicy.HasValue());
+    EXPECT_EQ(blobProperties.ImmutabilityPolicy.Value(), policy);
+    auto downloadResponse = blobClient.Download();
+    ASSERT_TRUE(downloadResponse.Value.Details.ImmutabilityPolicy.HasValue());
+    EXPECT_EQ(downloadResponse.Value.Details.ImmutabilityPolicy.Value(), policy);
+    auto blobItem = GetBlobItem(blobName, Blobs::Models::ListBlobsIncludeFlags::ImmutabilityPolicy);
+    ASSERT_TRUE(blobItem.Details.ImmutabilityPolicy.HasValue());
+    EXPECT_EQ(blobItem.Details.ImmutabilityPolicy.Value(), policy);
+
+    EXPECT_NO_THROW(blobClient.DeleteImmutabilityPolicy());
+    blobProperties = blobClient.GetProperties().Value;
+    EXPECT_FALSE(blobProperties.ImmutabilityPolicy.HasValue());
+    downloadResponse = blobClient.Download();
+    ASSERT_FALSE(downloadResponse.Value.Details.ImmutabilityPolicy.HasValue());
+    blobItem = GetBlobItem(blobName, Blobs::Models::ListBlobsIncludeFlags::ImmutabilityPolicy);
+    ASSERT_FALSE(blobItem.Details.ImmutabilityPolicy.HasValue());
+
+    auto copySourceBlobClient = GetBlockBlobClientForTest(blobName + "src");
+    copySourceBlobClient.UploadFrom(emptyContent.data(), emptyContent.size());
     {
-      actualDownloadSize = std::min(p.Length.Value(), blobSize - p.Offset.Value());
-      if (actualDownloadSize >= 0)
-      {
-        expectedData.assign(
-            m_blobContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value()),
-            m_blobContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value() + actualDownloadSize));
-      }
-      else
-      {
-        expectedData.clear();
-      }
+      auto copyDestinationBlobClient = GetBlockBlobClientForTest(blobName + "dest1");
+      Blobs::StartBlobCopyFromUriOptions options;
+      options.ImmutabilityPolicy = policy;
+      copyDestinationBlobClient.StartCopyFromUri(copySourceBlobClient.GetUrl() + GetSas(), options)
+          .PollUntilDone(std::chrono::seconds(1));
+      EXPECT_EQ(copyDestinationBlobClient.GetProperties().Value.ImmutabilityPolicy.Value(), policy);
     }
-    else if (p.Offset.HasValue())
     {
-      actualDownloadSize = blobSize - p.Offset.Value();
-      if (actualDownloadSize >= 0)
-      {
-        expectedData.assign(
-            m_blobContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value()), m_blobContent.end());
-      }
-      else
-      {
-        expectedData.clear();
-      }
+      auto copyDestinationBlobClient = GetBlockBlobClientForTest(blobName + "dest2");
+      Blobs::CopyBlobFromUriOptions options;
+      options.ImmutabilityPolicy = policy;
+      copyDestinationBlobClient.CopyFromUri(copySourceBlobClient.GetUrl() + GetSas(), options);
+      EXPECT_EQ(copyDestinationBlobClient.GetProperties().Value.ImmutabilityPolicy.Value(), policy);
     }
-    Blobs::DownloadBlobToOptions options;
-    options.TransferOptions.Concurrency = p.Concurrency;
-    if (p.Offset.HasValue() || p.Length.HasValue())
-    {
-      options.Range = Core::Http::HttpRange();
-      options.Range.Value().Offset = p.Offset.Value();
-      options.Range.Value().Length = p.Length;
-    }
-    if (p.InitialChunkSize.HasValue())
-    {
-      options.TransferOptions.InitialChunkSize = p.InitialChunkSize.Value();
-    }
-    if (p.ChunkSize.HasValue())
-    {
-      options.TransferOptions.ChunkSize = p.ChunkSize.Value();
-    }
-    if (actualDownloadSize > 0)
-    {
-      auto res = client.DownloadTo(tempFilename, options);
-      EXPECT_EQ(res.Value.BlobSize, blobSize);
-      EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
-      EXPECT_EQ(res.Value.ContentRange.Offset, p.Offset.HasValue() ? p.Offset.Value() : 0);
-      EXPECT_EQ(ReadFile(tempFilename), expectedData);
-    }
-    else
-    {
-      EXPECT_THROW(client.DownloadTo(tempFilename, options), StorageException);
-    }
-    DeleteFile(tempFilename);
+
+    std::this_thread::sleep_for(ImmutabilityMaxLength);
   }
 
-  INSTANTIATE_TEST_SUITE_P(
-      withParam,
-      DownloadBlockBlob,
-      testing::ValuesIn(GetDownloadParameters(8_MB)),
-      GetDownloadSuffix);
-
-  TEST_F(BlockBlobClientTest, ConcurrentDownload_LIVEONLY_)
+  TEST_F(BlockBlobClientTest, DISABLED_ImmutabilityAccessCondition)
   {
-    CHECK_SKIP_TEST();
-    auto const testName(GetTestName());
-    auto client = GetBlockBlobClient(testName);
-    UploadBlockBlob(8_MB);
+    const auto ImmutabilityMaxLength = std::chrono::seconds(5);
 
-    auto testDownloadToBuffer = [&](int concurrency,
-                                    int64_t downloadSize,
-                                    Azure::Nullable<int64_t> offset = {},
-                                    Azure::Nullable<int64_t> length = {},
-                                    Azure::Nullable<int64_t> initialChunkSize = {},
-                                    Azure::Nullable<int64_t> chunkSize = {}) {
-      std::vector<uint8_t> downloadBuffer;
-      std::vector<uint8_t> expectedData = m_blobContent;
-      int64_t blobSize = m_blobContent.size();
-      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
-      if (offset.HasValue() && length.HasValue())
-      {
-        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
-        if (actualDownloadSize >= 0)
-        {
-          expectedData.assign(
-              m_blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
-              m_blobContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
-        }
-        else
-        {
-          expectedData.clear();
-        }
-      }
-      else if (offset.HasValue())
-      {
-        actualDownloadSize = blobSize - offset.Value();
-        if (actualDownloadSize >= 0)
-        {
-          expectedData.assign(
-              m_blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()), m_blobContent.end());
-        }
-        else
-        {
-          expectedData.clear();
-        }
-      }
-      downloadBuffer.resize(static_cast<size_t>(downloadSize), '\x00');
-      Blobs::DownloadBlobToOptions options;
-      options.TransferOptions.Concurrency = concurrency;
-      if (offset.HasValue() || length.HasValue())
-      {
-        options.Range = Core::Http::HttpRange();
-        options.Range.Value().Offset = offset.Value();
-        options.Range.Value().Length = length;
-      }
-      if (initialChunkSize.HasValue())
-      {
-        options.TransferOptions.InitialChunkSize = initialChunkSize.Value();
-      }
-      if (chunkSize.HasValue())
-      {
-        options.TransferOptions.ChunkSize = chunkSize.Value();
-      }
-      if (actualDownloadSize > 0)
-      {
-        auto res = client.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options);
-        EXPECT_EQ(res.Value.BlobSize, blobSize);
-        EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
-        EXPECT_EQ(res.Value.ContentRange.Offset, offset.HasValue() ? offset.Value() : 0);
-        downloadBuffer.resize(static_cast<size_t>(res.Value.ContentRange.Length.Value()));
-        EXPECT_EQ(downloadBuffer, expectedData);
-      }
-      else
-      {
-        EXPECT_THROW(
-            client.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options),
-            StorageException);
-      }
-    };
+    auto blobClient = *m_blockBlobClient;
+    std::vector<uint8_t> emptyContent;
+    auto uploadResponse = blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+    auto lastModifiedTime = uploadResponse.Value.LastModified;
+    auto timeBeforeStr = lastModifiedTime - std::chrono::minutes(1);
+    auto timeAfterStr = lastModifiedTime + std::chrono::minutes(1);
 
-    auto testDownloadToFile = [&](int concurrency,
-                                  int64_t downloadSize,
-                                  Azure::Nullable<int64_t> offset = {},
-                                  Azure::Nullable<int64_t> length = {},
-                                  Azure::Nullable<int64_t> initialChunkSize = {},
-                                  Azure::Nullable<int64_t> chunkSize = {}) {
-      std::string tempFilename = testName + "file" + std::to_string(concurrency);
-      if (offset)
-      {
-        tempFilename.append(std::to_string(offset.Value()));
-      }
-      std::vector<uint8_t> expectedData = m_blobContent;
-      int64_t blobSize = m_blobContent.size();
-      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
-      if (offset.HasValue() && length.HasValue())
-      {
-        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
-        if (actualDownloadSize >= 0)
-        {
-          expectedData.assign(
-              m_blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
-              m_blobContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
-        }
-        else
-        {
-          expectedData.clear();
-        }
-      }
-      else if (offset.HasValue())
-      {
-        actualDownloadSize = blobSize - offset.Value();
-        if (actualDownloadSize >= 0)
-        {
-          expectedData.assign(
-              m_blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()), m_blobContent.end());
-        }
-        else
-        {
-          expectedData.clear();
-        }
-      }
-      Blobs::DownloadBlobToOptions options;
-      options.TransferOptions.Concurrency = concurrency;
-      if (offset.HasValue() || length.HasValue())
-      {
-        options.Range = Core::Http::HttpRange();
-        options.Range.Value().Offset = offset.Value();
-        options.Range.Value().Length = length;
-      }
-      if (initialChunkSize.HasValue())
-      {
-        options.TransferOptions.InitialChunkSize = initialChunkSize.Value();
-      }
-      if (chunkSize.HasValue())
-      {
-        options.TransferOptions.ChunkSize = chunkSize.Value();
-      }
-      if (actualDownloadSize > 0)
-      {
-        auto res = client.DownloadTo(tempFilename, options);
-        EXPECT_EQ(res.Value.BlobSize, blobSize);
-        EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
-        EXPECT_EQ(res.Value.ContentRange.Offset, offset.HasValue() ? offset.Value() : 0);
-        EXPECT_EQ(ReadFile(tempFilename), expectedData);
-      }
-      else
-      {
-        EXPECT_THROW(client.DownloadTo(tempFilename, options), StorageException);
-      }
-      DeleteFile(tempFilename);
-    };
+    Blobs::Models::BlobImmutabilityPolicy policy;
+    policy.ExpiresOn = Azure::DateTime::Parse(
+        Azure::DateTime(std::chrono::system_clock::now() + ImmutabilityMaxLength)
+            .ToString(Azure::DateTime::DateFormat::Rfc1123),
+        Azure::DateTime::DateFormat::Rfc1123);
+    policy.PolicyMode = Blobs::Models::BlobImmutabilityPolicyMode::Unlocked;
 
-    const int64_t blobSize = m_blobContent.size();
-    std::vector<std::future<void>> futures;
-    for (int c : {1, 2, 4})
+    Blobs::SetBlobImmutabilityPolicyOptions options;
+    options.AccessConditions.IfUnmodifiedSince = timeBeforeStr;
+    EXPECT_THROW(blobClient.SetImmutabilityPolicy(policy, options), StorageException);
+    options.AccessConditions.IfUnmodifiedSince = timeAfterStr;
+    EXPECT_NO_THROW(blobClient.SetImmutabilityPolicy(policy, options));
+
+    std::this_thread::sleep_for(ImmutabilityMaxLength);
+  }
+
+  TEST_F(BlockBlobClientTest, DISABLED_LegalHold)
+  {
+    const auto testName = m_blobName;
+    auto blobClient = *m_blockBlobClient;
+    std::vector<uint8_t> emptyContent;
+
+    auto setLegalHoldResponse = blobClient.SetLegalHold(true);
+    EXPECT_TRUE(setLegalHoldResponse.Value.HasLegalHold);
+    auto blobProperties = blobClient.GetProperties().Value;
+    EXPECT_TRUE(blobProperties.HasLegalHold);
+    auto downloadResponse = blobClient.Download();
+    EXPECT_TRUE(downloadResponse.Value.Details.HasLegalHold);
+    auto blobItem = GetBlobItem(testName, Blobs::Models::ListBlobsIncludeFlags::LegalHold);
+    EXPECT_TRUE(blobItem.Details.HasLegalHold);
+
+    setLegalHoldResponse = blobClient.SetLegalHold(false);
+    EXPECT_FALSE(setLegalHoldResponse.Value.HasLegalHold);
+
+    auto copySourceBlobClient = GetBlockBlobClientForTest(RandomString() + "src");
+    copySourceBlobClient.UploadFrom(emptyContent.data(), emptyContent.size());
     {
-      // random range
-      std::mt19937_64 random_generator(std::random_device{}());
-      for (int i = 0; i < 16; ++i)
-      {
-        std::uniform_int_distribution<int64_t> offsetDistribution(0, m_blobContent.size() - 1);
-        int64_t offset = offsetDistribution(random_generator);
-        std::uniform_int_distribution<int64_t> lengthDistribution(1, 64_KB);
-        int64_t length = lengthDistribution(random_generator);
-        futures.emplace_back(std::async(
-            std::launch::async, testDownloadToBuffer, c, blobSize, offset, length, 4_KB, 4_KB));
-        futures.emplace_back(std::async(
-            std::launch::async, testDownloadToFile, c, blobSize, offset, length, 4_KB, 4_KB));
-      }
-
-      // // buffer not big enough
-      Blobs::DownloadBlobToOptions options;
-      options.TransferOptions.Concurrency = c;
-      options.Range = Core::Http::HttpRange();
-      options.Range.Value().Offset = 1;
-      for (int64_t length : {1ULL, 2ULL, 4_KB, 5_KB, 8_KB, 11_KB, 20_KB})
-      {
-        std::vector<uint8_t> downloadBuffer;
-        downloadBuffer.resize(static_cast<size_t>(length - 1));
-        options.Range.Value().Length = length;
-        EXPECT_THROW(
-            client.DownloadTo(downloadBuffer.data(), static_cast<size_t>(length - 1), options),
-            std::runtime_error);
-      }
+      auto copyDestinationBlobClient = GetBlockBlobClientForTest(RandomString() + "dest1");
+      Blobs::StartBlobCopyFromUriOptions options;
+      options.HasLegalHold = true;
+      copyDestinationBlobClient.StartCopyFromUri(copySourceBlobClient.GetUrl() + GetSas(), options)
+          .PollUntilDone(std::chrono::seconds(1));
+      EXPECT_TRUE(copyDestinationBlobClient.GetProperties().Value.HasLegalHold);
     }
-    for (auto& f : futures)
     {
-      f.get();
+      auto copyDestinationBlobClient = GetBlockBlobClientForTest(RandomString() + "dest2");
+      Blobs::CopyBlobFromUriOptions options;
+      options.HasLegalHold = true;
+      copyDestinationBlobClient.CopyFromUri(copySourceBlobClient.GetUrl() + GetSas(), options);
+      EXPECT_TRUE(copyDestinationBlobClient.GetProperties().Value.HasLegalHold);
     }
+  }
+
+  TEST_F(BlockBlobClientTest, ContentHash)
+  {
+    auto srcBlobClient = *m_blockBlobClient;
+    std::vector<uint8_t> blobContent = RandomBuffer(100);
+    srcBlobClient.UploadFrom(blobContent.data(), blobContent.size());
+    const std::vector<uint8_t> contentMd5
+        = Azure::Core::Cryptography::Md5Hash().Final(blobContent.data(), blobContent.size());
+    const std::vector<uint8_t> contentCrc64
+        = Azure::Storage::Crc64Hash().Final(blobContent.data(), blobContent.size());
+
+    Azure::Core::IO::MemoryBodyStream stream(blobContent.data(), blobContent.size());
+
+    {
+      auto destBlobClient = GetBlockBlobClientForTest(RandomString() + "dest0");
+      Blobs::UploadBlockBlobOptions options;
+      options.TransactionalContentHash = ContentHash();
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
+      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
+      stream.Rewind();
+      EXPECT_THROW(destBlobClient.Upload(stream, options), StorageException);
+      options.TransactionalContentHash.Value().Value = contentMd5;
+      stream.Rewind();
+      EXPECT_NO_THROW(destBlobClient.Upload(stream, options));
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
+      options.TransactionalContentHash.Value().Value
+          = Azure::Core::Convert::Base64Decode(DummyCrc64);
+      stream.Rewind();
+      EXPECT_THROW(destBlobClient.Upload(stream, options), StorageException);
+      options.TransactionalContentHash.Value().Value = contentCrc64;
+      stream.Rewind();
+      EXPECT_NO_THROW(destBlobClient.Upload(stream, options));
+    }
+    {
+      auto destBlobClient = GetBlockBlobClientForTest(RandomString() + "dest1");
+      Blobs::UploadBlockBlobFromUriOptions options;
+      options.TransactionalContentHash = ContentHash();
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
+      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
+      stream.Rewind();
+      EXPECT_THROW(
+          destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options),
+          StorageException);
+      options.TransactionalContentHash.Value().Value = contentMd5;
+      stream.Rewind();
+      EXPECT_NO_THROW(destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options));
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
+      options.TransactionalContentHash.Value().Value
+          = Azure::Core::Convert::Base64Decode(DummyCrc64);
+      stream.Rewind();
+      EXPECT_THROW(
+          destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options),
+          StorageException);
+      options.TransactionalContentHash.Value().Value = contentCrc64;
+      stream.Rewind();
+      EXPECT_NO_THROW(destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options));
+    }
+    {
+      auto destBlobClient = GetBlockBlobClientForTest(RandomString() + "dest2");
+      Blobs::CopyBlobFromUriOptions options;
+      options.TransactionalContentHash = ContentHash();
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
+      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
+      stream.Rewind();
+      EXPECT_THROW(
+          destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + GetSas(), options), StorageException);
+      options.TransactionalContentHash.Value().Value = contentMd5;
+      stream.Rewind();
+      EXPECT_NO_THROW(destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + GetSas(), options));
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
+      options.TransactionalContentHash.Value().Value
+          = Azure::Core::Convert::Base64Decode(DummyCrc64);
+      stream.Rewind();
+      EXPECT_THROW(
+          destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + GetSas(), options), StorageException);
+      options.TransactionalContentHash.Value().Value = contentCrc64;
+      stream.Rewind();
+      EXPECT_NO_THROW(destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + GetSas(), options));
+    }
+    {
+      auto destBlobClient = GetBlockBlobClientForTest(RandomString() + "dest3");
+      Blobs::StageBlockOptions options;
+      options.TransactionalContentHash = ContentHash();
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
+      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
+      stream.Rewind();
+      EXPECT_THROW(destBlobClient.StageBlock("YWJjZA==", stream, options), StorageException);
+      options.TransactionalContentHash.Value().Value = contentMd5;
+      stream.Rewind();
+      EXPECT_NO_THROW(destBlobClient.StageBlock("YWJjZA==", stream, options));
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
+      options.TransactionalContentHash.Value().Value
+          = Azure::Core::Convert::Base64Decode(DummyCrc64);
+      stream.Rewind();
+      EXPECT_THROW(destBlobClient.StageBlock("YWJjZA==", stream, options), StorageException);
+      options.TransactionalContentHash.Value().Value = contentCrc64;
+      stream.Rewind();
+      EXPECT_NO_THROW(destBlobClient.StageBlock("YWJjZA==", stream, options));
+    }
+    {
+      auto destBlobClient = GetBlockBlobClientForTest(RandomString() + "dest4");
+      Blobs::StageBlockFromUriOptions options;
+      options.TransactionalContentHash = ContentHash();
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
+      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
+      EXPECT_THROW(
+          destBlobClient.StageBlockFromUri("YWJjZA==", srcBlobClient.GetUrl() + GetSas(), options),
+          StorageException);
+      options.TransactionalContentHash.Value().Value = contentMd5;
+      EXPECT_NO_THROW(
+          destBlobClient.StageBlockFromUri("YWJjZA==", srcBlobClient.GetUrl() + GetSas(), options));
+      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
+      options.TransactionalContentHash.Value().Value
+          = Azure::Core::Convert::Base64Decode(DummyCrc64);
+      EXPECT_THROW(
+          destBlobClient.StageBlockFromUri("YWJjZA==", srcBlobClient.GetUrl() + GetSas(), options),
+          StorageException);
+      options.TransactionalContentHash.Value().Value = contentCrc64;
+      EXPECT_NO_THROW(
+          destBlobClient.StageBlockFromUri("YWJjZA==", srcBlobClient.GetUrl() + GetSas(), options));
+    }
+  }
+
+  TEST_F(BlockBlobClientTest, UploadFromUri)
+  {
+    auto srcBlobClient = *m_blockBlobClient;
+    std::vector<uint8_t> blobContent(100, 'a');
+    srcBlobClient.UploadFrom(blobContent.data(), blobContent.size());
+    std::map<std::string, std::string> srcTags;
+    srcTags["srctags"] = "a1212";
+    srcBlobClient.SetTags(srcTags);
+
+    const std::vector<uint8_t> blobMd5
+        = Azure::Core::Cryptography::Md5Hash().Final(blobContent.data(), blobContent.size());
+    const std::vector<uint8_t> blobCrc64
+        = Azure::Storage::Crc64Hash().Final(blobContent.data(), blobContent.size());
+
+    auto destBlobClient = GetBlockBlobClientForTest(RandomString() + "dest");
+    auto uploadFromUriResult = destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas());
+    EXPECT_TRUE(uploadFromUriResult.Value.ETag.HasValue());
+    EXPECT_TRUE(IsValidTime(uploadFromUriResult.Value.LastModified));
+    EXPECT_TRUE(uploadFromUriResult.Value.VersionId.HasValue());
+    EXPECT_TRUE(uploadFromUriResult.Value.IsServerEncrypted);
+    ASSERT_TRUE(uploadFromUriResult.Value.TransactionalContentHash.HasValue());
+    if (uploadFromUriResult.Value.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
+    {
+      EXPECT_EQ(uploadFromUriResult.Value.TransactionalContentHash.Value().Value, blobMd5);
+    }
+    else if (
+        uploadFromUriResult.Value.TransactionalContentHash.Value().Algorithm
+        == HashAlgorithm::Crc64)
+    {
+      EXPECT_EQ(uploadFromUriResult.Value.TransactionalContentHash.Value().Value, blobCrc64);
+    }
+
+    Blobs::UploadBlockBlobFromUriOptions options;
+    options.CopySourceBlobProperties = false;
+    options.HttpHeaders.ContentLanguage = "en-US";
+    options.HttpHeaders.ContentType = "application/octet-stream";
+    options.Metadata["k"] = "v";
+    options.AccessTier = Blobs::Models::AccessTier::Cool;
+    options.Tags["k1"] = "v1";
+    uploadFromUriResult = destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options);
+    auto destBlobProperties = destBlobClient.GetProperties().Value;
+    destBlobProperties.HttpHeaders.ContentHash.Value.clear();
+    EXPECT_EQ(destBlobProperties.HttpHeaders, options.HttpHeaders);
+    EXPECT_EQ(destBlobProperties.Metadata, options.Metadata);
+    EXPECT_EQ(destBlobProperties.AccessTier.Value(), options.AccessTier.Value());
+    EXPECT_EQ(static_cast<size_t>(destBlobProperties.TagCount.Value()), options.Tags.size());
+
+    options.CopySourceTagsMode = Blobs::Models::BlobCopySourceTagsMode::Copy;
+    options.Tags.clear();
+    uploadFromUriResult = destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options);
+    EXPECT_EQ(destBlobClient.GetTags().Value, srcTags);
+  }
+
+  TEST_F(BlockBlobClientTest, SetGetTagsWithLeaseId)
+  {
+    auto blobClient = *m_blockBlobClient;
+    std::vector<uint8_t> emptyContent;
+    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+
+    const std::map<std::string, std::string> tags{{"k", "v"}};
+
+    Blobs::BlobLeaseClient leaseClient(blobClient, RandomUUID());
+
+    leaseClient.Acquire(std::chrono::seconds(60));
+
+    Blobs::SetBlobTagsOptions setTagsOptions;
+    setTagsOptions.AccessConditions.LeaseId = RandomUUID();
+    EXPECT_THROW(blobClient.SetTags(tags, setTagsOptions), StorageException);
+    Blobs::GetBlobTagsOptions getTagsOptions;
+    getTagsOptions.AccessConditions.LeaseId = RandomUUID();
+    EXPECT_THROW(blobClient.GetTags(getTagsOptions), StorageException);
+
+    setTagsOptions.AccessConditions.LeaseId = leaseClient.GetLeaseId();
+    EXPECT_NO_THROW(blobClient.SetTags(tags, setTagsOptions));
+    getTagsOptions.AccessConditions.LeaseId = leaseClient.GetLeaseId();
+    EXPECT_NO_THROW(blobClient.GetTags(getTagsOptions));
+
+    leaseClient.Release();
+  }
+
+  TEST_F(BlockBlobClientTest, MaximumBlocks)
+  {
+    auto blobClient = *m_blockBlobClient;
+
+    const std::vector<uint8_t> content(static_cast<size_t>(1), 'a');
+    const std::string blockId = Base64EncodeText(std::string(64, '0'));
+    auto blockContent = Azure::Core::IO::MemoryBodyStream(content.data(), content.size());
+    blobClient.StageBlock(blockId, blockContent);
+
+    std::vector<std::string> blockIds(50000, blockId);
+    EXPECT_NO_THROW(blobClient.CommitBlockList(blockIds));
+
+    EXPECT_EQ(
+        blobClient.GetProperties().Value.BlobSize,
+        static_cast<int64_t>(blockIds.size() * content.size()));
+  }
+
+  TEST_F(BlockBlobClientTest, DownloadError)
+  {
+    auto blockBlobClient = GetBlockBlobClientForTest(RandomString());
+
+    bool exceptionCaught = false;
+    try
+    {
+      blockBlobClient.Download();
+    }
+    catch (const StorageException& e)
+    {
+      exceptionCaught = true;
+      EXPECT_EQ(e.StatusCode, Azure::Core::Http::HttpStatusCode::NotFound);
+      EXPECT_FALSE(e.ReasonPhrase.empty());
+      EXPECT_FALSE(e.RequestId.empty());
+      EXPECT_FALSE(e.ErrorCode.empty());
+      EXPECT_FALSE(e.Message.empty());
+      EXPECT_TRUE(e.RawResponse);
+    }
+    EXPECT_TRUE(exceptionCaught);
+  }
+
+  TEST_F(BlockBlobClientTest, DownloadNonExistingToFile)
+  {
+    auto blockBlobClient = GetBlockBlobClientForTest(RandomString());
+
+    const std::string filename = RandomString();
+    EXPECT_THROW(blockBlobClient.DownloadTo(filename), StorageException);
+    EXPECT_THROW(ReadFile(filename), std::runtime_error);
   }
 
   TEST_F(BlockBlobClientTest, ConcurrentUploadFromNonExistingFile)
   {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
+    auto blockBlobClient = GetBlockBlobClientForTest(RandomString());
 
-    std::string emptyFilename(testName);
+    std::string emptyFilename = RandomString();
     EXPECT_THROW(blockBlobClient.UploadFrom(emptyFilename), std::runtime_error);
     EXPECT_THROW(blockBlobClient.Delete(), StorageException);
   }
 
   TEST_F(BlockBlobClientTest, ConcurrentDownloadNonExistingBlob)
   {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
+    auto blockBlobClient = GetBlockBlobClientForTest(RandomString());
 
     std::vector<uint8_t> blobContent(100);
-    std::string tempFilename(testName);
+    std::string tempFilename = RandomString();
 
     EXPECT_THROW(
         blockBlobClient.DownloadTo(blobContent.data(), blobContent.size()), StorageException);
     EXPECT_THROW(blockBlobClient.DownloadTo(tempFilename), StorageException);
-    DeleteFile(tempFilename);
   }
 
   TEST_F(BlockBlobClientTest, ConcurrentUploadEmptyBlob)
   {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
+    auto blockBlobClient = GetBlockBlobClientForTest(RandomString());
 
     std::vector<uint8_t> emptyContent;
 
     blockBlobClient.UploadFrom(emptyContent.data(), emptyContent.size());
     EXPECT_NO_THROW(blockBlobClient.Delete());
 
-    std::string emptyFilename(testName);
+    std::string emptyFilename = RandomString();
     WriteFile(emptyFilename, std::vector<uint8_t>{});
     blockBlobClient.UploadFrom(emptyFilename);
     EXPECT_NO_THROW(blockBlobClient.Delete());
@@ -1178,9 +1391,8 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, ConcurrentDownloadEmptyBlob)
   {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
-    std::string tempFilename(testName);
+    auto blockBlobClient = GetBlockBlobClientForTest(RandomString());
+    std::string tempFilename = RandomString();
 
     std::vector<uint8_t> emptyContent;
 
@@ -1283,747 +1495,270 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
-  TEST_P(UploadBlockBlob, fromBuffer)
+  TEST_F(BlockBlobClientTest, ConcurrentDownload_LIVEONLY_)
   {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
-    SetOptions();
-    UploadBlockBlob::ParamType const& p(GetParam());
-    auto const blobSize = p.Size;
-    std::vector<uint8_t> blobContent(static_cast<size_t>(8_MB), 'x');
+    CHECK_SKIP_TEST();
 
-    Azure::Storage::Blobs::UploadBlockBlobFromOptions options;
-    options.TransferOptions.ChunkSize = 1_MB;
-    options.TransferOptions.Concurrency = p.Concurrency;
-    options.HttpHeaders = m_blobUploadOptions.HttpHeaders;
-    options.HttpHeaders.ContentHash.Value.clear();
-    options.Metadata = m_blobUploadOptions.Metadata;
-    options.AccessTier = m_blobUploadOptions.AccessTier;
-    auto res
-        = blockBlobClient.UploadFrom(blobContent.data(), static_cast<size_t>(blobSize), options);
-    EXPECT_TRUE(res.Value.ETag.HasValue());
-    EXPECT_TRUE(IsValidTime(res.Value.LastModified));
-    auto properties = blockBlobClient.GetProperties().Value;
-    properties.HttpHeaders.ContentHash.Value.clear();
-    EXPECT_EQ(properties.BlobSize, blobSize);
-    EXPECT_EQ(properties.HttpHeaders, options.HttpHeaders);
-    EXPECT_EQ(properties.Metadata, options.Metadata);
-    EXPECT_EQ(properties.AccessTier.Value(), options.AccessTier.Value());
-    EXPECT_EQ(properties.ETag, res.Value.ETag);
-    EXPECT_EQ(properties.LastModified, res.Value.LastModified);
-    std::vector<uint8_t> downloadContent(static_cast<size_t>(blobSize), '\x00');
-    blockBlobClient.DownloadTo(downloadContent.data(), static_cast<size_t>(blobSize));
-    EXPECT_EQ(
-        downloadContent,
-        std::vector<uint8_t>(
-            blobContent.begin(), blobContent.begin() + static_cast<size_t>(blobSize)));
-  }
+    auto blobClient = *m_blockBlobClient;
+    const auto blobContent = RandomBuffer(8_MB);
+    blobClient.UploadFrom(blobContent.data(), blobContent.size());
 
-  TEST_P(UploadBlockBlob, fromFile)
-  {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
-    SetOptions();
-    UploadBlockBlob::ParamType const& p(GetParam());
-    auto const blobSize = p.Size;
-    std::vector<uint8_t> blobContent(static_cast<size_t>(p.Size), 'x');
+    auto testDownloadToBuffer = [&](int concurrency,
+                                    int64_t downloadSize,
+                                    Azure::Nullable<int64_t> offset = {},
+                                    Azure::Nullable<int64_t> length = {},
+                                    Azure::Nullable<int64_t> initialChunkSize = {},
+                                    Azure::Nullable<int64_t> chunkSize = {}) {
+      std::vector<uint8_t> downloadBuffer;
+      std::vector<uint8_t> expectedData = blobContent;
+      int64_t blobSize = blobContent.size();
+      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
+      if (offset.HasValue() && length.HasValue())
+      {
+        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
+        if (actualDownloadSize >= 0)
+        {
+          expectedData.assign(
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
+        }
+        else
+        {
+          expectedData.clear();
+        }
+      }
+      else if (offset.HasValue())
+      {
+        actualDownloadSize = blobSize - offset.Value();
+        if (actualDownloadSize >= 0)
+        {
+          expectedData.assign(
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()), blobContent.end());
+        }
+        else
+        {
+          expectedData.clear();
+        }
+      }
+      downloadBuffer.resize(static_cast<size_t>(downloadSize), '\x00');
+      Blobs::DownloadBlobToOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (offset.HasValue() || length.HasValue())
+      {
+        options.Range = Core::Http::HttpRange();
+        options.Range.Value().Offset = offset.Value();
+        options.Range.Value().Length = length;
+      }
+      if (initialChunkSize.HasValue())
+      {
+        options.TransferOptions.InitialChunkSize = initialChunkSize.Value();
+      }
+      if (chunkSize.HasValue())
+      {
+        options.TransferOptions.ChunkSize = chunkSize.Value();
+      }
+      if (actualDownloadSize > 0)
+      {
+        auto res = blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options);
+        EXPECT_EQ(res.Value.BlobSize, blobSize);
+        EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
+        EXPECT_EQ(res.Value.ContentRange.Offset, offset.HasValue() ? offset.Value() : 0);
+        downloadBuffer.resize(static_cast<size_t>(res.Value.ContentRange.Length.Value()));
+        EXPECT_EQ(downloadBuffer, expectedData);
+      }
+      else
+      {
+        EXPECT_THROW(
+            blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options),
+            StorageException);
+      }
+    };
 
-    Azure::Storage::Blobs::UploadBlockBlobFromOptions options;
-    options.TransferOptions.ChunkSize = 1_MB;
-    options.TransferOptions.Concurrency = p.Concurrency;
-    options.HttpHeaders = m_blobUploadOptions.HttpHeaders;
-    options.HttpHeaders.ContentHash.Value.clear();
-    options.Metadata = m_blobUploadOptions.Metadata;
-    options.AccessTier = m_blobUploadOptions.AccessTier;
+    auto testDownloadToFile = [&](int concurrency,
+                                  int64_t downloadSize,
+                                  Azure::Nullable<int64_t> offset = {},
+                                  Azure::Nullable<int64_t> length = {},
+                                  Azure::Nullable<int64_t> initialChunkSize = {},
+                                  Azure::Nullable<int64_t> chunkSize = {}) {
+      std::string tempFilename = RandomString() + "file" + std::to_string(concurrency);
+      if (offset)
+      {
+        tempFilename.append(std::to_string(offset.Value()));
+      }
+      std::vector<uint8_t> expectedData = blobContent;
+      int64_t blobSize = blobContent.size();
+      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
+      if (offset.HasValue() && length.HasValue())
+      {
+        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
+        if (actualDownloadSize >= 0)
+        {
+          expectedData.assign(
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
+        }
+        else
+        {
+          expectedData.clear();
+        }
+      }
+      else if (offset.HasValue())
+      {
+        actualDownloadSize = blobSize - offset.Value();
+        if (actualDownloadSize >= 0)
+        {
+          expectedData.assign(
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()), blobContent.end());
+        }
+        else
+        {
+          expectedData.clear();
+        }
+      }
+      Blobs::DownloadBlobToOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (offset.HasValue() || length.HasValue())
+      {
+        options.Range = Core::Http::HttpRange();
+        options.Range.Value().Offset = offset.Value();
+        options.Range.Value().Length = length;
+      }
+      if (initialChunkSize.HasValue())
+      {
+        options.TransferOptions.InitialChunkSize = initialChunkSize.Value();
+      }
+      if (chunkSize.HasValue())
+      {
+        options.TransferOptions.ChunkSize = chunkSize.Value();
+      }
+      if (actualDownloadSize > 0)
+      {
+        auto res = blobClient.DownloadTo(tempFilename, options);
+        EXPECT_EQ(res.Value.BlobSize, blobSize);
+        EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
+        EXPECT_EQ(res.Value.ContentRange.Offset, offset.HasValue() ? offset.Value() : 0);
+        EXPECT_EQ(ReadFile(tempFilename), expectedData);
+      }
+      else
+      {
+        EXPECT_THROW(blobClient.DownloadTo(tempFilename, options), StorageException);
+      }
+      DeleteFile(tempFilename);
+    };
 
-    std::string tempFilename(testName);
-    WriteFile(tempFilename, blobContent);
-    auto res = blockBlobClient.UploadFrom(tempFilename, options);
-    EXPECT_TRUE(res.Value.ETag.HasValue());
-    EXPECT_TRUE(IsValidTime(res.Value.LastModified));
-    auto properties = blockBlobClient.GetProperties().Value;
-    properties.HttpHeaders.ContentHash.Value.clear();
-    EXPECT_EQ(properties.BlobSize, blobSize);
-    EXPECT_EQ(properties.HttpHeaders, options.HttpHeaders);
-    EXPECT_EQ(properties.Metadata, options.Metadata);
-    EXPECT_EQ(properties.AccessTier.Value(), options.AccessTier.Value());
-    EXPECT_EQ(properties.ETag, res.Value.ETag);
-    EXPECT_EQ(properties.LastModified, res.Value.LastModified);
-    std::vector<uint8_t> downloadContent(static_cast<size_t>(blobSize), '\x00');
-    blockBlobClient.DownloadTo(downloadContent.data(), static_cast<size_t>(blobSize));
-    EXPECT_EQ(
-        downloadContent,
-        std::vector<uint8_t>(
-            blobContent.begin(), blobContent.begin() + static_cast<size_t>(blobSize)));
-    DeleteFile(tempFilename);
-  }
-
-  INSTANTIATE_TEST_SUITE_P(
-      withParam,
-      UploadBlockBlob,
-      testing::ValuesIn(GetUploadParameters()),
-      GetUploadSuffix);
-
-  TEST_F(BlockBlobClientTest, DownloadError)
-  {
-    auto const testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
-
-    bool exceptionCaught = false;
-    try
+    const int64_t blobSize = blobContent.size();
+    std::vector<std::future<void>> futures;
+    for (int c : {1, 2, 4})
     {
-      blockBlobClient.Download();
+      // random range
+      for (int i = 0; i < 16; ++i)
+      {
+        int64_t offset = RandomInt(0, blobContent.size() - 1);
+        int64_t length = RandomInt(1, 64_KB);
+        futures.emplace_back(std::async(
+            std::launch::async, testDownloadToBuffer, c, blobSize, offset, length, 8_KB, 4_KB));
+        futures.emplace_back(std::async(
+            std::launch::async, testDownloadToFile, c, blobSize, offset, length, 4_KB, 7_KB));
+      }
+
+      // buffer not big enough
+      Blobs::DownloadBlobToOptions options;
+      options.TransferOptions.Concurrency = c;
+      options.Range = Core::Http::HttpRange();
+      options.Range.Value().Offset = 1;
+      for (int64_t length : {1ULL, 2ULL, 4_KB, 5_KB, 8_KB, 11_KB, 20_KB})
+      {
+        std::vector<uint8_t> downloadBuffer;
+        downloadBuffer.resize(static_cast<size_t>(length - 1));
+        options.Range.Value().Length = length;
+        EXPECT_THROW(
+            blobClient.DownloadTo(downloadBuffer.data(), static_cast<size_t>(length - 1), options),
+            std::runtime_error);
+      }
     }
-    catch (const StorageException& e)
+    for (auto& f : futures)
     {
-      exceptionCaught = true;
-      EXPECT_EQ(e.StatusCode, Azure::Core::Http::HttpStatusCode::NotFound);
-      EXPECT_FALSE(e.ReasonPhrase.empty());
-      EXPECT_FALSE(e.RequestId.empty());
-      EXPECT_FALSE(e.ErrorCode.empty());
-      EXPECT_FALSE(e.Message.empty());
-      EXPECT_TRUE(e.RawResponse);
-    }
-    EXPECT_TRUE(exceptionCaught);
-  }
-
-  TEST_F(BlockBlobClientTest, DownloadNonExistingToFile)
-  {
-    const auto testName(GetTestName());
-    auto blockBlobClient = GetBlockBlobClient(testName);
-
-    EXPECT_THROW(blockBlobClient.DownloadTo(testName), StorageException);
-    EXPECT_THROW(ReadFile(testName), std::runtime_error);
-  }
-
-  TEST_F(BlockBlobClientTest, DeleteIfExists)
-  {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-
-    auto blobClientWithoutAuth = Azure::Storage::Blobs::BlockBlobClient(
-        blobClient.GetUrl(), InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
-    {
-      auto response = blobClient.DeleteIfExists();
-      EXPECT_FALSE(response.Value.Deleted);
-    }
-    std::vector<uint8_t> emptyContent;
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-    EXPECT_THROW(blobClientWithoutAuth.DeleteIfExists(), StorageException);
-    {
-      auto response = blobClient.DeleteIfExists();
-      EXPECT_TRUE(response.Value.Deleted);
-    }
-
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-    auto snapshot = blobClient.CreateSnapshot().Value.Snapshot;
-    auto blobClientWithSnapshot = blobClient.WithSnapshot(snapshot);
-    {
-      auto response = blobClientWithSnapshot.DeleteIfExists();
-      EXPECT_TRUE(response.Value.Deleted);
-    }
-    {
-      auto response = blobClientWithSnapshot.DeleteIfExists();
-      EXPECT_FALSE(response.Value.Deleted);
-    }
-  }
-
-  TEST_F(BlockBlobClientTest, DeleteSnapshots)
-  {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-
-    std::vector<uint8_t> emptyContent;
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-    auto s1 = blobClient.CreateSnapshot().Value.Snapshot;
-    Blobs::DeleteBlobOptions deleteOptions;
-    EXPECT_THROW(blobClient.Delete(deleteOptions), StorageException);
-    deleteOptions.DeleteSnapshots = Blobs::Models::DeleteSnapshotsOption::OnlySnapshots;
-    EXPECT_NO_THROW(blobClient.Delete(deleteOptions));
-    EXPECT_NO_THROW(blobClient.GetProperties());
-    EXPECT_THROW(blobClient.WithSnapshot(s1).GetProperties(), StorageException);
-    auto s2 = blobClient.CreateSnapshot().Value.Snapshot;
-    deleteOptions.DeleteSnapshots = Blobs::Models::DeleteSnapshotsOption::IncludeSnapshots;
-    EXPECT_NO_THROW(blobClient.Delete(deleteOptions));
-    EXPECT_THROW(blobClient.GetProperties(), StorageException);
-    EXPECT_THROW(blobClient.WithSnapshot(s2).GetProperties(), StorageException);
-  }
-
-  TEST_F(BlockBlobClientTest, SetTier)
-  {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-
-    std::vector<uint8_t> emptyContent;
-    std::string blobName(testName);
-
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-
-    auto properties = blobClient.GetProperties().Value;
-    ASSERT_TRUE(properties.AccessTier.HasValue());
-    ASSERT_TRUE(properties.IsAccessTierInferred.HasValue());
-    EXPECT_TRUE(properties.IsAccessTierInferred.Value());
-    EXPECT_FALSE(properties.AccessTierChangedOn.HasValue());
-
-    auto blobItem = GetBlobItem(blobName);
-    ASSERT_TRUE(blobItem.Details.AccessTier.HasValue());
-    ASSERT_TRUE(blobItem.Details.IsAccessTierInferred.HasValue());
-    EXPECT_TRUE(blobItem.Details.IsAccessTierInferred.Value());
-    EXPECT_FALSE(blobItem.Details.AccessTierChangedOn.HasValue());
-
-    // choose a different tier
-    auto targetTier = properties.AccessTier.Value() == Blobs::Models::AccessTier::Hot
-        ? Blobs::Models::AccessTier::Cool
-        : Blobs::Models::AccessTier::Hot;
-    blobClient.SetAccessTier(targetTier);
-
-    properties = blobClient.GetProperties().Value;
-    ASSERT_TRUE(properties.AccessTier.HasValue());
-    ASSERT_TRUE(properties.IsAccessTierInferred.HasValue());
-    EXPECT_FALSE(properties.IsAccessTierInferred.Value());
-    EXPECT_TRUE(properties.AccessTierChangedOn.HasValue());
-
-    blobItem = GetBlobItem(blobName);
-    ASSERT_TRUE(blobItem.Details.AccessTier.HasValue());
-    ASSERT_TRUE(blobItem.Details.IsAccessTierInferred.HasValue());
-    EXPECT_FALSE(blobItem.Details.IsAccessTierInferred.Value());
-    EXPECT_TRUE(blobItem.Details.AccessTierChangedOn.HasValue());
-
-    // set to archive, then rehydrate
-    blobClient.SetAccessTier(Blobs::Models::AccessTier::Archive);
-    blobClient.SetAccessTier(Blobs::Models::AccessTier::Hot);
-    properties = blobClient.GetProperties().Value;
-    ASSERT_TRUE(properties.ArchiveStatus.HasValue());
-    EXPECT_EQ(
-        properties.ArchiveStatus.Value(), Blobs::Models::ArchiveStatus::RehydratePendingToHot);
-    ASSERT_TRUE(properties.RehydratePriority.HasValue());
-    EXPECT_EQ(properties.RehydratePriority.Value(), Blobs::Models::RehydratePriority::Standard);
-
-    blobItem = GetBlobItem(blobName);
-    ASSERT_TRUE(blobItem.Details.ArchiveStatus.HasValue());
-    EXPECT_EQ(
-        blobItem.Details.ArchiveStatus.Value(),
-        Blobs::Models::ArchiveStatus::RehydratePendingToHot);
-    ASSERT_TRUE(blobItem.Details.RehydratePriority.HasValue());
-    EXPECT_EQ(
-        blobItem.Details.RehydratePriority.Value(), Blobs::Models::RehydratePriority::Standard);
-  }
-
-  TEST_F(BlockBlobClientTest, DISABLED_SetTierCold)
-  {
-
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-
-    std::vector<uint8_t> emptyContent;
-    std::string blobName(testName);
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-
-    // set to cold
-    blobClient.SetAccessTier(Blobs::Models::AccessTier::Cold);
-    auto properties = blobClient.GetProperties().Value;
-    EXPECT_EQ(properties.AccessTier.Value(), Blobs::Models::AccessTier::Cold);
-  }
-
-  TEST_F(BlockBlobClientTest, SetTierWithLeaseId)
-  {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-
-    std::vector<uint8_t> emptyContent;
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-
-    const std::string leaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
-    Blobs::BlobLeaseClient leaseClient(blobClient, leaseId);
-    leaseClient.Acquire(std::chrono::seconds(30));
-
-    EXPECT_THROW(blobClient.SetAccessTier(Blobs::Models::AccessTier::Cool), StorageException);
-
-    Blobs::SetBlobAccessTierOptions options;
-    options.AccessConditions.LeaseId = leaseId;
-    EXPECT_NO_THROW(blobClient.SetAccessTier(Blobs::Models::AccessTier::Cool, options));
-  }
-
-  TEST_F(BlockBlobClientTest, UncommittedBlob)
-  {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-
-    const std::string blobName(testName);
-
-    std::vector<uint8_t> buffer(100);
-    Azure::Core::IO::MemoryBodyStream stream(buffer.data(), buffer.size());
-    blobClient.StageBlock("YWJjZA==", stream);
-
-    Blobs::GetBlockListOptions getBlockListOptions;
-    getBlockListOptions.ListType = Blobs::Models::BlockListType::All;
-    auto res = blobClient.GetBlockList(getBlockListOptions).Value;
-    EXPECT_FALSE(res.ETag.HasValue());
-    EXPECT_EQ(res.BlobSize, 0);
-    EXPECT_TRUE(res.CommittedBlocks.empty());
-    EXPECT_FALSE(res.UncommittedBlocks.empty());
-
-    auto blobItem = GetBlobItem(blobName, Blobs::Models::ListBlobsIncludeFlags::UncomittedBlobs);
-    EXPECT_EQ(blobItem.BlobSize, 0);
-  }
-
-  TEST_F(BlobContainerClientTest, SourceTagsConditions)
-  {
-    auto const testName(GetTestNameLowerCase());
-    auto containerClient = GetBlobContainerTestClient();
-    containerClient.CreateIfNotExists();
-
-    auto sourceBlobClient = Azure::Storage::Blobs::BlockBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        testName,
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
-    std::vector<uint8_t> buffer;
-    buffer.resize(1024);
-  }
-
-  TEST_F(BlobContainerClientTest, SourceBlobAccessConditions)
-  {
-    auto const testName(GetTestNameLowerCase());
-    auto containerClient = GetBlobContainerTestClient();
-    containerClient.CreateIfNotExists();
-
-    auto sourceBlobClient = containerClient.GetBlockBlobClient(testName);
-
-    std::vector<uint8_t> buffer;
-    buffer.resize(1024);
-    auto createResponse = sourceBlobClient.UploadFrom(buffer.data(), buffer.size());
-    Azure::ETag eTag = createResponse.Value.ETag;
-    auto lastModifiedTime = createResponse.Value.LastModified;
-    auto timeBeforeStr = lastModifiedTime - std::chrono::seconds(2);
-    auto timeAfterStr = lastModifiedTime + std::chrono::seconds(2);
-
-    auto destBlobClient = containerClient.GetBlockBlobClient(testName + "2");
-
-    {
-      Blobs::StartBlobCopyFromUriOptions options;
-      options.SourceAccessConditions.IfMatch = eTag;
-      EXPECT_NO_THROW(destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options));
-      options.SourceAccessConditions.IfMatch = DummyETag;
-      EXPECT_THROW(
-          destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options), StorageException);
-
-      Blobs::CopyBlobFromUriOptions options2;
-      options2.SourceAccessConditions.IfMatch = eTag;
-      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
-      options2.SourceAccessConditions.IfMatch = DummyETag;
-      EXPECT_THROW(
-          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2),
-          StorageException);
-    }
-    {
-      Blobs::StartBlobCopyFromUriOptions options;
-      options.SourceAccessConditions.IfNoneMatch = DummyETag;
-      EXPECT_NO_THROW(destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options));
-      options.SourceAccessConditions.IfNoneMatch = eTag;
-      EXPECT_THROW(
-          destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options), StorageException);
-
-      Blobs::CopyBlobFromUriOptions options2;
-      options2.SourceAccessConditions.IfNoneMatch = DummyETag;
-      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
-      options2.SourceAccessConditions.IfNoneMatch = eTag;
-      EXPECT_THROW(
-          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2),
-          StorageException);
-    }
-    {
-      Blobs::StartBlobCopyFromUriOptions options;
-      options.SourceAccessConditions.IfModifiedSince = timeBeforeStr;
-      EXPECT_NO_THROW(destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options));
-      options.SourceAccessConditions.IfModifiedSince = timeAfterStr;
-      EXPECT_THROW(
-          destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options), StorageException);
-
-      sourceBlobClient.GetProperties();
-      Blobs::CopyBlobFromUriOptions options2;
-      options2.SourceAccessConditions.IfModifiedSince = timeBeforeStr;
-      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
-      options2.SourceAccessConditions.IfModifiedSince = timeAfterStr;
-      EXPECT_THROW(
-          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2),
-          StorageException);
-    }
-    {
-      Blobs::StartBlobCopyFromUriOptions options;
-      options.SourceAccessConditions.IfUnmodifiedSince = timeAfterStr;
-      EXPECT_NO_THROW(destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options));
-      options.SourceAccessConditions.IfUnmodifiedSince = timeBeforeStr;
-      EXPECT_THROW(
-          destBlobClient.StartCopyFromUri(sourceBlobClient.GetUrl(), options), StorageException);
-
-      Blobs::CopyBlobFromUriOptions options2;
-      options2.SourceAccessConditions.IfUnmodifiedSince = timeAfterStr;
-      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2));
-      options2.SourceAccessConditions.IfUnmodifiedSince = timeBeforeStr;
-      EXPECT_THROW(
-          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options2),
-          StorageException);
-    }
-
-    // lease
-    {
-      const std::string leaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
-      const std::string dummyLeaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
-      Blobs::BlobLeaseClient leaseClient(destBlobClient, leaseId);
-
-      leaseClient.Acquire(std::chrono::seconds(60));
-
-      Blobs::CopyBlobFromUriOptions options;
-      options.AccessConditions.LeaseId = dummyLeaseId;
-      EXPECT_THROW(
-          destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options),
-          StorageException);
-      options.AccessConditions.LeaseId = leaseId;
-      EXPECT_NO_THROW(destBlobClient.CopyFromUri(sourceBlobClient.GetUrl() + GetSas(), options));
-      leaseClient.Release();
+      f.get();
     }
   }
 
-  TEST_F(BlockBlobClientTest, DISABLED_Immutability)
+  TEST_F(BlockBlobClientTest, ConcurrentUpload_LIVEONLY_)
   {
-    auto const testName(GetTestName());
+    CHECK_SKIP_TEST();
 
-    auto blobClient = GetBlockBlobClient(testName);
-    std::vector<uint8_t> emptyContent;
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+    const auto blobContent = RandomBuffer(8_MB);
 
-    auto blobContainerClient = GetBlobContainerTestClient();
-    ASSERT_TRUE(blobContainerClient.GetProperties().Value.HasImmutableStorageWithVersioning);
+    auto testUploadFromBuffer = [&](int concurrency,
+                                    int64_t bufferSize,
+                                    Azure::Nullable<int64_t> singleUploadThreshold = {},
+                                    Azure::Nullable<int64_t> chunkSize = {}) {
+      Blobs::UploadBlockBlobFromOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (singleUploadThreshold.HasValue())
+      {
+        options.TransferOptions.SingleUploadThreshold = singleUploadThreshold.Value();
+      }
+      if (chunkSize.HasValue())
+      {
+        options.TransferOptions.ChunkSize = chunkSize.Value();
+      }
 
-    Blobs::Models::BlobImmutabilityPolicy policy;
-    policy.ExpiresOn = Azure::DateTime::Parse(
-        Azure::DateTime(std::chrono::system_clock::now() + std::chrono::hours(24))
-            .ToString(Azure::DateTime::DateFormat::Rfc1123),
-        Azure::DateTime::DateFormat::Rfc1123);
-    policy.PolicyMode = Blobs::Models::BlobImmutabilityPolicyMode::Unlocked;
-    auto setPolicyResponse = blobClient.SetImmutabilityPolicy(policy);
-    EXPECT_EQ(setPolicyResponse.Value.ImmutabilityPolicy, policy);
-    auto blobProperties = blobClient.GetProperties().Value;
-    ASSERT_TRUE(blobProperties.ImmutabilityPolicy.HasValue());
-    EXPECT_EQ(blobProperties.ImmutabilityPolicy.Value(), policy);
-    auto downloadResponse = blobClient.Download();
-    ASSERT_TRUE(downloadResponse.Value.Details.ImmutabilityPolicy.HasValue());
-    EXPECT_EQ(downloadResponse.Value.Details.ImmutabilityPolicy.Value(), policy);
-    auto blobItem = GetBlobItem(testName, Blobs::Models::ListBlobsIncludeFlags::ImmutabilityPolicy);
-    ASSERT_TRUE(blobItem.Details.ImmutabilityPolicy.HasValue());
-    EXPECT_EQ(blobItem.Details.ImmutabilityPolicy.Value(), policy);
+      auto blobClient = m_blobContainerClient->GetBlockBlobClient(RandomString());
+      EXPECT_NO_THROW(blobClient.UploadFrom(blobContent.data(), bufferSize, options));
+      std::vector<uint8_t> downloadBuffer(bufferSize, '\x00');
+      blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + bufferSize);
+      EXPECT_EQ(downloadBuffer, expectedData);
+    };
 
-    EXPECT_NO_THROW(blobClient.DeleteImmutabilityPolicy());
-    blobProperties = blobClient.GetProperties().Value;
-    EXPECT_FALSE(blobProperties.ImmutabilityPolicy.HasValue());
-    downloadResponse = blobClient.Download();
-    ASSERT_FALSE(downloadResponse.Value.Details.ImmutabilityPolicy.HasValue());
-    blobItem = GetBlobItem(testName, Blobs::Models::ListBlobsIncludeFlags::ImmutabilityPolicy);
-    ASSERT_FALSE(blobItem.Details.ImmutabilityPolicy.HasValue());
+    auto testUploadFromFile = [&](int concurrency,
+                                  int64_t fileSize,
+                                  Azure::Nullable<int64_t> singleUploadThreshold = {},
+                                  Azure::Nullable<int64_t> chunkSize = {}) {
+      Blobs::UploadBlockBlobFromOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (singleUploadThreshold.HasValue())
+      {
+        options.TransferOptions.SingleUploadThreshold = singleUploadThreshold.Value();
+      }
+      if (chunkSize.HasValue())
+      {
+        options.TransferOptions.ChunkSize = chunkSize.Value();
+      }
 
-    auto copySourceBlobClient = GetBlockBlobClient(testName + "src");
-    copySourceBlobClient.UploadFrom(emptyContent.data(), emptyContent.size());
+      const std::string tempFileName = RandomString();
+      WriteFile(
+          tempFileName, std::vector<uint8_t>(blobContent.begin(), blobContent.begin() + fileSize));
+      auto blobClient = m_blobContainerClient->GetBlockBlobClient(RandomString());
+      EXPECT_NO_THROW(blobClient.UploadFrom(tempFileName, options));
+      DeleteFile(tempFileName);
+      std::vector<uint8_t> downloadBuffer(fileSize, '\x00');
+      blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + fileSize);
+      EXPECT_EQ(downloadBuffer, expectedData);
+    };
+
+    std::vector<std::future<void>> futures;
+    for (int c : {1, 2, 4})
     {
-      auto copyDestinationBlobClient = GetBlockBlobClient(testName + "dest1");
-      Blobs::StartBlobCopyFromUriOptions options;
-      options.ImmutabilityPolicy = policy;
-      copyDestinationBlobClient.StartCopyFromUri(copySourceBlobClient.GetUrl() + GetSas(), options)
-          .PollUntilDone(std::chrono::seconds(1));
-      EXPECT_EQ(copyDestinationBlobClient.GetProperties().Value.ImmutabilityPolicy.Value(), policy);
+      // random range
+      for (int i = 0; i < 16; ++i)
+      {
+        int64_t fileSize = RandomInt(1, 1_MB);
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 4_KB, 4_KB));
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromFile, c, fileSize, 2_KB, 16_KB));
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 0, 12_KB));
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromFile, c, fileSize, 0, 25_KB));
+      }
     }
+    for (auto& f : futures)
     {
-      auto copyDestinationBlobClient = GetBlockBlobClient(testName + "dest2");
-      Blobs::CopyBlobFromUriOptions options;
-      options.ImmutabilityPolicy = policy;
-      copyDestinationBlobClient.CopyFromUri(copySourceBlobClient.GetUrl() + GetSas(), options);
-      EXPECT_EQ(copyDestinationBlobClient.GetProperties().Value.ImmutabilityPolicy.Value(), policy);
+      f.get();
     }
-  }
-
-  TEST_F(BlockBlobClientTest, DISABLED_ImmutabilityAccessCondition)
-  {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-    std::vector<uint8_t> emptyContent;
-    auto uploadResponse = blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-    auto lastModifiedTime = uploadResponse.Value.LastModified;
-    auto timeBeforeStr = lastModifiedTime - std::chrono::minutes(1);
-    auto timeAfterStr = lastModifiedTime + std::chrono::minutes(1);
-
-    Blobs::Models::BlobImmutabilityPolicy policy;
-    policy.ExpiresOn = Azure::DateTime::Parse(
-        Azure::DateTime(std::chrono::system_clock::now() + std::chrono::hours(24))
-            .ToString(Azure::DateTime::DateFormat::Rfc1123),
-        Azure::DateTime::DateFormat::Rfc1123);
-    policy.PolicyMode = Blobs::Models::BlobImmutabilityPolicyMode::Unlocked;
-
-    Blobs::SetBlobImmutabilityPolicyOptions options;
-    options.AccessConditions.IfUnmodifiedSince = timeBeforeStr;
-    EXPECT_THROW(blobClient.SetImmutabilityPolicy(policy, options), StorageException);
-    options.AccessConditions.IfUnmodifiedSince = timeAfterStr;
-    EXPECT_NO_THROW(blobClient.SetImmutabilityPolicy(policy, options));
-  }
-
-  TEST_F(BlockBlobClientTest, DISABLED_LegalHold)
-  {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-    std::vector<uint8_t> emptyContent;
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-
-    auto setLegalHoldResponse = blobClient.SetLegalHold(true);
-    EXPECT_TRUE(setLegalHoldResponse.Value.HasLegalHold);
-    auto blobProperties = blobClient.GetProperties().Value;
-    EXPECT_TRUE(blobProperties.HasLegalHold);
-    auto downloadResponse = blobClient.Download();
-    EXPECT_TRUE(downloadResponse.Value.Details.HasLegalHold);
-    auto blobItem = GetBlobItem(testName, Blobs::Models::ListBlobsIncludeFlags::LegalHold);
-    EXPECT_TRUE(blobItem.Details.HasLegalHold);
-
-    setLegalHoldResponse = blobClient.SetLegalHold(false);
-    EXPECT_FALSE(setLegalHoldResponse.Value.HasLegalHold);
-
-    auto copySourceBlobClient = GetBlockBlobClient(testName + "src");
-    copySourceBlobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-    {
-      auto copyDestinationBlobClient = GetBlockBlobClient(testName + "dest1");
-      Blobs::StartBlobCopyFromUriOptions options;
-      options.HasLegalHold = true;
-      copyDestinationBlobClient.StartCopyFromUri(copySourceBlobClient.GetUrl() + GetSas(), options)
-          .PollUntilDone(std::chrono::seconds(1));
-      EXPECT_TRUE(copyDestinationBlobClient.GetProperties().Value.HasLegalHold);
-    }
-    {
-      auto copyDestinationBlobClient = GetBlockBlobClient(testName + "dest2");
-      Blobs::CopyBlobFromUriOptions options;
-      options.HasLegalHold = true;
-      copyDestinationBlobClient.CopyFromUri(copySourceBlobClient.GetUrl() + GetSas(), options);
-      EXPECT_TRUE(copyDestinationBlobClient.GetProperties().Value.HasLegalHold);
-    }
-  }
-
-  TEST_F(BlockBlobClientTest, ContentHash)
-  {
-    auto const testName(GetTestName());
-    auto srcBlobClient = GetBlockBlobClient(testName + "src");
-    std::vector<uint8_t> blobContent = RandomBuffer(100);
-    srcBlobClient.UploadFrom(blobContent.data(), blobContent.size());
-    const std::vector<uint8_t> contentMd5
-        = Azure::Core::Cryptography::Md5Hash().Final(blobContent.data(), blobContent.size());
-    const std::vector<uint8_t> contentCrc64
-        = Azure::Storage::Crc64Hash().Final(blobContent.data(), blobContent.size());
-
-    Azure::Core::IO::MemoryBodyStream stream(blobContent.data(), blobContent.size());
-
-    {
-      auto destBlobClient = GetBlockBlobClient(testName + "dest0");
-      Blobs::UploadBlockBlobOptions options;
-      options.TransactionalContentHash = ContentHash();
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
-      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
-      stream.Rewind();
-      EXPECT_THROW(destBlobClient.Upload(stream, options), StorageException);
-      options.TransactionalContentHash.Value().Value = contentMd5;
-      stream.Rewind();
-      EXPECT_NO_THROW(destBlobClient.Upload(stream, options));
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
-      options.TransactionalContentHash.Value().Value
-          = Azure::Core::Convert::Base64Decode(DummyCrc64);
-      stream.Rewind();
-      EXPECT_THROW(destBlobClient.Upload(stream, options), StorageException);
-      options.TransactionalContentHash.Value().Value = contentCrc64;
-      stream.Rewind();
-      EXPECT_NO_THROW(destBlobClient.Upload(stream, options));
-    }
-    {
-      auto destBlobClient = GetBlockBlobClient(testName + "dest1");
-      Blobs::UploadBlockBlobFromUriOptions options;
-      options.TransactionalContentHash = ContentHash();
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
-      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
-      stream.Rewind();
-      EXPECT_THROW(
-          destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options),
-          StorageException);
-      options.TransactionalContentHash.Value().Value = contentMd5;
-      stream.Rewind();
-      EXPECT_NO_THROW(destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options));
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
-      options.TransactionalContentHash.Value().Value
-          = Azure::Core::Convert::Base64Decode(DummyCrc64);
-      stream.Rewind();
-      EXPECT_THROW(
-          destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options),
-          StorageException);
-      options.TransactionalContentHash.Value().Value = contentCrc64;
-      stream.Rewind();
-      EXPECT_NO_THROW(destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options));
-    }
-    {
-      auto destBlobClient = GetBlockBlobClient(testName + "dest2");
-      Blobs::CopyBlobFromUriOptions options;
-      options.TransactionalContentHash = ContentHash();
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
-      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
-      stream.Rewind();
-      EXPECT_THROW(
-          destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + GetSas(), options), StorageException);
-      options.TransactionalContentHash.Value().Value = contentMd5;
-      stream.Rewind();
-      EXPECT_NO_THROW(destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + GetSas(), options));
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
-      options.TransactionalContentHash.Value().Value
-          = Azure::Core::Convert::Base64Decode(DummyCrc64);
-      stream.Rewind();
-      EXPECT_THROW(
-          destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + GetSas(), options), StorageException);
-      options.TransactionalContentHash.Value().Value = contentCrc64;
-      stream.Rewind();
-      EXPECT_NO_THROW(destBlobClient.CopyFromUri(srcBlobClient.GetUrl() + GetSas(), options));
-    }
-    {
-      auto destBlobClient = GetBlockBlobClient(testName + "dest3");
-      Blobs::StageBlockOptions options;
-      options.TransactionalContentHash = ContentHash();
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
-      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
-      stream.Rewind();
-      EXPECT_THROW(destBlobClient.StageBlock("YWJjZA==", stream, options), StorageException);
-      options.TransactionalContentHash.Value().Value = contentMd5;
-      stream.Rewind();
-      EXPECT_NO_THROW(destBlobClient.StageBlock("YWJjZA==", stream, options));
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
-      options.TransactionalContentHash.Value().Value
-          = Azure::Core::Convert::Base64Decode(DummyCrc64);
-      stream.Rewind();
-      EXPECT_THROW(destBlobClient.StageBlock("YWJjZA==", stream, options), StorageException);
-      options.TransactionalContentHash.Value().Value = contentCrc64;
-      stream.Rewind();
-      EXPECT_NO_THROW(destBlobClient.StageBlock("YWJjZA==", stream, options));
-    }
-    {
-      auto destBlobClient = GetBlockBlobClient(testName + "dest4");
-      Blobs::StageBlockFromUriOptions options;
-      options.TransactionalContentHash = ContentHash();
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Md5;
-      options.TransactionalContentHash.Value().Value = Azure::Core::Convert::Base64Decode(DummyMd5);
-      EXPECT_THROW(
-          destBlobClient.StageBlockFromUri("YWJjZA==", srcBlobClient.GetUrl() + GetSas(), options),
-          StorageException);
-      options.TransactionalContentHash.Value().Value = contentMd5;
-      EXPECT_NO_THROW(
-          destBlobClient.StageBlockFromUri("YWJjZA==", srcBlobClient.GetUrl() + GetSas(), options));
-      options.TransactionalContentHash.Value().Algorithm = HashAlgorithm::Crc64;
-      options.TransactionalContentHash.Value().Value
-          = Azure::Core::Convert::Base64Decode(DummyCrc64);
-      EXPECT_THROW(
-          destBlobClient.StageBlockFromUri("YWJjZA==", srcBlobClient.GetUrl() + GetSas(), options),
-          StorageException);
-      options.TransactionalContentHash.Value().Value = contentCrc64;
-      EXPECT_NO_THROW(
-          destBlobClient.StageBlockFromUri("YWJjZA==", srcBlobClient.GetUrl() + GetSas(), options));
-    }
-  }
-
-  TEST_F(BlockBlobClientTest, UploadFromUri)
-  {
-    auto const testName(GetTestName());
-    auto srcBlobClient = GetBlockBlobClient(testName + "src");
-    std::vector<uint8_t> blobContent(100, 'a');
-    srcBlobClient.UploadFrom(blobContent.data(), blobContent.size());
-    std::map<std::string, std::string> srcTags;
-    srcTags["srctags"] = "a1212";
-    srcBlobClient.SetTags(srcTags);
-
-    const std::vector<uint8_t> blobMd5
-        = Azure::Core::Cryptography::Md5Hash().Final(blobContent.data(), blobContent.size());
-    const std::vector<uint8_t> blobCrc64
-        = Azure::Storage::Crc64Hash().Final(blobContent.data(), blobContent.size());
-
-    auto destBlobClient = GetBlockBlobClient(testName + "dest");
-    auto uploadFromUriResult = destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas());
-    EXPECT_TRUE(uploadFromUriResult.Value.ETag.HasValue());
-    EXPECT_TRUE(IsValidTime(uploadFromUriResult.Value.LastModified));
-    EXPECT_TRUE(uploadFromUriResult.Value.VersionId.HasValue());
-    EXPECT_TRUE(uploadFromUriResult.Value.IsServerEncrypted);
-    ASSERT_TRUE(uploadFromUriResult.Value.TransactionalContentHash.HasValue());
-    if (uploadFromUriResult.Value.TransactionalContentHash.Value().Algorithm == HashAlgorithm::Md5)
-    {
-      EXPECT_EQ(uploadFromUriResult.Value.TransactionalContentHash.Value().Value, blobMd5);
-    }
-    else if (
-        uploadFromUriResult.Value.TransactionalContentHash.Value().Algorithm
-        == HashAlgorithm::Crc64)
-    {
-      EXPECT_EQ(uploadFromUriResult.Value.TransactionalContentHash.Value().Value, blobCrc64);
-    }
-
-    Blobs::UploadBlockBlobFromUriOptions options;
-    options.CopySourceBlobProperties = false;
-    options.HttpHeaders.ContentLanguage = "en-US";
-    options.HttpHeaders.ContentType = "application/octet-stream";
-    options.Metadata["k"] = "v";
-    options.AccessTier = Blobs::Models::AccessTier::Cool;
-    options.Tags["k1"] = "v1";
-    uploadFromUriResult = destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options);
-    auto destBlobProperties = destBlobClient.GetProperties().Value;
-    destBlobProperties.HttpHeaders.ContentHash.Value.clear();
-    EXPECT_EQ(destBlobProperties.HttpHeaders, options.HttpHeaders);
-    EXPECT_EQ(destBlobProperties.Metadata, options.Metadata);
-    EXPECT_EQ(destBlobProperties.AccessTier.Value(), options.AccessTier.Value());
-    EXPECT_EQ(static_cast<size_t>(destBlobProperties.TagCount.Value()), options.Tags.size());
-
-    options.CopySourceTagsMode = Blobs::Models::BlobCopySourceTagsMode::Copy;
-    options.Tags.clear();
-    uploadFromUriResult = destBlobClient.UploadFromUri(srcBlobClient.GetUrl() + GetSas(), options);
-    EXPECT_EQ(destBlobClient.GetTags().Value, srcTags);
-  }
-
-  TEST_F(BlockBlobClientTest, SetGetTagsWithLeaseId)
-  {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-    std::vector<uint8_t> emptyContent;
-    blobClient.UploadFrom(emptyContent.data(), emptyContent.size());
-
-    const std::map<std::string, std::string> tags{{"k", "v"}};
-
-    Blobs::BlobLeaseClient leaseClient(blobClient, Blobs::BlobLeaseClient::CreateUniqueLeaseId());
-
-    leaseClient.Acquire(std::chrono::seconds(60));
-
-    Blobs::SetBlobTagsOptions setTagsOptions;
-    setTagsOptions.AccessConditions.LeaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
-    EXPECT_THROW(blobClient.SetTags(tags, setTagsOptions), StorageException);
-    Blobs::GetBlobTagsOptions getTagsOptions;
-    getTagsOptions.AccessConditions.LeaseId = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
-    EXPECT_THROW(blobClient.GetTags(getTagsOptions), StorageException);
-
-    setTagsOptions.AccessConditions.LeaseId = leaseClient.GetLeaseId();
-    EXPECT_NO_THROW(blobClient.SetTags(tags, setTagsOptions));
-    getTagsOptions.AccessConditions.LeaseId = leaseClient.GetLeaseId();
-    EXPECT_NO_THROW(blobClient.GetTags(getTagsOptions));
-
-    leaseClient.Release();
-  }
-
-  TEST_F(BlockBlobClientTest, MaximumBlocks)
-  {
-    auto const testName(GetTestName());
-    auto blobClient = GetBlockBlobClient(testName);
-
-    const std::vector<uint8_t> content(static_cast<size_t>(1), 'a');
-    const std::string blockId = Base64EncodeText(std::string(64, '0'));
-    auto blockContent = Azure::Core::IO::MemoryBodyStream(content.data(), content.size());
-    blobClient.StageBlock(blockId, blockContent);
-
-    std::vector<std::string> blockIds(50000, blockId);
-    EXPECT_NO_THROW(blobClient.CommitBlockList(blockIds));
-
-    EXPECT_EQ(
-        blobClient.GetProperties().Value.BlobSize,
-        static_cast<int64_t>(blockIds.size() * content.size()));
   }
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -1491,7 +1491,7 @@ namespace Azure { namespace Storage { namespace Test {
     CHECK_SKIP_TEST();
 
     auto blobClient = *m_blockBlobClient;
-    const auto blobContent = RandomBuffer(8_MB);
+    const auto blobContent = RandomBuffer(static_cast<size_t>(8_MB));
     blobClient.UploadFrom(blobContent.data(), blobContent.size());
 
     auto testDownloadToBuffer = [&](int concurrency,
@@ -1677,7 +1677,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     CHECK_SKIP_TEST();
 
-    const auto blobContent = RandomBuffer(8_MB);
+    const auto blobContent = RandomBuffer(static_cast<size_t>(8_MB));
 
     auto testUploadFromBuffer = [&](int concurrency,
                                     int64_t bufferSize,
@@ -1695,10 +1695,12 @@ namespace Azure { namespace Storage { namespace Test {
       }
 
       auto blobClient = m_blobContainerClient->GetBlockBlobClient(RandomString());
-      EXPECT_NO_THROW(blobClient.UploadFrom(blobContent.data(), bufferSize, options));
-      std::vector<uint8_t> downloadBuffer(bufferSize, '\x00');
+      EXPECT_NO_THROW(
+          blobClient.UploadFrom(blobContent.data(), static_cast<size_t>(bufferSize), options));
+      std::vector<uint8_t> downloadBuffer(static_cast<size_t>(bufferSize), '\x00');
       blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
-      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + bufferSize);
+      std::vector<uint8_t> expectedData(
+          blobContent.begin(), blobContent.begin() + static_cast<size_t>(bufferSize));
       EXPECT_EQ(downloadBuffer, expectedData);
     };
 
@@ -1719,13 +1721,16 @@ namespace Azure { namespace Storage { namespace Test {
 
       const std::string tempFileName = RandomString();
       WriteFile(
-          tempFileName, std::vector<uint8_t>(blobContent.begin(), blobContent.begin() + fileSize));
+          tempFileName,
+          std::vector<uint8_t>(
+              blobContent.begin(), blobContent.begin() + static_cast<size_t>(fileSize)));
       auto blobClient = m_blobContainerClient->GetBlockBlobClient(RandomString());
       EXPECT_NO_THROW(blobClient.UploadFrom(tempFileName, options));
       DeleteFile(tempFileName);
-      std::vector<uint8_t> downloadBuffer(fileSize, '\x00');
+      std::vector<uint8_t> downloadBuffer(static_cast<size_t>(fileSize), '\x00');
       blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
-      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + fileSize);
+      std::vector<uint8_t> expectedData(
+          blobContent.begin(), blobContent.begin() + static_cast<size_t>(fileSize));
       EXPECT_EQ(downloadBuffer, expectedData);
     };
 

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -33,6 +33,10 @@ namespace Azure { namespace Storage { namespace Test {
   void BlockBlobClientTest::SetUp()
   {
     BlobContainerClientTest::SetUp();
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_blobName = RandomString();
     m_blockBlobClient = std::make_shared<Blobs::BlockBlobClient>(
         m_blobContainerClient->GetBlockBlobClient(m_blobName));
@@ -1488,8 +1492,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, ConcurrentDownload_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
-
     auto blobClient = *m_blockBlobClient;
     const auto blobContent = RandomBuffer(static_cast<size_t>(8_MB));
     blobClient.UploadFrom(blobContent.data(), blobContent.size());
@@ -1675,7 +1677,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(BlockBlobClientTest, ConcurrentUpload_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
 
     const auto blobContent = RandomBuffer(static_cast<size_t>(8_MB));
 

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.hpp
@@ -4,67 +4,26 @@
 #include <azure/storage/blobs.hpp>
 
 #include "blob_container_client_test.hpp"
-#include "test/ut/test_base.hpp"
 
 namespace Azure { namespace Storage { namespace Test {
 
   class BlockBlobClientTest : public BlobContainerClientTest {
-  private:
-    std::shared_ptr<Azure::Storage::Blobs::BlockBlobClient> m_blockBlobClient;
-    std::string m_blobName;
+  protected:
+    void SetUp() override;
+
+    Blobs::BlockBlobClient GetBlockBlobClientForTest(
+        const std::string& blobName,
+        Blobs::BlobClientOptions clientOptions = Blobs::BlobClientOptions())
+    {
+      auto containerClient = GetBlobContainerClientForTest(m_containerName, clientOptions);
+      return containerClient.GetBlockBlobClient(blobName);
+    }
 
   protected:
-    virtual void SetUp() override;
-    virtual void TearDown() override;
+    std::shared_ptr<Azure::Storage::Blobs::BlockBlobClient> m_blockBlobClient;
+    std::string m_blobName;
     std::vector<uint8_t> m_blobContent;
     Azure::Storage::Blobs::UploadBlockBlobOptions m_blobUploadOptions;
-
-    Azure::Storage::Blobs::BlockBlobClient const& GetBlockBlobClient(std::string const& blobName)
-    {
-      // Create container
-      auto const testName(GetTestNameLowerCase(true));
-      auto containerClient = GetBlobContainerTestClient();
-      containerClient.CreateIfNotExists();
-
-      m_blockBlobClient = std::make_shared<Azure::Storage::Blobs::BlockBlobClient>(
-          containerClient.GetBlockBlobClient(blobName));
-
-      return *m_blockBlobClient;
-    }
-
-    std::unique_ptr<Azure::Storage::Blobs::BlobClient> GetBlobClient(std::string const& blobName)
-    {
-      // Create container
-      auto const testName(GetTestNameLowerCase());
-      auto containerClient = GetBlobContainerTestClient();
-      containerClient.CreateIfNotExists();
-
-      return std::make_unique<Azure::Storage::Blobs::BlobClient>(
-          containerClient.GetBlobClient(blobName));
-    }
-
-    void SetOptions()
-    {
-      m_blobUploadOptions.Metadata = {{"key1", "V1"}, {"key2", "Value2"}};
-      m_blobUploadOptions.HttpHeaders.ContentType = "application/x-binary";
-      m_blobUploadOptions.HttpHeaders.ContentLanguage = "en-US";
-      m_blobUploadOptions.HttpHeaders.ContentDisposition = "attachment";
-      m_blobUploadOptions.HttpHeaders.CacheControl = "no-cache";
-      m_blobUploadOptions.HttpHeaders.ContentEncoding = "identity";
-      m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
-      m_blobUploadOptions.AccessTier = Azure::Storage::Blobs::Models::AccessTier::Hot;
-    }
-
-    void UploadBlockBlob(unsigned long long blobSize = 1_KB)
-    {
-      m_blobContent = std::vector<uint8_t>(static_cast<size_t>(blobSize), 'x');
-      SetOptions();
-      auto blobContent
-          = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-      m_blockBlobClient->Upload(blobContent, m_blobUploadOptions);
-      m_blobUploadOptions.HttpHeaders.ContentHash
-          = m_blockBlobClient->GetProperties().Value.HttpHeaders.ContentHash;
-    }
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
@@ -30,7 +30,7 @@ namespace Azure { namespace Storage { namespace Test {
         = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
     m_pageBlobClient->Create(2_KB);
     m_pageBlobClient->UploadPages(0, blobContent);
-    m_blobContent.resize(2_KB);
+    m_blobContent.resize(static_cast<size_t>(2_KB));
   }
 
   TEST_F(PageBlobClientTest, CreateDelete)
@@ -81,7 +81,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     auto pageBlobClient = *m_pageBlobClient;
 
-    std::vector<uint8_t> blobContent = RandomBuffer(4_KB);
+    std::vector<uint8_t> blobContent = RandomBuffer(static_cast<size_t>(4_KB));
 
     pageBlobClient.Create(8_KB);
     auto pageContent = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());

--- a/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
@@ -22,6 +22,10 @@ namespace Azure { namespace Storage { namespace Test {
   void PageBlobClientTest::SetUp()
   {
     BlobContainerClientTest::SetUp();
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_blobName = RandomString();
     m_pageBlobClient = std::make_shared<Blobs::PageBlobClient>(
         m_blobContainerClient->GetPageBlobClient(m_blobName));

--- a/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.cpp
@@ -11,18 +11,43 @@
 #include <azure/storage/common/crypt.hpp>
 #include <azure/storage/common/internal/file_io.hpp>
 
+namespace Azure { namespace Storage { namespace Blobs { namespace Models {
+
+  bool operator==(const BlobHttpHeaders& lhs, const BlobHttpHeaders& rhs);
+
+}}}} // namespace Azure::Storage::Blobs::Models
+
 namespace Azure { namespace Storage { namespace Test {
 
-  void PageBlobClientTest::SetUp() { BlobContainerClientTest::SetUp(); }
-
-  void PageBlobClientTest::TearDown() { BlobContainerClientTest::TearDown(); }
+  void PageBlobClientTest::SetUp()
+  {
+    BlobContainerClientTest::SetUp();
+    m_blobName = RandomString();
+    m_pageBlobClient = std::make_shared<Blobs::PageBlobClient>(
+        m_blobContainerClient->GetPageBlobClient(m_blobName));
+    m_blobContent = std::vector<uint8_t>(static_cast<size_t>(1_KB), 'x');
+    auto blobContent
+        = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
+    m_pageBlobClient->Create(2_KB);
+    m_pageBlobClient->UploadPages(0, blobContent);
+    m_blobContent.resize(2_KB);
+  }
 
   TEST_F(PageBlobClientTest, CreateDelete)
   {
-    auto const testName(GetTestName());
-    auto pageBlobClient = GetPageBlobClient(testName);
+    auto pageBlobClient = *m_pageBlobClient;
 
-    auto blobContentInfo = pageBlobClient.Create(0, m_blobUploadOptions);
+    Blobs::CreatePageBlobOptions createOptions;
+    createOptions.HttpHeaders.ContentType = "application/x-binary";
+    createOptions.HttpHeaders.ContentLanguage = "en-US";
+    createOptions.HttpHeaders.ContentDisposition = "attachment";
+    createOptions.HttpHeaders.CacheControl = "no-cache";
+    createOptions.HttpHeaders.ContentEncoding = "identify";
+    createOptions.Metadata = RandomMetadata();
+    createOptions.Tags["key1"] = "value1";
+    createOptions.Tags["key2"] = "value2";
+    createOptions.Tags["key3 +-./:=_"] = "v1 +-./:=_";
+    auto blobContentInfo = pageBlobClient.Create(0, createOptions);
     EXPECT_TRUE(blobContentInfo.Value.ETag.HasValue());
     EXPECT_TRUE(IsValidTime(blobContentInfo.Value.LastModified));
     EXPECT_TRUE(blobContentInfo.Value.VersionId.HasValue());
@@ -30,30 +55,20 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(blobContentInfo.Value.EncryptionScope.HasValue());
     EXPECT_FALSE(blobContentInfo.Value.EncryptionKeySha256.HasValue());
 
+    auto properties = pageBlobClient.GetProperties().Value;
+    EXPECT_EQ(properties.Metadata, createOptions.Metadata);
+    EXPECT_EQ(properties.HttpHeaders, createOptions.HttpHeaders);
+    EXPECT_EQ(pageBlobClient.GetTags().Value, createOptions.Tags);
+
     pageBlobClient.Delete();
     EXPECT_THROW(pageBlobClient.Delete(), StorageException);
   }
 
-  TEST_F(PageBlobClientTest, CreateWithTags)
-  {
-    auto const testName(GetTestName());
-    auto pageBlobClient = GetPageBlobClient(testName);
-
-    Blobs::CreatePageBlobOptions options;
-    options.Tags["key1"] = "value1";
-    options.Tags["key2"] = "value2";
-    options.Tags["key3 +-./:=_"] = "v1 +-./:=_";
-    pageBlobClient.Create(512, options);
-
-    EXPECT_EQ(pageBlobClient.GetTags().Value, options.Tags);
-  }
-
   TEST_F(PageBlobClientTest, Resize)
   {
-    auto const testName(GetTestName());
-    auto pageBlobClient = GetPageBlobClient(testName);
+    auto pageBlobClient = *m_pageBlobClient;
 
-    pageBlobClient.Create(0, m_blobUploadOptions);
+    pageBlobClient.Create(0);
 
     EXPECT_EQ(pageBlobClient.GetProperties().Value.BlobSize, 0);
     pageBlobClient.Resize(static_cast<int64_t>(2_KB));
@@ -62,15 +77,13 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(static_cast<uint64_t>(pageBlobClient.GetProperties().Value.BlobSize), 1_KB);
   }
 
-  TEST_F(PageBlobClientTest, UploadClear_LIVEONLY_)
+  TEST_F(PageBlobClientTest, UploadClear)
   {
-    CHECK_SKIP_TEST();
-    auto const testName(GetTestName());
-    auto pageBlobClient = GetPageBlobClient(testName);
+    auto pageBlobClient = *m_pageBlobClient;
 
-    std::vector<uint8_t> blobContent = std::vector<uint8_t>(static_cast<size_t>(4_KB), 'x');
+    std::vector<uint8_t> blobContent = RandomBuffer(4_KB);
 
-    pageBlobClient.Create(8_KB, m_blobUploadOptions);
+    pageBlobClient.Create(8_KB);
     auto pageContent = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
     pageBlobClient.UploadPages(2_KB, pageContent);
     // |_|_|x|x|  |x|x|_|_|
@@ -140,12 +153,11 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(PageBlobClientTest, GetPageRangesContinuation)
   {
-    auto const testName(GetTestName());
-    auto pageBlobClient = GetPageBlobClient(testName);
+    auto pageBlobClient = *m_pageBlobClient;
 
-    std::vector<uint8_t> blobContent = std::vector<uint8_t>(static_cast<size_t>(512), 'x');
+    std::vector<uint8_t> blobContent = RandomBuffer(512);
 
-    pageBlobClient.Create(8_KB, m_blobUploadOptions);
+    pageBlobClient.Create(8_KB);
     auto pageContent = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
     pageBlobClient.UploadPages(0, pageContent);
     pageContent.Rewind();
@@ -167,36 +179,28 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(PageBlobClientTest, UploadFromUri)
   {
-    auto const testName(GetTestName());
-    auto testPageBlobClient = GetPageBlobClient(testName);
-    UploadPage();
+    auto pageBlobClient = *m_pageBlobClient;
 
-    auto pageBlobClient = Azure::Storage::Blobs::PageBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        testName + "2",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
-    pageBlobClient.Create(m_blobContent.size(), m_blobUploadOptions);
-    pageBlobClient.UploadPagesFromUri(
-        0, testPageBlobClient.GetUrl() + GetSas(), {0, static_cast<int64_t>(m_blobContent.size())});
+    auto pageBlobClient2 = GetPageBlobClientTestForTest(RandomString());
+    pageBlobClient2.Create(m_blobContent.size());
+    pageBlobClient2.UploadPagesFromUri(
+        0, pageBlobClient.GetUrl() + GetSas(), {0, static_cast<int64_t>(m_blobContent.size())});
+    EXPECT_EQ(
+        pageBlobClient2.Download().Value.BodyStream->ReadToEnd(),
+        pageBlobClient.Download().Value.BodyStream->ReadToEnd());
   }
 
   TEST_F(PageBlobClientTest, StartCopyIncremental)
   {
-    auto const testName(GetTestName());
-    auto testPageBlobClient = GetPageBlobClient(testName);
-    UploadPage();
+    auto pageBlobClient = *m_pageBlobClient;
 
-    const std::string blobName(testName + "2");
-    auto pageBlobClient = Azure::Storage::Blobs::PageBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        blobName,
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+    const std::string blobName = RandomString();
+    auto pageBlobClient2 = GetPageBlobClientTestForTest(blobName);
 
-    std::string snapshot = testPageBlobClient.CreateSnapshot().Value.Snapshot;
-    Azure::Core::Url sourceUri(testPageBlobClient.WithSnapshot(snapshot).GetUrl());
-    auto copyInfo = pageBlobClient.StartCopyIncremental(AppendQueryParameters(sourceUri, GetSas()));
+    std::string snapshot = pageBlobClient.CreateSnapshot().Value.Snapshot;
+    Azure::Core::Url sourceUri(pageBlobClient.WithSnapshot(snapshot).GetUrl());
+    auto copyInfo
+        = pageBlobClient2.StartCopyIncremental(AppendQueryParameters(sourceUri, GetSas()));
     EXPECT_EQ(
         copyInfo.GetRawResponse().GetStatusCode(), Azure::Core::Http::HttpStatusCode::Accepted);
     auto getPropertiesResult = copyInfo.PollUntilDone(PollInterval());
@@ -222,16 +226,14 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(blobItem.Details.IncrementalCopyDestinationSnapshot.Value().empty());
   }
 
-  TEST_F(PageBlobClientTest, Lease_LIVEONLY_)
+  TEST_F(PageBlobClientTest, Lease)
   {
-    auto const testName(GetTestName());
-    auto testPageBlobClient = GetPageBlobClient(testName);
-    UploadPage();
+    auto pageBlobClient = *m_pageBlobClient;
 
     {
-      std::string leaseId1 = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
+      std::string leaseId1 = RandomUUID();
       auto leaseDuration = std::chrono::seconds(20);
-      Blobs::BlobLeaseClient leaseClient(testPageBlobClient, leaseId1);
+      Blobs::BlobLeaseClient leaseClient(pageBlobClient, leaseId1);
       auto aLease = leaseClient.Acquire(leaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
       EXPECT_TRUE(IsValidTime(aLease.LastModified));
@@ -242,7 +244,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(IsValidTime(aLease.LastModified));
       EXPECT_EQ(aLease.LeaseId, leaseId1);
 
-      auto properties = testPageBlobClient.GetProperties().Value;
+      auto properties = pageBlobClient.GetProperties().Value;
       EXPECT_EQ(properties.LeaseState.Value(), Blobs::Models::LeaseState::Leased);
       EXPECT_EQ(properties.LeaseStatus.Value(), Blobs::Models::LeaseStatus::Locked);
       EXPECT_EQ(properties.LeaseDuration.Value(), Blobs::Models::LeaseDurationType::Fixed);
@@ -252,7 +254,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(IsValidTime(rLease.LastModified));
       EXPECT_EQ(rLease.LeaseId, leaseId1);
 
-      std::string leaseId2 = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
+      std::string leaseId2 = RandomUUID();
       EXPECT_NE(leaseId1, leaseId2);
       auto cLease = leaseClient.Change(leaseId2).Value;
       EXPECT_TRUE(cLease.ETag.HasValue());
@@ -266,10 +268,9 @@ namespace Azure { namespace Storage { namespace Test {
     }
 
     {
-      Blobs::BlobLeaseClient leaseClient(
-          testPageBlobClient, Blobs::BlobLeaseClient::CreateUniqueLeaseId());
+      Blobs::BlobLeaseClient leaseClient(pageBlobClient, RandomUUID());
       auto aLease = leaseClient.Acquire(Blobs::BlobLeaseClient::InfiniteLeaseDuration).Value;
-      auto properties = testPageBlobClient.GetProperties().Value;
+      auto properties = pageBlobClient.GetProperties().Value;
       EXPECT_EQ(properties.LeaseDuration.Value(), Blobs::Models::LeaseDurationType::Infinite);
       auto brokenLease = leaseClient.Break().Value;
       EXPECT_TRUE(brokenLease.ETag.HasValue());
@@ -277,8 +278,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
 
     {
-      Blobs::BlobLeaseClient leaseClient(
-          testPageBlobClient, Blobs::BlobLeaseClient::CreateUniqueLeaseId());
+      Blobs::BlobLeaseClient leaseClient(pageBlobClient, RandomUUID());
       auto leaseDuration = std::chrono::seconds(20);
       auto aLease = leaseClient.Acquire(leaseDuration).Value;
       auto brokenLease = leaseClient.Break().Value;
@@ -293,8 +293,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(PageBlobClientTest, ContentHash)
   {
-    auto const testName(GetTestName());
-    auto pageBlobClient = GetPageBlobClient(testName);
+    auto pageBlobClient = *m_pageBlobClient;
 
     std::vector<uint8_t> blobContent = RandomBuffer(static_cast<size_t>(4_KB));
     const std::vector<uint8_t> contentMd5
@@ -306,7 +305,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto contentStream = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
     pageBlobClient.UploadPages(0, contentStream);
 
-    auto pageBlobClient2 = GetPageBlobClient(testName + "2");
+    auto pageBlobClient2 = GetPageBlobClientTestForTest(RandomString());
     pageBlobClient2.Create(blobContent.size());
 
     Blobs::UploadPagesOptions options1;
@@ -355,32 +354,30 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(PageBlobClientTest, CreateIfNotExists)
   {
-    auto const testName(GetTestName());
-    auto blobClient = GetPageBlobClient(testName);
+    auto pageBlobClient = GetPageBlobClientTestForTest(RandomString());
 
     auto blobClientWithoutAuth = Azure::Storage::Blobs::PageBlobClient(
-        blobClient.GetUrl(), InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+        pageBlobClient.GetUrl(), InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
     EXPECT_THROW(blobClientWithoutAuth.CreateIfNotExists(m_blobContent.size()), StorageException);
     {
-      auto response = blobClient.CreateIfNotExists(m_blobContent.size());
+      auto response = pageBlobClient.CreateIfNotExists(m_blobContent.size());
       EXPECT_TRUE(response.Value.Created);
     }
 
     auto blobContent
         = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-    blobClient.UploadPages(0, blobContent);
+    pageBlobClient.UploadPages(0, blobContent);
     {
-      auto response = blobClient.CreateIfNotExists(m_blobContent.size());
+      auto response = pageBlobClient.CreateIfNotExists(m_blobContent.size());
       EXPECT_FALSE(response.Value.Created);
     }
-    auto downloadStream = std::move(blobClient.Download().Value.BodyStream);
+    auto downloadStream = std::move(pageBlobClient.Download().Value.BodyStream);
     EXPECT_EQ(downloadStream->ReadToEnd(Azure::Core::Context()), m_blobContent);
   }
 
   TEST_F(PageBlobClientTest, SourceBlobAccessConditions)
   {
-    auto const testName(GetTestName());
-    auto sourceBlobClient = GetPageBlobClient(testName);
+    auto sourceBlobClient = GetPageBlobClientTestForTest("source" + RandomString());
 
     const std::string url = sourceBlobClient.GetUrl() + GetSas();
 
@@ -391,11 +388,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto timeBeforeStr = lastModifiedTime - std::chrono::seconds(1);
     auto timeAfterStr = lastModifiedTime + std::chrono::seconds(1);
 
-    auto destBlobClient = Azure::Storage::Blobs::PageBlobClient::CreateFromConnectionString(
-        StandardStorageConnectionString(),
-        m_containerName,
-        testName + "2",
-        InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
+    auto destBlobClient = GetPageBlobClientTestForTest("dest" + RandomString());
     destBlobClient.Create(blobSize);
 
     {
@@ -434,8 +427,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(PageBlobClientTest, UpdateSequenceNumber)
   {
-    auto const testName(GetTestName());
-    auto blobClient = GetPageBlobClient(testName);
+    auto blobClient = *m_pageBlobClient;
 
     blobClient.Create(512);
 
@@ -476,8 +468,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(PageBlobClientTest, PageBlobAccessConditions)
   {
-    auto const testName(GetTestName());
-    auto blobClient = GetPageBlobClient(testName);
+    auto blobClient = *m_pageBlobClient;
 
     blobClient.Create(1024);
     Blobs::UpdatePageBlobSequenceNumberOptions updateSequenceNumberOptions;

--- a/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/page_blob_client_test.hpp
@@ -4,58 +4,25 @@
 #include <azure/storage/blobs.hpp>
 
 #include "blob_container_client_test.hpp"
-#include "test/ut/test_base.hpp"
 
 namespace Azure { namespace Storage { namespace Test {
 
   class PageBlobClientTest : public BlobContainerClientTest {
-  private:
-    std::shared_ptr<Azure::Storage::Blobs::PageBlobClient> m_pageBlobClient;
+  protected:
+    void SetUp() override;
+
+    Blobs::PageBlobClient GetPageBlobClientTestForTest(
+        const std::string& blobName,
+        Blobs::BlobClientOptions clientOptions = Blobs::BlobClientOptions())
+    {
+      auto containerClient = GetBlobContainerClientForTest(m_containerName, clientOptions);
+      return containerClient.GetPageBlobClient(blobName);
+    }
 
   protected:
+    std::shared_ptr<Azure::Storage::Blobs::PageBlobClient> m_pageBlobClient;
     std::string m_blobName;
-    Azure::Storage::Blobs::CreatePageBlobOptions m_blobUploadOptions;
     std::vector<uint8_t> m_blobContent;
-
-    virtual void SetUp() override;
-    virtual void TearDown() override;
-
-    Azure::Storage::Blobs::PageBlobClient const& GetPageBlobClient(std::string const& blobName)
-    {
-      // Create container
-      auto containerClient = GetBlobContainerTestClient();
-      containerClient.CreateIfNotExists();
-
-      m_blobContent = std::vector<uint8_t>(static_cast<size_t>(1_KB), 'x');
-      m_pageBlobClient = std::make_unique<Azure::Storage::Blobs::PageBlobClient>(
-          containerClient.GetPageBlobClient(blobName));
-
-      return *m_pageBlobClient;
-    }
-
-    void SetOptions()
-    {
-      m_blobUploadOptions.Metadata = {{"key1", "V1"}, {"key2", "Value2"}};
-      m_blobUploadOptions.HttpHeaders.ContentType = "application/x-binary";
-      m_blobUploadOptions.HttpHeaders.ContentLanguage = "en-US";
-      m_blobUploadOptions.HttpHeaders.ContentDisposition = "attachment";
-      m_blobUploadOptions.HttpHeaders.CacheControl = "no-cache";
-      m_blobUploadOptions.HttpHeaders.ContentEncoding = "identity";
-      m_blobUploadOptions.HttpHeaders.ContentHash.Value.clear();
-    }
-
-    void UploadPage(unsigned long long blobSize = 1_KB)
-    {
-      SetOptions();
-
-      m_blobContent = std::vector<uint8_t>(static_cast<size_t>(blobSize), 'x');
-      m_pageBlobClient->Create(m_blobContent.size(), m_blobUploadOptions);
-      auto pageContent
-          = Azure::Core::IO::MemoryBodyStream(m_blobContent.data(), m_blobContent.size());
-      m_pageBlobClient->UploadPages(0, pageContent);
-      m_blobUploadOptions.HttpHeaders.ContentHash
-          = m_pageBlobClient->GetProperties().Value.HttpHeaders.ContentHash;
-    }
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-common/test/ut/bearer_token_test.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/bearer_token_test.cpp
@@ -11,7 +11,10 @@ namespace Azure { namespace Storage { namespace Test {
     auto containerClient = Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
         StandardStorageConnectionString(), containerName);
     auto credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-        AadTenantId(), AadClientId(), AadClientSecret());
+        AadTenantId(),
+        AadClientId(),
+        AadClientSecret(),
+        InitClientOptions<Core::Credentials::TokenCredentialOptions>());
     containerClient = Blobs::BlobContainerClient(
         containerClient.GetUrl(), credential, InitClientOptions<Blobs::BlobClientOptions>());
 

--- a/sdk/storage/azure-storage-common/test/ut/bearer_token_test.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/bearer_token_test.cpp
@@ -5,7 +5,7 @@
 
 namespace Azure { namespace Storage { namespace Test {
 
-  TEST_F(StorageTest, ClientSecretCredentialWorks)
+  TEST_F(StorageTest, ClientSecretCredentialWorks_LIVEONLY_)
   {
     const std::string containerName = LowercaseRandomString();
     auto containerClient = Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(

--- a/sdk/storage/azure-storage-common/test/ut/bearer_token_test.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/bearer_token_test.cpp
@@ -5,9 +5,15 @@
 
 namespace Azure { namespace Storage { namespace Test {
 
-  TEST_F(ClientSecretCredentialTest, ClientSecretCredentialWorks_LIVEONLY_)
+  TEST_F(StorageTest, ClientSecretCredentialWorks)
   {
-    auto containerClient = GetClientForTest(GetTestName());
+    const std::string containerName = LowercaseRandomString();
+    auto containerClient = Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
+        StandardStorageConnectionString(), containerName);
+    auto credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
+        AadTenantId(), AadClientId(), AadClientSecret());
+    containerClient = Blobs::BlobContainerClient(
+        containerClient.GetUrl(), credential, InitClientOptions<Blobs::BlobClientOptions>());
 
     EXPECT_NO_THROW(containerClient.Create());
     EXPECT_NO_THROW(containerClient.Delete());

--- a/sdk/storage/azure-storage-common/test/ut/crypt_functions_test.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/crypt_functions_test.cpp
@@ -9,6 +9,9 @@
 
 namespace Azure { namespace Storage { namespace Test {
 
+  class CryptFunctionsTest : public StorageTest {
+  };
+
   std::vector<uint8_t> ToBinaryVector(const char* text)
   {
     const uint8_t* start = reinterpret_cast<const uint8_t*>(text);
@@ -109,34 +112,6 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(
         crc64Streaming.Final(),
         crc64Single.Final(reinterpret_cast<const uint8_t*>(allData.data()), allData.size()));
-  }
-
-  TEST_F(CryptFunctionsTest, Crc64Hash_ExpectThrow)
-  {
-    std::string data = "";
-    const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data.data());
-    Crc64Hash instance;
-
-#if GTEST_HAS_DEATH_TEST
-    ASSERT_DEATH(instance.Final(nullptr, 1), "");
-    ASSERT_DEATH(instance.Append(nullptr, 1), "");
-#endif
-
-    EXPECT_EQ(
-        Azure::Core::Convert::Base64Encode(instance.Final(ptr, data.length())), "AAAAAAAAAAA=");
-
-#if GTEST_HAS_DEATH_TEST
-#if defined(NDEBUG)
-    // Release build won't provide assert msg
-    ASSERT_DEATH(instance.Final(), "");
-    ASSERT_DEATH(instance.Final(ptr, data.length()), "");
-    ASSERT_DEATH(instance.Append(ptr, data.length()), "");
-#else
-    ASSERT_DEATH(instance.Final(), "Cannot call Final");
-    ASSERT_DEATH(instance.Final(ptr, data.length()), "Cannot call Final");
-    ASSERT_DEATH(instance.Append(ptr, data.length()), "Cannot call Append after calling Final");
-#endif
-#endif
   }
 
   TEST_F(CryptFunctionsTest, Crc64Hash_CtorDtor)

--- a/sdk/storage/azure-storage-common/test/ut/test_base.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.cpp
@@ -47,8 +47,6 @@ namespace Azure { namespace Storage { namespace Test {
   {
     Azure::Core::Test::TestBase::SetUpTestBase(AZURE_TEST_RECORDING_DIR);
 
-    // Need to call this function to skip live-only cases
-    CHECK_SKIP_TEST();
     if (m_testContext.IsLiveMode())
     {
       m_randomGenerator.seed(std::random_device{}());

--- a/sdk/storage/azure-storage-common/test/ut/test_base.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.cpp
@@ -211,15 +211,18 @@ namespace Azure { namespace Storage { namespace Test {
 
   uint64_t StorageTest::RandomInt(uint64_t minNumber, uint64_t maxNumber)
   {
-    std::uniform_int_distribution<uint64_t> distribution(minNumber, maxNumber);
-    return distribution(m_randomGenerator);
+    uint64_t val = m_randomGenerator();
+    if (minNumber == 0 && maxNumber == std::numeric_limits<decltype(maxNumber)>::max())
+    {
+      return val;
+    }
+    return minNumber + val % (maxNumber - minNumber + 1);
   }
 
   char StorageTest::RandomChar()
   {
     const char charset[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    std::uniform_int_distribution<size_t> distribution(0, sizeof(charset) - 2);
-    return charset[distribution(m_randomGenerator)];
+    return charset[RandomInt(0, sizeof(charset) - 2)];
   }
 
   std::string StorageTest::RandomString(size_t size)
@@ -257,11 +260,10 @@ namespace Azure { namespace Storage { namespace Test {
       *(start_addr++) = RandomChar();
     }
 
-    std::uniform_int_distribution<uint64_t> distribution(
-        0ULL, std::numeric_limits<uint64_t>::max());
     while (start_addr + rand_int_size <= end_addr)
     {
-      *reinterpret_cast<uint64_t*>(start_addr) = distribution(m_randomGenerator);
+      *reinterpret_cast<uint64_t*>(start_addr)
+          = RandomInt(0ULL, std::numeric_limits<uint64_t>::max());
       start_addr += rand_int_size;
     }
     while (start_addr < end_addr)

--- a/sdk/storage/azure-storage-common/test/ut/test_base.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.cpp
@@ -48,7 +48,7 @@ namespace Azure { namespace Storage { namespace Test {
     Azure::Core::Test::TestBase::SetUpTestBase(AZURE_TEST_RECORDING_DIR);
 
     // Need to call this function to skip live-only cases
-    GetTestName();
+    CHECK_SKIP_TEST();
     if (m_testContext.IsLiveMode())
     {
       m_randomGenerator.seed(std::random_device{}());

--- a/sdk/storage/azure-storage-common/test/ut/test_base.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.cpp
@@ -47,6 +47,8 @@ namespace Azure { namespace Storage { namespace Test {
   {
     Azure::Core::Test::TestBase::SetUpTestBase(AZURE_TEST_RECORDING_DIR);
 
+    // Need to call this function to skip live-only cases
+    GetTestName();
     if (m_testContext.IsLiveMode())
     {
       m_randomGenerator.seed(std::random_device{}());

--- a/sdk/storage/azure-storage-common/test/ut/test_base.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.cpp
@@ -43,6 +43,37 @@ namespace Azure { namespace Storage { namespace Test {
   constexpr static const char* AadClientIdValue = "";
   constexpr static const char* AadClientSecretValue = "";
 
+  void StorageTest::SetUp()
+  {
+    Azure::Core::Test::TestBase::SetUpTestBase(AZURE_TEST_RECORDING_DIR);
+
+    if (m_testContext.IsLiveMode())
+    {
+      m_randomGenerator.seed(std::random_device{}());
+    }
+    else
+    {
+      auto seedStr = GetIdentifier();
+      std::seed_seq seedSeq(seedStr.begin(), seedStr.end());
+      m_randomGenerator.seed(seedSeq);
+    }
+  }
+
+  void StorageTest::TearDown()
+  {
+    for (auto& f : m_resourceCleanupFunctions)
+    {
+      try
+      {
+        f();
+      }
+      catch (...)
+      {
+      }
+    }
+    TestBase::TearDown();
+  }
+
   const std::string& StorageTest::StandardStorageConnectionString()
   {
     const static std::string connectionString = [&]() -> std::string {
@@ -176,53 +207,24 @@ namespace Azure { namespace Storage { namespace Test {
     return absoluteUrl;
   }
 
-  static thread_local std::mt19937_64 random_generator(std::random_device{}());
-
   uint64_t StorageTest::RandomInt(uint64_t minNumber, uint64_t maxNumber)
   {
     std::uniform_int_distribution<uint64_t> distribution(minNumber, maxNumber);
-    return distribution(random_generator);
+    return distribution(m_randomGenerator);
   }
 
-  static char RandomChar()
+  char StorageTest::RandomChar()
   {
     const char charset[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     std::uniform_int_distribution<size_t> distribution(0, sizeof(charset) - 2);
-    return charset[distribution(random_generator)];
+    return charset[distribution(m_randomGenerator)];
   }
 
   std::string StorageTest::RandomString(size_t size)
   {
     std::string str;
     str.resize(size);
-    std::generate(str.begin(), str.end(), RandomChar);
-    return str;
-  }
-
-  std::string StorageTest::GetStringOfSize(size_t size, bool lowercase)
-  {
-    auto const testName = GetTestName();
-    auto const testNameSize = testName.size();
-    auto duplicationTimes = size / testNameSize;
-    auto leftToFill = size % testNameSize;
-    std::string str;
-
-    while (duplicationTimes != 0)
-    {
-      str.append(testName);
-      duplicationTimes -= 1;
-    }
-    while (leftToFill != 0)
-    {
-      // do % 10 to use only one digit per appending
-      str.append(std::to_string(leftToFill % 10));
-      leftToFill -= 1;
-    }
-
-    if (lowercase)
-    {
-      return Azure::Core::_internal::StringExtensions::ToLower(str);
-    }
+    std::generate(str.begin(), str.end(), [this]() { return RandomChar(); });
     return str;
   }
 
@@ -231,12 +233,12 @@ namespace Azure { namespace Storage { namespace Test {
     return Azure::Core::_internal::StringExtensions::ToLower(RandomString(size));
   }
 
-  Storage::Metadata StorageTest::GetMetadata(size_t size)
+  Storage::Metadata StorageTest::RandomMetadata(size_t size)
   {
     Storage::Metadata result;
     for (size_t i = 0; i < size; ++i)
     {
-      result["meta" + std::to_string(i % 10)] = "value";
+      result["meta" + LowercaseRandomString(5)] = RandomString(10);
     }
     return result;
   }
@@ -257,13 +259,53 @@ namespace Azure { namespace Storage { namespace Test {
         0ULL, std::numeric_limits<uint64_t>::max());
     while (start_addr + rand_int_size <= end_addr)
     {
-      *reinterpret_cast<uint64_t*>(start_addr) = distribution(random_generator);
+      *reinterpret_cast<uint64_t*>(start_addr) = distribution(m_randomGenerator);
       start_addr += rand_int_size;
     }
     while (start_addr < end_addr)
     {
       *(start_addr++) = RandomChar();
     }
+  }
+
+  std::vector<uint8_t> StorageTest::RandomBuffer(size_t length)
+  {
+    std::vector<uint8_t> result(length);
+    if (length != 0)
+    {
+      char* dataPtr = reinterpret_cast<char*>(&result[0]);
+      RandomBuffer(dataPtr, length);
+    }
+    return result;
+  }
+
+  std::string StorageTest::RandomUUID()
+  {
+    std::vector<uint8_t> randomNum = RandomBuffer(16);
+    char buffer[37];
+
+    std::snprintf(
+        buffer,
+        sizeof(buffer),
+        "%2.2x%2.2x%2.2x%2.2x-%2.2x%2.2x-%2.2x%2.2x-%2.2x%2.2x-%2.2x%2.2x%2.2x%2.2x%2.2x%2.2x",
+        randomNum[0],
+        randomNum[1],
+        randomNum[2],
+        randomNum[3],
+        randomNum[4],
+        randomNum[5],
+        randomNum[6],
+        randomNum[7],
+        randomNum[8],
+        randomNum[9],
+        randomNum[10],
+        randomNum[11],
+        randomNum[12],
+        randomNum[13],
+        randomNum[14],
+        randomNum[15]);
+
+    return std::string(buffer);
   }
 
   std::vector<uint8_t> StorageTest::ReadFile(const std::string& filename)
@@ -301,17 +343,6 @@ namespace Azure { namespace Storage { namespace Test {
   }
 
   void StorageTest::DeleteFile(const std::string& filename) { std::remove(filename.data()); }
-
-  std::vector<uint8_t> StorageTest::RandomBuffer(size_t length)
-  {
-    std::vector<uint8_t> result(length);
-    if (length != 0)
-    {
-      char* dataPtr = reinterpret_cast<char*>(&result[0]);
-      RandomBuffer(dataPtr, length);
-    }
-    return result;
-  }
 
   std::string StorageTest::InferSecondaryUrl(const std::string primaryUrl)
   {

--- a/sdk/storage/azure-storage-common/test/ut/test_base.hpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.hpp
@@ -28,16 +28,14 @@ namespace Azure { namespace Storage {
 
     class StorageTest : public Azure::Core::Test::TestBase {
     public:
-<<<<<<< HEAD
       StorageTest() { TestBase::SetUpTestSuiteLocal(AZURE_TEST_ASSETS_DIR); }
-=======
+
       const static Azure::ETag DummyETag;
       const static Azure::ETag DummyETag2;
       /* cspell:disable-next-line */
       constexpr static const char* DummyMd5 = "tQbD1aMPeB+LiPffUwFQJQ==";
       /* cspell:disable-next-line */
       constexpr static const char* DummyCrc64 = "+DNR5PON4EM=";
->>>>>>> 476e518c (test-proxy)
 
     protected:
       const std::string& StandardStorageConnectionString();

--- a/sdk/storage/azure-storage-common/test/ut/test_base.hpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.hpp
@@ -107,6 +107,11 @@ namespace Azure { namespace Storage {
        *
        * To make record-playback testing work, you have to call these functions in a determined way,
        * e.g. always in the same order, the same times and with the same parameters.
+       *
+       * Note that in C++, evaluation order of function parameters is undefined. So you CANNOT do:
+       * `auto ret = RandomInt() + RandomInt();`
+       * or
+       * `auto ret = function1(RandomInt()) + function2(RandomInt());`
        */
       uint64_t RandomInt(
           uint64_t minNumber = std::numeric_limits<uint64_t>::min(),

--- a/sdk/storage/azure-storage-common/test/ut/test_base.hpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.hpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <cstdint>
 #include <limits>
+#include <random>
 #include <vector>
 
 #include <azure/core/base64.hpp>
@@ -27,7 +28,16 @@ namespace Azure { namespace Storage {
 
     class StorageTest : public Azure::Core::Test::TestBase {
     public:
+<<<<<<< HEAD
       StorageTest() { TestBase::SetUpTestSuiteLocal(AZURE_TEST_ASSETS_DIR); }
+=======
+      const static Azure::ETag DummyETag;
+      const static Azure::ETag DummyETag2;
+      /* cspell:disable-next-line */
+      constexpr static const char* DummyMd5 = "tQbD1aMPeB+LiPffUwFQJQ==";
+      /* cspell:disable-next-line */
+      constexpr static const char* DummyCrc64 = "+DNR5PON4EM=";
+>>>>>>> 476e518c (test-proxy)
 
     protected:
       const std::string& StandardStorageConnectionString();
@@ -39,40 +49,47 @@ namespace Azure { namespace Storage {
       const std::string& AadClientId();
       const std::string& AadClientSecret();
 
-      std::string GetContainerValidName() const
+      void SetUp() override;
+      void TearDown() override;
+
+      /**
+       * @brief Retruns a string related to test suite name and test case name.
+       */
+      std::string GetIdentifier() const
       {
-        std::string name(m_testContext.GetTestSuiteName() + m_testContext.GetTestName());
-        // Make sure the name is less than 63 characters long
-        auto const nameSize = name.size();
-        size_t const maxContainerNameSize = 63;
-        if (nameSize > maxContainerNameSize)
-        {
-          name = std::string(name.begin() + nameSize - maxContainerNameSize, name.end());
-        }
-        // Check name won't start with `-`
+        size_t MaxLength = 63;
+        std::string name = m_testContext.GetTestSuiteName() + m_testContext.GetTestName();
         if (name[0] == '-')
         {
-          name = std::string(name.begin() + 1, name.end());
+          name = name.substr(1);
         }
-        return Azure::Core::_internal::StringExtensions::ToLower(name);
+        if (name.length() > MaxLength)
+        {
+          name.resize(MaxLength);
+        }
+        return name;
       }
 
-      std::string GetFileSystemValidName() const
+      /**
+       * @brief Retruns a lowercase string related to test suite name and test case name.
+       */
+      std::string GetLowercaseIdentifier() const
       {
-        std::string name(m_testContext.GetTestSuiteName() + m_testContext.GetTestName());
-        // Make sure the name is less than 63 characters long
-        auto const nameSize = name.size();
-        size_t const maxContainerNameSize = 63;
-        if (nameSize > maxContainerNameSize)
+        return Azure::Core::_internal::StringExtensions::ToLower(GetIdentifier());
+      }
+
+      bool IsValidTime(const Azure::DateTime& datetime) const
+      {
+        // Playback won't check dates
+        if (m_testContext.IsPlaybackMode())
         {
-          name = std::string(name.begin() + nameSize - maxContainerNameSize, name.end());
+          return true;
         }
-        // Check name won't start with `-`
-        if (name[0] == '-')
-        {
-          name = std::string(name.begin() + 1, name.end());
-        }
-        return Azure::Core::_internal::StringExtensions::ToLower(name);
+
+        // We assume datetime within a week is valid.
+        const auto minTime = std::chrono::system_clock::now() - std::chrono::hours(24 * 7);
+        const auto maxTime = std::chrono::system_clock::now() + std::chrono::hours(24 * 7);
+        return datetime > minTime && datetime < maxTime;
       }
 
       static std::string GetTestEncryptionScope()
@@ -85,29 +102,26 @@ namespace Azure { namespace Storage {
           const Azure::Core::Url& url,
           const std::string& queryParameters);
 
-      /* cspell:disable-next-line */
-      constexpr static const char* DummyMd5 = "tQbD1aMPeB+LiPffUwFQJQ==";
-      /* cspell:disable-next-line */
-      constexpr static const char* DummyCrc64 = "+DNR5PON4EM=";
-
-      static uint64_t RandomInt(
+      /**
+       * Random functions below are not thread-safe. You must NOT call them from multiple threads.
+       *
+       * To make record-playback testing work, you have to call these functions in a determined way,
+       * e.g. always in the same order, the same times and with the same parameters.
+       */
+      uint64_t RandomInt(
           uint64_t minNumber = std::numeric_limits<uint64_t>::min(),
           uint64_t maxNumber = std::numeric_limits<uint64_t>::max());
-
-      static std::string RandomString(size_t size = 10);
-
-      std::string GetStringOfSize(size_t size = 10, bool lowercase = false);
-
-      static std::string LowercaseRandomString(size_t size = 10);
-
-      static Storage::Metadata GetMetadata(size_t size = 5);
-
-      static void RandomBuffer(char* buffer, size_t length);
-      static void RandomBuffer(uint8_t* buffer, size_t length)
+      char RandomChar();
+      std::string RandomString(size_t size = 10);
+      std::string LowercaseRandomString(size_t size = 10);
+      Storage::Metadata RandomMetadata(size_t size = 5);
+      void RandomBuffer(char* buffer, size_t length);
+      void RandomBuffer(uint8_t* buffer, size_t length)
       {
         RandomBuffer(reinterpret_cast<char*>(buffer), length);
       }
-      static std::vector<uint8_t> RandomBuffer(size_t length);
+      std::vector<uint8_t> RandomBuffer(size_t length);
+      std::string RandomUUID();
 
       static std::vector<uint8_t> ReadBodyStream(
           std::unique_ptr<Azure::Core::IO::BodyStream>& stream)
@@ -135,14 +149,11 @@ namespace Azure { namespace Storage {
         return Azure::Core::Convert::Base64Encode(std::vector<uint8_t>(text.begin(), text.end()));
       }
 
-      void SetUp() override
-      {
-        Azure::Core::Test::TestBase::SetUpTestBase(AZURE_TEST_RECORDING_DIR);
-      }
+    protected:
+      std::vector<std::function<void()>> m_resourceCleanupFunctions;
 
-    public:
-      const static Azure::ETag DummyETag;
-      const static Azure::ETag DummyETag2;
+    private:
+      std::mt19937_64 m_randomGenerator;
     };
 
     constexpr inline unsigned long long operator""_KB(unsigned long long x) { return x * 1024; }
@@ -158,49 +169,6 @@ namespace Azure { namespace Storage {
     {
       return x * 1024 * 1024 * 1024 * 1024;
     }
-
-    class CryptFunctionsTest : public StorageTest {
-    };
-
-    class ClientSecretCredentialTest : public StorageTest {
-
-    private:
-      std::unique_ptr<Azure::Storage::Blobs::BlobContainerClient> m_client;
-
-    protected:
-      std::shared_ptr<Core::Credentials::TokenCredential> m_credential;
-      std::string m_containerName;
-
-      // Required to rename the test propertly once the test is started.
-      // We can only know the test instance name until the test instance is run.
-      Azure::Storage::Blobs::BlobContainerClient const& GetClientForTest(
-          std::string const& testName)
-      {
-        // set the interceptor for the current test
-        m_testContext.RenameTest(testName);
-        return *m_client;
-      }
-
-      void SetUp() override
-      {
-        StorageTest::SetUp();
-        m_containerName = Azure::Core::_internal::StringExtensions::ToLower(GetTestName());
-
-        m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-            AadTenantId(), AadClientId(), AadClientSecret());
-
-        Azure::Storage::Blobs::BlobClientOptions options;
-
-        m_client = InitTestClient<
-            Azure::Storage::Blobs::BlobContainerClient,
-            Azure::Storage::Blobs::BlobClientOptions>(
-            Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
-                StandardStorageConnectionString(), m_containerName)
-                .GetUrl(),
-            m_credential,
-            options);
-      }
-    };
 
   } // namespace Test
 

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_directory_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_directory_client_test.cpp
@@ -14,7 +14,10 @@ namespace Azure { namespace Storage { namespace Test {
   void DataLakeDirectoryClientTest::SetUp()
   {
     DataLakeFileSystemClientTest::SetUp();
-
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_directoryName = RandomString();
     m_directoryClient = std::make_shared<Files::DataLake::DataLakeDirectoryClient>(
         m_fileSystemClient->GetDirectoryClient(m_directoryName));

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_directory_client_test.hpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_directory_client_test.hpp
@@ -4,15 +4,14 @@
 #include <azure/storage/files/datalake.hpp>
 
 #include "datalake_path_client_test.hpp"
-#include "test/ut/test_base.hpp"
 
 namespace Azure { namespace Storage { namespace Test {
 
   class DataLakeDirectoryClientTest : public DataLakePathClientTest {
   protected:
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
 
+  protected:
     std::shared_ptr<Files::DataLake::DataLakeDirectoryClient> m_directoryClient;
     std::string m_directoryName;
   };

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
@@ -866,9 +866,9 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(downloadBuffer, expectedData);
     };
 
-    std::vector<std::future<void>> futures;
     for (int c : {1, 2, 4})
     {
+      std::vector<std::future<void>> futures;
       // random range
       for (int i = 0; i < 16; ++i)
       {
@@ -882,10 +882,10 @@ namespace Azure { namespace Storage { namespace Test {
         futures.emplace_back(
             std::async(std::launch::async, testUploadFromFile, c, fileSize, 0, 25_KB));
       }
-    }
-    for (auto& f : futures)
-    {
-      f.get();
+      for (auto& f : futures)
+      {
+        f.get();
+      }
     }
   }
 

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
@@ -623,7 +623,7 @@ namespace Azure { namespace Storage { namespace Test {
     CHECK_SKIP_TEST();
 
     auto fileClient = *m_fileClient;
-    const auto blobContent = RandomBuffer(8_MB);
+    const auto blobContent = RandomBuffer(static_cast<size_t>(8_MB));
     fileClient.UploadFrom(blobContent.data(), blobContent.size());
 
     auto testDownloadToBuffer = [&](int concurrency,
@@ -809,7 +809,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     CHECK_SKIP_TEST();
 
-    const auto blobContent = RandomBuffer(8_MB);
+    const auto blobContent = RandomBuffer(static_cast<size_t>(8_MB));
 
     auto testUploadFromBuffer = [&](int concurrency,
                                     int64_t bufferSize,
@@ -827,10 +827,12 @@ namespace Azure { namespace Storage { namespace Test {
       }
 
       auto fileClient = m_fileSystemClient->GetFileClient(RandomString());
-      EXPECT_NO_THROW(fileClient.UploadFrom(blobContent.data(), bufferSize, options));
-      std::vector<uint8_t> downloadBuffer(bufferSize, '\x00');
+      EXPECT_NO_THROW(
+          fileClient.UploadFrom(blobContent.data(), static_cast<size_t>(bufferSize), options));
+      std::vector<uint8_t> downloadBuffer(static_cast<size_t>(bufferSize), '\x00');
       fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
-      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + bufferSize);
+      std::vector<uint8_t> expectedData(
+          blobContent.begin(), blobContent.begin() + static_cast<size_t>(bufferSize));
       EXPECT_EQ(downloadBuffer, expectedData);
     };
 
@@ -851,13 +853,16 @@ namespace Azure { namespace Storage { namespace Test {
 
       const std::string tempFileName = RandomString();
       WriteFile(
-          tempFileName, std::vector<uint8_t>(blobContent.begin(), blobContent.begin() + fileSize));
+          tempFileName,
+          std::vector<uint8_t>(
+              blobContent.begin(), blobContent.begin() + static_cast<size_t>(fileSize)));
       auto fileClient = m_fileSystemClient->GetFileClient(RandomString());
       EXPECT_NO_THROW(fileClient.UploadFrom(tempFileName, options));
       DeleteFile(tempFileName);
-      std::vector<uint8_t> downloadBuffer(fileSize, '\x00');
+      std::vector<uint8_t> downloadBuffer(static_cast<size_t>(fileSize), '\x00');
       fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
-      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + fileSize);
+      std::vector<uint8_t> expectedData(
+          blobContent.begin(), blobContent.begin() + static_cast<size_t>(fileSize));
       EXPECT_EQ(downloadBuffer, expectedData);
     };
 

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
@@ -29,18 +29,10 @@ namespace Azure { namespace Storage { namespace Test {
   void DataLakeFileClientTest::SetUp()
   {
     DataLakeFileSystemClientTest::SetUp();
-    CHECK_SKIP_TEST();
-    m_fileName = GetFileSystemValidName();
+    m_fileName = RandomString();
     m_fileClient = std::make_shared<Files::DataLake::DataLakeFileClient>(
         m_fileSystemClient->GetFileClient(m_fileName));
     m_fileClient->CreateIfNotExists();
-  }
-
-  void DataLakeFileClientTest::TearDown()
-  {
-    CHECK_SKIP_TEST();
-    m_fileSystemClient->GetFileClient(m_fileName).Delete();
-    DataLakeFileSystemClientTest::TearDown();
   }
 
   TEST_F(DataLakeFileClientTest, CreateDeleteFiles)
@@ -119,22 +111,17 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_FALSE(deleted);
     }
     {
-      std::string testName(GetTestNameLowerCase());
-      auto client = Files::DataLake::DataLakeFileClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(),
-          testName + "a",
-          testName + "b",
-          InitClientOptions<Files::DataLake::DataLakeClientOptions>());
+      auto fileClient = m_fileSystemClient->GetFileClient(RandomString());
       bool deleted = false;
-      EXPECT_NO_THROW(deleted = client.DeleteIfExists().Value.Deleted);
+      EXPECT_NO_THROW(deleted = fileClient.DeleteIfExists().Value.Deleted);
       EXPECT_FALSE(deleted);
     }
   }
 
   TEST_F(DataLakeFileClientTest, FileMetadata)
   {
-    auto metadata1 = GetMetadata();
-    auto metadata2 = GetMetadata();
+    auto metadata1 = RandomMetadata();
+    auto metadata2 = RandomMetadata();
     {
       // Set/Get Metadata works
       EXPECT_NO_THROW(m_fileClient->SetMetadata(metadata1));
@@ -167,8 +154,8 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakeFileClientTest, FileProperties)
   {
-    auto metadata1 = GetMetadata();
-    auto metadata2 = GetMetadata();
+    auto metadata1 = RandomMetadata();
+    auto metadata2 = RandomMetadata();
     {
       // Get Metadata via properties works
       EXPECT_NO_THROW(m_fileClient->SetMetadata(metadata1));
@@ -196,23 +183,29 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       // HTTP headers works.
-      auto httpHeader = GetInterestingHttpHeaders();
+      auto httpHeaders = Files::DataLake::Models::PathHttpHeaders();
+      httpHeaders.ContentType = "application/x-binary";
+      httpHeaders.ContentLanguage = "en-US";
+      httpHeaders.ContentDisposition = "attachment";
+      httpHeaders.CacheControl = "no-cache";
+      httpHeaders.ContentEncoding = "identity";
       std::vector<Files::DataLake::DataLakeFileClient> fileClient;
       for (int32_t i = 0; i < 2; ++i)
       {
         auto client = m_fileSystemClient->GetFileClient("client" + std::to_string(i));
         Files::DataLake::CreateFileOptions options;
-        options.HttpHeaders = httpHeader;
+        options.HttpHeaders = httpHeaders;
         EXPECT_NO_THROW(client.Create(options));
         fileClient.emplace_back(std::move(client));
       }
       for (const auto& client : fileClient)
       {
         auto result = client.GetProperties();
-        EXPECT_EQ(httpHeader.CacheControl, result.Value.HttpHeaders.CacheControl);
-        EXPECT_EQ(httpHeader.ContentDisposition, result.Value.HttpHeaders.ContentDisposition);
-        EXPECT_EQ(httpHeader.ContentLanguage, result.Value.HttpHeaders.ContentLanguage);
-        EXPECT_EQ(httpHeader.ContentType, result.Value.HttpHeaders.ContentType);
+        EXPECT_EQ(httpHeaders.ContentType, result.Value.HttpHeaders.ContentType);
+        EXPECT_EQ(httpHeaders.ContentLanguage, result.Value.HttpHeaders.ContentLanguage);
+        EXPECT_EQ(httpHeaders.ContentDisposition, result.Value.HttpHeaders.ContentDisposition);
+        EXPECT_EQ(httpHeaders.CacheControl, result.Value.HttpHeaders.CacheControl);
+        EXPECT_EQ(httpHeaders.ContentEncoding, result.Value.HttpHeaders.ContentEncoding);
         EXPECT_NO_THROW(client.Delete());
       }
     }
@@ -254,7 +247,7 @@ namespace Azure { namespace Storage { namespace Test {
 
     // Append with flush option
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "_flush_true");
+      auto client = m_fileSystemClient->GetFileClient(RandomString());
       client.Create();
       auto properties1 = client.GetProperties();
       Files::DataLake::AppendFileOptions options;
@@ -266,7 +259,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(bufferSize, properties2.Value.FileSize);
     }
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "_flush_false");
+      auto client = m_fileSystemClient->GetFileClient(RandomString());
       client.Create();
       auto properties1 = client.GetProperties();
       Files::DataLake::AppendFileOptions options;
@@ -559,13 +552,13 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakeFileClientTest, ReadEmptyFile)
   {
-    auto fileClient = m_fileSystemClient->GetFileClient(GetTestNameLowerCase());
+    auto fileClient = m_fileSystemClient->GetFileClient(RandomString());
     fileClient.Create();
 
     auto res = fileClient.Download();
     EXPECT_EQ(res.Value.Body->Length(), 0);
 
-    std::string tempFilename(GetTestNameLowerCase());
+    std::string tempFilename(RandomString());
     EXPECT_NO_THROW(fileClient.DownloadTo(tempFilename));
     EXPECT_TRUE(ReadFile(tempFilename).empty());
     DeleteFile(tempFilename);
@@ -577,7 +570,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakeFileClientTest, DownloadNonExistingToFile)
   {
-    const auto testName(GetTestName());
+    const auto testName = RandomString();
     auto fileClient = m_fileSystemClient->GetFileClient(testName);
 
     EXPECT_THROW(fileClient.DownloadTo(testName), StorageException);
@@ -587,7 +580,7 @@ namespace Azure { namespace Storage { namespace Test {
   TEST_F(DataLakeFileClientTest, ScheduleForDeletion)
   {
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase());
+      auto client = m_fileSystemClient->GetFileClient(RandomString());
       auto createResponse = client.Create();
       auto scheduleDeletionResponse
           = client.ScheduleDeletion(Files::DataLake::ScheduleFileExpiryOriginType::NeverExpire);
@@ -595,7 +588,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(scheduleDeletionResponse.Value.LastModified, createResponse.Value.LastModified);
     }
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "1");
+      auto client = m_fileSystemClient->GetFileClient(RandomString());
       EXPECT_NO_THROW(client.Create());
       Files::DataLake::ScheduleFileDeletionOptions options;
       EXPECT_THROW(
@@ -607,7 +600,7 @@ namespace Azure { namespace Storage { namespace Test {
           Files::DataLake::ScheduleFileExpiryOriginType::RelativeToNow, options));
     }
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "2");
+      auto client = m_fileSystemClient->GetFileClient(RandomString());
       EXPECT_NO_THROW(client.Create());
       Files::DataLake::ScheduleFileDeletionOptions options;
       EXPECT_THROW(
@@ -625,181 +618,270 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
-  namespace {
+  TEST_F(DataLakeFileClientTest, ConcurrentDownload_LIVEONLY_)
+  {
+    CHECK_SKIP_TEST();
 
-    struct FileConcurrentUploadParameter
-    {
-      int Concurrency;
-      int64_t FileSize;
-    };
+    auto fileClient = *m_fileClient;
+    const auto blobContent = RandomBuffer(8_MB);
+    fileClient.UploadFrom(blobContent.data(), blobContent.size());
 
-    class UploadFile : public DataLakeFileClientTest,
-                       public ::testing::WithParamInterface<FileConcurrentUploadParameter> {
-    };
-
-    std::string GetUploadSuffix(const testing::TestParamInfo<UploadFile::ParamType>& info)
-    {
-      // Can't use empty spaces or underscores (_) as per google test documentation
-      // http://google.github.io/googletest/advanced.html#specifying-names-for-value-parameterized-test-parameters
-      auto const& p = info.param;
-      std::string suffix("c" + std::to_string(p.Concurrency) + "s" + std::to_string(p.FileSize));
-      return suffix;
-    }
-
-    std::vector<FileConcurrentUploadParameter> GetUploadParameters()
-    {
-      std::vector<FileConcurrentUploadParameter> testParametes;
-      for (int c : {1, 2, 5})
+    auto testDownloadToBuffer = [&](int concurrency,
+                                    int64_t downloadSize,
+                                    Azure::Nullable<int64_t> offset = {},
+                                    Azure::Nullable<int64_t> length = {},
+                                    Azure::Nullable<int64_t> initialChunkSize = {},
+                                    Azure::Nullable<int64_t> chunkSize = {}) {
+      std::vector<uint8_t> downloadBuffer;
+      std::vector<uint8_t> expectedData = blobContent;
+      int64_t blobSize = blobContent.size();
+      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
+      if (offset.HasValue() && length.HasValue())
       {
-        for (int64_t l :
-             {0ULL, 1ULL, 2ULL, 2_KB, 4_KB, 999_KB, 1_MB, 2_MB - 1, 3_MB, 5_MB, 8_MB - 1234, 8_MB})
+        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
+        if (actualDownloadSize >= 0)
         {
-          testParametes.emplace_back(FileConcurrentUploadParameter({c, l}));
+          expectedData.assign(
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
+        }
+        else
+        {
+          expectedData.clear();
         }
       }
-      return testParametes;
+      else if (offset.HasValue())
+      {
+        actualDownloadSize = blobSize - offset.Value();
+        if (actualDownloadSize >= 0)
+        {
+          expectedData.assign(
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()), blobContent.end());
+        }
+        else
+        {
+          expectedData.clear();
+        }
+      }
+      downloadBuffer.resize(static_cast<size_t>(downloadSize), '\x00');
+      Files::DataLake::DownloadFileToOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (offset.HasValue() || length.HasValue())
+      {
+        options.Range = Core::Http::HttpRange();
+        options.Range.Value().Offset = offset.Value();
+        options.Range.Value().Length = length;
+      }
+      if (initialChunkSize.HasValue())
+      {
+        options.TransferOptions.InitialChunkSize = initialChunkSize.Value();
+      }
+      if (chunkSize.HasValue())
+      {
+        options.TransferOptions.ChunkSize = chunkSize.Value();
+      }
+      if (actualDownloadSize > 0)
+      {
+        auto res = fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options);
+        EXPECT_EQ(res.Value.FileSize, blobSize);
+        EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
+        EXPECT_EQ(res.Value.ContentRange.Offset, offset.HasValue() ? offset.Value() : 0);
+        downloadBuffer.resize(static_cast<size_t>(res.Value.ContentRange.Length.Value()));
+        EXPECT_EQ(downloadBuffer, expectedData);
+      }
+      else
+      {
+        EXPECT_THROW(
+            fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options),
+            StorageException);
+      }
+    };
+
+    auto testDownloadToFile = [&](int concurrency,
+                                  int64_t downloadSize,
+                                  Azure::Nullable<int64_t> offset = {},
+                                  Azure::Nullable<int64_t> length = {},
+                                  Azure::Nullable<int64_t> initialChunkSize = {},
+                                  Azure::Nullable<int64_t> chunkSize = {}) {
+      std::string tempFilename = RandomString() + "file" + std::to_string(concurrency);
+      if (offset)
+      {
+        tempFilename.append(std::to_string(offset.Value()));
+      }
+      std::vector<uint8_t> expectedData = blobContent;
+      int64_t blobSize = blobContent.size();
+      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
+      if (offset.HasValue() && length.HasValue())
+      {
+        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
+        if (actualDownloadSize >= 0)
+        {
+          expectedData.assign(
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
+        }
+        else
+        {
+          expectedData.clear();
+        }
+      }
+      else if (offset.HasValue())
+      {
+        actualDownloadSize = blobSize - offset.Value();
+        if (actualDownloadSize >= 0)
+        {
+          expectedData.assign(
+              blobContent.begin() + static_cast<ptrdiff_t>(offset.Value()), blobContent.end());
+        }
+        else
+        {
+          expectedData.clear();
+        }
+      }
+      Files::DataLake::DownloadFileToOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (offset.HasValue() || length.HasValue())
+      {
+        options.Range = Core::Http::HttpRange();
+        options.Range.Value().Offset = offset.Value();
+        options.Range.Value().Length = length;
+      }
+      if (initialChunkSize.HasValue())
+      {
+        options.TransferOptions.InitialChunkSize = initialChunkSize.Value();
+      }
+      if (chunkSize.HasValue())
+      {
+        options.TransferOptions.ChunkSize = chunkSize.Value();
+      }
+      if (actualDownloadSize > 0)
+      {
+        auto res = fileClient.DownloadTo(tempFilename, options);
+        EXPECT_EQ(res.Value.FileSize, blobSize);
+        EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
+        EXPECT_EQ(res.Value.ContentRange.Offset, offset.HasValue() ? offset.Value() : 0);
+        EXPECT_EQ(ReadFile(tempFilename), expectedData);
+      }
+      else
+      {
+        EXPECT_THROW(fileClient.DownloadTo(tempFilename, options), StorageException);
+      }
+      DeleteFile(tempFilename);
+    };
+
+    const int64_t blobSize = blobContent.size();
+    std::vector<std::future<void>> futures;
+    for (int c : {1, 2, 4})
+    {
+      // random range
+      for (int i = 0; i < 16; ++i)
+      {
+        int64_t offset = RandomInt(0, blobContent.size() - 1);
+        int64_t length = RandomInt(1, 64_KB);
+        futures.emplace_back(std::async(
+            std::launch::async, testDownloadToBuffer, c, blobSize, offset, length, 8_KB, 4_KB));
+        futures.emplace_back(std::async(
+            std::launch::async, testDownloadToFile, c, blobSize, offset, length, 4_KB, 7_KB));
+      }
+
+      // buffer not big enough
+      Files::DataLake::DownloadFileToOptions options;
+      options.TransferOptions.Concurrency = c;
+      options.Range = Core::Http::HttpRange();
+      options.Range.Value().Offset = 1;
+      for (int64_t length : {1ULL, 2ULL, 4_KB, 5_KB, 8_KB, 11_KB, 20_KB})
+      {
+        std::vector<uint8_t> downloadBuffer;
+        downloadBuffer.resize(static_cast<size_t>(length - 1));
+        options.Range.Value().Length = length;
+        EXPECT_THROW(
+            fileClient.DownloadTo(downloadBuffer.data(), static_cast<size_t>(length - 1), options),
+            std::runtime_error);
+      }
     }
-  } // namespace
-
-  TEST_P(UploadFile, fromBuffer)
-  {
-    UploadFile::ParamType const& p(GetParam());
-    std::vector<uint8_t> fileContent(static_cast<size_t>(8_MB), 'x');
-    auto fileClient = m_fileSystemClient->GetFileClient(GetTestNameLowerCase());
-
-    Azure::Storage::Files::DataLake::UploadFileFromOptions options;
-    options.TransferOptions.ChunkSize = 1_MB;
-    options.TransferOptions.Concurrency = p.Concurrency;
-    options.HttpHeaders = GetInterestingHttpHeaders();
-    options.Metadata = GetMetadata();
-    auto res = fileClient.UploadFrom(fileContent.data(), static_cast<size_t>(p.FileSize), options);
-    auto lastModified = fileClient.GetProperties().Value.LastModified;
-    EXPECT_TRUE(res.Value.ETag.HasValue());
-    EXPECT_TRUE(IsValidTime(res.Value.LastModified));
-    EXPECT_EQ(res.Value.LastModified, lastModified);
-    auto properties = fileClient.GetProperties().Value;
-    EXPECT_EQ(properties.FileSize, p.FileSize);
-    EXPECT_EQ(properties.HttpHeaders, options.HttpHeaders);
-    EXPECT_EQ(properties.Metadata, options.Metadata);
-    EXPECT_EQ(properties.ETag, res.Value.ETag);
-    EXPECT_TRUE(IsValidTime(res.Value.LastModified));
-    EXPECT_EQ(properties.LastModified, res.Value.LastModified);
-    std::vector<uint8_t> downloadContent(static_cast<size_t>(p.FileSize), '\x00');
-    fileClient.DownloadTo(downloadContent.data(), static_cast<size_t>(p.FileSize));
-    EXPECT_EQ(
-        downloadContent,
-        std::vector<uint8_t>(
-            fileContent.begin(), fileContent.begin() + static_cast<size_t>(p.FileSize)));
-    fileClient.Delete();
+    for (auto& f : futures)
+    {
+      f.get();
+    }
   }
 
-  TEST_P(UploadFile, fromFile)
+  TEST_F(DataLakeFileClientTest, ConcurrentUpload_LIVEONLY_)
   {
-    UploadFile::ParamType const& p(GetParam());
-    std::vector<uint8_t> fileContent(static_cast<size_t>(p.FileSize), 'x');
-    auto fileClient = m_fileSystemClient->GetFileClient(GetTestNameLowerCase());
+    CHECK_SKIP_TEST();
 
-    Azure::Storage::Files::DataLake::UploadFileFromOptions options;
-    options.TransferOptions.ChunkSize = 1_MB;
-    options.TransferOptions.Concurrency = p.Concurrency;
-    options.HttpHeaders = GetInterestingHttpHeaders();
-    options.Metadata = GetMetadata();
+    const auto blobContent = RandomBuffer(8_MB);
 
-    std::string tempFilename = GetTestNameLowerCase();
-    WriteFile(tempFilename, fileContent);
-    auto res = fileClient.UploadFrom(tempFilename, options);
-    auto lastModified = fileClient.GetProperties().Value.LastModified;
-    EXPECT_TRUE(res.Value.ETag.HasValue());
-    EXPECT_TRUE(IsValidTime(res.Value.LastModified));
-    EXPECT_EQ(res.Value.LastModified, lastModified);
-    auto properties = fileClient.GetProperties().Value;
-    EXPECT_EQ(properties.FileSize, p.FileSize);
-    EXPECT_EQ(properties.HttpHeaders, options.HttpHeaders);
-    EXPECT_EQ(properties.Metadata, options.Metadata);
-    EXPECT_EQ(properties.ETag, res.Value.ETag);
-    EXPECT_EQ(properties.LastModified, res.Value.LastModified);
-    std::vector<uint8_t> downloadContent(static_cast<size_t>(p.FileSize), '\x00');
-    fileClient.DownloadTo(downloadContent.data(), static_cast<size_t>(p.FileSize));
-    EXPECT_EQ(
-        downloadContent,
-        std::vector<uint8_t>(
-            fileContent.begin(), fileContent.begin() + static_cast<size_t>(p.FileSize)));
-    std::string tempFileDestinationName = RandomString();
-    fileClient.DownloadTo(tempFileDestinationName);
-    EXPECT_EQ(ReadFile(tempFileDestinationName), fileContent);
-    DeleteFile(tempFileDestinationName);
-    DeleteFile(tempFilename);
-    fileClient.Delete();
+    auto testUploadFromBuffer = [&](int concurrency,
+                                    int64_t bufferSize,
+                                    Azure::Nullable<int64_t> singleUploadThreshold = {},
+                                    Azure::Nullable<int64_t> chunkSize = {}) {
+      Files::DataLake::UploadFileFromOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (singleUploadThreshold.HasValue())
+      {
+        options.TransferOptions.SingleUploadThreshold = singleUploadThreshold.Value();
+      }
+      if (chunkSize.HasValue())
+      {
+        options.TransferOptions.ChunkSize = chunkSize.Value();
+      }
+
+      auto fileClient = m_fileSystemClient->GetFileClient(RandomString());
+      EXPECT_NO_THROW(fileClient.UploadFrom(blobContent.data(), bufferSize, options));
+      std::vector<uint8_t> downloadBuffer(bufferSize, '\x00');
+      fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + bufferSize);
+      EXPECT_EQ(downloadBuffer, expectedData);
+    };
+
+    auto testUploadFromFile = [&](int concurrency,
+                                  int64_t fileSize,
+                                  Azure::Nullable<int64_t> singleUploadThreshold = {},
+                                  Azure::Nullable<int64_t> chunkSize = {}) {
+      Files::DataLake::UploadFileFromOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (singleUploadThreshold.HasValue())
+      {
+        options.TransferOptions.SingleUploadThreshold = singleUploadThreshold.Value();
+      }
+      if (chunkSize.HasValue())
+      {
+        options.TransferOptions.ChunkSize = chunkSize.Value();
+      }
+
+      const std::string tempFileName = RandomString();
+      WriteFile(
+          tempFileName, std::vector<uint8_t>(blobContent.begin(), blobContent.begin() + fileSize));
+      auto fileClient = m_fileSystemClient->GetFileClient(RandomString());
+      EXPECT_NO_THROW(fileClient.UploadFrom(tempFileName, options));
+      DeleteFile(tempFileName);
+      std::vector<uint8_t> downloadBuffer(fileSize, '\x00');
+      fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + fileSize);
+      EXPECT_EQ(downloadBuffer, expectedData);
+    };
+
+    std::vector<std::future<void>> futures;
+    for (int c : {1, 2, 4})
+    {
+      // random range
+      for (int i = 0; i < 16; ++i)
+      {
+        int64_t fileSize = RandomInt(1, 1_MB);
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 4_KB, 4_KB));
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromFile, c, fileSize, 2_KB, 16_KB));
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 0, 12_KB));
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromFile, c, fileSize, 0, 25_KB));
+      }
+    }
+    for (auto& f : futures)
+    {
+      f.get();
+    }
   }
 
-  INSTANTIATE_TEST_SUITE_P(
-      withParam,
-      UploadFile,
-      testing::ValuesIn(GetUploadParameters()),
-      GetUploadSuffix);
-
-  TEST_F(DataLakeFileClientTest, ConstructorsWorks)
-  {
-    {
-      // Create from connection string validates static creator function and shared key
-      // constructor.
-      auto fileName = GetTestNameLowerCase();
-      auto connectionStringClient
-          = Azure::Storage::Files::DataLake::DataLakeFileClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(),
-              m_fileSystemName,
-              fileName,
-              InitClientOptions<Azure::Storage::Files::DataLake::DataLakeClientOptions>());
-      EXPECT_NO_THROW(connectionStringClient.Create());
-      EXPECT_NO_THROW(connectionStringClient.Delete());
-    }
-
-    {
-      // Create from client secret credential.
-      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
-          = std::make_shared<Azure::Identity::ClientSecretCredential>(
-              AadTenantId(), AadClientId(), AadClientSecret());
-      Azure::Storage::Files::DataLake::DataLakeClientOptions options;
-
-      auto clientSecretClient = InitTestClient<
-          Azure::Storage::Files::DataLake::DataLakeFileClient,
-          Azure::Storage::Files::DataLake::DataLakeClientOptions>(
-          Azure::Storage::Files::DataLake::_detail::GetDfsUrlFromUrl(
-              Azure::Storage::Files::DataLake::DataLakeFileClient::CreateFromConnectionString(
-                  AdlsGen2ConnectionString(), m_fileSystemName, "credential")
-                  .GetUrl()),
-          credential,
-          options);
-
-      EXPECT_NO_THROW(clientSecretClient->Create());
-      EXPECT_NO_THROW(clientSecretClient->Delete());
-    }
-
-    {
-      // Create from Anonymous credential.
-      std::vector<uint8_t> blobContent(static_cast<size_t>(1_MB), 'x');
-
-      auto objectName = "testObject";
-      auto containerClient = Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(),
-          m_fileSystemName,
-          InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
-      Azure::Storage::Blobs::SetBlobContainerAccessPolicyOptions options;
-      options.AccessType = Azure::Storage::Blobs::Models::PublicAccessType::Blob;
-      containerClient.SetAccessPolicy(options);
-      auto blobClient = containerClient.GetBlockBlobClient(objectName);
-      auto memoryStream = Azure::Core::IO::MemoryBodyStream(blobContent.data(), blobContent.size());
-      EXPECT_NO_THROW(blobClient.Upload(memoryStream));
-
-      auto anonymousClient = Azure::Storage::Files::DataLake::DataLakeFileClient(
-          Azure::Storage::Files::DataLake::DataLakeFileClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, objectName)
-              .GetUrl(),
-          InitClientOptions<Azure::Storage::Files::DataLake::DataLakeClientOptions>());
-
-      TestSleep(std::chrono::seconds(30));
-
-      EXPECT_NO_THROW(anonymousClient.Download());
-    }
-  }
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
@@ -772,9 +772,9 @@ namespace Azure { namespace Storage { namespace Test {
     };
 
     const int64_t blobSize = blobContent.size();
-    std::vector<std::future<void>> futures;
     for (int c : {1, 2, 4})
     {
+      std::vector<std::future<void>> futures;
       // random range
       for (int i = 0; i < 16; ++i)
       {
@@ -800,10 +800,10 @@ namespace Azure { namespace Storage { namespace Test {
             fileClient.DownloadTo(downloadBuffer.data(), static_cast<size_t>(length - 1), options),
             std::runtime_error);
       }
-    }
-    for (auto& f : futures)
-    {
-      f.get();
+      for (auto& f : futures)
+      {
+        f.get();
+      }
     }
   }
 

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.hpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.hpp
@@ -4,15 +4,14 @@
 #include <azure/storage/files/datalake.hpp>
 
 #include "datalake_file_system_client_test.hpp"
-#include "test/ut/test_base.hpp"
 
 namespace Azure { namespace Storage { namespace Test {
 
   class DataLakeFileClientTest : public DataLakeFileSystemClientTest {
   protected:
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
 
+  protected:
     std::shared_ptr<Files::DataLake::DataLakeFileClient> m_fileClient;
     std::string m_fileName;
   };

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
@@ -318,8 +318,6 @@ xx
 
   TEST_F(DataLakeFileClientTest, QueryLargeBlob_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
-
     auto client = m_fileSystemClient->GetFileClient(RandomString());
 
     constexpr size_t DataSize = static_cast<size_t>(32_MB);

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
@@ -69,10 +69,9 @@ id,name,price
       "b25fY29sdW1ucyI6IFtdfQAYKmZhc3RwYXJxdWV0LXB5dGhvbiB2ZXJzaW9uIDAuOC4xIChidWlsZCAwKQDXAwAAUEFS"
       "MQ==");
 
-  TEST_F(DataLakeFileClientTest, QueryJsonInputCsvOutput_LIVEONLY_)
+  TEST_F(DataLakeFileClientTest, QueryJsonInputCsvOutput)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
 
     client.UploadFrom(
         reinterpret_cast<const uint8_t*>(JsonQueryTestData.data()), JsonQueryTestData.size());
@@ -110,10 +109,9 @@ id,name,price
     }
   }
 
-  TEST_F(DataLakeFileClientTest, QueryCsvInputJsonOutput_LIVEONLY_)
+  TEST_F(DataLakeFileClientTest, QueryCsvInputJsonOutput)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
 
     client.UploadFrom(
         reinterpret_cast<const uint8_t*>(CsvQueryTestData.data()), CsvQueryTestData.size());
@@ -133,10 +131,9 @@ id,name,price
         R"json({"id":"103","name":"apples","price":"99"}|{"id":"106","name":"lemons","price":"69"}|{"id":"110","name":"bananas","price":"39"}|{"id":"112","name":"sapote,mamey","price":"50"}|)json");
   }
 
-  TEST_F(DataLakeFileClientTest, QueryCsvInputArrowOutput_LIVEONLY_)
+  TEST_F(DataLakeFileClientTest, QueryCsvInputArrowOutput)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
 
     client.UploadFrom(
         reinterpret_cast<const uint8_t*>(CsvQueryTestData.data()), CsvQueryTestData.size());
@@ -184,10 +181,9 @@ id,name,price
     EXPECT_EQ(data, expectedData);
   }
 
-  TEST_F(DataLakeFileClientTest, QueryParquetInputArrowOutput_LIVEONLY_)
+  TEST_F(DataLakeFileClientTest, QueryParquetInputArrowOutput)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
 
     client.UploadFrom(ParquetQueryTestData.data(), ParquetQueryTestData.size());
 
@@ -243,10 +239,9 @@ id,name,price
     EXPECT_EQ(data, expectedData);
   }
 
-  TEST_F(DataLakeFileClientTest, QueryWithError_LIVEONLY_)
+  TEST_F(DataLakeFileClientTest, QueryWithError)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
 
     const std::string malformedData =
         R"json(
@@ -310,10 +305,9 @@ xx
     EXPECT_TRUE(progressCallbackCalled);
   }
 
-  TEST_F(DataLakeFileClientTest, QueryDefaultInputOutput_LIVEONLY_)
+  TEST_F(DataLakeFileClientTest, QueryDefaultInputOutput)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
 
     const std::string csvData = "100,oranges,100";
     client.UploadFrom(reinterpret_cast<const uint8_t*>(csvData.data()), csvData.size());
@@ -324,8 +318,9 @@ xx
 
   TEST_F(DataLakeFileClientTest, QueryLargeBlob_LIVEONLY_)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    CHECK_SKIP_TEST();
+
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
 
     constexpr size_t DataSize = static_cast<size_t>(32_MB);
 
@@ -365,29 +360,25 @@ xx
     }
   }
 
-  TEST_F(DataLakeFileClientTest, QueryBlobAccessConditionLeaseId_LIVEONLY_)
+  TEST_F(DataLakeFileClientTest, QueryBlobAccessConditionLeaseId)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
     client.UploadFrom(nullptr, 0);
 
-    Files::DataLake::DataLakeLeaseClient leaseClient(
-        client, Files::DataLake::DataLakeLeaseClient::CreateUniqueLeaseId());
+    Files::DataLake::DataLakeLeaseClient leaseClient(client, RandomUUID());
     leaseClient.Acquire(Files::DataLake::DataLakeLeaseClient::InfiniteLeaseDuration);
 
     Files::DataLake::QueryFileOptions queryOptions;
-    queryOptions.AccessConditions.LeaseId
-        = Files::DataLake::DataLakeLeaseClient::CreateUniqueLeaseId();
+    queryOptions.AccessConditions.LeaseId = RandomUUID();
     EXPECT_THROW(client.Query("SELECT * FROM BlobStorage;", queryOptions), StorageException);
 
     queryOptions.AccessConditions.LeaseId = leaseClient.GetLeaseId();
     EXPECT_NO_THROW(client.Query("SELECT * FROM BlobStorage;", queryOptions));
   }
 
-  TEST_F(DataLakeFileClientTest, QueryBlobAccessConditionLastModifiedTime_LIVEONLY_)
+  TEST_F(DataLakeFileClientTest, QueryBlobAccessConditionLastModifiedTime)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
     client.UploadFrom(nullptr, 0);
 
     auto lastModifiedTime = client.GetProperties().Value.LastModified;
@@ -407,10 +398,9 @@ xx
     EXPECT_NO_THROW(client.Query("SELECT * FROM BlobStorage;", queryOptions));
   }
 
-  TEST_F(DataLakeFileClientTest, QueryBlobAccessConditionETag_LIVEONLY_)
+  TEST_F(DataLakeFileClientTest, QueryBlobAccessConditionETag)
   {
-    auto const testName(GetTestName());
-    auto client = m_fileSystemClient->GetFileClient(testName);
+    auto client = m_fileSystemClient->GetFileClient(RandomString());
     client.UploadFrom(nullptr, 0);
 
     auto etag = client.GetProperties().Value.ETag;

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_system_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_system_client_test.cpp
@@ -17,8 +17,6 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Models {
 
 namespace Azure { namespace Storage { namespace Test {
 
-  const size_t PathTestSize = 5;
-
   std::string DataLakeFileSystemClientTest::GetSas()
   {
     Sas::DataLakeSasBuilder sasBuilder;
@@ -31,304 +29,203 @@ namespace Azure { namespace Storage { namespace Test {
         *_internal::ParseConnectionString(AdlsGen2ConnectionString()).KeyCredential);
   }
 
-  void DataLakeFileSystemClientTest::CreateDirectoryList()
-  {
-    std::string const directoryName(GetFileSystemValidName());
-    std::string const prefix(directoryName.begin(), directoryName.end() - 2);
-    m_directoryA = prefix + "a";
-    m_directoryB = prefix + "b";
-    m_pathNameSetA.clear();
-    m_pathNameSetB.clear();
-    for (size_t i = 0; i < PathTestSize; ++i)
-    {
-      {
-        auto name = m_directoryA + "/" + std::to_string(i);
-        m_fileSystemClient->GetFileClient(name).Create();
-        m_pathNameSetA.emplace_back(std::move(name));
-      }
-      {
-        auto name = m_directoryB + "/" + std::to_string(i);
-        m_fileSystemClient->GetFileClient(name).Create();
-        m_pathNameSetB.emplace_back(std::move(name));
-      }
-    }
-  }
-
   void DataLakeFileSystemClientTest::SetUp()
   {
     DataLakeServiceClientTest::SetUp();
-    CHECK_SKIP_TEST();
 
-    m_fileSystemName = GetFileSystemValidName();
+    m_fileSystemName = GetLowercaseIdentifier();
     m_fileSystemClient = std::make_shared<Files::DataLake::DataLakeFileSystemClient>(
         m_dataLakeServiceClient->GetFileSystemClient(m_fileSystemName));
-    m_fileSystemClient->CreateIfNotExists();
-  }
-
-  void DataLakeFileSystemClientTest::TearDown()
-  {
-    CHECK_SKIP_TEST();
-    m_fileSystemClient->Delete();
-    DataLakeServiceClientTest::TearDown();
-  }
-
-  std::vector<Files::DataLake::Models::PathItem> DataLakeFileSystemClientTest::ListAllPaths(
-      bool recursive,
-      const std::string& directory)
-  {
-    std::vector<Files::DataLake::Models::PathItem> result;
-    std::string continuation;
-    Files::DataLake::ListPathsOptions options;
-    if (directory.empty())
+    while (true)
     {
-      for (auto pageResult = m_fileSystemClient->ListPaths(recursive, options);
-           pageResult.HasPage();
-           pageResult.MoveToNextPage())
+      try
       {
-        result.insert(result.end(), pageResult.Paths.begin(), pageResult.Paths.end());
+        m_fileSystemClient->CreateIfNotExists();
+        break;
       }
-    }
-    else
-    {
-      auto directoryClient = m_fileSystemClient->GetDirectoryClient(directory);
-      for (auto pageResult = directoryClient.ListPaths(recursive, options); pageResult.HasPage();
-           pageResult.MoveToNextPage())
+      catch (StorageException& e)
       {
-        result.insert(result.end(), pageResult.Paths.begin(), pageResult.Paths.end());
+        if (e.ErrorCode != "ContainerBeingDeleted")
+        {
+          throw;
+        }
+        SUCCEED() << "Cotnainer is being deleted. Will try again after 3 seconds.";
+        std::this_thread::sleep_for(std::chrono::seconds(3));
       }
     }
 
-    return result;
+    m_resourceCleanupFunctions.push_back(
+        [fileSystemClient = *m_fileSystemClient]() { fileSystemClient.DeleteIfExists(); });
   }
 
-  Files::DataLake::Models::PathHttpHeaders DataLakeFileSystemClientTest::GetInterestingHttpHeaders()
+  Files::DataLake::DataLakeFileSystemClient
+  DataLakeFileSystemClientTest::GetFileSystemClientForTest(
+      const std::string& fileSystemName,
+      Files::DataLake::DataLakeClientOptions clientOptions)
   {
-    static Files::DataLake::Models::PathHttpHeaders result = []() {
-      Files::DataLake::Models::PathHttpHeaders ret;
-      ret.CacheControl = std::string("no-cache");
-      ret.ContentDisposition = std::string("attachment");
-      ret.ContentEncoding = std::string("deflate");
-      ret.ContentLanguage = std::string("en-US");
-      ret.ContentType = std::string("application/octet-stream");
-      return ret;
-    }();
-    return result;
+    InitClientOptions(clientOptions);
+    auto fsClient = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
+        AdlsGen2ConnectionString(), fileSystemName, clientOptions);
+    m_resourceCleanupFunctions.push_back([fsClient]() { fsClient.DeleteIfExists(); });
+    return fsClient;
   }
 
   TEST_F(DataLakeFileSystemClientTest, CreateDeleteFileSystems)
   {
-    std::string fileSystemName("prefix");
+    auto fsClient = GetFileSystemClientForTest(LowercaseRandomString());
+    EXPECT_THROW(fsClient.Delete(), StorageException);
+    EXPECT_NO_THROW(fsClient.Create());
+    EXPECT_NO_THROW(fsClient.CreateIfNotExists());
+    EXPECT_THROW(fsClient.Create(), StorageException);
+    EXPECT_NO_THROW(fsClient.Delete());
+    EXPECT_NO_THROW(fsClient.DeleteIfExists());
+  }
+
+  TEST_F(DataLakeFileSystemClientTest, CreateDeleteFileSystemsWithAccessCondition)
+  {
     {
-      // Normal create/delete.
-      std::vector<Files::DataLake::DataLakeFileSystemClient> fileSystemClient;
-      for (int32_t i = 0; i < 5; ++i)
-      {
-        auto client = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-            AdlsGen2ConnectionString(),
-            fileSystemName + std::to_string(i),
-            InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-        EXPECT_NO_THROW(client.Create());
-        fileSystemClient.emplace_back(std::move(client));
-      }
-      for (const auto& client : fileSystemClient)
-      {
-        EXPECT_NO_THROW(client.Delete());
-      }
+      auto fsClient = GetFileSystemClientForTest(LowercaseRandomString());
+      fsClient.Create();
+      auto properties = fsClient.GetProperties().Value;
+
+      Files::DataLake::DeleteFileSystemOptions deleteOptions;
+      deleteOptions.AccessConditions.IfModifiedSince
+          = properties.LastModified + std::chrono::seconds(5);
+      EXPECT_THROW(fsClient.Delete(deleteOptions), StorageException);
+      deleteOptions.AccessConditions.IfModifiedSince
+          = properties.LastModified - std::chrono::seconds(5);
+      EXPECT_NO_THROW(fsClient.Delete(deleteOptions));
     }
     {
-      std::string fileSystemNameAccessCondition(fileSystemName + "a");
-      // Normal delete with access condition.
-      std::vector<Files::DataLake::DataLakeFileSystemClient> fileSystemClient;
-      for (int32_t i = 0; i < 5; ++i)
-      {
-        auto client = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-            AdlsGen2ConnectionString(),
-            fileSystemNameAccessCondition + std::to_string(i),
-            InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-        EXPECT_NO_THROW(client.Create());
-        fileSystemClient.emplace_back(std::move(client));
-      }
-      for (const auto& client : fileSystemClient)
-      {
-        auto response = client.GetProperties();
-        Files::DataLake::DeleteFileSystemOptions options1;
-        options1.AccessConditions.IfModifiedSince = response.Value.LastModified;
-        EXPECT_THROW(client.Delete(options1), StorageException);
-        Files::DataLake::DeleteFileSystemOptions options2;
-        options2.AccessConditions.IfUnmodifiedSince = response.Value.LastModified;
-        EXPECT_NO_THROW(client.Delete(options2));
-      }
+      auto fsClient = GetFileSystemClientForTest(LowercaseRandomString());
+      fsClient.Create();
+      auto properties = fsClient.GetProperties().Value;
+
+      Files::DataLake::DeleteFileSystemOptions deleteOptions;
+      deleteOptions.AccessConditions.IfUnmodifiedSince
+          = properties.LastModified - std::chrono::seconds(5);
+      EXPECT_THROW(fsClient.Delete(deleteOptions), StorageException);
+      deleteOptions.AccessConditions.IfUnmodifiedSince
+          = properties.LastModified + std::chrono::seconds(5);
+      EXPECT_NO_THROW(fsClient.Delete(deleteOptions));
     }
     {
-      // CreateIfNotExists & DeleteIfExists.
-      {
-        std::string fileSystemNameCreate(fileSystemName + "c");
-        auto client = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-            AdlsGen2ConnectionString(),
-            fileSystemNameCreate,
-            InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-        EXPECT_NO_THROW(client.Create());
-        EXPECT_NO_THROW(client.CreateIfNotExists());
-        EXPECT_NO_THROW(client.Delete());
-        EXPECT_NO_THROW(client.DeleteIfExists());
-      }
-      {
-        std::string fileSystemNameCreateIf(fileSystemName + "ci");
-        auto client = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-            AdlsGen2ConnectionString(),
-            fileSystemNameCreateIf,
-            InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-        EXPECT_NO_THROW(client.CreateIfNotExists());
-        EXPECT_THROW(client.Create(), StorageException);
-        EXPECT_NO_THROW(client.DeleteIfExists());
-      }
-      {
-        std::string fileSystemNameCreateIfNot(fileSystemName + "cid");
-        auto client = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-            AdlsGen2ConnectionString(),
-            fileSystemNameCreateIfNot,
-            InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-        auto created = client.Create().Value.Created;
-        EXPECT_TRUE(created);
-        auto createResult = client.CreateIfNotExists();
-        EXPECT_FALSE(createResult.Value.Created);
-        EXPECT_FALSE(createResult.Value.ETag.HasValue());
-        EXPECT_EQ(DateTime(), createResult.Value.LastModified);
-        auto deleted = client.Delete().Value.Deleted;
-        EXPECT_TRUE(deleted);
-      }
-      {
-        std::string fileSystemNameDelete(fileSystemName + "d");
-        auto client = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-            AdlsGen2ConnectionString(),
-            fileSystemNameDelete,
-            InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-        auto deleteResult = client.DeleteIfExists();
-        EXPECT_FALSE(deleteResult.Value.Deleted);
-      }
+      auto leaseId = RandomUUID();
+      auto dummyLeaseId = RandomUUID();
+      auto fsClient = GetFileSystemClientForTest(LowercaseRandomString());
+      fsClient.Create();
+
+      Files::DataLake::DataLakeLeaseClient leaseClient(fsClient, leaseId);
+      leaseClient.Acquire(std::chrono::seconds(30));
+      EXPECT_THROW(fsClient.Delete(), StorageException);
+      Files::DataLake::DeleteFileSystemOptions deleteOptions;
+      deleteOptions.AccessConditions.LeaseId = dummyLeaseId;
+      EXPECT_THROW(fsClient.Delete(deleteOptions), StorageException);
+      deleteOptions.AccessConditions.LeaseId = leaseId;
+      EXPECT_NO_THROW(fsClient.Delete(deleteOptions));
     }
   }
 
   TEST_F(DataLakeFileSystemClientTest, FileSystemMetadata)
   {
-    auto metadata1 = GetMetadata();
-    auto metadata2 = GetMetadata();
     {
+      auto metadata = RandomMetadata();
       // Set/Get Metadata works
-      EXPECT_NO_THROW(m_fileSystemClient->SetMetadata(metadata1));
-      auto result = m_fileSystemClient->GetProperties().Value.Metadata;
-      EXPECT_EQ(metadata1, result);
-      EXPECT_NO_THROW(m_fileSystemClient->SetMetadata(metadata2));
-      result = m_fileSystemClient->GetProperties().Value.Metadata;
-      EXPECT_EQ(metadata2, result);
+      EXPECT_NO_THROW(m_fileSystemClient->SetMetadata(metadata));
+      EXPECT_EQ(metadata, m_fileSystemClient->GetProperties().Value.Metadata);
+      EXPECT_NO_THROW(m_fileSystemClient->SetMetadata({}));
+      EXPECT_TRUE(m_fileSystemClient->GetProperties().Value.Metadata.empty());
     }
 
     {
-      // Create file system with metadata works
-      auto options = InitClientOptions<Files::DataLake::DataLakeClientOptions>();
-      auto client1 = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(), m_fileSystemName + "1", options);
-      auto client2 = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(), m_fileSystemName + "2", options);
-      Files::DataLake::CreateFileSystemOptions options1;
-      Files::DataLake::CreateFileSystemOptions options2;
-      options1.Metadata = metadata1;
-      options2.Metadata = metadata2;
-
-      EXPECT_NO_THROW(client1.Create(options1));
-      EXPECT_NO_THROW(client2.Create(options2));
-      auto result = client1.GetProperties().Value.Metadata;
-      EXPECT_EQ(metadata1, result);
-      result = client2.GetProperties().Value.Metadata;
-      EXPECT_EQ(metadata2, result);
-      client1.DeleteIfExists();
-      client2.DeleteIfExists();
+      auto fsClient = GetFileSystemClientForTest(LowercaseRandomString());
+      Files::DataLake::CreateFileSystemOptions options;
+      options.Metadata = RandomMetadata();
+      fsClient.Create(options);
+      EXPECT_EQ(fsClient.GetProperties().Value.Metadata, options.Metadata);
     }
   }
 
   TEST_F(DataLakeFileSystemClientTest, GetDataLakeFileSystemPropertiesResult)
   {
-    auto metadata1 = GetMetadata();
-    auto metadata2 = GetMetadata();
-    {
-      // Get Metadata via properties works
-      EXPECT_NO_THROW(m_fileSystemClient->SetMetadata(metadata1));
-      auto result = m_fileSystemClient->GetProperties();
-      EXPECT_EQ(metadata1, result.Value.Metadata);
-      EXPECT_NO_THROW(m_fileSystemClient->SetMetadata(metadata2));
-      result = m_fileSystemClient->GetProperties();
-      EXPECT_EQ(metadata2, result.Value.Metadata);
-    }
-
-    {
-      // Last modified Etag works.
-      auto properties1 = m_fileSystemClient->GetProperties();
-      auto properties2 = m_fileSystemClient->GetProperties();
-      EXPECT_EQ(properties1.Value.ETag, properties2.Value.ETag);
-      EXPECT_EQ(properties1.Value.LastModified, properties2.Value.LastModified);
-
-      // This operation changes ETag/LastModified.
-      EXPECT_NO_THROW(m_fileSystemClient->SetMetadata(metadata1));
-
-      auto properties3 = m_fileSystemClient->GetProperties();
-      EXPECT_NE(properties1.Value.ETag, properties3.Value.ETag);
-    }
+    auto metadata1 = RandomMetadata();
+    // Get Metadata via properties works
+    EXPECT_NO_THROW(m_fileSystemClient->SetMetadata(metadata1));
+    auto properties = m_fileSystemClient->GetProperties().Value;
+    EXPECT_EQ(metadata1, properties.Metadata);
+    EXPECT_TRUE(IsValidTime(properties.LastModified));
+    EXPECT_TRUE(properties.ETag.HasValue());
+    EXPECT_FALSE(properties.DefaultEncryptionScope.empty());
+    EXPECT_FALSE(properties.PreventEncryptionScopeOverride);
   }
 
   TEST_F(DataLakeFileSystemClientTest, ListPaths)
   {
-    CreateDirectoryList();
+    std::set<std::string> paths;
+    const std::string dir1 = RandomString();
+    const std::string dir2 = RandomString();
+
+    std::set<std::string> rootPaths;
+    rootPaths.emplace(dir1);
+    rootPaths.emplace(dir2);
+
+    {
+      auto dirClient = m_fileSystemClient->GetDirectoryClient(dir1);
+      for (int i = 0; i < 3; ++i)
+      {
+        std::string filename = RandomString();
+        auto fileClient = dirClient.GetFileClient(filename);
+        fileClient.CreateIfNotExists();
+        paths.emplace(dir1 + "/" + filename);
+      }
+
+      dirClient = m_fileSystemClient->GetDirectoryClient(dir2);
+      for (int i = 0; i < 4; ++i)
+      {
+        std::string filename = RandomString();
+        auto fileClient = dirClient.GetFileClient(filename);
+        fileClient.CreateIfNotExists();
+        paths.emplace(dir2 + "/" + filename);
+      }
+      std::string filename = RandomString();
+      auto fileClient = m_fileSystemClient->GetFileClient(filename);
+      fileClient.CreateIfNotExists();
+      paths.emplace(filename);
+      rootPaths.emplace(filename);
+    }
+
     {
       // Normal list recursively.
-      auto result = ListAllPaths(true);
-      for (const auto& name : m_pathNameSetA)
+      std::set<std::string> results;
+      for (auto page = m_fileSystemClient->ListPaths(true); page.HasPage(); page.MoveToNextPage())
       {
-        auto iter = std::find_if(
-            result.begin(), result.end(), [&name](const Files::DataLake::Models::PathItem& path) {
-              return path.Name == name;
-            });
-        EXPECT_NE(result.end(), iter);
-        EXPECT_EQ(iter->Name, name);
-        EXPECT_EQ(iter->Name.substr(0U, m_directoryA.size()), m_directoryA);
-        EXPECT_TRUE(iter->CreatedOn.HasValue());
-        EXPECT_FALSE(iter->ExpiresOn.HasValue());
+        for (auto& path : page.Paths)
+        {
+          results.insert(path.Name);
+        }
       }
-      for (const auto& name : m_pathNameSetB)
+
+      for (const auto& path : paths)
       {
-        auto iter = std::find_if(
-            result.begin(), result.end(), [&name](const Files::DataLake::Models::PathItem& path) {
-              return path.Name == name;
-            });
-        EXPECT_NE(result.end(), iter);
-        EXPECT_EQ(iter->Name, name);
-        EXPECT_EQ(iter->Name.substr(0U, m_directoryB.size()), m_directoryB);
-        EXPECT_TRUE(iter->CreatedOn.HasValue());
-        EXPECT_FALSE(iter->ExpiresOn.HasValue());
+        EXPECT_NE(results.find(path), results.end());
       }
     }
     {
-      // List with directory.
-      auto result = ListAllPaths(true, m_directoryA);
-      for (const auto& name : m_pathNameSetA)
+      // non-recursive
+      std::set<std::string> results;
+      for (auto page = m_fileSystemClient->ListPaths(false); page.HasPage(); page.MoveToNextPage())
       {
-        auto iter = std::find_if(
-            result.begin(), result.end(), [&name](const Files::DataLake::Models::PathItem& path) {
-              return path.Name == name;
-            });
-        EXPECT_NE(result.end(), iter);
-        EXPECT_EQ(iter->Name, name);
-        EXPECT_EQ(iter->Name.substr(0U, m_directoryA.size()), m_directoryA);
-        EXPECT_TRUE(iter->CreatedOn.HasValue());
-        EXPECT_FALSE(iter->ExpiresOn.HasValue());
+        for (auto& path : page.Paths)
+        {
+          results.insert(path.Name);
+        }
       }
-      for (const auto& name : m_pathNameSetB)
+
+      for (const auto& path : rootPaths)
       {
-        auto iter = std::find_if(
-            result.begin(), result.end(), [&name](const Files::DataLake::Models::PathItem& path) {
-              return path.Name == name;
-            });
-        EXPECT_EQ(result.end(), iter);
+        EXPECT_NE(results.find(path), results.end());
       }
+      EXPECT_LT(results.size(), paths.size());
     }
     {
       // List max result
@@ -336,23 +233,6 @@ namespace Azure { namespace Storage { namespace Test {
       options.PageSizeHint = 2;
       auto response = m_fileSystemClient->ListPaths(true, options);
       EXPECT_LE(2U, response.Paths.size());
-    }
-    {
-      // check expiry time
-      const std::string filename = GetTestNameLowerCase() + "check_expiry";
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "check_expiry");
-      Files::DataLake::CreateFileOptions createOptions;
-      createOptions.ScheduleDeletionOptions.ExpiresOn = Azure::DateTime::Parse(
-          "Wed, 29 Sep 2100 09:53:03 GMT", Azure::DateTime::DateFormat::Rfc1123);
-      client.Create(createOptions);
-
-      auto result = ListAllPaths(false);
-      auto iter = std::find_if(
-          result.begin(), result.end(), [&filename](const Files::DataLake::Models::PathItem& path) {
-            return path.Name == filename;
-          });
-      EXPECT_TRUE(iter->ExpiresOn.HasValue());
-      EXPECT_EQ(createOptions.ScheduleDeletionOptions.ExpiresOn.Value(), iter->ExpiresOn.Value());
     }
   }
 
@@ -362,14 +242,14 @@ namespace Azure { namespace Storage { namespace Test {
     const std::string encoded_non_ascii_word = "%E6%B5%8B%E8%AF%95";
     std::string baseName = "a b c / !@#$%^&*(?/<>,.;:'\"[]{}|`~\\) def" + non_ascii_word;
     {
-      std::string pathName = baseName + GetTestNameLowerCase();
+      std::string pathName = baseName + RandomString();
       auto fileClient = m_fileSystemClient->GetFileClient(pathName);
       EXPECT_NO_THROW(fileClient.Create());
       auto fileUrl = fileClient.GetUrl();
       EXPECT_EQ(fileUrl, m_fileSystemClient->GetUrl() + "/" + _internal::UrlEncodePath(pathName));
     }
     {
-      std::string directoryName = baseName + GetTestNameLowerCase() + "1";
+      std::string directoryName = baseName + RandomString() + "1";
       auto directoryClient = m_fileSystemClient->GetDirectoryClient(directoryName);
       EXPECT_NO_THROW(directoryClient.Create());
       auto directoryUrl = directoryClient.GetUrl();
@@ -378,7 +258,7 @@ namespace Azure { namespace Storage { namespace Test {
           m_fileSystemClient->GetUrl() + "/" + _internal::UrlEncodePath(directoryName));
     }
     {
-      std::string fileName = baseName + GetTestNameLowerCase() + "2";
+      std::string fileName = baseName + RandomString() + "2";
       auto fileClient = m_fileSystemClient->GetFileClient(fileName);
       EXPECT_NO_THROW(fileClient.Create());
       auto fileUrl = fileClient.GetUrl();
@@ -390,7 +270,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     {
       // Create from connection string validates static creator function and shared key constructor.
-      auto fileSystemName = GetTestNameLowerCase() + "1";
+      auto fileSystemName = LowercaseRandomString() + "1";
       auto connectionStringClient
           = Azure::Storage::Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
               AdlsGen2ConnectionString(),
@@ -411,7 +291,7 @@ namespace Azure { namespace Storage { namespace Test {
           Azure::Storage::Files::DataLake::DataLakeFileSystemClient,
           Azure::Storage::Files::DataLake::DataLakeClientOptions>(
           Azure::Storage::Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), GetTestNameLowerCase())
+              AdlsGen2ConnectionString(), LowercaseRandomString())
               .GetUrl(),
           credential,
           options);
@@ -421,14 +301,11 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
-  TEST_F(DataLakeFileSystemClientTest, CustomerProvidedKey_LIVEONLY_)
+  TEST_F(DataLakeFileSystemClientTest, CustomerProvidedKey)
   {
-
     auto getRandomCustomerProvidedKey = [&]() {
       Files::DataLake::EncryptionKey key;
-      std::vector<uint8_t> aes256Key;
-      aes256Key.resize(32);
-      RandomBuffer(&aes256Key[0], aes256Key.size());
+      std::vector<uint8_t> aes256Key = RandomBuffer(32);
       key.Key = Azure::Core::Convert::Base64Encode(aes256Key);
       key.KeyHash = Azure::Core::Cryptography::_internal::Sha256Hash().Final(
           aes256Key.data(), aes256Key.size());
@@ -436,74 +313,58 @@ namespace Azure { namespace Storage { namespace Test {
       return key;
     };
 
-    const int32_t bufferSize = 1024; // 1KB data size
-    auto buffer = std::make_shared<std::vector<uint8_t>>(bufferSize, 'x');
-    Azure::Core::IO::MemoryBodyStream bodyStream(buffer->data(), buffer->size());
+    auto buffer = RandomBuffer(10);
+    Azure::Core::IO::MemoryBodyStream bodyStream(buffer.data(), buffer.size());
 
-    auto customerProvidedKey
-        = std::make_shared<Files::DataLake::EncryptionKey>(getRandomCustomerProvidedKey());
-    Files::DataLake::DataLakeClientOptions options;
-    options.CustomerProvidedKey = *customerProvidedKey;
-    auto fileServiceClient = std::make_shared<Files::DataLake::DataLakeServiceClient>(
-        Files::DataLake::DataLakeServiceClient::CreateFromConnectionString(
-            AdlsGen2ConnectionString(), options));
-    auto fileSystemClient = std::make_shared<Files::DataLake::DataLakeFileSystemClient>(
-        fileServiceClient->GetFileSystemClient(m_fileSystemName));
+    auto customerProvidedKey = getRandomCustomerProvidedKey();
+    Files::DataLake::DataLakeClientOptions clientOptionsWithCPK;
+    clientOptionsWithCPK.CustomerProvidedKey = customerProvidedKey;
+    auto fileSystemClientWithCPK
+        = GetFileSystemClientForTest(m_fileSystemName, clientOptionsWithCPK);
+    auto fileSystemClientWithoutCPK = GetFileSystemClientForTest(m_fileSystemName);
 
     // fileSystem works
     {
-      auto fileSystemClientWithoutEncryptionKey
-          = Azure::Storage::Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName);
       // Rename File
-      const std::string filename1 = GetTestName() + "file1";
-      const std::string filename2 = GetTestName() + "file2";
-      const std::string filename3 = GetTestName() + "file3";
-      const std::string filename4 = GetTestName() + "file4";
+      const std::string filename1 = RandomString() + "file1";
+      const std::string filename2 = RandomString() + "file2";
+      const std::string filename3 = RandomString() + "file3";
+      const std::string filename4 = RandomString() + "file4";
 
-      auto oldFileClient = fileSystemClient->GetFileClient(filename1);
+      auto oldFileClient = fileSystemClientWithCPK.GetFileClient(filename1);
       oldFileClient.Create();
-      auto newFileClient = fileSystemClient->RenameFile(filename1, filename2).Value;
-      auto properties = std::make_shared<Files::DataLake::Models::PathProperties>(
-          newFileClient.GetProperties().Value);
-      EXPECT_EQ(customerProvidedKey->KeyHash, properties->EncryptionKeySha256.Value());
-      auto newFileClientWithoutEncryptionKey
-          = Files::DataLake::DataLakeFileClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, filename2);
+      auto newFileClient = fileSystemClientWithCPK.RenameFile(filename1, filename2).Value;
+      auto properties = newFileClient.GetProperties().Value;
+      EXPECT_EQ(customerProvidedKey.KeyHash, properties.EncryptionKeySha256.Value());
+      auto newFileClientWithoutEncryptionKey = fileSystemClientWithoutCPK.GetFileClient(filename2);
       EXPECT_THROW(newFileClientWithoutEncryptionKey.GetProperties(), StorageException);
-      EXPECT_NO_THROW(fileSystemClientWithoutEncryptionKey.RenameFile(filename2, filename3));
+      EXPECT_NO_THROW(fileSystemClientWithoutCPK.RenameFile(filename2, filename3));
 
       // Rename Directory
-      const std::string testName(GetTestName());
-      const std::string oldDirectoryName = testName + "dir1";
-      const std::string newDirectoryName = testName + "dir2";
-      const std::string newDirectoryName2 = testName + "dir3";
+      const std::string baseName = RandomString();
+      const std::string oldDirectoryName = baseName + "dir1";
+      const std::string newDirectoryName = baseName + "dir2";
+      const std::string newDirectoryName2 = baseName + "dir3";
 
-      auto oldDirectoryClient = fileSystemClient->GetDirectoryClient(oldDirectoryName);
+      auto oldDirectoryClient = fileSystemClientWithCPK.GetDirectoryClient(oldDirectoryName);
       oldDirectoryClient.Create();
-      oldDirectoryClient.GetFileClient(testName + "file3").Create();
-      oldDirectoryClient.GetSubdirectoryClient(testName + "dir4").Create();
+      oldDirectoryClient.GetFileClient(baseName + "file3").Create();
+      oldDirectoryClient.GetSubdirectoryClient(baseName + "dir4").Create();
 
       auto newDirectoryClient
-          = fileSystemClient->RenameDirectory(oldDirectoryName, newDirectoryName).Value;
-      properties = std::make_shared<Files::DataLake::Models::PathProperties>(
-          newDirectoryClient.GetProperties().Value);
-      EXPECT_TRUE(properties->EncryptionKeySha256.HasValue());
-      EXPECT_EQ(customerProvidedKey->KeyHash, properties->EncryptionKeySha256.Value());
+          = fileSystemClientWithCPK.RenameDirectory(oldDirectoryName, newDirectoryName).Value;
+      properties = newDirectoryClient.GetProperties().Value;
+      EXPECT_TRUE(properties.EncryptionKeySha256.HasValue());
+      EXPECT_EQ(customerProvidedKey.KeyHash, properties.EncryptionKeySha256.Value());
       auto newDirectoryClientWithoutEncryptionKey
-          = Files::DataLake::DataLakeDirectoryClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, newDirectoryName);
+          = fileSystemClientWithoutCPK.GetDirectoryClient(newDirectoryName);
       EXPECT_THROW(newDirectoryClientWithoutEncryptionKey.GetProperties(), StorageException);
-      EXPECT_NO_THROW(fileSystemClientWithoutEncryptionKey.RenameDirectory(
-          newDirectoryName, newDirectoryName2));
+      EXPECT_NO_THROW(
+          fileSystemClientWithoutCPK.RenameDirectory(newDirectoryName, newDirectoryName2));
 
-      auto fileSystemClientWithEncryptionKey
-          = Azure::Storage::Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, options);
-      auto created = std::make_shared<Files::DataLake::Models::CreatePathResult>(
-          fileSystemClientWithEncryptionKey.GetFileClient(filename4).Create().Value);
-      EXPECT_TRUE(created->EncryptionKeySha256.HasValue());
-      EXPECT_EQ(customerProvidedKey->KeyHash, created->EncryptionKeySha256.Value());
+      auto createResult = fileSystemClientWithCPK.GetFileClient(filename4).Create().Value;
+      EXPECT_TRUE(createResult.EncryptionKeySha256.HasValue());
+      EXPECT_EQ(customerProvidedKey.KeyHash, createResult.EncryptionKeySha256.Value());
     }
 
     // path works
@@ -511,74 +372,67 @@ namespace Azure { namespace Storage { namespace Test {
       const std::string pathName = "path";
       const std::string pathName2 = "path2";
 
-      auto pathClient = Files::DataLake::DataLakePathClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(), m_fileSystemName, pathName, options);
-      EXPECT_NO_THROW(pathClient.Create(Files::DataLake::Models::PathResourceType::File));
-      EXPECT_NO_THROW(pathClient.SetMetadata(GetMetadata()));
-      auto properties = std::make_shared<Files::DataLake::Models::PathProperties>(
-          pathClient.GetProperties().Value);
-      EXPECT_TRUE(properties->EncryptionKeySha256.HasValue());
-      EXPECT_EQ(customerProvidedKey->KeyHash, properties->EncryptionKeySha256.Value());
-      auto pathClientWithoutEncryptionKey
-          = Files::DataLake::DataLakePathClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, pathName);
-      EXPECT_THROW(pathClientWithoutEncryptionKey.SetMetadata(GetMetadata()), StorageException);
-      EXPECT_THROW(pathClientWithoutEncryptionKey.GetProperties(), StorageException);
-      EXPECT_NO_THROW(pathClientWithoutEncryptionKey.GetAccessControlList());
-      EXPECT_NO_THROW(pathClientWithoutEncryptionKey.SetHttpHeaders(
-          Files::DataLake::Models::PathHttpHeaders()));
-      EXPECT_NO_THROW(pathClientWithoutEncryptionKey.SetPermissions("rwxrw-rw-"));
+      auto pathClientWithCPK
+          = Files::DataLake::DataLakePathClient(fileSystemClientWithCPK.GetFileClient(pathName));
+      auto pathClientWithoutCPK
+          = Files::DataLake::DataLakePathClient(fileSystemClientWithoutCPK.GetFileClient(pathName));
+      auto pathClient2WithCPK
+          = Files::DataLake::DataLakePathClient(fileSystemClientWithCPK.GetFileClient(pathName2));
 
-      auto pathClientWithEncryptionKey
-          = Files::DataLake::DataLakePathClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, pathName2, options);
-      auto created
-          = pathClientWithEncryptionKey.Create(Files::DataLake::Models::PathResourceType::File)
-                .Value;
-      EXPECT_TRUE(created.EncryptionKeySha256.HasValue());
-      EXPECT_EQ(customerProvidedKey->KeyHash, created.EncryptionKeySha256.Value());
+      EXPECT_NO_THROW(pathClientWithCPK.Create(Files::DataLake::Models::PathResourceType::File));
+      EXPECT_NO_THROW(pathClientWithCPK.SetMetadata(RandomMetadata()));
+      auto properties = pathClientWithCPK.GetProperties().Value;
+      EXPECT_TRUE(properties.EncryptionKeySha256.HasValue());
+      EXPECT_EQ(customerProvidedKey.KeyHash, properties.EncryptionKeySha256.Value());
+
+      EXPECT_THROW(pathClientWithoutCPK.SetMetadata(RandomMetadata()), StorageException);
+      EXPECT_THROW(pathClientWithoutCPK.GetProperties(), StorageException);
+      EXPECT_NO_THROW(pathClientWithoutCPK.GetAccessControlList());
+      EXPECT_NO_THROW(
+          pathClientWithoutCPK.SetHttpHeaders(Files::DataLake::Models::PathHttpHeaders()));
+      EXPECT_NO_THROW(pathClientWithoutCPK.SetPermissions("rwxrw-rw-"));
+
+      auto createResult
+          = pathClient2WithCPK.Create(Files::DataLake::Models::PathResourceType::File).Value;
+      EXPECT_TRUE(createResult.EncryptionKeySha256.HasValue());
+      EXPECT_EQ(customerProvidedKey.KeyHash, createResult.EncryptionKeySha256.Value());
     }
 
     // file works
     {
       const std::string fileName = "file";
       const std::string fileName2 = "file2";
-      auto fileClient = fileSystemClient->GetFileClient(fileName);
-      auto fileClientWithoutEncryptionKey
-          = Files::DataLake::DataLakeFileClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, fileName);
-      // upload test
-      EXPECT_NO_THROW(fileClient.Create());
-      EXPECT_NO_THROW(fileClient.UploadFrom(buffer->data(), bufferSize));
-      auto result = fileClient.Download();
-      auto downloaded = std::make_shared<std::vector<uint8_t>>(ReadBodyStream(result.Value.Body));
-      EXPECT_EQ(*buffer, *downloaded);
-      EXPECT_NO_THROW(fileClient.Delete());
-      // append test
-      EXPECT_NO_THROW(fileClient.Create());
-      bodyStream.Rewind();
-      EXPECT_NO_THROW(fileClient.Append(bodyStream, 0));
-      bodyStream.Rewind();
-      EXPECT_THROW(fileClientWithoutEncryptionKey.Append(bodyStream, bufferSize), StorageException);
-      EXPECT_NO_THROW(fileClient.Flush(bufferSize));
-      result = fileClient.Download();
-      downloaded = std::make_shared<std::vector<uint8_t>>(ReadBodyStream(result.Value.Body));
-      EXPECT_EQ(*buffer, *downloaded);
-      EXPECT_NO_THROW(fileClient.SetMetadata(GetMetadata()));
-      auto properties = std::make_shared<Files::DataLake::Models::PathProperties>(
-          fileClient.GetProperties().Value);
-      EXPECT_TRUE(properties->EncryptionKeySha256.HasValue());
-      EXPECT_EQ(customerProvidedKey->KeyHash, properties->EncryptionKeySha256.Value());
-      EXPECT_THROW(fileClientWithoutEncryptionKey.Flush(bufferSize), StorageException);
-      EXPECT_THROW(fileClientWithoutEncryptionKey.Download(), StorageException);
+      auto fileClientWithCPK = fileSystemClientWithCPK.GetFileClient(fileName);
+      auto fileClientWithoutCPK = fileSystemClientWithoutCPK.GetFileClient(fileName);
+      auto fileClient2WithCPK = fileSystemClientWithCPK.GetFileClient(fileName2);
 
-      auto fileClientWithEncryptionKey
-          = Files::DataLake::DataLakeFileClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, fileName2, options);
-      auto created = std::make_shared<Files::DataLake::Models::CreatePathResult>(
-          fileClientWithEncryptionKey.Create().Value);
-      EXPECT_TRUE(created->EncryptionKeySha256.HasValue());
-      EXPECT_EQ(customerProvidedKey->KeyHash, created->EncryptionKeySha256.Value());
+      // upload test
+      EXPECT_NO_THROW(fileClientWithCPK.Create());
+      EXPECT_NO_THROW(fileClientWithCPK.UploadFrom(buffer.data(), buffer.size()));
+      auto result = fileClientWithCPK.Download();
+      auto downloaded = ReadBodyStream(result.Value.Body);
+      EXPECT_EQ(buffer, downloaded);
+      EXPECT_NO_THROW(fileClientWithCPK.Delete());
+      // append test
+      EXPECT_NO_THROW(fileClientWithCPK.Create());
+      bodyStream.Rewind();
+      EXPECT_NO_THROW(fileClientWithCPK.Append(bodyStream, 0));
+      bodyStream.Rewind();
+      EXPECT_THROW(fileClientWithoutCPK.Append(bodyStream, buffer.size()), StorageException);
+      EXPECT_NO_THROW(fileClientWithCPK.Flush(buffer.size()));
+      result = fileClientWithCPK.Download();
+      downloaded = ReadBodyStream(result.Value.Body);
+      EXPECT_EQ(buffer, downloaded);
+      EXPECT_NO_THROW(fileClientWithCPK.SetMetadata(RandomMetadata()));
+      auto properties = fileClientWithCPK.GetProperties().Value;
+      EXPECT_TRUE(properties.EncryptionKeySha256.HasValue());
+      EXPECT_EQ(customerProvidedKey.KeyHash, properties.EncryptionKeySha256.Value());
+      EXPECT_THROW(fileClientWithoutCPK.Flush(buffer.size()), StorageException);
+      EXPECT_THROW(fileClientWithoutCPK.Download(), StorageException);
+
+      auto createResult = fileClient2WithCPK.Create().Value;
+      EXPECT_TRUE(createResult.EncryptionKeySha256.HasValue());
+      EXPECT_EQ(customerProvidedKey.KeyHash, createResult.EncryptionKeySha256.Value());
     }
     // directory works
     {
@@ -590,59 +444,49 @@ namespace Azure { namespace Storage { namespace Test {
       const std::string fileName1 = "file1";
       const std::string fileName2 = "file2";
       const std::string fileName3 = "file3";
-      auto directoryClient = fileSystemClient->GetDirectoryClient(directoryName);
-      auto directoryClientWithoutEncryptionKey
-          = Files::DataLake::DataLakeDirectoryClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, directoryName);
+
+      auto directoryClientWithCPK = fileSystemClientWithCPK.GetDirectoryClient(directoryName);
+      auto directoryClientWithoutCPK = fileSystemClientWithoutCPK.GetDirectoryClient(directoryName);
+
       // create subdirectory/file
-      EXPECT_NO_THROW(directoryClient.Create());
-      auto subdirectoryClient = directoryClient.GetSubdirectoryClient(subdirectoryName1);
-      EXPECT_NO_THROW(subdirectoryClient.Create());
-      auto fileClient = directoryClient.GetFileClient(fileName1);
-      EXPECT_NO_THROW(fileClient.Create());
-      auto subdirectoryProperties = std::make_shared<Files::DataLake::Models::PathProperties>(
-          subdirectoryClient.GetProperties().Value);
-      EXPECT_EQ(customerProvidedKey->KeyHash, subdirectoryProperties->EncryptionKeySha256.Value());
-      auto fileProperties = fileClient.GetProperties();
-      EXPECT_EQ(customerProvidedKey->KeyHash, fileProperties.Value.EncryptionKeySha256.Value());
+      EXPECT_NO_THROW(directoryClientWithCPK.Create());
+      auto subdirectoryClientWithCPK
+          = directoryClientWithCPK.GetSubdirectoryClient(subdirectoryName1);
+      EXPECT_NO_THROW(subdirectoryClientWithCPK.Create());
+      auto fileClientWithCPK = directoryClientWithCPK.GetFileClient(fileName1);
+      EXPECT_NO_THROW(fileClientWithCPK.Create());
+      auto subdirectoryProperties = subdirectoryClientWithCPK.GetProperties().Value;
+      EXPECT_EQ(customerProvidedKey.KeyHash, subdirectoryProperties.EncryptionKeySha256.Value());
+      auto fileProperties = fileClientWithCPK.GetProperties();
+      EXPECT_EQ(customerProvidedKey.KeyHash, fileProperties.Value.EncryptionKeySha256.Value());
 
       // rename file
       auto newFileClient
-          = directoryClient.RenameFile(fileName1, directoryName + "/" + fileName2).Value;
-      auto newFileProperties = std::make_shared<Files::DataLake::Models::PathProperties>(
-          newFileClient.GetProperties().Value);
-      EXPECT_EQ(customerProvidedKey->KeyHash, newFileProperties->EncryptionKeySha256.Value());
-      auto newFileClientWithoutEncryptionKey
-          = Files::DataLake::DataLakeFileClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, directoryName + "/" + fileName2);
-      EXPECT_THROW(newFileClientWithoutEncryptionKey.GetProperties(), StorageException);
-      EXPECT_NO_THROW(directoryClientWithoutEncryptionKey.RenameFile(
-          fileName2, directoryName + "/" + fileName3));
+          = directoryClientWithCPK.RenameFile(fileName1, directoryName + "/" + fileName2).Value;
+      auto newFileProperties = newFileClient.GetProperties().Value;
+      EXPECT_EQ(customerProvidedKey.KeyHash, newFileProperties.EncryptionKeySha256.Value());
+      auto newFileClientWithoutCPK
+          = fileSystemClientWithoutCPK.GetFileClient(directoryName + "/" + fileName2);
+      EXPECT_THROW(newFileClientWithoutCPK.GetProperties(), StorageException);
+      EXPECT_NO_THROW(
+          directoryClientWithoutCPK.RenameFile(fileName2, directoryName + "/" + fileName3));
 
-      auto newSubdirectoryClient
-          = directoryClient
+      auto newSubdirectoryClientWithCPK
+          = directoryClientWithCPK
                 .RenameSubdirectory(subdirectoryName1, directoryName + "/" + subdirectoryName2)
                 .Value;
-      auto newSubdirectoryProperties = std::make_shared<Files::DataLake::Models::PathProperties>(
-          newSubdirectoryClient.GetProperties().Value);
-      EXPECT_EQ(
-          customerProvidedKey->KeyHash, newSubdirectoryProperties->EncryptionKeySha256.Value());
-      auto newsubdirectoryClientWithoutEncryptionKey
-          = Files::DataLake::DataLakeDirectoryClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(),
-              m_fileSystemName,
-              directoryName + "/" + subdirectoryName2);
-      EXPECT_THROW(newsubdirectoryClientWithoutEncryptionKey.GetProperties(), StorageException);
-      EXPECT_NO_THROW(directoryClientWithoutEncryptionKey.RenameSubdirectory(
+      auto newSubdirectoryProperties = newSubdirectoryClientWithCPK.GetProperties().Value;
+      EXPECT_EQ(customerProvidedKey.KeyHash, newSubdirectoryProperties.EncryptionKeySha256.Value());
+      auto newsubdirectoryClientWithoutCPK
+          = fileSystemClientWithoutCPK.GetDirectoryClient(directoryName + "/" + subdirectoryName2);
+      EXPECT_THROW(newsubdirectoryClientWithoutCPK.GetProperties(), StorageException);
+      EXPECT_NO_THROW(directoryClientWithoutCPK.RenameSubdirectory(
           subdirectoryName2, directoryName + "/" + subdirectoryName3));
 
-      auto directoryClientWithEncryptionKey
-          = Files::DataLake::DataLakeDirectoryClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(), m_fileSystemName, directoryName2, options);
-      auto created = std::make_shared<Files::DataLake::Models::CreatePathResult>(
-          directoryClientWithEncryptionKey.Create().Value);
-      EXPECT_TRUE(created->EncryptionKeySha256.HasValue());
-      EXPECT_EQ(customerProvidedKey->KeyHash, created->EncryptionKeySha256.Value());
+      auto directoryClient2WithCPK = fileSystemClientWithCPK.GetDirectoryClient(directoryName2);
+      auto createResult = directoryClient2WithCPK.Create().Value;
+      EXPECT_TRUE(createResult.EncryptionKeySha256.HasValue());
+      EXPECT_EQ(customerProvidedKey.KeyHash, createResult.EncryptionKeySha256.Value());
     }
   }
 
@@ -657,9 +501,9 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // with EncryptionScope
     {
-      std::string fileSystemName = GetFileSystemValidName() + "1";
-      std::string pathName = GetTestName() + "1";
-      auto fileSystemClient = m_dataLakeServiceClient->GetFileSystemClient(fileSystemName);
+      std::string fileSystemName = LowercaseRandomString() + "1";
+      std::string pathName = RandomString() + "1";
+      auto fileSystemClient = GetFileSystemClientForTest(fileSystemName);
       Files::DataLake::CreateFileSystemOptions createOptions;
       createOptions.DefaultEncryptionScope = testEncryptionScope;
       createOptions.PreventEncryptionScopeOverride = true;
@@ -685,40 +529,17 @@ namespace Azure { namespace Storage { namespace Test {
               createOptions.PreventEncryptionScopeOverride.Value());
         }
       }
-      auto fileClient = fileSystemClient.GetFileClient(pathName);
-      fileClient.Create();
-      Files::DataLake::ListPathsOptions listOptions;
-      for (auto page = fileSystemClient.ListPaths(false, listOptions); page.HasPage();
-           page.MoveToNextPage())
-      {
-        for (auto& path : page.Paths)
-        {
-          if (path.Name == pathName)
-          {
-            EXPECT_TRUE(path.EncryptionScope.HasValue());
-            EXPECT_EQ(path.EncryptionScope.Value(), testEncryptionScope);
-          }
-        }
-      }
-      auto fileProperties = fileClient.GetProperties().Value;
-      EXPECT_TRUE(fileProperties.EncryptionScope.HasValue());
-      EXPECT_EQ(fileProperties.EncryptionScope.Value(), testEncryptionScope);
-      fileSystemClient.Delete();
     }
   }
 
-  TEST_F(DataLakeFileSystemClientTest, GetSetAccessPolicy_LIVEONLY_)
+  TEST_F(DataLakeFileSystemClientTest, GetSetAccessPolicy)
   {
-    CHECK_SKIP_TEST();
     {
-      auto fileSystem = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(),
-          GetTestNameLowerCase(),
-          InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-      fileSystem.Create();
+      auto fileSystem = GetFileSystemClientForTest(LowercaseRandomString());
+      fileSystem.CreateIfNotExists();
 
       Files::DataLake::SetFileSystemAccessPolicyOptions options;
-      options.AccessType = Files::DataLake::Models::PublicAccessType::Path;
+      options.AccessType = Files::DataLake::Models::PublicAccessType::None;
       {
         Files::DataLake::Models::SignedIdentifier identifier;
         identifier.Id = std::string(64, 'a');
@@ -757,9 +578,9 @@ namespace Azure { namespace Storage { namespace Test {
       auto ret2 = fileSystem.GetAccessPolicy();
       EXPECT_EQ(ret2.Value.AccessType, options.AccessType);
       ASSERT_EQ(ret2.Value.SignedIdentifiers.size(), options.SignedIdentifiers.size());
-      for (size_t i = 0; i < ret2.Value.SignedIdentifiers.size(); ++i)
+      if (m_testContext.IsLiveMode())
       {
-        EXPECT_EQ(ret2.Value.SignedIdentifiers[i], options.SignedIdentifiers[i]);
+        EXPECT_EQ(ret2.Value.SignedIdentifiers, options.SignedIdentifiers);
       }
 
       options.AccessType = Files::DataLake::Models::PublicAccessType::FileSystem;
@@ -771,51 +592,37 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(fileSystem.SetAccessPolicy(options));
       ret2 = fileSystem.GetAccessPolicy();
       EXPECT_EQ(ret2.Value.AccessType, options.AccessType);
-
-      fileSystem.Delete();
     }
     {
-      auto fileSystem = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(),
-          GetTestNameLowerCase() + "1",
-          InitClientOptions<Files::DataLake::DataLakeClientOptions>());
+      auto fileSystem = GetFileSystemClientForTest(LowercaseRandomString());
       Files::DataLake::CreateFileSystemOptions options;
       options.AccessType = Files::DataLake::Models::PublicAccessType::FileSystem;
       fileSystem.Create(options);
       auto ret = fileSystem.GetAccessPolicy();
       EXPECT_EQ(Files::DataLake::Models::PublicAccessType::FileSystem, ret.Value.AccessType);
-      fileSystem.Delete();
     }
     {
-      auto fileSystem = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(),
-          GetTestNameLowerCase() + "2",
-          InitClientOptions<Files::DataLake::DataLakeClientOptions>());
+      auto fileSystem = GetFileSystemClientForTest(LowercaseRandomString());
       Files::DataLake::CreateFileSystemOptions options;
       options.AccessType = Files::DataLake::Models::PublicAccessType::Path;
       fileSystem.Create(options);
       auto ret = fileSystem.GetAccessPolicy();
       EXPECT_EQ(Files::DataLake::Models::PublicAccessType::Path, ret.Value.AccessType);
-      fileSystem.Delete();
     }
     {
-      auto fileSystem = Files::DataLake::DataLakeFileSystemClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(),
-          GetTestNameLowerCase() + "3",
-          InitClientOptions<Files::DataLake::DataLakeClientOptions>());
+      auto fileSystem = GetFileSystemClientForTest(LowercaseRandomString());
       Files::DataLake::CreateFileSystemOptions options;
       options.AccessType = Files::DataLake::Models::PublicAccessType::Path;
       fileSystem.Create(options);
       auto ret = fileSystem.GetAccessPolicy();
       EXPECT_EQ(Files::DataLake::Models::PublicAccessType::Path, ret.Value.AccessType);
-      fileSystem.Delete();
     }
   }
 
   TEST_F(DataLakeFileSystemClientTest, RenameFile)
   {
-    const std::string oldFilename = GetTestName() + "1";
-    const std::string newFilename = GetTestName() + "2";
+    const std::string oldFilename = RandomString() + "1";
+    const std::string newFilename = RandomString() + "2";
 
     auto oldFileClient = m_fileSystemClient->GetFileClient(oldFilename);
     oldFileClient.Create();
@@ -826,10 +633,10 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_NO_THROW(m_fileSystemClient->GetFileClient(newFilename).GetProperties());
     EXPECT_THROW(oldFileClient.GetProperties(), StorageException);
 
-    const std::string newFileSystemName = GetTestNameLowerCase() + "1";
-    const std::string newFilename2 = GetTestName() + "3";
+    const std::string newFileSystemName = LowercaseRandomString() + "1";
+    const std::string newFilename2 = LowercaseRandomString() + "3";
 
-    auto newFileSystem = m_dataLakeServiceClient->GetFileSystemClient(newFileSystemName);
+    auto newFileSystem = GetFileSystemClientForTest(newFileSystemName);
     newFileSystem.Create();
 
     Files::DataLake::RenameFileOptions options;
@@ -844,14 +651,14 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakeFileSystemClientTest, RenameDirectory)
   {
-    const std::string testName(GetTestName());
-    const std::string oldDirectoryName = testName + "1";
-    const std::string newDirectoryName = testName + "2";
+    const std::string baseName = RandomString();
+    const std::string oldDirectoryName = baseName + "1";
+    const std::string newDirectoryName = baseName + "2";
 
     auto oldDirectoryClient = m_fileSystemClient->GetDirectoryClient(oldDirectoryName);
     oldDirectoryClient.Create();
-    oldDirectoryClient.GetFileClient(testName + "3").Create();
-    oldDirectoryClient.GetSubdirectoryClient(testName + "4").Create();
+    oldDirectoryClient.GetFileClient(baseName + "3").Create();
+    oldDirectoryClient.GetSubdirectoryClient(baseName + "4").Create();
 
     auto newDirectoryClient
         = m_fileSystemClient->RenameDirectory(oldDirectoryName, newDirectoryName).Value;
@@ -860,10 +667,10 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_NO_THROW(m_fileSystemClient->GetDirectoryClient(newDirectoryName).GetProperties());
     EXPECT_THROW(oldDirectoryClient.GetProperties(), StorageException);
 
-    const std::string newFileSystemName = GetTestNameLowerCase();
-    const std::string newDirectoryName2 = testName + "5";
+    const std::string newFileSystemName = LowercaseRandomString();
+    const std::string newDirectoryName2 = baseName + "5";
 
-    auto newFileSystem = m_dataLakeServiceClient->GetFileSystemClient(newFileSystemName);
+    auto newFileSystem = GetFileSystemClientForTest(newFileSystemName);
     newFileSystem.Create();
 
     Files::DataLake::RenameDirectoryOptions options;
@@ -877,23 +684,26 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_THROW(newDirectoryClient.GetProperties(), StorageException);
   }
 
-  TEST_F(DataLakeFileSystemClientTest, RenameFileSasAuthentication_LIVEONLY_)
+  TEST_F(DataLakeFileSystemClientTest, RenameFileSasAuthentication)
   {
-    const std::string testName(GetTestName());
-    const std::string sourceFilename = testName + "1";
-    const std::string destinationFilename = testName + "2";
+    const std::string baseName = RandomString();
+    const std::string sourceFilename = baseName + "1";
+    const std::string destinationFilename = baseName + "2";
     auto fileClient = m_fileSystemClient->GetFileClient(sourceFilename);
     fileClient.CreateIfNotExists();
 
+    Files::DataLake::DataLakeClientOptions options;
+    InitClientOptions(options);
     Files::DataLake::DataLakeFileSystemClient fileSystemClientSas(
-        Files::DataLake::_detail::GetDfsUrlFromUrl(m_fileSystemClient->GetUrl()) + GetSas());
+        Files::DataLake::_detail::GetDfsUrlFromUrl(m_fileSystemClient->GetUrl()) + GetSas(),
+        options);
     fileSystemClientSas.RenameFile(sourceFilename, destinationFilename);
     EXPECT_THROW(
         m_fileSystemClient->GetFileClient(sourceFilename).GetProperties(), StorageException);
     EXPECT_NO_THROW(m_fileSystemClient->GetFileClient(destinationFilename).GetProperties());
 
-    const std::string sourceDirectoryName = testName + "3";
-    const std::string destinationDirectoryName = testName + "4";
+    const std::string sourceDirectoryName = baseName + "3";
+    const std::string destinationDirectoryName = baseName + "4";
     auto directoryClient = m_fileSystemClient->GetDirectoryClient(sourceDirectoryName);
     directoryClient.CreateIfNotExists();
 
@@ -907,10 +717,10 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakeFileSystemClientTest, ListDeletedPaths)
   {
-    const std::string deletedFilename = GetTestNameLowerCase() + "_file_deleted";
-    const std::string nonDeletedFilename = GetTestNameLowerCase() + "_file";
-    const std::string deletedDirectoryName = GetTestNameLowerCase() + "_dir_deleted";
-    const std::string nonDeletedDirectoryName = GetTestNameLowerCase() + "_dir";
+    const std::string deletedFilename = RandomString() + "_file_deleted";
+    const std::string nonDeletedFilename = RandomString() + "_file";
+    const std::string deletedDirectoryName = RandomString() + "_dir_deleted";
+    const std::string nonDeletedDirectoryName = RandomString() + "_dir";
 
     auto deletedFileClient = m_fileSystemClient->GetFileClient(deletedFilename);
     auto nonDeletedFileClient = m_fileSystemClient->GetFileClient(nonDeletedFilename);
@@ -926,15 +736,17 @@ namespace Azure { namespace Storage { namespace Test {
     nonDeletedDirectoryClient.Create();
 
     {
-      std::vector<Files::DataLake::Models::PathDeletedItem> paths;
+      std::set<std::string> paths;
       for (auto pageResult = m_fileSystemClient->ListDeletedPaths(); pageResult.HasPage();
            pageResult.MoveToNextPage())
       {
-        paths.insert(paths.end(), pageResult.DeletedPaths.begin(), pageResult.DeletedPaths.end());
+        for (const auto& p : pageResult.DeletedPaths)
+        {
+          paths.insert(p.Name);
+        }
       }
-      EXPECT_EQ(2, paths.size());
-      EXPECT_EQ(deletedDirectoryName, paths[0].Name);
-      EXPECT_EQ(deletedFilename, paths[1].Name);
+      EXPECT_NE(paths.find(deletedDirectoryName), paths.end());
+      EXPECT_NE(paths.find(deletedFilename), paths.end());
     }
     //  List max result
     {
@@ -951,7 +763,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // prefix works
     {
-      const std::string directoryName = GetTestNameLowerCase() + "_prefix";
+      const std::string directoryName = RandomString() + "_prefix";
       const std::string filename = "file";
 
       auto directoryClient = m_fileSystemClient->GetDirectoryClient(directoryName);
@@ -975,7 +787,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakeFileSystemClientTest, Undelete)
   {
-    const std::string directoryName = GetTestNameLowerCase() + "_dir";
+    const std::string directoryName = RandomString() + "_dir";
     const std::string subFileName = "sub_file";
 
     auto directoryClient = m_fileSystemClient->GetDirectoryClient(directoryName);

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_system_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_system_client_test.cpp
@@ -32,7 +32,10 @@ namespace Azure { namespace Storage { namespace Test {
   void DataLakeFileSystemClientTest::SetUp()
   {
     DataLakeServiceClientTest::SetUp();
-
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_fileSystemName = GetLowercaseIdentifier();
     m_fileSystemClient = std::make_shared<Files::DataLake::DataLakeFileSystemClient>(
         m_dataLakeServiceClient->GetFileSystemClient(m_fileSystemName));

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_system_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_system_client_test.cpp
@@ -49,7 +49,7 @@ namespace Azure { namespace Storage { namespace Test {
         {
           throw;
         }
-        SUCCEED() << "Cotnainer is being deleted. Will try again after 3 seconds.";
+        SUCCEED() << "Container is being deleted. Will try again after 3 seconds.";
         std::this_thread::sleep_for(std::chrono::seconds(3));
       }
     }

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_system_client_test.hpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_system_client_test.hpp
@@ -4,31 +4,23 @@
 #include <azure/storage/files/datalake.hpp>
 
 #include "datalake_service_client_test.hpp"
-#include "test/ut/test_base.hpp"
 
 namespace Azure { namespace Storage { namespace Test {
 
   class DataLakeFileSystemClientTest : public DataLakeServiceClientTest {
   protected:
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
+
     std::string GetSas();
-    void CreateDirectoryList();
 
-    std::vector<Files::DataLake::Models::PathItem> ListAllPaths(
-        bool recursive,
-        const std::string& directory = std::string());
+    Files::DataLake::DataLakeFileSystemClient GetFileSystemClientForTest(
+        const std::string& fileSystemName,
+        Files::DataLake::DataLakeClientOptions clientOptions
+        = Files::DataLake::DataLakeClientOptions());
 
-    Files::DataLake::Models::PathHttpHeaders GetInterestingHttpHeaders();
-
+  protected:
     std::shared_ptr<Files::DataLake::DataLakeFileSystemClient> m_fileSystemClient;
     std::string m_fileSystemName;
-
-    // Path related
-    std::vector<std::string> m_pathNameSetA;
-    std::string m_directoryA;
-    std::vector<std::string> m_pathNameSetB;
-    std::string m_directoryB;
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_path_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_path_client_test.cpp
@@ -13,7 +13,10 @@ namespace Azure { namespace Storage { namespace Test {
   void DataLakePathClientTest::SetUp()
   {
     DataLakeFileSystemClientTest::SetUp();
-
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_pathName = RandomString();
     m_pathClient = std::make_shared<Files::DataLake::DataLakePathClient>(
         m_fileSystemClient->GetFileClient(m_pathName));

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_path_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_path_client_test.cpp
@@ -13,22 +13,14 @@ namespace Azure { namespace Storage { namespace Test {
   void DataLakePathClientTest::SetUp()
   {
     DataLakeFileSystemClientTest::SetUp();
-    CHECK_SKIP_TEST();
 
-    m_pathName = GetFileSystemValidName();
+    m_pathName = RandomString();
     m_pathClient = std::make_shared<Files::DataLake::DataLakePathClient>(
         m_fileSystemClient->GetFileClient(m_pathName));
     m_fileSystemClient->GetFileClient(m_pathName).Create();
   }
 
-  void DataLakePathClientTest::TearDown()
-  {
-    CHECK_SKIP_TEST();
-    m_pathClient->Delete();
-    DataLakeFileSystemClientTest::TearDown();
-  }
-
-  std::vector<Files::DataLake::Models::Acl> DataLakePathClientTest::GetValidAcls()
+  std::vector<Files::DataLake::Models::Acl> DataLakePathClientTest::GetAclsForTesting()
   {
     static std::vector<Files::DataLake::Models::Acl> result = []() {
       std::vector<Files::DataLake::Models::Acl> ret;
@@ -61,7 +53,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     // owner&group
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "owner_group");
+      auto client = m_fileSystemClient->GetFileClient(RandomString() + "owner_group");
       Files::DataLake::CreateFileOptions options;
       options.Group = "$superuser";
       options.Owner = "$superuser";
@@ -72,9 +64,9 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // acl
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "_acl");
+      auto client = m_fileSystemClient->GetFileClient(RandomString() + "_acl");
       Files::DataLake::CreateFileOptions options;
-      auto acls = GetValidAcls();
+      auto acls = GetAclsForTesting();
       options.Acls = acls;
       EXPECT_NO_THROW(client.Create(options));
       auto resultAcls = client.GetAccessControlList().Value.Acls;
@@ -94,9 +86,9 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // lease
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "_lease");
+      auto client = m_fileSystemClient->GetFileClient(RandomString() + "_lease");
       Files::DataLake::CreateFileOptions options;
-      options.LeaseId = Files::DataLake::DataLakeLeaseClient::CreateUniqueLeaseId();
+      options.LeaseId = RandomUUID();
       options.LeaseDuration = std::chrono::seconds(20);
       EXPECT_NO_THROW(client.Create(options));
       auto response = client.GetProperties();
@@ -110,7 +102,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // relative expiry
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "_relative_expiry");
+      auto client = m_fileSystemClient->GetFileClient(RandomString() + "_relative_expiry");
       Files::DataLake::CreateFileOptions options;
       options.ScheduleDeletionOptions.TimeToExpire = std::chrono::hours(1);
       EXPECT_NO_THROW(client.Create(options));
@@ -126,7 +118,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // absolute expiry
     {
-      auto client = m_fileSystemClient->GetFileClient(GetTestNameLowerCase() + "_absolute_expiry");
+      auto client = m_fileSystemClient->GetFileClient(RandomString() + "_absolute_expiry");
       Files::DataLake::CreateFileOptions options;
       options.ScheduleDeletionOptions.ExpiresOn = Azure::DateTime::Parse(
           "Wed, 29 Sep 2100 09:53:03 GMT", Azure::DateTime::DateFormat::Rfc1123);
@@ -140,8 +132,8 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakePathClientTest, PathMetadata)
   {
-    auto metadata1 = GetMetadata();
-    auto metadata2 = GetMetadata();
+    auto metadata1 = RandomMetadata();
+    auto metadata2 = RandomMetadata();
     {
       // Set/Get Metadata works
       EXPECT_NO_THROW(m_pathClient->SetMetadata(metadata1));
@@ -154,9 +146,9 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       // Create path with metadata works
-      std::string const testName(GetTestName());
-      auto client1 = m_fileSystemClient->GetFileClient(testName + "1");
-      auto client2 = m_fileSystemClient->GetFileClient(testName + "1");
+      std::string const baseName = RandomString();
+      auto client1 = m_fileSystemClient->GetFileClient(baseName + "1");
+      auto client2 = m_fileSystemClient->GetFileClient(baseName + "2");
       Files::DataLake::CreatePathOptions options1;
       Files::DataLake::CreatePathOptions options2;
       options1.Metadata = metadata1;
@@ -173,8 +165,8 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakePathClientTest, GetDataLakePathPropertiesResult)
   {
-    auto metadata1 = GetMetadata();
-    auto metadata2 = GetMetadata();
+    auto metadata1 = RandomMetadata();
+    auto metadata2 = RandomMetadata();
     {
       // Get Metadata via properties works
       EXPECT_NO_THROW(m_pathClient->SetMetadata(metadata1));
@@ -203,48 +195,55 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakePathClientTest, PathHttpHeaders)
   {
-    const std::string testName(GetTestName());
+    auto httpHeaders = Files::DataLake::Models::PathHttpHeaders();
+    httpHeaders.ContentType = "application/x-binary";
+    httpHeaders.ContentLanguage = "en-US";
+    httpHeaders.ContentDisposition = "attachment";
+    httpHeaders.CacheControl = "no-cache";
+    httpHeaders.ContentEncoding = "identity";
+
+    const std::string baseName = RandomString();
     {
       // HTTP headers works with create.
-      auto httpHeader = GetInterestingHttpHeaders();
       std::vector<Files::DataLake::DataLakePathClient> pathClient;
       for (int32_t i = 0; i < 2; ++i)
       {
-        auto client = m_fileSystemClient->GetFileClient(testName + std::to_string(i));
+        auto client = m_fileSystemClient->GetFileClient(baseName + std::to_string(i));
         Files::DataLake::CreatePathOptions options;
-        options.HttpHeaders = httpHeader;
+        options.HttpHeaders = httpHeaders;
         EXPECT_NO_THROW(client.Create(options));
         pathClient.emplace_back(std::move(client));
       }
       for (const auto& client : pathClient)
       {
         auto result = client.GetProperties();
-        EXPECT_EQ(httpHeader.CacheControl, result.Value.HttpHeaders.CacheControl);
-        EXPECT_EQ(httpHeader.ContentDisposition, result.Value.HttpHeaders.ContentDisposition);
-        EXPECT_EQ(httpHeader.ContentLanguage, result.Value.HttpHeaders.ContentLanguage);
-        EXPECT_EQ(httpHeader.ContentType, result.Value.HttpHeaders.ContentType);
+        EXPECT_EQ(httpHeaders.CacheControl, result.Value.HttpHeaders.CacheControl);
+        EXPECT_EQ(httpHeaders.ContentDisposition, result.Value.HttpHeaders.ContentDisposition);
+        EXPECT_EQ(httpHeaders.ContentLanguage, result.Value.HttpHeaders.ContentLanguage);
+        EXPECT_EQ(httpHeaders.ContentType, result.Value.HttpHeaders.ContentType);
+        EXPECT_EQ(httpHeaders.ContentEncoding, result.Value.HttpHeaders.ContentEncoding);
         client.Delete();
       }
     }
 
     {
       // HTTP headers works with SetHttpHeaders.
-      auto httpHeader = GetInterestingHttpHeaders();
       std::vector<Files::DataLake::DataLakePathClient> pathClient;
       for (int32_t i = 0; i < 2; ++i)
       {
-        auto client = m_fileSystemClient->GetFileClient(testName + "2" + std::to_string(i));
+        auto client = m_fileSystemClient->GetFileClient(baseName + "2" + std::to_string(i));
         EXPECT_NO_THROW(client.Create());
-        EXPECT_NO_THROW(client.SetHttpHeaders(httpHeader));
+        EXPECT_NO_THROW(client.SetHttpHeaders(httpHeaders));
         pathClient.emplace_back(std::move(client));
       }
       for (const auto& client : pathClient)
       {
         auto result = client.GetProperties();
-        EXPECT_EQ(httpHeader.CacheControl, result.Value.HttpHeaders.CacheControl);
-        EXPECT_EQ(httpHeader.ContentDisposition, result.Value.HttpHeaders.ContentDisposition);
-        EXPECT_EQ(httpHeader.ContentLanguage, result.Value.HttpHeaders.ContentLanguage);
-        EXPECT_EQ(httpHeader.ContentType, result.Value.HttpHeaders.ContentType);
+        EXPECT_EQ(httpHeaders.CacheControl, result.Value.HttpHeaders.CacheControl);
+        EXPECT_EQ(httpHeaders.ContentDisposition, result.Value.HttpHeaders.ContentDisposition);
+        EXPECT_EQ(httpHeaders.ContentLanguage, result.Value.HttpHeaders.ContentLanguage);
+        EXPECT_EQ(httpHeaders.ContentType, result.Value.HttpHeaders.ContentType);
+        EXPECT_EQ(httpHeaders.ContentEncoding, result.Value.HttpHeaders.ContentEncoding);
         client.Delete();
       }
     }
@@ -254,11 +253,10 @@ namespace Azure { namespace Storage { namespace Test {
       auto response = m_pathClient->GetProperties();
       Files::DataLake::SetPathHttpHeadersOptions options1;
       options1.AccessConditions.IfModifiedSince = response.Value.LastModified;
-      EXPECT_THROW(
-          m_pathClient->SetHttpHeaders(GetInterestingHttpHeaders(), options1), StorageException);
+      EXPECT_THROW(m_pathClient->SetHttpHeaders(httpHeaders, options1), StorageException);
       Files::DataLake::SetPathHttpHeadersOptions options2;
       options2.AccessConditions.IfUnmodifiedSince = response.Value.LastModified;
-      EXPECT_NO_THROW(m_pathClient->SetHttpHeaders(GetInterestingHttpHeaders(), options2));
+      EXPECT_NO_THROW(m_pathClient->SetHttpHeaders(httpHeaders, options2));
     }
 
     {
@@ -266,11 +264,10 @@ namespace Azure { namespace Storage { namespace Test {
       auto response = m_pathClient->GetProperties();
       Files::DataLake::SetPathHttpHeadersOptions options1;
       options1.AccessConditions.IfNoneMatch = response.Value.ETag;
-      EXPECT_THROW(
-          m_pathClient->SetHttpHeaders(GetInterestingHttpHeaders(), options1), StorageException);
+      EXPECT_THROW(m_pathClient->SetHttpHeaders(httpHeaders, options1), StorageException);
       Files::DataLake::SetPathHttpHeadersOptions options2;
       options2.AccessConditions.IfMatch = response.Value.ETag;
-      EXPECT_NO_THROW(m_pathClient->SetHttpHeaders(GetInterestingHttpHeaders(), options2));
+      EXPECT_NO_THROW(m_pathClient->SetHttpHeaders(httpHeaders, options2));
     }
   }
 
@@ -278,7 +275,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     {
       // Set/Get Acls works.
-      std::vector<Files::DataLake::Models::Acl> acls = GetValidAcls();
+      std::vector<Files::DataLake::Models::Acl> acls = GetAclsForTesting();
       EXPECT_NO_THROW(m_pathClient->SetAccessControlList(acls));
       std::vector<Files::DataLake::Models::Acl> resultAcls;
       EXPECT_NO_THROW(resultAcls = m_pathClient->GetAccessControlList().Value.Acls);
@@ -299,7 +296,7 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       // Set/Get Acls works with last modified access condition.
-      std::vector<Files::DataLake::Models::Acl> acls = GetValidAcls();
+      std::vector<Files::DataLake::Models::Acl> acls = GetAclsForTesting();
 
       auto response = m_pathClient->GetProperties();
       Files::DataLake::SetPathAccessControlListOptions options1;
@@ -312,7 +309,7 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       // Set/Get Acls works with if match access condition.
-      std::vector<Files::DataLake::Models::Acl> acls = GetValidAcls();
+      std::vector<Files::DataLake::Models::Acl> acls = GetAclsForTesting();
       auto response = m_pathClient->GetProperties();
       Files::DataLake::SetPathAccessControlListOptions options1;
       options1.AccessConditions.IfNoneMatch = response.Value.ETag;
@@ -325,12 +322,12 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakePathClientTest, PathSetPermissions)
   {
-    std::string const testName(GetTestName());
+    std::string const baseName = RandomString();
     {
       auto pathClient = Files::DataLake::DataLakePathClient::CreateFromConnectionString(
           AdlsGen2ConnectionString(),
           m_fileSystemName,
-          testName + "1",
+          baseName + "1",
           InitClientOptions<Files::DataLake::DataLakeClientOptions>());
       pathClient.Create(Files::DataLake::Models::PathResourceType::File);
       std::string pathPermissions = "rwxrw-rw-";
@@ -352,7 +349,7 @@ namespace Azure { namespace Storage { namespace Test {
       auto pathClient = Files::DataLake::DataLakePathClient::CreateFromConnectionString(
           AdlsGen2ConnectionString(),
           m_fileSystemName,
-          testName + "2",
+          baseName + "2",
           InitClientOptions<Files::DataLake::DataLakeClientOptions>());
       auto response = pathClient.Create(Files::DataLake::Models::PathResourceType::File);
       Files::DataLake::SetPathPermissionsOptions options1, options2;
@@ -367,7 +364,7 @@ namespace Azure { namespace Storage { namespace Test {
       auto pathClient = Files::DataLake::DataLakePathClient::CreateFromConnectionString(
           AdlsGen2ConnectionString(),
           m_fileSystemName,
-          testName + "3",
+          baseName + "3",
           InitClientOptions<Files::DataLake::DataLakeClientOptions>());
       auto response = pathClient.Create(Files::DataLake::Models::PathResourceType::File);
       Files::DataLake::SetPathPermissionsOptions options1, options2;
@@ -378,135 +375,5 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(pathClient.SetPermissions(pathPermissions, options1));
     }
   }
-#if 0
-    TEST_F(DataLakePathClientTest, LeaseRelated)
-    {
-      std::string leaseId1 = CreateUniqueLeaseId();
-      int32_t leaseDuration = 20;
-      auto lastModified = m_pathClient->GetProperties().Value.LastModified;
-      auto aLease = *m_pathClient->AcquireLease(leaseId1, leaseDuration);
-      EXPECT_FALSE(aLease.ETag.empty());
-      EXPECT_FALSE(aLease.LastModified > lastModified);
-      EXPECT_EQ(aLease.LeaseId, leaseId1);
-      aLease = *m_pathClient->AcquireLease(leaseId1, leaseDuration);
-      EXPECT_FALSE(aLease.ETag.empty());
-      EXPECT_FALSE(aLease.LastModified > lastModified);
-      EXPECT_EQ(aLease.LeaseId, leaseId1);
 
-      auto properties = *m_pathClient->GetProperties();
-      EXPECT_EQ(properties.LeaseState.Value(),
-      Files::DataLake::Models::LeaseStateType::Leased);
-      EXPECT_EQ(properties.LeaseStatus.Value(),
-      Files::DataLake::Models::LeaseStatusType::Locked);
-      EXPECT_FALSE(properties.LeaseDuration.Value().empty());
-
-      lastModified = properties.LastModified;
-      auto rLease = *m_pathClient->RenewLease(leaseId1);
-      EXPECT_FALSE(rLease.ETag.empty());
-      EXPECT_FALSE(rLease.LastModified > lastModified);
-      EXPECT_EQ(rLease.LeaseId, leaseId1);
-
-      std::string leaseId2 = CreateUniqueLeaseId();
-      EXPECT_NE(leaseId1, leaseId2);
-      lastModified = m_pathClient->GetProperties().Value.LastModified;
-      auto cLease = *m_pathClient->ChangeLease(leaseId1, leaseId2);
-      EXPECT_FALSE(cLease.ETag.empty());
-      EXPECT_FALSE(cLease.LastModified > lastModified);
-      EXPECT_EQ(cLease.LeaseId, leaseId2);
-
-      lastModified = m_pathClient->GetProperties().Value.LastModified;
-      auto pathInfo = *m_pathClient->ReleaseLease(leaseId2);
-      EXPECT_FALSE(pathInfo.ETag.empty());
-      EXPECT_FALSE(pathInfo.LastModified > lastModified);
-
-      lastModified = m_pathClient->GetProperties().Value.LastModified;
-      aLease = *m_pathClient->AcquireLease(CreateUniqueLeaseId(), InfiniteLeaseDuration);
-      properties = *m_pathClient->GetProperties();
-      EXPECT_FALSE(properties.LeaseDuration.Value().empty());
-      auto brokenLease = *m_pathClient->BreakLease();
-      EXPECT_FALSE(brokenLease.ETag.empty());
-      EXPECT_FALSE(brokenLease.LastModified > lastModified);
-      EXPECT_EQ(brokenLease.LeaseTime, 0);
-
-      aLease = *m_pathClient->AcquireLease(CreateUniqueLeaseId(), leaseDuration);
-      Files::DataLake::BreakDataLakePathLeaseOptions breakOptions;
-      breakOptions.BreakPeriod = 30;
-      lastModified = m_pathClient->GetProperties().Value.LastModified;
-      brokenLease = *m_pathClient->BreakLease(breakOptions);
-      EXPECT_FALSE(brokenLease.ETag.empty());
-      EXPECT_FALSE(brokenLease.LastModified > lastModified);
-      EXPECT_NE(brokenLease.LeaseTime, 0);
-
-      Files::DataLake::BreakDataLakePathLeaseOptions options;
-      options.BreakPeriod = 0;
-      m_pathClient->BreakLease(options);
-    }
-#endif
-  TEST_F(DataLakePathClientTest, ConstructorsWorks)
-  {
-    {
-      // Create from connection string validates static creator function and shared key constructor.
-      auto pathName = GetTestName();
-      auto connectionStringClient
-          = Azure::Storage::Files::DataLake::DataLakePathClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(),
-              m_fileSystemName,
-              pathName,
-              InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-      EXPECT_NO_THROW(
-          connectionStringClient.Create(Files::DataLake::Models::PathResourceType::File));
-      EXPECT_NO_THROW(connectionStringClient.Delete());
-    }
-
-    {
-      // Create from client secret credential.
-      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
-          = std::make_shared<Azure::Identity::ClientSecretCredential>(
-              AadTenantId(), AadClientId(), AadClientSecret());
-      Files::DataLake::DataLakeClientOptions options;
-
-      auto clientSecretClient = InitTestClient<
-          Azure::Storage::Files::DataLake::DataLakePathClient,
-          Files::DataLake::DataLakeClientOptions>(
-          Files::DataLake::_detail::GetDfsUrlFromUrl(
-              Azure::Storage::Files::DataLake::DataLakePathClient::CreateFromConnectionString(
-                  AdlsGen2ConnectionString(),
-                  m_fileSystemName,
-                  GetTestName() + "withSecret",
-                  InitClientOptions<Files::DataLake::DataLakeClientOptions>())
-                  .GetUrl()),
-          credential,
-          options);
-
-      EXPECT_NO_THROW(clientSecretClient->Create(Files::DataLake::Models::PathResourceType::File));
-      EXPECT_NO_THROW(clientSecretClient->Delete());
-    }
-
-    {
-      // Create from Anonymous credential.
-      auto objectName = "objectName";
-      auto containerClient = Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
-          AdlsGen2ConnectionString(),
-          m_fileSystemName,
-          InitClientOptions<Azure::Storage::Blobs::BlobClientOptions>());
-      Azure::Storage::Blobs::SetBlobContainerAccessPolicyOptions options;
-      options.AccessType = Azure::Storage::Blobs::Models::PublicAccessType::BlobContainer;
-      containerClient.SetAccessPolicy(options);
-
-      auto pathClient
-          = Azure::Storage::Files::DataLake::DataLakePathClient::CreateFromConnectionString(
-              AdlsGen2ConnectionString(),
-              m_fileSystemName,
-              objectName,
-              InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-      EXPECT_NO_THROW(pathClient.Create(Files::DataLake::Models::PathResourceType::File));
-
-      auto anonymousClient = Azure::Storage::Files::DataLake::DataLakePathClient(
-          pathClient.GetUrl(), InitClientOptions<Files::DataLake::DataLakeClientOptions>());
-
-      TestSleep(std::chrono::seconds(30));
-
-      EXPECT_NO_THROW(anonymousClient.GetProperties());
-    }
-  }
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_path_client_test.hpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_path_client_test.hpp
@@ -4,17 +4,16 @@
 #include <azure/storage/files/datalake.hpp>
 
 #include "datalake_file_system_client_test.hpp"
-#include "test/ut/test_base.hpp"
 
 namespace Azure { namespace Storage { namespace Test {
 
   class DataLakePathClientTest : public DataLakeFileSystemClientTest {
   protected:
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
 
-    std::vector<Files::DataLake::Models::Acl> GetValidAcls();
+    std::vector<Files::DataLake::Models::Acl> GetAclsForTesting();
 
+  protected:
     std::shared_ptr<Files::DataLake::DataLakePathClient> m_pathClient;
     std::string m_pathName;
   };

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_sas_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_sas_test.cpp
@@ -13,8 +13,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakeFileSystemClientTest, DataLakeSasTest_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
-
     auto sasStartsOn = std::chrono::system_clock::now() - std::chrono::minutes(5);
     auto sasExpiredOn = std::chrono::system_clock::now() - std::chrono::minutes(1);
     auto sasExpiresOn = std::chrono::system_clock::now() + std::chrono::minutes(60);

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_service_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_service_client_test.cpp
@@ -161,8 +161,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(DataLakeServiceClientTest, AnonymousConstructorsWorks)
   {
-    CHECK_SKIP_TEST();
-
     auto keyCredential
         = Azure::Storage::_internal::ParseConnectionString(AdlsGen2ConnectionString())
               .KeyCredential;

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_service_client_test.hpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_service_client_test.hpp
@@ -9,32 +9,17 @@ namespace Azure { namespace Storage { namespace Test {
 
   class DataLakeServiceClientTest : public Azure::Storage::Test::StorageTest {
   protected:
-    std::shared_ptr<Files::DataLake::DataLakeServiceClient> m_dataLakeServiceClient;
-    std::vector<std::string> m_fileSystemNameSetA;
-    std::string m_fileSystemPrefixA;
-    std::vector<std::string> m_fileSystemNameSetB;
-    std::string m_fileSystemPrefixB;
-
-    virtual void SetUp() override;
-
-    void CreateFileSystemList();
-
-    virtual void TearDown() override
+    void SetUp() override
     {
-      for (const auto& name : m_fileSystemNameSetA)
-      {
-        m_dataLakeServiceClient->GetFileSystemClient(name).Delete();
-      }
-      for (const auto& name : m_fileSystemNameSetB)
-      {
-        m_dataLakeServiceClient->GetFileSystemClient(name).Delete();
-      }
-
-      StorageTest::TearDown();
+      StorageTest::SetUp();
+      auto options = InitClientOptions<Files::DataLake::DataLakeClientOptions>();
+      m_dataLakeServiceClient = std::make_shared<Files::DataLake::DataLakeServiceClient>(
+          Files::DataLake::DataLakeServiceClient::CreateFromConnectionString(
+              AdlsGen2ConnectionString(), options));
     }
 
-    std::vector<Files::DataLake::Models::FileSystemItem> ListAllFileSystems(
-        const std::string& prefix = std::string());
+  protected:
+    std::shared_ptr<Files::DataLake::DataLakeServiceClient> m_dataLakeServiceClient;
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.cpp
@@ -31,7 +31,10 @@ namespace Azure { namespace Storage { namespace Test {
   void FileShareClientTest::SetUp()
   {
     FileShareServiceClientTest::SetUp();
-
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_shareName = GetLowercaseIdentifier();
     m_shareClient = std::make_shared<Files::Shares::ShareClient>(
         m_shareServiceClient->GetShareClient(m_shareName));

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.cpp
@@ -48,7 +48,7 @@ namespace Azure { namespace Storage { namespace Test {
         {
           throw;
         }
-        SUCCEED() << "Cotnainer is being deleted. Will try again after 3 seconds.";
+        SUCCEED() << "Share is being deleted. Will try again after 3 seconds.";
         std::this_thread::sleep_for(std::chrono::seconds(3));
       }
     }

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.hpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.hpp
@@ -1,24 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "test/ut/test_base.hpp"
-
 #include <azure/storage/files/shares.hpp>
+
+#include "share_service_client_test.hpp"
 
 namespace Azure { namespace Storage { namespace Test {
 
-  class FileShareClientTest : public Azure::Storage::Test::StorageTest {
+  class FileShareClientTest : public FileShareServiceClientTest {
   protected:
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
 
-    Files::Shares::Models::FileHttpHeaders GetInterestingHttpHeaders();
+    Files::Shares::ShareClient GetShareClientForTest(
+        const std::string& shareName,
+        Files::Shares::ShareClientOptions clientOptions = Files::Shares::ShareClientOptions());
+    Files::Shares::ShareClient GetPremiumShareClientForTest(
+        const std::string& shareName,
+        Files::Shares::ShareClientOptions clientOptions = Files::Shares::ShareClientOptions());
 
+  protected:
     std::shared_ptr<Files::Shares::ShareClient> m_shareClient;
     std::string m_shareName;
-    Files::Shares::ShareClientOptions m_options;
-    std::string m_testName;
-    std::string m_testNameLowercase;
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_directory_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_directory_client_test.cpp
@@ -11,7 +11,10 @@ namespace Azure { namespace Storage { namespace Test {
   void FileShareDirectoryClientTest::SetUp()
   {
     FileShareClientTest::SetUp();
-
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_directoryName = RandomString();
     m_fileShareDirectoryClient = std::make_shared<Files::Shares::ShareDirectoryClient>(
         m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_directoryName));

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_directory_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_directory_client_test.cpp
@@ -11,100 +11,47 @@ namespace Azure { namespace Storage { namespace Test {
   void FileShareDirectoryClientTest::SetUp()
   {
     FileShareClientTest::SetUp();
-    CHECK_SKIP_TEST();
 
-    m_directoryName = GetTestName() + "base";
+    m_directoryName = RandomString();
     m_fileShareDirectoryClient = std::make_shared<Files::Shares::ShareDirectoryClient>(
         m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_directoryName));
     m_fileShareDirectoryClient->Create();
-  }
-
-  void FileShareDirectoryClientTest::TearDown()
-  {
-    CHECK_SKIP_TEST();
-    m_shareClient->DeleteIfExists();
-    FileShareClientTest::TearDown();
-  }
-
-  std::pair<
-      std::vector<Files::Shares::Models::FileItem>,
-      std::vector<Files::Shares::Models::DirectoryItem>>
-  FileShareDirectoryClientTest::ListAllFilesAndDirectories(
-      const std::string& directoryPath,
-      const std::string& prefix)
-  {
-    std::vector<Files::Shares::Models::DirectoryItem> directoryResult;
-    std::vector<Files::Shares::Models::FileItem> fileResult;
-    Files::Shares::ListFilesAndDirectoriesOptions options;
-    if (!prefix.empty())
-    {
-      options.Prefix = prefix;
-    }
-    auto directoryClient
-        = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(directoryPath);
-    for (auto pageResult = directoryClient.ListFilesAndDirectories(options); pageResult.HasPage();
-         pageResult.MoveToNextPage())
-    {
-      directoryResult.insert(
-          directoryResult.end(), pageResult.Directories.begin(), pageResult.Directories.end());
-      fileResult.insert(fileResult.end(), pageResult.Files.begin(), pageResult.Files.end());
-    }
-    return std::make_pair<
-        std::vector<Files::Shares::Models::FileItem>,
-        std::vector<Files::Shares::Models::DirectoryItem>>(
-        std::move(fileResult), std::move(directoryResult));
   }
 
   TEST_F(FileShareDirectoryClientTest, CreateDeleteDirectories)
   {
     {
       // Normal create/delete.
-      std::vector<Files::Shares::ShareDirectoryClient> directoryClients;
-      for (int32_t i = 0; i < 5; ++i)
-      {
-        Files::Shares::ShareDirectoryClient client
-            = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(
-                m_testName + std::to_string(i));
-        EXPECT_NO_THROW(client.Create());
-        directoryClients.emplace_back(std::move(client));
-      }
-      for (const auto& client : directoryClients)
-      {
-        EXPECT_NO_THROW(client.Delete());
-      }
+      Files::Shares::ShareDirectoryClient client
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
+      EXPECT_NO_THROW(client.Create());
+      EXPECT_NO_THROW(client.Delete());
     }
 
     {
       // Create directory that already exist throws.
-      for (int32_t i = 0; i < 5; ++i)
-      {
-        Files::Shares::ShareDirectoryClient client
-            = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(
-                m_testName + "e" + std::to_string(i));
-        EXPECT_NO_THROW(client.Create());
-        EXPECT_THROW(client.Create(), StorageException);
-      }
+      Files::Shares::ShareDirectoryClient client
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
+      EXPECT_NO_THROW(client.Create());
+      EXPECT_THROW(client.Create(), StorageException);
     }
     {
       // CreateIfNotExists & DeleteIfExists.
       {
-        auto client = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(
-            m_testName + "CreateIfNotExists");
+        auto client = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
         EXPECT_NO_THROW(client.Create());
         EXPECT_NO_THROW(client.CreateIfNotExists());
         EXPECT_NO_THROW(client.Delete());
         EXPECT_NO_THROW(client.DeleteIfExists());
       }
       {
-        auto client = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(
-            m_testName + "StorageException");
+        auto client = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
         EXPECT_NO_THROW(client.CreateIfNotExists());
         EXPECT_THROW(client.Create(), StorageException);
         EXPECT_NO_THROW(client.DeleteIfExists());
       }
       {
-        auto client
-            = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "delete");
+        auto client = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
         auto created = client.Create().Value.Created;
         EXPECT_TRUE(created);
         auto createResult = client.CreateIfNotExists();
@@ -115,23 +62,19 @@ namespace Azure { namespace Storage { namespace Test {
         EXPECT_TRUE(deleted);
       }
       {
-        auto client
-            = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "deleted");
+        auto client = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
         auto deleteResult = client.DeleteIfExists();
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }
       {
-        auto shareClient = Files::Shares::ShareClient::CreateFromConnectionString(
-            StandardStorageConnectionString(), m_testNameLowercase + "1", m_options);
-        auto client
-            = shareClient.GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "new");
+        auto client = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
         auto deleteResult = client.DeleteIfExists();
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }
       {
         auto client = m_shareClient->GetRootDirectoryClient()
-                          .GetSubdirectoryClient(m_testName + "s")
-                          .GetSubdirectoryClient(m_testName + "s1");
+                          .GetSubdirectoryClient(RandomString())
+                          .GetSubdirectoryClient(RandomString());
         auto deleteResult = client.DeleteIfExists();
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }
@@ -140,18 +83,18 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareDirectoryClientTest, RenameFile)
   {
-    const std::string testName(GetTestName());
-    const std::string baseDirectoryName = testName + "1";
+    const std::string baseName = RandomString();
+    const std::string baseDirectoryName = baseName + "1";
     auto rootDirectoryClient = m_shareClient->GetRootDirectoryClient();
     auto baseDirectoryClient
         = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(baseDirectoryName);
     baseDirectoryClient.Create();
     // base test
     {
-      const std::string oldFilename = testName + "2";
+      const std::string oldFilename = baseName + "2";
       auto oldFileClient = baseDirectoryClient.GetFileClient(oldFilename);
       oldFileClient.Create(512);
-      const std::string newFilename = testName + "3";
+      const std::string newFilename = baseName + "3";
       auto newFileClient
           = baseDirectoryClient.RenameFile(oldFilename, baseDirectoryName + "/" + newFilename)
                 .Value;
@@ -161,10 +104,10 @@ namespace Azure { namespace Storage { namespace Test {
 
     // overwrite
     {
-      const std::string oldFilename = testName + "4";
+      const std::string oldFilename = baseName + "4";
       auto oldFileClient = baseDirectoryClient.GetFileClient(oldFilename);
       oldFileClient.Create(512);
-      const std::string newFilename = testName + "5";
+      const std::string newFilename = baseName + "5";
       auto newFileClient = baseDirectoryClient.GetFileClient(newFilename);
       newFileClient.Create(512);
       EXPECT_THROW(
@@ -183,10 +126,10 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // overwrite readOnly
     {
-      const std::string oldFilename = testName + "6";
+      const std::string oldFilename = baseName + "6";
       auto oldFileClient = baseDirectoryClient.GetFileClient(oldFilename);
       oldFileClient.Create(512);
-      const std::string newFilename = testName + "7";
+      const std::string newFilename = baseName + "7";
       Files::Shares::CreateFileOptions createOptions;
       Files::Shares::Models::FileSmbProperties properties;
       properties.Attributes = Files::Shares::Models::FileAttributes::ReadOnly;
@@ -216,12 +159,12 @@ namespace Azure { namespace Storage { namespace Test {
             "2127521184-1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;"
             "0x1200a9;;;S-1-5-21-397955417-626881126-188441444-3053964)";
 
-      const std::string oldFilename = testName + "8";
+      const std::string oldFilename = baseName + "8";
       auto oldFileClient = baseDirectoryClient.GetFileClient(oldFilename);
       oldFileClient.Create(512);
-      const std::string newFilename = testName + "9";
+      const std::string newFilename = baseName + "9";
       Files::Shares::RenameFileOptions renameOptions;
-      renameOptions.Metadata = GetMetadata();
+      renameOptions.Metadata = RandomMetadata();
       renameOptions.FilePermission = permission;
       Files::Shares::Models::FileSmbProperties properties;
       properties.ChangedOn = std::chrono::system_clock::now();
@@ -242,17 +185,17 @@ namespace Azure { namespace Storage { namespace Test {
 
     // diff directory
     {
-      const std::string oldSubdirectoryName = testName + "10";
+      const std::string oldSubdirectoryName = baseName + "10";
       auto oldSubdirectoryClient = baseDirectoryClient.GetSubdirectoryClient(oldSubdirectoryName);
       oldSubdirectoryClient.Create();
-      const std::string oldFilename = testName + "11";
+      const std::string oldFilename = baseName + "11";
       auto oldFileClient = oldSubdirectoryClient.GetFileClient(oldFilename);
       oldFileClient.Create(512);
 
-      const std::string otherDirectoryname = testName + "12";
+      const std::string otherDirectoryname = baseName + "12";
       auto otherDirectoryClient = rootDirectoryClient.GetSubdirectoryClient(otherDirectoryname);
       otherDirectoryClient.Create();
-      const std::string newFilename = testName + "13";
+      const std::string newFilename = baseName + "13";
       auto newFileClient
           = baseDirectoryClient
                 .RenameFile(
@@ -263,26 +206,26 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // root directory
     {
-      const std::string oldFilename = testName + "14";
+      const std::string oldFilename = baseName + "14";
       auto oldFileClient = baseDirectoryClient.GetFileClient(oldFilename);
       oldFileClient.Create(512);
-      const std::string newFilename = testName + "15";
+      const std::string newFilename = baseName + "15";
       auto newFileClient = baseDirectoryClient.RenameFile(oldFilename, newFilename).Value;
       EXPECT_NO_THROW(newFileClient.GetProperties());
       EXPECT_THROW(oldFileClient.GetProperties(), StorageException);
     }
     // lease
     {
-      const std::string oldFilename = testName + "16";
+      const std::string oldFilename = baseName + "16";
       auto oldFileClient = baseDirectoryClient.GetFileClient(oldFilename);
       oldFileClient.Create(512);
-      const std::string oldLeaseId = Files::Shares::ShareLeaseClient::CreateUniqueLeaseId();
+      const std::string oldLeaseId = RandomUUID();
       Files::Shares::ShareLeaseClient oldLeaseClient(oldFileClient, oldLeaseId);
       oldLeaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration);
-      const std::string newFilename = testName + "17";
+      const std::string newFilename = baseName + "17";
       auto newFileClient = baseDirectoryClient.GetFileClient(newFilename);
       newFileClient.Create(512);
-      const std::string newLeaseId = Files::Shares::ShareLeaseClient::CreateUniqueLeaseId();
+      const std::string newLeaseId = RandomUUID();
       Files::Shares::ShareLeaseClient newLeaseClient(newFileClient, newLeaseId);
       newLeaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration);
 
@@ -303,19 +246,19 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareDirectoryClientTest, RenameSubdirectory)
   {
-    const std::string testName(GetTestName());
-    const std::string baseDirectoryName = testName + "1";
+    const std::string baseName = RandomString();
+    const std::string baseDirectoryName = baseName + "1";
     auto rootDirectoryClient = m_shareClient->GetRootDirectoryClient();
     auto baseDirectoryClient
         = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(baseDirectoryName);
     baseDirectoryClient.Create();
     // base test
     {
-      const std::string oldSubdirectoryName = testName + "2";
+      const std::string oldSubdirectoryName = baseName + "2";
       auto oldSubdirectoryClient = baseDirectoryClient.GetSubdirectoryClient(oldSubdirectoryName);
       oldSubdirectoryClient.Create();
-      oldSubdirectoryClient.GetFileClient(testName + "File1").Create(512);
-      const std::string newSubdirectoryName = testName + "3";
+      oldSubdirectoryClient.GetFileClient(baseName + "File1").Create(512);
+      const std::string newSubdirectoryName = baseName + "3";
       auto newSubdirectoryClient
           = baseDirectoryClient
                 .RenameSubdirectory(
@@ -327,10 +270,10 @@ namespace Azure { namespace Storage { namespace Test {
 
     // overwrite
     {
-      const std::string oldSubdirectoryName = testName + "4";
+      const std::string oldSubdirectoryName = baseName + "4";
       auto oldSubdirectoryClient = baseDirectoryClient.GetSubdirectoryClient(oldSubdirectoryName);
       oldSubdirectoryClient.Create();
-      const std::string existFilename = testName + "5";
+      const std::string existFilename = baseName + "5";
       auto existFileClient = baseDirectoryClient.GetFileClient(existFilename);
       existFileClient.Create(512);
       EXPECT_THROW(
@@ -346,10 +289,10 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // overwrite readOnly
     {
-      const std::string oldSubdirectoryName = testName + "6";
+      const std::string oldSubdirectoryName = baseName + "6";
       auto oldSubdirectoryClient = baseDirectoryClient.GetSubdirectoryClient(oldSubdirectoryName);
       oldSubdirectoryClient.Create();
-      const std::string existFilename = testName + "7";
+      const std::string existFilename = baseName + "7";
       Files::Shares::CreateFileOptions createOptions;
       Files::Shares::Models::FileSmbProperties properties;
       properties.Attributes = Files::Shares::Models::FileAttributes::ReadOnly;
@@ -375,12 +318,12 @@ namespace Azure { namespace Storage { namespace Test {
             "2127521184-1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;"
             "0x1200a9;;;S-1-5-21-397955417-626881126-188441444-3053964)";
 
-      const std::string oldSubdirectoryName = testName + "8";
+      const std::string oldSubdirectoryName = baseName + "8";
       auto oldSubdirectoryClient = baseDirectoryClient.GetSubdirectoryClient(oldSubdirectoryName);
       oldSubdirectoryClient.Create();
-      const std::string newSubdirectoryName = testName + "9";
+      const std::string newSubdirectoryName = baseName + "9";
       Files::Shares::RenameDirectoryOptions renameOptions;
-      renameOptions.Metadata = GetMetadata();
+      renameOptions.Metadata = RandomMetadata();
       renameOptions.FilePermission = permission;
       Files::Shares::Models::FileSmbProperties properties;
       properties.ChangedOn = std::chrono::system_clock::now();
@@ -401,19 +344,19 @@ namespace Azure { namespace Storage { namespace Test {
 
     // diff directory
     {
-      const std::string oldMiddleDirectoryName = testName + "10";
+      const std::string oldMiddleDirectoryName = baseName + "10";
       auto oldMiddleDirectoryClient
           = baseDirectoryClient.GetSubdirectoryClient(oldMiddleDirectoryName);
       oldMiddleDirectoryClient.Create();
-      const std::string oldSubdirectoryName = testName + "11";
+      const std::string oldSubdirectoryName = baseName + "11";
       auto oldSubdirectoryClient
           = oldMiddleDirectoryClient.GetSubdirectoryClient(oldSubdirectoryName);
       oldSubdirectoryClient.Create();
 
-      const std::string otherDirectoryName = testName + "12";
+      const std::string otherDirectoryName = baseName + "12";
       auto otherDirectoryClient = rootDirectoryClient.GetSubdirectoryClient(otherDirectoryName);
       otherDirectoryClient.Create();
-      const std::string newSubdirectoryName = testName + "13";
+      const std::string newSubdirectoryName = baseName + "13";
       auto newSubdirectoryClient = baseDirectoryClient
                                        .RenameSubdirectory(
                                            oldMiddleDirectoryName + "/" + oldSubdirectoryName,
@@ -424,11 +367,11 @@ namespace Azure { namespace Storage { namespace Test {
     }
     // root directory
     {
-      const std::string oldSubdirectoryName = testName + "14";
+      const std::string oldSubdirectoryName = baseName + "14";
       auto oldSubdirectoryClient = baseDirectoryClient.GetSubdirectoryClient(oldSubdirectoryName);
       oldSubdirectoryClient.Create();
-      oldSubdirectoryClient.GetFileClient(testName + "File1").Create(512);
-      const std::string newSubdirectoryName = testName + "15";
+      oldSubdirectoryClient.GetFileClient(baseName + "File1").Create(512);
+      const std::string newSubdirectoryName = baseName + "15";
       auto newSubdirectoryClient
           = baseDirectoryClient.RenameSubdirectory(oldSubdirectoryName, newSubdirectoryName).Value;
       EXPECT_NO_THROW(newSubdirectoryClient.GetProperties());
@@ -438,8 +381,8 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareDirectoryClientTest, DirectoryMetadata)
   {
-    auto metadata1 = GetMetadata();
-    auto metadata2 = GetMetadata();
+    auto metadata1 = RandomMetadata();
+    auto metadata2 = RandomMetadata();
     {
       // Set/Get Metadata works
       EXPECT_NO_THROW(m_fileShareDirectoryClient->SetMetadata(metadata1));
@@ -453,9 +396,9 @@ namespace Azure { namespace Storage { namespace Test {
     {
       // Create directory with metadata works
       auto client1
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "meta1");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "meta1");
       auto client2
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "meta2");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "meta2");
       Files::Shares::CreateDirectoryOptions options1;
       Files::Shares::CreateDirectoryOptions options2;
       options1.Metadata = metadata1;
@@ -481,9 +424,9 @@ namespace Azure { namespace Storage { namespace Test {
     {
       // Create directory with permission/permission key works
       auto client1
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "1");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "1");
       auto client2
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "2");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "2");
       Files::Shares::CreateDirectoryOptions options1;
       Files::Shares::CreateDirectoryOptions options2;
       options1.DirectoryPermission = permission;
@@ -496,7 +439,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(result1.Value(), result2.Value());
 
       auto client3
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "3");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "3");
       Files::Shares::CreateDirectoryOptions options3;
       options3.SmbProperties.PermissionKey = result1;
       EXPECT_NO_THROW(client3.Create(options3));
@@ -513,9 +456,9 @@ namespace Azure { namespace Storage { namespace Test {
       properties.LastWrittenOn = std::chrono::system_clock::now();
       properties.PermissionKey = "";
       auto client1
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "4");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "4");
       auto client2
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "5");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "5");
 
       EXPECT_NO_THROW(client1.Create());
       EXPECT_NO_THROW(client2.Create());
@@ -530,7 +473,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(result1.Value(), result2.Value());
 
       auto client3
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "6");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "6");
       Files::Shares::CreateDirectoryOptions options3;
       options3.SmbProperties.PermissionKey = result1;
       std::string permissionKey;
@@ -554,9 +497,9 @@ namespace Azure { namespace Storage { namespace Test {
     {
       // Create directory with SmbProperties works
       auto client1
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "1");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "1");
       auto client2
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "2");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "2");
       Files::Shares::CreateDirectoryOptions options1;
       Files::Shares::CreateDirectoryOptions options2;
       options1.SmbProperties = properties;
@@ -583,9 +526,9 @@ namespace Azure { namespace Storage { namespace Test {
     {
       // SetProperties works
       auto client1
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "3");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "3");
       auto client2
-          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName + "4");
+          = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "4");
 
       EXPECT_NO_THROW(client1.Create());
       EXPECT_NO_THROW(client2.Create());
@@ -611,7 +554,7 @@ namespace Azure { namespace Storage { namespace Test {
   TEST_F(FileShareDirectoryClientTest, SmbPropertiesDefaultValue)
   {
     auto directoryClient
-        = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(m_testName);
+        = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
     directoryClient.Create();
     auto smbProperties = directoryClient.GetProperties().Value.SmbProperties;
     EXPECT_EQ(smbProperties.Attributes, Files::Shares::Models::FileAttributes::Directory);
@@ -641,6 +584,7 @@ namespace Azure { namespace Storage { namespace Test {
     std::vector<std::string> directoryNameSetB;
     std::vector<std::string> fileNameSetA;
     std::vector<std::string> fileNameSetB;
+    std::string prefix = RandomString();
     auto clientA = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(directoryNameA);
     clientA.Create();
     auto clientB = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(directoryNameB);
@@ -648,16 +592,16 @@ namespace Azure { namespace Storage { namespace Test {
     for (size_t i = 0; i < 5; ++i)
     {
       {
-        auto directoryName = m_testName + std::to_string(i);
-        auto fileName = "file" + std::to_string(i);
+        auto directoryName = RandomString() + std::to_string(i);
+        auto fileName = RandomString() + std::to_string(i);
         EXPECT_NO_THROW(clientA.GetSubdirectoryClient(directoryName).Create());
         EXPECT_NO_THROW(clientA.GetFileClient(fileName).Create(1024));
         directoryNameSetA.emplace_back(std::move(directoryName));
         fileNameSetA.emplace_back(std::move(fileName));
       }
       {
-        auto directoryName = m_testName + "B" + std::to_string(i);
-        auto fileName = "fileB" + std::to_string(i);
+        auto directoryName = RandomString() + std::to_string(i);
+        auto fileName = RandomString() + std::to_string(i);
         EXPECT_NO_THROW(clientB.GetSubdirectoryClient(directoryName).Create());
         EXPECT_NO_THROW(clientB.GetFileClient(fileName).Create(1024));
         directoryNameSetB.emplace_back(std::move(directoryName));
@@ -665,76 +609,98 @@ namespace Azure { namespace Storage { namespace Test {
       }
     }
     {
-      // Normal root share list.
-      auto result = ListAllFilesAndDirectories();
-      EXPECT_TRUE(result.first.empty());
-      EXPECT_TRUE(result.second.size() >= 2);
-      auto iter = std::find_if(
-          result.second.begin(),
-          result.second.end(),
-          [&directoryNameA](const Files::Shares::Models::DirectoryItem& item) {
-            return item.Name == directoryNameA;
-          });
-      EXPECT_EQ(iter->Name, directoryNameA);
-      EXPECT_NE(result.second.end(), iter);
-      iter = std::find_if(
-          result.second.begin(),
-          result.second.end(),
-          [&directoryNameB](const Files::Shares::Models::DirectoryItem& item) {
-            return item.Name == directoryNameB;
-          });
-      EXPECT_EQ(iter->Name, directoryNameB);
-      EXPECT_NE(result.second.end(), iter);
+      auto dirName = prefix + RandomString();
+      auto filename = prefix + RandomString();
+      clientB.GetSubdirectoryClient(dirName).Create();
+      clientB.GetFileClient(filename).Create(1024);
+      directoryNameSetB.emplace_back(dirName);
+      fileNameSetB.emplace_back(filename);
     }
     {
-      // List with directory.
-      auto result = ListAllFilesAndDirectories(directoryNameA, std::string());
-      for (const auto& name : directoryNameSetA)
+      // Normal root share list.
+      std::set<std::string> files;
+      std::set<std::string> dirs;
+      for (auto page = m_shareClient->GetRootDirectoryClient().ListFilesAndDirectories();
+           page.HasPage();
+           page.MoveToNextPage())
       {
-        auto iter = std::find_if(
-            result.second.begin(),
-            result.second.end(),
-            [&name](const Files::Shares::Models::DirectoryItem& item) {
-              return item.Name == name;
-            });
-        EXPECT_EQ(iter->Name, name);
-        EXPECT_NE(result.second.end(), iter);
+        for (const auto& f : page.Files)
+        {
+          files.insert(f.Name);
+        }
+        for (const auto& d : page.Directories)
+        {
+          dirs.insert(d.Name);
+        }
       }
-      for (const auto& name : fileNameSetA)
+      EXPECT_TRUE(files.empty());
+      EXPECT_FALSE(dirs.empty());
+      EXPECT_NE(dirs.find(directoryNameA), dirs.end());
+      EXPECT_NE(dirs.find(directoryNameB), dirs.end());
+    }
+    {
+      std::set<std::string> files;
+      std::set<std::string> dirs;
+      for (auto page = clientA.ListFilesAndDirectories(); page.HasPage(); page.MoveToNextPage())
       {
-        auto iter = std::find_if(
-            result.first.begin(),
-            result.first.end(),
-            [&name](const Files::Shares::Models::FileItem& item) { return item.Name == name; });
-        EXPECT_EQ(iter->Name, name);
-        EXPECT_EQ(1024, iter->Details.FileSize);
-        EXPECT_NE(result.first.end(), iter);
+        for (const auto& f : page.Files)
+        {
+          files.insert(f.Name);
+        }
+        for (const auto& d : page.Directories)
+        {
+          dirs.insert(d.Name);
+        }
       }
-      for (const auto& name : directoryNameSetB)
+      for (const auto& d : directoryNameSetA)
       {
-        auto iter = std::find_if(
-            result.second.begin(),
-            result.second.end(),
-            [&name](const Files::Shares::Models::DirectoryItem& item) {
-              return item.Name == name;
-            });
-        EXPECT_EQ(result.second.end(), iter);
+        EXPECT_NE(dirs.find(d), dirs.end());
       }
-      for (const auto& name : fileNameSetB)
+      for (const auto& f : fileNameSetA)
       {
-        auto iter = std::find_if(
-            result.first.begin(),
-            result.first.end(),
-            [&name](const Files::Shares::Models::FileItem& item) { return item.Name == name; });
-        EXPECT_EQ(result.first.end(), iter);
+        EXPECT_NE(files.find(f), files.end());
       }
     }
     {
       // List with prefix.
-      auto result = ListAllFilesAndDirectories(std::string(), directoryNameA);
-      EXPECT_TRUE(result.first.empty());
-      EXPECT_EQ(result.second.size(), size_t(1));
-      EXPECT_EQ(directoryNameA, result.second[0].Name);
+      std::set<std::string> files;
+      std::set<std::string> dirs;
+      Files::Shares::ListFilesAndDirectoriesOptions listOptions;
+      listOptions.Prefix = prefix;
+      for (auto page = clientB.ListFilesAndDirectories(listOptions); page.HasPage();
+           page.MoveToNextPage())
+      {
+        for (const auto& f : page.Files)
+        {
+          files.insert(f.Name);
+        }
+        for (const auto& d : page.Directories)
+        {
+          dirs.insert(d.Name);
+        }
+      }
+      for (const auto& f : fileNameSetB)
+      {
+        if (f.substr(0, prefix.length()) == prefix)
+        {
+          EXPECT_NE(files.find(f), files.end());
+        }
+        else
+        {
+          EXPECT_EQ(files.find(f), files.end());
+        }
+      }
+      for (const auto& d : directoryNameSetB)
+      {
+        if (d.substr(0, prefix.length()) == prefix)
+        {
+          EXPECT_NE(dirs.find(d), dirs.end());
+        }
+        else
+        {
+          EXPECT_EQ(dirs.find(d), dirs.end());
+        }
+      }
     }
     {
       // List max result

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_directory_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_directory_client_test.cpp
@@ -75,9 +75,8 @@ namespace Azure { namespace Storage { namespace Test {
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }
       {
-        auto client = m_shareClient->GetRootDirectoryClient()
-                          .GetSubdirectoryClient(RandomString())
-                          .GetSubdirectoryClient(RandomString());
+        auto client = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString());
+        client = client.GetSubdirectoryClient(RandomString());
         auto deleteResult = client.DeleteIfExists();
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_directory_client_test.hpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_directory_client_test.hpp
@@ -10,15 +10,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   class FileShareDirectoryClientTest : public FileShareClientTest {
   protected:
-    void SetUp();
-    void TearDown();
-
-    std::pair<
-        std::vector<Files::Shares::Models::FileItem>,
-        std::vector<Files::Shares::Models::DirectoryItem>>
-    ListAllFilesAndDirectories(
-        const std::string& directoryPath = std::string(),
-        const std::string& prefix = std::string());
+    void SetUp() override;
 
     std::shared_ptr<Files::Shares::ShareDirectoryClient> m_fileShareDirectoryClient;
     std::string m_directoryName;

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
@@ -370,7 +370,7 @@ namespace Azure { namespace Storage { namespace Test {
   {
     CHECK_SKIP_TEST();
 
-    const auto blobContent = RandomBuffer(8_MB);
+    const auto blobContent = RandomBuffer(static_cast<size_t>(8_MB));
 
     auto testUploadFromBuffer = [&](int concurrency,
                                     int64_t bufferSize,
@@ -388,10 +388,12 @@ namespace Azure { namespace Storage { namespace Test {
       }
 
       auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
-      EXPECT_NO_THROW(fileClient.UploadFrom(blobContent.data(), bufferSize, options));
-      std::vector<uint8_t> downloadBuffer(bufferSize, '\x00');
+      EXPECT_NO_THROW(
+          fileClient.UploadFrom(blobContent.data(), static_cast<size_t>(bufferSize), options));
+      std::vector<uint8_t> downloadBuffer(static_cast<size_t>(bufferSize), '\x00');
       fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
-      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + bufferSize);
+      std::vector<uint8_t> expectedData(
+          blobContent.begin(), blobContent.begin() + static_cast<size_t>(bufferSize));
       EXPECT_EQ(downloadBuffer, expectedData);
     };
 
@@ -412,13 +414,16 @@ namespace Azure { namespace Storage { namespace Test {
 
       const std::string tempFileName = RandomString();
       WriteFile(
-          tempFileName, std::vector<uint8_t>(blobContent.begin(), blobContent.begin() + fileSize));
+          tempFileName,
+          std::vector<uint8_t>(
+              blobContent.begin(), blobContent.begin() + static_cast<size_t>(fileSize)));
       auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
       EXPECT_NO_THROW(fileClient.UploadFrom(tempFileName, options));
       DeleteFile(tempFileName);
-      std::vector<uint8_t> downloadBuffer(fileSize, '\x00');
+      std::vector<uint8_t> downloadBuffer(static_cast<size_t>(fileSize), '\x00');
       fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
-      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + fileSize);
+      std::vector<uint8_t> expectedData(
+          blobContent.begin(), blobContent.begin() + static_cast<size_t>(fileSize));
       EXPECT_EQ(downloadBuffer, expectedData);
     };
 

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
@@ -18,7 +18,10 @@ namespace Azure { namespace Storage { namespace Test {
   void FileShareFileClientTest::SetUp()
   {
     FileShareDirectoryClientTest::SetUp();
-
+    if (shouldSkipTest())
+    {
+      return;
+    }
     m_fileName = RandomString();
     m_fileClient = std::make_shared<Files::Shares::ShareFileClient>(
         m_fileShareDirectoryClient->GetFileClient(m_fileName));
@@ -368,8 +371,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareFileClientTest, ConcurrentUpload_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
-
     const auto blobContent = RandomBuffer(static_cast<size_t>(8_MB));
 
     auto testUploadFromBuffer = [&](int concurrency,
@@ -452,8 +453,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareFileClientTest, ConcurrentDownload_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
-
     auto fileContent = RandomBuffer(8 * 1024 * 1024);
     m_fileClient->UploadFrom(fileContent.data(), 8 * 1024 * 1024);
     auto testDownloadToBuffer = [&](int concurrency,

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
@@ -428,9 +428,9 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(downloadBuffer, expectedData);
     };
 
-    std::vector<std::future<void>> futures;
     for (int c : {1, 2, 4})
     {
+      std::vector<std::future<void>> futures;
       // random range
       for (int i = 0; i < 16; ++i)
       {
@@ -444,10 +444,10 @@ namespace Azure { namespace Storage { namespace Test {
         futures.emplace_back(
             std::async(std::launch::async, testUploadFromFile, c, fileSize, 0, 25_KB));
       }
-    }
-    for (auto& f : futures)
-    {
-      f.get();
+      for (auto& f : futures)
+      {
+        f.get();
+      }
     }
   }
 

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
@@ -18,76 +18,53 @@ namespace Azure { namespace Storage { namespace Test {
   void FileShareFileClientTest::SetUp()
   {
     FileShareDirectoryClientTest::SetUp();
-    CHECK_SKIP_TEST();
 
-    m_fileName = m_testName + "basefile";
+    m_fileName = RandomString();
     m_fileClient = std::make_shared<Files::Shares::ShareFileClient>(
         m_fileShareDirectoryClient->GetFileClient(m_fileName));
     m_fileClient->Create(1024);
-  }
-
-  void FileShareFileClientTest::TearDown()
-  {
-    CHECK_SKIP_TEST();
-
-    Files::Shares::DeleteShareOptions options;
-    options.DeleteSnapshots = true;
-    m_shareClient->Delete(options);
-
-    FileShareDirectoryClientTest::TearDown();
   }
 
   TEST_F(FileShareFileClientTest, CreateDeleteFiles)
   {
     {
       // Normal create/delete.
-      std::vector<Files::Shares::ShareFileClient> fileClients;
-      for (int32_t i = 0; i < 5; ++i)
-      {
-        auto fileName = m_testName + std::to_string(i);
-        Files::Shares::ShareFileClient client = m_fileShareDirectoryClient->GetFileClient(fileName);
-        EXPECT_NO_THROW(client.Create(1024));
-        fileClients.emplace_back(std::move(client));
-      }
-      for (const auto& client : fileClients)
-      {
-        EXPECT_NO_THROW(client.Delete());
-      }
+      auto fileName = RandomString();
+      Files::Shares::ShareFileClient client = m_fileShareDirectoryClient->GetFileClient(fileName);
+      EXPECT_NO_THROW(client.Create(1024));
+      EXPECT_NO_THROW(client.Delete());
     }
     {
       // Create file that already exist overwrites.
-      for (int32_t i = 0; i < 5; ++i)
-      {
-        auto fileName = m_testName + "a" + std::to_string(i);
-        Files::Shares::ShareFileClient client = m_fileShareDirectoryClient->GetFileClient(fileName);
-        EXPECT_NO_THROW(client.Create(1024));
-        EXPECT_NO_THROW(client.Create(1024));
-      }
+      auto fileName = RandomString();
+      Files::Shares::ShareFileClient client = m_fileShareDirectoryClient->GetFileClient(fileName);
+      EXPECT_NO_THROW(client.Create(1024));
+      EXPECT_NO_THROW(client.Create(1024));
     }
     {
       // DeleteIfExists.
       {
-        auto client = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName + "1");
+        auto client = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString() + "1");
         EXPECT_NO_THROW(client.Create(1024));
         EXPECT_NO_THROW(client.Delete());
         EXPECT_NO_THROW(client.DeleteIfExists());
       }
       {
-        auto client = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName + "2");
+        auto client = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString() + "2");
         auto deleteResult = client.DeleteIfExists();
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }
       {
         auto shareClient = Files::Shares::ShareClient::CreateFromConnectionString(
             StandardStorageConnectionString(), LowercaseRandomString());
-        auto client = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName + "3");
+        auto client = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString() + "3");
         auto deleteResult = client.DeleteIfExists();
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }
       {
         auto client = m_shareClient->GetRootDirectoryClient()
-                          .GetSubdirectoryClient(m_testName + "4")
-                          .GetFileClient(m_testName + "5");
+                          .GetSubdirectoryClient(RandomString() + "4")
+                          .GetFileClient(RandomString() + "5");
         auto deleteResult = client.DeleteIfExists();
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }
@@ -96,13 +73,13 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareFileClientTest, DownloadEmptyFile)
   {
-    auto fileClient = m_fileShareDirectoryClient->GetFileClient(m_testName);
+    auto fileClient = m_fileShareDirectoryClient->GetFileClient(RandomString());
     fileClient.Create(0);
 
     auto res = fileClient.Download();
     EXPECT_EQ(res.Value.BodyStream->Length(), 0);
 
-    std::string tempFilename = m_testName + "1";
+    std::string tempFilename = RandomString() + "1";
     EXPECT_NO_THROW(fileClient.DownloadTo(tempFilename));
     EXPECT_TRUE(ReadFile(tempFilename).empty());
     DeleteFile(tempFilename);
@@ -113,17 +90,18 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareFileClientTest, DownloadNonExistingToFile)
   {
-    const auto testName(GetTestName());
-    auto fileClient = m_fileShareDirectoryClient->GetFileClient(m_testName);
+    const auto tempFilename = RandomString();
+    auto fileClient = m_fileShareDirectoryClient->GetFileClient(RandomString());
 
-    EXPECT_THROW(fileClient.DownloadTo(testName), StorageException);
-    EXPECT_THROW(ReadFile(testName), std::runtime_error);
+    EXPECT_THROW(fileClient.DownloadTo(tempFilename), StorageException);
+    EXPECT_THROW(ReadFile(tempFilename), std::runtime_error);
+    DeleteFile(tempFilename);
   }
 
   TEST_F(FileShareFileClientTest, FileMetadata)
   {
-    auto metadata1 = GetMetadata();
-    auto metadata2 = GetMetadata();
+    auto metadata1 = RandomMetadata();
+    auto metadata2 = RandomMetadata();
     {
       // Set/Get Metadata works
       EXPECT_NO_THROW(m_fileClient->SetMetadata(metadata1));
@@ -136,8 +114,8 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       // Create directory with metadata works
-      auto client1 = m_fileShareDirectoryClient->GetFileClient(m_testName + "1");
-      auto client2 = m_fileShareDirectoryClient->GetFileClient(m_testName + "2");
+      auto client1 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "1");
+      auto client2 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "2");
       Files::Shares::CreateFileOptions options1;
       Files::Shares::CreateFileOptions options2;
       options1.Metadata = metadata1;
@@ -160,8 +138,8 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       // Create directory with permission/permission key works
-      auto client1 = m_fileShareDirectoryClient->GetFileClient(m_testName + "d1");
-      auto client2 = m_fileShareDirectoryClient->GetFileClient(m_testName + "d2");
+      auto client1 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "d1");
+      auto client2 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "d2");
       Files::Shares::CreateFileOptions options1;
       Files::Shares::CreateFileOptions options2;
       options1.Permission = permission;
@@ -175,7 +153,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_TRUE(result2.HasValue());
       EXPECT_EQ(result1.Value(), result2.Value());
 
-      auto client3 = m_fileShareDirectoryClient->GetFileClient(m_testName + "d3");
+      auto client3 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "d3");
       Files::Shares::CreateFileOptions options3;
       options3.SmbProperties.PermissionKey = result1;
       EXPECT_NO_THROW(client3.Create(1024, options3));
@@ -186,14 +164,21 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       // Set permission with SetProperties works
+      Files::Shares::Models::FileHttpHeaders httpHeaders;
+      httpHeaders.ContentType = "application/x-binary";
+      httpHeaders.ContentLanguage = "en-US";
+      httpHeaders.ContentDisposition = "attachment";
+      httpHeaders.CacheControl = "no-cache";
+      httpHeaders.ContentEncoding = "identity";
+
       Files::Shares::Models::FileSmbProperties properties;
       properties.Attributes = Files::Shares::Models::FileAttributes::System
           | Files::Shares::Models::FileAttributes::NotContentIndexed;
       properties.CreatedOn = std::chrono::system_clock::now();
       properties.LastWrittenOn = std::chrono::system_clock::now();
       properties.PermissionKey = "";
-      auto client1 = m_fileShareDirectoryClient->GetFileClient(m_testName + "a1");
-      auto client2 = m_fileShareDirectoryClient->GetFileClient(m_testName + "a2");
+      auto client1 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "a1");
+      auto client2 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "a2");
 
       EXPECT_NO_THROW(client1.Create(1024));
       EXPECT_NO_THROW(client2.Create(1024));
@@ -201,15 +186,15 @@ namespace Azure { namespace Storage { namespace Test {
       Files::Shares::SetFilePropertiesOptions options2;
       options1.Permission = permission;
       options2.Permission = permission;
-      EXPECT_NO_THROW(client1.SetProperties(GetInterestingHttpHeaders(), properties, options1));
-      EXPECT_NO_THROW(client2.SetProperties(GetInterestingHttpHeaders(), properties, options2));
+      EXPECT_NO_THROW(client1.SetProperties(httpHeaders, properties, options1));
+      EXPECT_NO_THROW(client2.SetProperties(httpHeaders, properties, options2));
       auto result1 = client1.GetProperties().Value.SmbProperties.PermissionKey;
       auto result2 = client1.GetProperties().Value.SmbProperties.PermissionKey;
       EXPECT_TRUE(result1.HasValue());
       EXPECT_TRUE(result2.HasValue());
       EXPECT_EQ(result1.Value(), result2.Value());
 
-      auto client3 = m_fileShareDirectoryClient->GetFileClient(m_testName + "a3");
+      auto client3 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "a3");
       Files::Shares::CreateFileOptions options3;
       options3.SmbProperties.PermissionKey = result1;
       std::string permissionKey;
@@ -232,8 +217,8 @@ namespace Azure { namespace Storage { namespace Test {
     properties.PermissionKey = m_fileClient->GetProperties().Value.SmbProperties.PermissionKey;
     {
       // Create directory with SmbProperties works
-      auto client1 = m_fileShareDirectoryClient->GetFileClient(m_testName + "1");
-      auto client2 = m_fileShareDirectoryClient->GetFileClient(m_testName + "2");
+      auto client1 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "1");
+      auto client2 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "2");
       Files::Shares::CreateFileOptions options1;
       Files::Shares::CreateFileOptions options2;
       options1.SmbProperties = properties;
@@ -259,13 +244,20 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       // SetProperties works
-      auto client1 = m_fileShareDirectoryClient->GetFileClient(m_testName + "3");
-      auto client2 = m_fileShareDirectoryClient->GetFileClient(m_testName + "4");
+      Files::Shares::Models::FileHttpHeaders httpHeaders;
+      httpHeaders.ContentType = "application/x-binary";
+      httpHeaders.ContentLanguage = "en-US";
+      httpHeaders.ContentDisposition = "attachment";
+      httpHeaders.CacheControl = "no-cache";
+      httpHeaders.ContentEncoding = "identity";
+
+      auto client1 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "3");
+      auto client2 = m_fileShareDirectoryClient->GetFileClient(RandomString() + "4");
 
       EXPECT_NO_THROW(client1.Create(1024));
       EXPECT_NO_THROW(client2.Create(1024));
-      EXPECT_NO_THROW(client1.SetProperties(GetInterestingHttpHeaders(), properties));
-      EXPECT_NO_THROW(client2.SetProperties(GetInterestingHttpHeaders(), properties));
+      EXPECT_NO_THROW(client1.SetProperties(httpHeaders, properties));
+      EXPECT_NO_THROW(client2.SetProperties(httpHeaders, properties));
       auto directoryProperties1 = client1.GetProperties();
       auto directoryProperties2 = client2.GetProperties();
       EXPECT_EQ(
@@ -285,7 +277,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareFileClientTest, SmbPropertiesDefaultValue)
   {
-    auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName);
+    auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
     fileClient.Create(1024);
     auto smbProperties = fileClient.GetProperties().Value.SmbProperties;
     EXPECT_EQ(smbProperties.Attributes, Files::Shares::Models::FileAttributes::Archive);
@@ -326,10 +318,10 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
-  TEST_F(FileShareFileClientTest, LeaseRelated_LIVEONLY_)
+  TEST_F(FileShareFileClientTest, LeaseRelated)
   {
     {
-      std::string leaseId1 = Files::Shares::ShareLeaseClient::CreateUniqueLeaseId();
+      std::string leaseId1 = RandomUUID();
       auto lastModified = m_fileClient->GetProperties().Value.LastModified;
       Files::Shares::ShareLeaseClient leaseClient(*m_fileClient, leaseId1);
       auto aLease
@@ -347,7 +339,7 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(properties.LeaseState.Value(), Files::Shares::Models::LeaseState::Leased);
       EXPECT_EQ(properties.LeaseStatus.Value(), Files::Shares::Models::LeaseStatus::Locked);
 
-      std::string leaseId2 = Files::Shares::ShareLeaseClient::CreateUniqueLeaseId();
+      std::string leaseId2 = RandomUUID();
       EXPECT_NE(leaseId1, leaseId2);
       lastModified = m_fileClient->GetProperties().Value.LastModified;
       auto cLease = leaseClient.Change(leaseId2).Value;
@@ -364,8 +356,7 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
 
-      Files::Shares::ShareLeaseClient leaseClient(
-          *m_fileClient, Files::Shares::ShareLeaseClient::CreateUniqueLeaseId());
+      Files::Shares::ShareLeaseClient leaseClient(*m_fileClient, RandomUUID());
       auto aLease
           = leaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration).Value;
       auto lastModified = m_fileClient->GetProperties().Value.LastModified;
@@ -375,324 +366,91 @@ namespace Azure { namespace Storage { namespace Test {
     }
   }
 
-  namespace {
-    struct ShareConcurrentUploadParameter
-    {
-      int Concurrency;
-      int64_t FileSize;
-    };
-
-    class UploadShare : public FileShareFileClientTest,
-                        public ::testing::WithParamInterface<ShareConcurrentUploadParameter> {
-    };
-
-    std::string GetUploadSuffix(const testing::TestParamInfo<UploadShare::ParamType>& info)
-    {
-      // Can't use empty spaces or underscores (_) as per google test documentation
-      // http://google.github.io/googletest/advanced.html#specifying-names-for-value-parameterized-test-parameters
-      auto const& p = info.param;
-      std::string suffix("c" + std::to_string(p.Concurrency) + "s" + std::to_string(p.FileSize));
-      return suffix;
-    }
-
-    std::vector<ShareConcurrentUploadParameter> GetUploadParameters()
-    {
-      std::vector<ShareConcurrentUploadParameter> testParametes;
-      for (int c : {1, 2, 5})
-      {
-        for (int64_t l : {0ULL, 512ULL, 1_KB, 4_KB, 1_MB, 4_MB + 512})
-        {
-          testParametes.emplace_back(ShareConcurrentUploadParameter({c, l}));
-        }
-      }
-      return testParametes;
-    }
-  } // namespace
-
-  TEST_P(UploadShare, fromBuffer)
+  TEST_F(FileShareFileClientTest, ConcurrentUpload_LIVEONLY_)
   {
-    UploadShare::ParamType const& p(GetParam());
-    auto fileClient = m_fileShareDirectoryClient->GetFileClient(m_testName);
-    std::vector<uint8_t> fileContent(static_cast<size_t>(p.FileSize), 'x');
+    CHECK_SKIP_TEST();
 
-    Files::Shares::UploadFileFromOptions options;
-    options.TransferOptions.ChunkSize = 512_KB;
-    options.TransferOptions.Concurrency = p.Concurrency;
-    options.HttpHeaders = GetInterestingHttpHeaders();
-    options.Metadata = GetMetadata();
+    const auto blobContent = RandomBuffer(8_MB);
 
-    auto res = fileClient.UploadFrom(fileContent.data(), static_cast<size_t>(p.FileSize), options);
-
-    auto properties = fileClient.GetProperties().Value;
-    EXPECT_EQ(properties.FileSize, p.FileSize);
-    EXPECT_EQ(properties.Metadata, options.Metadata);
-    std::vector<uint8_t> downloadContent(static_cast<size_t>(p.FileSize), '\x00');
-    fileClient.DownloadTo(downloadContent.data(), static_cast<size_t>(p.FileSize));
-    EXPECT_EQ(downloadContent, fileContent);
-  }
-
-  TEST_P(UploadShare, fromFile)
-  {
-
-    UploadShare::ParamType const& p(GetParam());
-    auto fileClient = m_fileShareDirectoryClient->GetFileClient(m_testName);
-    std::vector<uint8_t> fileContent = std::vector<uint8_t>(static_cast<size_t>(p.FileSize), 'x');
-
-    Files::Shares::UploadFileFromOptions options;
-    options.TransferOptions.ChunkSize = 512_KB;
-    options.TransferOptions.Concurrency = p.Concurrency;
-    options.HttpHeaders = GetInterestingHttpHeaders();
-    options.Metadata = GetMetadata();
-
-    std::string tempFilename(m_testName);
-    WriteFile(tempFilename, fileContent);
-
-    auto res = fileClient.UploadFrom(tempFilename, options);
-
-    auto properties = fileClient.GetProperties().Value;
-    EXPECT_EQ(properties.FileSize, p.FileSize);
-    EXPECT_EQ(properties.Metadata, options.Metadata);
-    std::vector<uint8_t> downloadContent(static_cast<size_t>(p.FileSize), '\x00');
-    fileClient.DownloadTo(downloadContent.data(), static_cast<size_t>(p.FileSize));
-    EXPECT_EQ(
-        downloadContent,
-        std::vector<uint8_t>(
-            fileContent.begin(), fileContent.begin() + static_cast<size_t>(p.FileSize)));
-
-    DeleteFile(tempFilename);
-  }
-
-  INSTANTIATE_TEST_SUITE_P(
-      withParam,
-      UploadShare,
-      testing::ValuesIn(GetUploadParameters()),
-      GetUploadSuffix);
-
-  namespace {
-    struct ShareConcurrentDownloadParameter
-    {
-      int Concurrency;
-      int64_t DownloadSize;
-      Azure::Nullable<int64_t> Offset = {};
-      Azure::Nullable<int64_t> Length = {};
-      Azure::Nullable<int64_t> InitialChunkSize = {};
-      Azure::Nullable<int64_t> ChunkSize = {};
-    };
-
-    class DowloadShare : public FileShareFileClientTest,
-                         public ::testing::WithParamInterface<ShareConcurrentDownloadParameter> {
-    };
-
-#if !defined(APPEND_IF_NOT_NULL)
-#define APPEND_IF_NOT_NULL(value, suffix, destination) \
-  if (value) \
-  { \
-    destination.append(suffix + std::to_string(value.Value())); \
-  }
-#endif
-
-    std::string GetDownloadSuffix(const testing::TestParamInfo<DowloadShare::ParamType>& info)
-    {
-      // Can't use empty spaces or underscores (_) as per google test documentation
-      // http://google.github.io/googletest/advanced.html#specifying-names-for-value-parameterized-test-parameters
-      auto const& p = info.param;
-      std::string suffix(
-          "c" + std::to_string(p.Concurrency) + "s" + std::to_string(p.DownloadSize));
-      APPEND_IF_NOT_NULL(p.Offset, "o", suffix)
-      APPEND_IF_NOT_NULL(p.Length, "l", suffix)
-      APPEND_IF_NOT_NULL(p.InitialChunkSize, "ics", suffix)
-      APPEND_IF_NOT_NULL(p.ChunkSize, "cs", suffix)
-      return suffix;
-    }
-
-    std::vector<ShareConcurrentDownloadParameter> GetDownloadParameters(int64_t const fileSize)
-    {
-      std::vector<ShareConcurrentDownloadParameter> testParametes;
-      for (int c : {1, 2, 4})
+    auto testUploadFromBuffer = [&](int concurrency,
+                                    int64_t bufferSize,
+                                    Azure::Nullable<int64_t> singleUploadThreshold = {},
+                                    Azure::Nullable<int64_t> chunkSize = {}) {
+      Files::Shares::UploadFileFromOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (singleUploadThreshold.HasValue())
       {
-        // download whole file
-        testParametes.emplace_back(ShareConcurrentDownloadParameter({c, fileSize}));
-        testParametes.emplace_back(ShareConcurrentDownloadParameter({c, fileSize, 0}));
-        testParametes.emplace_back(ShareConcurrentDownloadParameter({c, fileSize, 0, fileSize}));
-        testParametes.emplace_back(
-            ShareConcurrentDownloadParameter({c, fileSize, 0, fileSize * 2}));
-        testParametes.emplace_back(ShareConcurrentDownloadParameter({c, fileSize * 2}));
-
-        // Do offset
-        testParametes.emplace_back(ShareConcurrentDownloadParameter({c, fileSize, 0, 1}));
-        testParametes.emplace_back(ShareConcurrentDownloadParameter({c, fileSize, 1, 1}));
-        testParametes.emplace_back(
-            ShareConcurrentDownloadParameter({c, fileSize, fileSize - 1, 1}));
-        testParametes.emplace_back(
-            ShareConcurrentDownloadParameter({c, fileSize, fileSize - 1, 2}));
-        testParametes.emplace_back(ShareConcurrentDownloadParameter({c, fileSize, fileSize, 1}));
-        testParametes.emplace_back(
-            ShareConcurrentDownloadParameter({c, fileSize, fileSize + 1, 2}));
-
-        // // initial chunk size
-        testParametes.emplace_back(
-            ShareConcurrentDownloadParameter({c, fileSize, 0, 1024, 512, 1024}));
-        testParametes.emplace_back(
-            ShareConcurrentDownloadParameter({c, fileSize, 0, 1024, 1024, 1024}));
-        testParametes.emplace_back(
-            ShareConcurrentDownloadParameter({c, fileSize, 0, 1024, 2048, 1024}));
+        options.TransferOptions.SingleUploadThreshold = singleUploadThreshold.Value();
       }
-      return testParametes;
-    }
-  } // namespace
-
-  TEST_P(DowloadShare, fromBuffer)
-  {
-    ShareConcurrentDownloadParameter const& p(GetParam());
-    m_fileContent = std::vector<uint8_t>(static_cast<size_t>(8_MB), 'x');
-    m_fileClient->UploadFrom(m_fileContent.data(), m_fileContent.size());
-
-    std::vector<uint8_t> downloadBuffer;
-    std::vector<uint8_t> expectedData = m_fileContent;
-    int64_t fileSize = m_fileContent.size();
-    int64_t actualDownloadSize = std::min(p.DownloadSize, fileSize);
-    auto length = p.Length;
-    auto chunkSize = p.ChunkSize;
-    auto concurrency = p.Concurrency;
-    auto initialChunkSize = p.InitialChunkSize;
-    if (p.Offset.HasValue() && length.HasValue())
-    {
-      actualDownloadSize = std::min(length.Value(), fileSize - p.Offset.Value());
-      if (actualDownloadSize >= 0)
+      if (chunkSize.HasValue())
       {
-        expectedData.assign(
-            m_fileContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value()),
-            m_fileContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value() + actualDownloadSize));
+        options.TransferOptions.ChunkSize = chunkSize.Value();
       }
-      else
-      {
-        expectedData.clear();
-      }
-    }
-    else if (p.Offset.HasValue())
-    {
-      actualDownloadSize = fileSize - p.Offset.Value();
-      if (actualDownloadSize >= 0)
-      {
-        expectedData.assign(
-            m_fileContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value()), m_fileContent.end());
-      }
-      else
-      {
-        expectedData.clear();
-      }
-    }
-    downloadBuffer.resize(static_cast<size_t>(p.DownloadSize), '\x00');
-    Files::Shares::DownloadFileToOptions options;
-    options.TransferOptions.Concurrency = concurrency;
-    if (p.Offset.HasValue())
-    {
-      options.Range = Core::Http::HttpRange();
-      options.Range.Value().Offset = p.Offset.Value();
-      options.Range.Value().Length = length;
-    }
 
-    if (initialChunkSize.HasValue())
-    {
-      options.TransferOptions.InitialChunkSize = initialChunkSize.Value();
-    }
-    if (chunkSize.HasValue())
-    {
-      options.TransferOptions.ChunkSize = chunkSize.Value();
-    }
-    if (actualDownloadSize > 0)
-    {
-      auto res = m_fileClient->DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options);
-      EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
-      downloadBuffer.resize(static_cast<size_t>(res.Value.ContentRange.Length.Value()));
+      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
+      EXPECT_NO_THROW(fileClient.UploadFrom(blobContent.data(), bufferSize, options));
+      std::vector<uint8_t> downloadBuffer(bufferSize, '\x00');
+      fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + bufferSize);
       EXPECT_EQ(downloadBuffer, expectedData);
-    }
-    else
+    };
+
+    auto testUploadFromFile = [&](int concurrency,
+                                  int64_t fileSize,
+                                  Azure::Nullable<int64_t> singleUploadThreshold = {},
+                                  Azure::Nullable<int64_t> chunkSize = {}) {
+      Files::Shares::UploadFileFromOptions options;
+      options.TransferOptions.Concurrency = concurrency;
+      if (singleUploadThreshold.HasValue())
+      {
+        options.TransferOptions.SingleUploadThreshold = singleUploadThreshold.Value();
+      }
+      if (chunkSize.HasValue())
+      {
+        options.TransferOptions.ChunkSize = chunkSize.Value();
+      }
+
+      const std::string tempFileName = RandomString();
+      WriteFile(
+          tempFileName, std::vector<uint8_t>(blobContent.begin(), blobContent.begin() + fileSize));
+      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
+      EXPECT_NO_THROW(fileClient.UploadFrom(tempFileName, options));
+      DeleteFile(tempFileName);
+      std::vector<uint8_t> downloadBuffer(fileSize, '\x00');
+      fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      std::vector<uint8_t> expectedData(blobContent.begin(), blobContent.begin() + fileSize);
+      EXPECT_EQ(downloadBuffer, expectedData);
+    };
+
+    std::vector<std::future<void>> futures;
+    for (int c : {1, 2, 4})
     {
-      EXPECT_THROW(
-          m_fileClient->DownloadTo(downloadBuffer.data(), downloadBuffer.size(), options),
-          StorageException);
+      // random range
+      for (int i = 0; i < 16; ++i)
+      {
+        int64_t fileSize = RandomInt(1, 1_MB);
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 4_KB, 4_KB));
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromFile, c, fileSize, 2_KB, 16_KB));
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 0, 12_KB));
+        futures.emplace_back(
+            std::async(std::launch::async, testUploadFromFile, c, fileSize, 0, 25_KB));
+      }
+    }
+    for (auto& f : futures)
+    {
+      f.get();
     }
   }
-
-  TEST_P(DowloadShare, fromFile)
-  {
-    ShareConcurrentDownloadParameter const& p(GetParam());
-    m_fileContent = std::vector<uint8_t>(static_cast<size_t>(8_MB), 'x');
-    m_fileClient->UploadFrom(m_fileContent.data(), m_fileContent.size());
-
-    std::string tempFilename = RandomString();
-    std::vector<uint8_t> expectedData = m_fileContent;
-    int64_t fileSize = m_fileContent.size();
-    int64_t actualDownloadSize = std::min(p.DownloadSize, fileSize);
-    if (p.Offset.HasValue() && p.Length.HasValue())
-    {
-      actualDownloadSize = std::min(p.Length.Value(), fileSize - p.Offset.Value());
-      if (actualDownloadSize >= 0)
-      {
-        expectedData.assign(
-            m_fileContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value()),
-            m_fileContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value() + actualDownloadSize));
-      }
-      else
-      {
-        expectedData.clear();
-      }
-    }
-    else if (p.Offset.HasValue())
-    {
-      actualDownloadSize = fileSize - p.Offset.Value();
-      if (actualDownloadSize >= 0)
-      {
-        expectedData.assign(
-            m_fileContent.begin() + static_cast<ptrdiff_t>(p.Offset.Value()), m_fileContent.end());
-      }
-      else
-      {
-        expectedData.clear();
-      }
-    }
-    Files::Shares::DownloadFileToOptions options;
-    options.TransferOptions.Concurrency = p.Concurrency;
-    if (p.Offset.HasValue())
-    {
-      options.Range = Core::Http::HttpRange();
-      options.Range.Value().Offset = p.Offset.Value();
-      options.Range.Value().Length = p.Length;
-    }
-    if (p.InitialChunkSize.HasValue())
-    {
-      options.TransferOptions.InitialChunkSize = p.InitialChunkSize.Value();
-    }
-    if (p.ChunkSize.HasValue())
-    {
-      options.TransferOptions.ChunkSize = p.ChunkSize.Value();
-    }
-    if (actualDownloadSize > 0)
-    {
-      auto res = m_fileClient->DownloadTo(tempFilename, options);
-      EXPECT_EQ(res.Value.ContentRange.Length.Value(), actualDownloadSize);
-      EXPECT_EQ(ReadFile(tempFilename), expectedData);
-    }
-    else
-    {
-      EXPECT_THROW(m_fileClient->DownloadTo(tempFilename, options), StorageException);
-    }
-    DeleteFile(tempFilename);
-  }
-
-  INSTANTIATE_TEST_SUITE_P(
-      withParam,
-      DowloadShare,
-      testing::ValuesIn(GetDownloadParameters(8_MB)),
-      GetDownloadSuffix);
 
   TEST_F(FileShareFileClientTest, ConcurrentDownload_LIVEONLY_)
   {
     CHECK_SKIP_TEST();
 
-    m_fileContent = RandomBuffer(8 * 1024 * 1024);
-    m_fileClient->UploadFrom(m_fileContent.data(), 8 * 1024 * 1024);
+    auto fileContent = RandomBuffer(8 * 1024 * 1024);
+    m_fileClient->UploadFrom(fileContent.data(), 8 * 1024 * 1024);
     auto testDownloadToBuffer = [&](int concurrency,
                                     int64_t downloadSize,
                                     Azure::Nullable<int64_t> offset = {},
@@ -700,8 +458,8 @@ namespace Azure { namespace Storage { namespace Test {
                                     Azure::Nullable<int64_t> initialChunkSize = {},
                                     Azure::Nullable<int64_t> chunkSize = {}) {
       std::vector<uint8_t> downloadBuffer;
-      std::vector<uint8_t> expectedData = m_fileContent;
-      int64_t fileSize = m_fileContent.size();
+      std::vector<uint8_t> expectedData = fileContent;
+      int64_t fileSize = fileContent.size();
       int64_t actualDownloadSize = std::min(downloadSize, fileSize);
       if (offset.HasValue() && length.HasValue())
       {
@@ -709,8 +467,8 @@ namespace Azure { namespace Storage { namespace Test {
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
-              m_fileContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
-              m_fileContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
+              fileContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
+              fileContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
         }
         else
         {
@@ -723,7 +481,7 @@ namespace Azure { namespace Storage { namespace Test {
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
-              m_fileContent.begin() + static_cast<ptrdiff_t>(offset.Value()), m_fileContent.end());
+              fileContent.begin() + static_cast<ptrdiff_t>(offset.Value()), fileContent.end());
         }
         else
         {
@@ -769,8 +527,8 @@ namespace Azure { namespace Storage { namespace Test {
                                   Azure::Nullable<int64_t> initialChunkSize = {},
                                   Azure::Nullable<int64_t> chunkSize = {}) {
       std::string tempFilename = RandomString();
-      std::vector<uint8_t> expectedData = m_fileContent;
-      int64_t fileSize = m_fileContent.size();
+      std::vector<uint8_t> expectedData = fileContent;
+      int64_t fileSize = fileContent.size();
       int64_t actualDownloadSize = std::min(downloadSize, fileSize);
       if (offset.HasValue() && length.HasValue())
       {
@@ -778,8 +536,8 @@ namespace Azure { namespace Storage { namespace Test {
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
-              m_fileContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
-              m_fileContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
+              fileContent.begin() + static_cast<ptrdiff_t>(offset.Value()),
+              fileContent.begin() + static_cast<ptrdiff_t>(offset.Value() + actualDownloadSize));
         }
         else
         {
@@ -792,7 +550,7 @@ namespace Azure { namespace Storage { namespace Test {
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
-              m_fileContent.begin() + static_cast<ptrdiff_t>(offset.Value()), m_fileContent.end());
+              fileContent.begin() + static_cast<ptrdiff_t>(offset.Value()), fileContent.end());
         }
         else
         {
@@ -828,7 +586,7 @@ namespace Azure { namespace Storage { namespace Test {
       DeleteFile(tempFilename);
     };
 
-    const int64_t fileSize = m_fileContent.size();
+    const int64_t fileSize = fileContent.size();
     std::vector<std::future<void>> futures;
     for (int c : {1, 2, 4})
     {
@@ -836,7 +594,7 @@ namespace Azure { namespace Storage { namespace Test {
       std::mt19937_64 random_generator(std::random_device{}());
       for (int i = 0; i < 16; ++i)
       {
-        std::uniform_int_distribution<int64_t> offsetDistribution(0, m_fileContent.size() - 1);
+        std::uniform_int_distribution<int64_t> offsetDistribution(0, fileContent.size() - 1);
         int64_t offset = offsetDistribution(random_generator);
         std::uniform_int_distribution<int64_t> lengthDistribution(1, 64_KB);
         int64_t length = lengthDistribution(random_generator);
@@ -870,13 +628,13 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareFileClientTest, RangeUploadDownload)
   {
-    auto rangeSize = 1 * 1024 * 1024;
+    auto rangeSize = 128;
     auto numOfChunks = 3;
-    std::vector<uint8_t> rangeContent(rangeSize, 'x');
+    std::vector<uint8_t> rangeContent = RandomBuffer(rangeSize);
     auto memBodyStream = Core::IO::MemoryBodyStream(rangeContent);
     {
       // Simple upload/download.
-      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName);
+      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
       fileClient.Create(static_cast<int64_t>(numOfChunks) * rangeSize);
       for (int32_t i = 0; i < numOfChunks; ++i)
       {
@@ -902,7 +660,7 @@ namespace Azure { namespace Storage { namespace Test {
     // last write time
     {
       memBodyStream.Rewind();
-      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName);
+      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
       fileClient.Create(static_cast<int64_t>(numOfChunks) * rangeSize);
       auto lastWriteTimeBeforeUpload
           = fileClient.GetProperties().Value.SmbProperties.LastWrittenOn.Value();
@@ -916,7 +674,7 @@ namespace Azure { namespace Storage { namespace Test {
     }
     {
       memBodyStream.Rewind();
-      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName);
+      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
       fileClient.Create(static_cast<int64_t>(numOfChunks) * rangeSize);
       auto lastWriteTimeBeforeUpload
           = fileClient.GetProperties().Value.SmbProperties.LastWrittenOn.Value();
@@ -933,7 +691,7 @@ namespace Azure { namespace Storage { namespace Test {
       memBodyStream.Rewind();
       Azure::Core::Cryptography::Md5Hash instance;
       auto md5 = instance.Final(rangeContent.data(), rangeContent.size());
-      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName + "2");
+      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString() + "2");
       Files::Shares::UploadFileRangeOptions uploadOptions;
       fileClient.Create(static_cast<int64_t>(numOfChunks) * rangeSize);
       ContentHash hash;
@@ -950,15 +708,16 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareFileClientTest, CopyRelated)
   {
-    size_t fileSize = 1 * 1024 * 1024;
-    std::vector<uint8_t> fileContent(fileSize, 'x');
+    size_t fileSize = 128;
+    std::vector<uint8_t> fileContent = RandomBuffer(fileSize);
     auto memBodyStream = Core::IO::MemoryBodyStream(fileContent);
     {
       // Simple copy works.
-      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName + "1");
+      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString() + "1");
       fileClient.Create(fileSize);
 
-      auto destFileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName + "2");
+      auto destFileClient
+          = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString() + "2");
       auto copyOperation = destFileClient.StartCopy(fileClient.GetUrl());
       EXPECT_EQ(
           copyOperation.GetRawResponse().GetStatusCode(),
@@ -969,22 +728,17 @@ namespace Azure { namespace Storage { namespace Test {
 
     {
       // Copy mode with override and empty permission throws error..
-      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName + "3");
+      auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString() + "3");
       fileClient.Create(fileSize);
 
-      auto destFileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName + "4");
+      auto destFileClient
+          = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString() + "4");
     }
   }
 
-  TEST_F(FileShareFileClientTest, RangeRelated_LIVEONLY_)
+  TEST_F(FileShareFileClientTest, RangeRelated)
   {
-    // Test uploads a file with some content.
-    // Then the content is updated in the server (second half is cleared)
-    // Then all file is downloaded and we checked the downloaded content
-    // Test is LIVE only as there's no support for this behavior from the test recorded.
-    CHECK_SKIP_TEST();
-
-    size_t fileSize = 1 * 1024 * 1024;
+    size_t fileSize = 1024 * 3;
     auto fileContent = RandomBuffer(fileSize);
     auto memBodyStream = Core::IO::MemoryBodyStream(fileContent);
     auto halfContent
@@ -1010,21 +764,15 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(static_cast<int32_t>(fileSize / 2) - 1024, result.Ranges[1].Length.Value());
   }
 
-  TEST_F(FileShareFileClientTest, PreviousRangeWithSnapshot_LIVEONLY_)
+  TEST_F(FileShareFileClientTest, PreviousRangeWithSnapshot)
   {
-    // Test uploads a file with some content.
-    // Then the content is updated in the server (second half is cleared)
-    // Then all file is downloaded and we checked the downloaded content
-    // Test is LIVE only as there's no support for this behavior from the test recorded.
-    CHECK_SKIP_TEST();
-
-    size_t fileSize = 1 * 1024 * 1024;
-    std::vector<uint8_t> fileContent(fileSize, 'x');
+    size_t fileSize = 1024 * 10;
+    std::vector<uint8_t> fileContent = RandomBuffer(fileSize);
     auto memBodyStream = Core::IO::MemoryBodyStream(fileContent);
     auto halfContent
         = std::vector<uint8_t>(fileContent.begin(), fileContent.begin() + fileSize / 2);
     halfContent.resize(fileSize);
-    auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName);
+    auto fileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString());
     fileClient.Create(fileSize);
     EXPECT_NO_THROW(fileClient.UploadRange(0, memBodyStream));
     EXPECT_NO_THROW(fileClient.ClearRange(fileSize / 2, fileSize / 2));
@@ -1094,7 +842,7 @@ namespace Azure { namespace Storage { namespace Test {
     };
     options.PerOperationPolicies.emplace_back(std::make_unique<InvalidQueryParameterPolicy>());
     auto fileClient = Azure::Storage::Files::Shares::ShareFileClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_shareName, m_testName, options);
+        StandardStorageConnectionString(), m_shareName, RandomString(), options);
     try
     {
       fileClient.Create(1024);
@@ -1115,15 +863,16 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(FileShareFileClientTest, UploadRangeFromUri)
   {
-    size_t fileSize = 1 * 1024 * 1024;
-    std::string fileName = m_testName + "file";
-    std::vector<uint8_t> fileContent(fileSize, 'x');
+    size_t fileSize = 1 * 1024;
+    std::string fileName = RandomString() + "file";
+    std::vector<uint8_t> fileContent = RandomBuffer(fileSize);
     auto memBodyStream = Core::IO::MemoryBodyStream(fileContent);
     auto sourceFileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(fileName);
     sourceFileClient.Create(fileSize);
     EXPECT_NO_THROW(sourceFileClient.UploadRange(0, memBodyStream));
 
-    auto destFileClient = m_shareClient->GetRootDirectoryClient().GetFileClient(m_testName + "f2");
+    auto destFileClient
+        = m_shareClient->GetRootDirectoryClient().GetFileClient(RandomString() + "f2");
     destFileClient.Create(fileSize * 4);
     Azure::Core::Http::HttpRange sourceRange;
     Azure::Core::Http::HttpRange destRange;
@@ -1201,10 +950,6 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_EQ(lastWriteTimeBeforeUpload, lastWriteTimeAfterUpload);
     }
     // source access condition works.
-    std::vector<uint8_t> invalidCrc64(
-        uploadResult.TransactionalContentHash.Value.begin(),
-        uploadResult.TransactionalContentHash.Value.begin()
-            + uploadResult.TransactionalContentHash.Value.size() / 2);
     {
       Files::Shares::UploadFileRangeFromUriOptions uploadRangeOptions;
       uploadRangeOptions.SourceAccessCondition.IfNoneMatchContentHash
@@ -1218,13 +963,17 @@ namespace Azure { namespace Storage { namespace Test {
                                  uploadRangeOptions)
                              .Value,
           StorageException);
-      // Below code seems to be triggering a server bug. Uncomment when server resolves the issue.
-      // uploadRangeOptions.SourceAccessCondition.IfNoneMatchContentHash.Value().Value
-      //    = invalidCrc64;
-      // EXPECT_NO_THROW(
-      //    uploadResult = *destFileClient.UploadRangeFromUri(
-      //        sourceFileClient.GetUrl() + sourceSas, sourceRange, destRange,
-      //        uploadRangeOptions));
+      uploadRangeOptions.SourceAccessCondition.IfNoneMatchContentHash.Value().Value
+          = Azure::Core::Convert::Base64Decode(DummyCrc64);
+
+      EXPECT_NO_THROW(
+          uploadResult = destFileClient
+                             .UploadRangeFromUri(
+                                 destRange.Offset,
+                                 sourceFileClient.GetUrl() + sourceSas,
+                                 sourceRange,
+                                 uploadRangeOptions)
+                             .Value);
     }
     {
       Files::Shares::UploadFileRangeFromUriOptions uploadRangeOptions;
@@ -1238,14 +987,19 @@ namespace Azure { namespace Storage { namespace Test {
                                  sourceRange,
                                  uploadRangeOptions)
                              .Value);
-      // Below code seems to be triggering a server high latency. Uncomment when server resolves
-      // the issue. uploadRangeOptions.SourceAccessCondition.IfMatchContentHash.Value().Value =
-      // invalidCrc64;
-      // EXPECT_THROW(
-      //    uploadResult = *destFileClient.UploadRangeFromUri(
-      //        sourceFileClient.GetUrl() + sourceSas, sourceRange, destRange,
-      //        uploadRangeOptions),
-      //    StorageException);
+
+      uploadRangeOptions.SourceAccessCondition.IfMatchContentHash.Value().Value
+          = Azure::Core::Convert::Base64Decode(DummyCrc64);
+      EXPECT_THROW(
+          uploadResult = destFileClient
+                             .UploadRangeFromUri(
+                                 destRange.Offset,
+                                 sourceFileClient.GetUrl() + sourceSas,
+                                 sourceRange,
+
+                                 uploadRangeOptions)
+                             .Value,
+          StorageException);
     }
     {
       Files::Shares::UploadFileRangeFromUriOptions uploadRangeOptions;
@@ -1258,13 +1012,17 @@ namespace Azure { namespace Storage { namespace Test {
                                  sourceRange,
                                  uploadRangeOptions)
                              .Value);
-      // Below code seems to be triggering a server high latency. Uncomment when server resolves
-      // the issue. uploadRangeOptions.SourceContentHash.Value().Value = invalidCrc64;
-      // EXPECT_THROW(
-      //    uploadResult = *destFileClient.UploadRangeFromUri(
-      //        sourceFileClient.GetUrl() + sourceSas, sourceRange, destRange,
-      //        uploadRangeOptions),
-      //    StorageException);
+      uploadRangeOptions.TransactionalContentHash.Value().Value
+          = Azure::Core::Convert::Base64Decode(DummyCrc64);
+      EXPECT_THROW(
+          uploadResult = destFileClient
+                             .UploadRangeFromUri(
+                                 destRange.Offset,
+                                 sourceFileClient.GetUrl() + sourceSas,
+                                 sourceRange,
+                                 uploadRangeOptions)
+                             .Value,
+          StorageException);
     }
   }
 

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
@@ -65,9 +65,9 @@ namespace Azure { namespace Storage { namespace Test {
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }
       {
-        auto client = m_shareClient->GetRootDirectoryClient()
-                          .GetSubdirectoryClient(RandomString() + "4")
-                          .GetFileClient(RandomString() + "5");
+        auto subdirClient
+            = m_shareClient->GetRootDirectoryClient().GetSubdirectoryClient(RandomString() + "4");
+        auto client = subdirClient.GetFileClient(RandomString() + "5");
         auto deleteResult = client.DeleteIfExists();
         EXPECT_FALSE(deleteResult.Value.Deleted);
       }

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.hpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.hpp
@@ -11,11 +11,9 @@ namespace Azure { namespace Storage { namespace Test {
   class FileShareFileClientTest : public FileShareDirectoryClientTest {
   protected:
     void SetUp();
-    void TearDown();
 
     std::shared_ptr<Files::Shares::ShareFileClient> m_fileClient;
     std::string m_fileName;
-    std::vector<uint8_t> m_fileContent;
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_service_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_service_client_test.cpp
@@ -16,8 +16,6 @@ namespace Azure { namespace Storage { namespace Test {
     }
   } // namespace
 
-  const size_t ShareTestSize = 5;
-
   void FileShareServiceClientTest::SetUp()
   {
     StorageTest::SetUp();

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_service_client_test.hpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_service_client_test.hpp
@@ -9,20 +9,10 @@ namespace Azure { namespace Storage { namespace Test {
 
   class FileShareServiceClientTest : public Azure::Storage::Test::StorageTest {
   protected:
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
 
-    std::vector<Files::Shares::Models::ShareItem> ListAllShares(
-        const std::string& prefix = std::string());
-
-    std::shared_ptr<Files::Shares::ShareServiceClient> m_fileShareServiceClient;
-    std::vector<std::string> m_shareNameSetA;
-    std::string m_sharePrefixA;
-    std::vector<std::string> m_shareNameSetB;
-    std::string m_sharePrefixB;
-    Files::Shares::ShareClientOptions m_options;
-    std::string m_testName;
-    std::string m_testNameLowercase;
+  protected:
+    std::shared_ptr<Files::Shares::ShareServiceClient> m_shareServiceClient;
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-queues/test/ut/queue_client_messages_test.cpp
+++ b/sdk/storage/azure-storage-queues/test/ut/queue_client_messages_test.cpp
@@ -10,9 +10,7 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(QueueClientTest, EnqueueMessage)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     const std::string message = "message content.";
     auto res = queueClient.EnqueueMessage(message).Value;
@@ -28,15 +26,11 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(peekedMessage.MessageId, res.MessageId);
     EXPECT_EQ(peekedMessage.InsertedOn, res.InsertedOn);
     EXPECT_EQ(peekedMessage.ExpiresOn, res.ExpiresOn);
-
-    queueClient.Delete();
   }
 
   TEST_F(QueueClientTest, EnqueueMessageTTL)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     const std::string message = "message content.";
     Queues::EnqueueMessageOptions enqueueOptions;
@@ -64,15 +58,11 @@ namespace Azure { namespace Storage { namespace Test {
     auto receiveRes = queueClient.ReceiveMessages();
     ASSERT_FALSE(receiveRes.Value.Messages.empty());
     EXPECT_EQ(receiveRes.Value.Messages[0].ExpiresOn, neverExpireDateTime);
-
-    queueClient.Delete();
   }
 
   TEST_F(QueueClientTest, ReceiveMessage)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     EXPECT_TRUE(queueClient.ReceiveMessages().Value.Messages.empty());
 
@@ -94,15 +84,11 @@ namespace Azure { namespace Storage { namespace Test {
     TestSleep(std::chrono::milliseconds(1200));
     receivedMessage = queueClient.ReceiveMessages().Value.Messages[0];
     EXPECT_EQ(receivedMessage.DequeueCount, 2);
-
-    queueClient.Delete();
   }
 
   TEST_F(QueueClientTest, ReceiveMessages)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     Queues::ReceiveMessagesOptions receiveOptions;
     receiveOptions.MaxMessages = 1;
@@ -135,15 +121,11 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(receivedMessages.size(), size_t(2));
     EXPECT_EQ(receivedMessages[0].MessageText, message3);
     EXPECT_EQ(receivedMessages[1].MessageText, message4);
-
-    queueClient.Delete();
   }
 
-  TEST_F(QueueClientTest, PeekMessage_LIVEONLY_)
+  TEST_F(QueueClientTest, PeekSingleMessage)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     EXPECT_TRUE(queueClient.PeekMessages().Value.Messages.empty());
 
@@ -157,15 +139,11 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(peekedMessage.InsertedOn, res.InsertedOn);
     EXPECT_EQ(peekedMessage.ExpiresOn, res.ExpiresOn);
     EXPECT_EQ(peekedMessage.DequeueCount, 0);
-
-    queueClient.Delete();
   }
 
   TEST_F(QueueClientTest, PeekMessages)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     Queues::PeekMessagesOptions peekOptions;
     peekOptions.MaxMessages = 1;
@@ -200,15 +178,11 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_EQ(peekedMessages[1].MessageText, message2);
     EXPECT_EQ(peekedMessages[2].MessageText, message3);
     EXPECT_EQ(peekedMessages[3].MessageText, message4);
-
-    queueClient.Delete();
   }
 
   TEST_F(QueueClientTest, UpdateMessage)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     const std::string message = "message content.";
     const std::string updatedMessage = "MESSAGE CONTENT2";
@@ -231,45 +205,33 @@ namespace Azure { namespace Storage { namespace Test {
     TestSleep(std::chrono::milliseconds(1200));
     peekedMessage = queueClient.PeekMessages().Value.Messages[0];
     EXPECT_EQ(peekedMessage.MessageText, updatedMessage);
-
-    queueClient.Delete();
   }
 
   TEST_F(QueueClientTest, DeleteMessage)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     const std::string message = "message content.";
     auto res = queueClient.EnqueueMessage(message).Value;
 
     EXPECT_NO_THROW(queueClient.DeleteMessage(res.MessageId, res.PopReceipt));
     EXPECT_TRUE(queueClient.PeekMessages().Value.Messages.empty());
-
-    queueClient.Delete();
   }
 
   TEST_F(QueueClientTest, ClearMessages)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     const std::string message = "message content.";
     queueClient.EnqueueMessage(message);
 
     EXPECT_NO_THROW(queueClient.ClearMessages());
     EXPECT_TRUE(queueClient.PeekMessages().Value.Messages.empty());
-
-    queueClient.Delete();
   }
 
   TEST_F(QueueClientTest, MessageSpecialCharacters)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     const std::string message = "message content`~!@#$%^&*()-=_+[]{}\\|;':\",.<>/?";
 
@@ -278,8 +240,6 @@ namespace Azure { namespace Storage { namespace Test {
     auto peekedMessage = queueClient.PeekMessages().Value.Messages[0];
 
     EXPECT_EQ(peekedMessage.MessageText, message);
-
-    queueClient.Delete();
   }
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-queues/test/ut/queue_client_test.cpp
+++ b/sdk/storage/azure-storage-queues/test/ut/queue_client_test.cpp
@@ -47,7 +47,7 @@ namespace Azure { namespace Storage { namespace Test {
         {
           throw;
         }
-        SUCCEED() << "Cotnainer is being deleted. Will try again after 3 seconds.";
+        SUCCEED() << "Queue is being deleted. Will try again after 3 seconds.";
         std::this_thread::sleep_for(std::chrono::seconds(3));
       }
     }

--- a/sdk/storage/azure-storage-queues/test/ut/queue_client_test.cpp
+++ b/sdk/storage/azure-storage-queues/test/ut/queue_client_test.cpp
@@ -24,37 +24,55 @@ namespace Azure { namespace Storage { namespace Test {
   void QueueClientTest::SetUp()
   {
     StorageTest::SetUp();
-    CHECK_SKIP_TEST();
 
-    m_options = InitClientOptions<Queues::QueueClientOptions>();
+    auto options = InitClientOptions<Queues::QueueClientOptions>();
     m_queueServiceClient = std::make_shared<Queues::QueueServiceClient>(
         Queues::QueueServiceClient::CreateFromConnectionString(
-            StandardStorageConnectionString(), m_options));
-    m_testName = GetTestName();
-    m_testNameLowercase = GetTestNameLowerCase();
+            StandardStorageConnectionString(), options));
 
-    m_queueName = m_testNameLowercase + "base";
+    m_queueName = GetLowercaseIdentifier();
     m_queueClient
         = std::make_shared<Queues::QueueClient>(m_queueServiceClient->GetQueueClient(m_queueName));
-    m_queueClient->Create();
+
+    while (true)
+    {
+      try
+      {
+        m_queueClient->Create();
+        break;
+      }
+      catch (StorageException& e)
+      {
+        if (e.ErrorCode != "QueueBeingDeleted")
+        {
+          throw;
+        }
+        SUCCEED() << "Cotnainer is being deleted. Will try again after 3 seconds.";
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+      }
+    }
+
+    m_resourceCleanupFunctions.push_back(
+        [queueClient = *m_queueClient]() { queueClient.Delete(); });
   }
 
-  void QueueClientTest::TearDown()
+  Queues::QueueClient QueueClientTest::GetQueueClientForTest(
+      const std::string& queueName,
+      Queues::QueueClientOptions clientOptions)
   {
-    CHECK_SKIP_TEST();
-    m_queueClient->Delete();
-    StorageTest::TearDown();
+    InitClientOptions(clientOptions);
+    auto queueClient = Queues::QueueClient::CreateFromConnectionString(
+        StandardStorageConnectionString(), queueName, clientOptions);
+    m_resourceCleanupFunctions.push_back([queueClient]() { queueClient.Delete(); });
+
+    return queueClient;
   }
 
   TEST_F(QueueClientTest, CreateDelete)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase, m_options);
+    auto queueClient = GetQueueClientForTest(LowercaseRandomString());
     Azure::Storage::Queues::CreateQueueOptions options;
-    Azure::Storage::Metadata metadata;
-    metadata["key1"] = "one";
-    metadata["key2"] = "TWO";
-    options.Metadata = metadata;
+    options.Metadata = RandomMetadata();
     auto res = queueClient.Create(options);
     EXPECT_TRUE(res.Value.Created);
     EXPECT_FALSE(res.RawResponse->GetHeaders().at(_internal::HttpHeaderRequestId).empty());
@@ -70,11 +88,10 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_FALSE(res2.RawResponse->GetHeaders().at(_internal::HttpHeaderDate).empty());
     EXPECT_FALSE(res2.RawResponse->GetHeaders().at(_internal::HttpHeaderXMsVersion).empty());
 
-    queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase + "UPPERCASE", m_options);
+    queueClient = GetQueueClientForTest(LowercaseRandomString() + "UPPERCASE");
     EXPECT_THROW(queueClient.Create(), StorageException);
-    queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), m_testNameLowercase + "2", m_options);
+
+    queueClient = GetQueueClientForTest(LowercaseRandomString());
     {
       auto response = queueClient.Delete();
       EXPECT_FALSE(response.Value.Deleted);
@@ -127,11 +144,9 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_TRUE(properties.Metadata.empty());
   }
 
-  TEST_F(QueueClientTest, AccessControlList_LIVEONLY_)
+  TEST_F(QueueClientTest, AccessControlList)
   {
-    auto queueClient = Azure::Storage::Queues::QueueClient::CreateFromConnectionString(
-        StandardStorageConnectionString(), LowercaseRandomString());
-    queueClient.Create();
+    auto queueClient = *m_queueClient;
 
     std::vector<Queues::Models::SignedIdentifier> signedIdentifiers;
     {
@@ -170,8 +185,10 @@ namespace Azure { namespace Storage { namespace Test {
     EXPECT_NO_THROW(queueClient.SetAccessPolicy(accessPolicy));
 
     auto ret = queueClient.GetAccessPolicy();
-    EXPECT_EQ(ret.Value.SignedIdentifiers, signedIdentifiers);
-
+    if (m_testContext.IsLiveMode())
+    {
+      EXPECT_EQ(ret.Value.SignedIdentifiers, signedIdentifiers);
+    }
     queueClient.Delete();
   }
 

--- a/sdk/storage/azure-storage-queues/test/ut/queue_client_test.cpp
+++ b/sdk/storage/azure-storage-queues/test/ut/queue_client_test.cpp
@@ -24,7 +24,10 @@ namespace Azure { namespace Storage { namespace Test {
   void QueueClientTest::SetUp()
   {
     StorageTest::SetUp();
-
+    if (shouldSkipTest())
+    {
+      return;
+    }
     auto options = InitClientOptions<Queues::QueueClientOptions>();
     m_queueServiceClient = std::make_shared<Queues::QueueServiceClient>(
         Queues::QueueServiceClient::CreateFromConnectionString(

--- a/sdk/storage/azure-storage-queues/test/ut/queue_client_test.hpp
+++ b/sdk/storage/azure-storage-queues/test/ut/queue_client_test.hpp
@@ -9,15 +9,16 @@ namespace Azure { namespace Storage { namespace Test {
 
   class QueueClientTest : public Azure::Storage::Test::StorageTest {
   protected:
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
 
+    Queues::QueueClient GetQueueClientForTest(
+        const std::string& queueName,
+        Queues::QueueClientOptions clientOptions = Queues::QueueClientOptions());
+
+  protected:
     std::shared_ptr<Queues::QueueServiceClient> m_queueServiceClient;
     std::shared_ptr<Queues::QueueClient> m_queueClient;
     std::string m_queueName;
-    Queues::QueueClientOptions m_options;
-    std::string m_testName;
-    std::string m_testNameLowercase;
   };
 
 }}} // namespace Azure::Storage::Test

--- a/sdk/storage/azure-storage-queues/test/ut/queue_sas_test.cpp
+++ b/sdk/storage/azure-storage-queues/test/ut/queue_sas_test.cpp
@@ -11,6 +11,8 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(QueueClientTest, QueueSasTest_LIVEONLY_)
   {
+    CHECK_SKIP_TEST();
+
     auto sasStartsOn = std::chrono::system_clock::now() - std::chrono::minutes(5);
     auto sasExpiredOn = std::chrono::system_clock::now() - std::chrono::minutes(1);
     auto sasExpiresOn = std::chrono::system_clock::now() + std::chrono::minutes(60);

--- a/sdk/storage/azure-storage-queues/test/ut/queue_sas_test.cpp
+++ b/sdk/storage/azure-storage-queues/test/ut/queue_sas_test.cpp
@@ -11,8 +11,6 @@ namespace Azure { namespace Storage { namespace Test {
 
   TEST_F(QueueClientTest, QueueSasTest_LIVEONLY_)
   {
-    CHECK_SKIP_TEST();
-
     auto sasStartsOn = std::chrono::system_clock::now() - std::chrono::minutes(5);
     auto sasExpiredOn = std::chrono::system_clock::now() - std::chrono::minutes(1);
     auto sasExpiresOn = std::chrono::system_clock::now() + std::chrono::minutes(60);

--- a/sdk/storage/azure-storage-queues/test/ut/queue_service_client_test.cpp
+++ b/sdk/storage/azure-storage-queues/test/ut/queue_service_client_test.cpp
@@ -43,7 +43,6 @@ namespace Azure { namespace Storage { namespace Test {
     void SetUp()
     {
       StorageTest::SetUp();
-      CHECK_SKIP_TEST();
 
       m_options = InitClientOptions<Queues::QueueClientOptions>();
       m_testName = GetTestName();


### PR DESCRIPTION
In this PR, we:

1. Removed unused definitions in `sdk/core/azure-core-test/inc/azure/core/test/network_models.hpp`.
2. Removed unused functions `TestBase::ValidateSkippingTest()` and `TestBase::IsValidTime()`.
3. Added an overload of function `TestBase::InitClientOptions()`.
4. Removed unused functions `TestProxyManager::SetStopRecordMode()`, `TestProxyManager::SetStopPlaybackMode()`.
5. Rewrote proxy matcher setting logic.
    1. Use json object rather than hard-coded json string, for better readability and maintenance.
    2. Exclude `Expect` and `Connection` headers so that recording made by libcurl can be used by WinHTTP and also the other way around
    3. Removed some unnecessary ignored headers
    4. Added some ignored query parameters
6. Fixed an issue in libcurl transport layer. Closes https://github.com/Azure/azure-sdk-for-cpp/issues/4213
7. Fixed an issue where libcurl transport layer adds `Content-Length` header for HEAD/GET/DELETE requests, which caused a behavior misalignment between libcurl and WinHTTP, making the requests recorded by one of the transport layer unusable by the other.
    1. Also removed `Content-Length` header for GET requests from existing recordings.
8. Fixed a bug where test proxy sometimes discarded request body.
9. Fixed a bug where requests were not properly redirected if `Host` was set in the original request *
10. Enabled some storage test cases that were disabled in https://github.com/Azure/azure-sdk-for-cpp/pull/4118. Closes https://github.com/Azure/azure-sdk-for-cpp/issues/4147
11. Removed `CHECK_SKIP_TEST` macro. We check if test cases is live-only in `SetUpTestBase()` function. With this change, the only thing we need to do to mark a test case live-only is to add `_LIVEONLY_` suffix in case name. There's no need to call `CHECK_SKIP_TEST` macro anymore.

\* A little more explanation of this bug: 
Transport layer accepts a request with a URL and request headers in it. If `Host` header is not in request headers, libcurl transport will extract host from URL and set `Host` header. If `Host` is already in request, libcurl transport does nothing.
Test-proxy policy modifies host in URL to `localhost:5001`, but it doesn't modify `Host` header (I think it's a negligence).
For most of the requests we don't set `Host` header. Test-proxy modifies host in the URL to `localhost:5001`, libcurl extracts `localhost:5001` from URL and set `Host` header. Everything works perfectly.
For very few requests, `Host` header is already set. Test-proxy only modifies host in the URL, libcurl doesn't set `Host` header because there's one already. Now the host in `Host` header and URL don't match. These requests cannot be recorded & played back.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
