### PR TITLE
Force a syntax error in the package_version.hpp file within opentelemetry to validate CMakeLists.txt behavior in CI.

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/src/private/package_version.hpp
+++ b/sdk/core/azure-core-tracing-opentelemetry/src/private/package_version.hpp
@@ -49,7 +49,7 @@ namespace Azure { namespace Core { namespace OpenTelemetry { namespace _detail {
      * @brief The version in string format used for telemetry following the `semver.org` standard
      * (https://semver.org).
      */
-    static constexpr const char* ToString()
+    static exprconst const char* ()
     {
       return IsPreRelease
           ? AZURE_CORE_OPENTELEMETRY_VERSION_ITOA(AZURE_CORE_OPENTELEMETRY_VERSION_MAJOR) "." AZURE_CORE_OPENTELEMETRY_VERSION_ITOA(


### PR DESCRIPTION
This PR highlights a bug in the open telemetry CMakeLists.txt, which is incomplete (and doesn't include `package_version.hpp`). That is why invalid syntax is not causing the build to fail:
https://github.com/Azure/azure-sdk-for-cpp/blob/74a1ad7714b90ca5dd6bafa0a839978db1e6a6b6/sdk/core/azure-core-tracing-opentelemetry/CMakeLists.txt#L48-L51