### PR TITLE
Fix vcpkg install

### DIFF
--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -93,7 +93,7 @@ macro(az_vcpkg_export targetName macroNamePart dllImportExportHeaderPath)
   include(GNUInstallDirs)
 
   # When installing, copy our "inc" directory (headers) to "include" directory at the install location.
-  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/inc/" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/inc/azure/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/azure")
 
   # Copy license as "copyright" (vcpkg dictates naming and location).
   install(FILES "${AZ_ROOT_DIR}/LICENSE.txt" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/${targetName}-cpp" RENAME "copyright")


### PR DESCRIPTION
There is `ApiViewSetting.json` in each `inc` directory.
We install the contents of `inc` directory.
So when user installs multiple azure vcpkgs, there is a collision, because the file already exists, and build fails.

This fix is to install `inc/azure` directory into `{vcpkg_install_directory}/azure`, instead of simply `inc/*` into `{vcpkg_install_directory}`.

Better than that, there will no longer be `{vcpkg_install_directory}/ApiViewSettings.json` installed on user machines, which is not needed, especially in the include directory, especially at the root include level (i.e. before the fix they'd type `#include <`, and `ApiViewSettings.json` might have shown up)