### PR TITLE
Update `CODEOWNERS` paths: fix invalid paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@
 /sdk/storage/            @vinjiang @katmsft @Jinming-Hu @EmmaZhu @antkmsft @vhvb1989 @gearama @LarryOsterman @microzchang
 
 # PRLabel: %EngSys
-/sdk/template/           @danieljurek @weshaggard
+/sdk/template/           @danieljurek @weshaggard @LarryOsterman @RickWinter 
 
 ################
 # Automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 ###########
 
 # Catch all for non-code project files and unowned files | folders
-/**                        @rickwinter @ahsonkhan @antkmsft @vhvb1989 @gearama @LarryOsterman
+/**                      @rickwinter @ahsonkhan @antkmsft @vhvb1989 @gearama @LarryOsterman
 /sdk/                    @rickwinter @ahsonkhan @antkmsft @vhvb1989 @gearama @LarryOsterman
 
 # Samples

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,12 @@
 # Instructions for CODEOWNERS file format and automatic build failure notifications:
 # https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners
 
-################
-# Automation
-################
-
-# Git Hub integration and bot rules
-/.github/                @jsquire @rickwinter @ronniegeraghty
-
 ###########
 # SDK
 ###########
 
 # Catch all for non-code project files and unowned files | folders
-*                        @rickwinter @ahsonkhan @antkmsft @vhvb1989 @gearama @LarryOsterman
+/**                        @rickwinter @ahsonkhan @antkmsft @vhvb1989 @gearama @LarryOsterman
 /sdk/                    @rickwinter @ahsonkhan @antkmsft @vhvb1989 @gearama @LarryOsterman
 
 # Samples
@@ -41,9 +34,14 @@
 # PRLabel: %EngSys
 /sdk/template/           @danieljurek @weshaggard
 
+################
+# Automation
+################
+
+# Git Hub integration and bot rules
+/.github/                @jsquire @rickwinter @ronniegeraghty
+
 ###########
 # Eng Sys
 ###########
 /eng/                    @danieljurek @weshaggard @benbp
-/**/ci.yml               @danieljurek
-/**/tests.yml            @danieljurek


### PR DESCRIPTION
As part of ongoing work of enabling wildcard support for `CODEOWNERS`:
- https://github.com/Azure/azure-sdk-tools/issues/2770
- https://github.com/Azure/azure-sdk-tools/pull/5088

and enabling stricter validation:
- https://github.com/Azure/azure-sdk-tools/issues/4859

this PR:
- fixes invalid paths, to match rules explained [here](https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners);
- removes `/**/tests.yml` and `/**/ci.yml`, to avoid all build failure notifications being routed to it once we enable the new regex-based, wildcard-supporting `CODEOWNERS` matcher, per: https://github.com/Azure/azure-sdk-tools/pull/5088#issuecomment-1397330147

Once this PR is merged, I will enable the new `CODEOWNERS` matcher, similar to how it was done for `net` repo by these two PRs:
- https://github.com/Azure/azure-sdk-tools/pull/5241
- https://github.com/Azure/azure-sdk-tools/pull/5240