### PR TITLE
Trigger`keyvault` on proxy changes

### DIFF
--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -21,6 +21,7 @@ pr:
   paths:
     include:
       - sdk/keyvault
+      - eng/common/testproxy
 
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -20,6 +20,7 @@ pr:
   paths:
     include:
       - sdk/storage
+      - eng/common/testproxy
 
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
So I don't need to manually queue this anymore. I prefer to only merge updates to `eng/common/testproxy/target_version.txt` after a completed CI run from every major language that uses the proxy.

This PR just ensures that I don't need to remember to queue it manually anymore.