### PR TITLE
Move cspell exceptions in markdown file to metadata that isn't visible using html comment syntax

### DIFF
--- a/sdk/core/azure-core/test/ut/proxy_tests/readme.md
+++ b/sdk/core/azure-core/test/ut/proxy_tests/readme.md
@@ -1,6 +1,4 @@
----
-# cspell:words gunicorn Nlcjpw userx Nlcng dvcm passwordx userc
----
+<!-- cspell:words gunicorn Nlcjpw userx Nlcng dvcm passwordx userc -->
 
 # Create squid proxy docker container
 


### PR DESCRIPTION
Using the yaml format style results in cspell rendered as a heading:
https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core/test/ut/proxy_tests/readme.md
![image](https://user-images.githubusercontent.com/6527137/215907252-6587e8e5-4c7c-499f-aa76-8f2f6469d43a.png)

The proposed approach of using HTML style comments is used elsewhere and works well to hide the cspell metadata:
https://github.com/Azure/azure-sdk-for-cpp/blob/86aa9b4b0cfdef2af103ed2330064079ada68773/doc/DistributedTracing.md

This file was added in https://github.com/Azure/azure-sdk-for-cpp/pull/3885/files#diff-1095e427b74a8e81c60f5076953b3bf077c346068734a7157fd16b9301ab4a1bR2