### PR TITLE
Fix spelling in doc comments within Certificate client models.

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -193,6 +193,13 @@
       ]
     },
     {
+      "filename": "**/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client_models.hpp",
+      "words": [
+        "SECG",
+        "SECP"
+      ]
+    },
+    {
       "filename": "**/sdk/core/azure-core/**",
       "words": [
         "TEAMPROJECTID"

--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client_models.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client_models.hpp
@@ -394,7 +394,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Certificat
   };
 
   /**
-   * @brief Content type of the certificate when downloaded from getecret.
+   * @brief Content type of the certificate when downloaded from getsecret.
    *
    */
   class CertificateContentType final {
@@ -977,7 +977,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Certificat
     Azure::Nullable<std::string> Id;
 
     /**
-     * @brief Organization Administators collection.
+     * @brief Organization Administrators collection.
      *
      */
     std::vector<AdministratorDetails> AdminDetails;


### PR DESCRIPTION
Discovered in https://dev.azure.com/azure-sdk/public/_build/results?buildId=2120396&view=logs&jobId=a129effc-2dd1-54d1-fb5a-ad7bdc0e851d&j=a129effc-2dd1-54d1-fb5a-ad7bdc0e851d&t=ccad100f-2904-5913-2083-c525ad929a03 from https://github.com/Azure/azure-sdk-for-cpp/pull/4134