### PR TITLE
proper regex for win 2022

### DIFF
--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -52,7 +52,7 @@ function getTargetOs {
         return "win-2019"
     }
 
-    if ($OsVMImage -match "^MMS2022$|^win-2022$") {
+    if ($OsVMImage -match "^MMS2022$|^win-2022$|^windows-2022$") {
         return "win-2022"
     }
 


### PR DESCRIPTION
The failing images that cause the error have an diffrent name for the  OsVMImage 'windows-2022'
need to account for that 
# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
