### PR TITLE
Removed unused APIs `SetScheme()` and `SetPort()` from `Core::Url`.

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- Removed unused APIs `SetScheme()` and `SetPort()` from `Azure::Core::Url`. After construction from a url string, these attributes don't need to be changed.
+
 ### Bugs Fixed
 
 ### Other Changes
@@ -19,7 +21,7 @@
 ### Breaking Changes
 
 - Bearer token authentication will not work for endpoint URL protocol schemes other than `"https"`. This ensures token security and is consistent with the Azure SDKs for other languages.
-- Removed `noexcept` specification from `Azure::DateTime::clock::now()`. 
+- Removed `noexcept` specification from `Azure::DateTime::clock::now()`.
 
 ## 1.8.0-beta.2 (2022-11-03)
 

--- a/sdk/core/azure-core/inc/azure/core/url.hpp
+++ b/sdk/core/azure-core/inc/azure/core/url.hpp
@@ -15,6 +15,13 @@
 #include <memory>
 #include <string>
 
+#if defined(TESTING_BUILD)
+// Define the class used from tests to validate http scheme
+namespace Azure { namespace Core { namespace Test {
+  class TransportAdapterOptions_ProxyWithPasswordHttp_Test;
+}}} // namespace Azure::Core::Test
+#endif
+
 namespace Azure { namespace Core {
   namespace _detail {
     inline std::string FormatEncodedUrlQueryParameters(
@@ -44,6 +51,11 @@ namespace Azure { namespace Core {
    * (scheme, host, path, etc.). Authority is not currently supported.
    */
   class Url final {
+#if defined(TESTING_BUILD)
+    // make tests classes friends to allow setting scheme to http
+    friend class Azure::Core::Test::TransportAdapterOptions_ProxyWithPasswordHttp_Test;
+#endif
+
   private:
     std::string m_scheme;
     std::string m_host;
@@ -102,25 +114,11 @@ namespace Azure { namespace Core {
     /******** API for building Url from scratch. Override state ********/
 
     /**
-     * @brief Sets URL scheme.
-     *
-     * @param scheme URL scheme.
-     */
-    void SetScheme(const std::string& scheme) { m_scheme = scheme; }
-
-    /**
      * @brief Sets URL host.
      *
      * @param encodedHost URL host, already encoded.
      */
     void SetHost(const std::string& encodedHost) { m_host = encodedHost; }
-
-    /**
-     * @brief Sets URL port.
-     *
-     * @param port URL port.
-     */
-    void SetPort(uint16_t port) { m_port = port; }
 
     /**
      * @brief Sets URL path.

--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -308,20 +308,6 @@ namespace Azure { namespace Core { namespace Test {
       CheckBodyFromBuffer(*response, expectedResponseBodySize);
       VerifyIsProxiedResponse(response, myIpAddress);
     }
-    {
-      Azure::Core::Http::Policies::TransportOptions transportOptions;
-
-      transportOptions.HttpProxy = HttpProxyServer();
-      HttpPipeline pipeline(CreateHttpPipeline(transportOptions));
-      testUrl.SetScheme("http");
-
-      auto request = Azure::Core::Http::Request(Azure::Core::Http::HttpMethod::Get, testUrl);
-      auto response = pipeline.Send(request, Azure::Core::Context::ApplicationContext);
-      checkResponseCode(response->GetStatusCode());
-      auto expectedResponseBodySize = std::stoull(response->GetHeaders().at("content-length"));
-      CheckBodyFromBuffer(*response, expectedResponseBodySize);
-      VerifyIsProxiedResponse(response, myIpAddress);
-    }
   }
 
 #if !defined(BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
@@ -385,7 +371,7 @@ namespace Azure { namespace Core { namespace Test {
     }
     Azure::Core::Url testUrl(AzureSdkHttpbinServer::Get());
     // HTTP Connections.
-    testUrl.SetScheme("http");
+    testUrl.m_scheme = "http";
     {
       Azure::Core::Http::Policies::TransportOptions transportOptions;
 

--- a/sdk/core/azure-core/test/ut/url_test.cpp
+++ b/sdk/core/azure-core/test/ut/url_test.cpp
@@ -241,7 +241,7 @@ namespace Azure { namespace Core { namespace Test {
         url.GetPort(),
         expected);
 
-    url.SetPort(40);
+    url = Core::Url("http://test.com:40");
     expected = 40;
 
     EXPECT_PRED2(
@@ -249,7 +249,7 @@ namespace Azure { namespace Core { namespace Test {
         url.GetPort(),
         expected);
 
-    url.SetPort(90);
+    url = Core::Url("http://test.com:90");
     expected = 90;
 
     EXPECT_PRED2(


### PR DESCRIPTION
These APIs are only used in testing atm.

After construction from a url string, these attributes don't need to be changed. We want to make more things immutable, unless absolutely necessary. For examples, aspects of the Url like query parameters need to remain mutable.

This came out of the discussion on client parameter validation, and how much validation we should do to keep core types well-formed after construction.

If we want to keep these, we need to decide on appropriate validation. For example, a scheme cannot allow any arbitrary characters:
https://www.rfc-editor.org/rfc/rfc1738#section-2.1
> Scheme names consist of a sequence of characters. The lower case
   letters "a"--"z", digits, and the characters plus ("+"), period
   ("."), and hyphen ("-") are allowed. For resiliency, programs
   interpreting URLs should treat upper case letters as equivalent to
   lower case in scheme names (e.g., allow "HTTP" as well as "http").