### PR TITLE
Added support to ignore invalid cert common name

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added the ability to ignore invalid certificate common name for TLS connections in WinHTTP transport.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Added the ability to ignore invalid certificate common name for TLS connections in WinHTTP transport.
-- Added `SslVerifyPeer` in `TransportOptions`.
+- Added `DisableTlsCertificateValidation` in `TransportOptions`.
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added the ability to ignore invalid certificate common name for TLS connections in WinHTTP transport.
+- Added `SslVerifyPeer` in `TransportOptions`.
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -174,6 +174,14 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     bool EnableCertificateRevocationListCheck{false};
 
     /**
+     * @brief Verify peer's SSL certificate.
+     *
+     * @remark This field is only used if the customer has not specified a default transport
+     * adapter. If the customer has set a Transport adapter, this option is ignored.
+     */
+    bool SslVerifyPeer{true};
+
+    /**
      * @brief Base64 encoded DER representation of an X.509 certificate expected in the certificate
      * chain used in TLS connections.
      *

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -174,12 +174,17 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     bool EnableCertificateRevocationListCheck{false};
 
     /**
-     * @brief Verify peer's SSL certificate.
+     * @brief Disable SSL/TLS certificate verification. This option allows transport layer to
+     * perform insecure SSL/TLS connections and skip SSL/TLS certificate checks while still having
+     * SSL/TLS-encrypted communications.
+     *
+     * @remark Disabling TLS security is generally a bad idea because it allows malicious actors to
+     * spoof the target server and should never be enabled in production code.
      *
      * @remark This field is only used if the customer has not specified a default transport
      * adapter. If the customer has set a Transport adapter, this option is ignored.
      */
-    bool SslVerifyPeer{true};
+    bool DisableTlsCertificateValidation{false};
 
     /**
      * @brief Base64 encoded DER representation of an X.509 certificate expected in the certificate

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -71,6 +71,11 @@ namespace Azure { namespace Core {
       bool IgnoreUnknownCertificateAuthority{false};
 
       /**
+       * @brief When `true`, allows an invalid common name in a certificate.
+       */
+      bool IgnoreInvalidCertificateCommonName{false};
+
+      /**
        * Proxy information.
        */
 

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -311,7 +311,7 @@ Azure::Core::Http::CurlTransportOptions CurlTransportOptionsFromTransportOptions
     curlOptions.SslOptions.PemEncodedExpectedRootCertificates
         = PemEncodeFromBase64(transportOptions.ExpectedTlsRootCertificate, "CERTIFICATE");
   }
-  curlOptions.SslVerifyPeer = transportOptions.SslVerifyPeer;
+  curlOptions.SslVerifyPeer = !transportOptions.DisableTlsCertificateValidation;
   return curlOptions;
 }
 

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -311,6 +311,7 @@ Azure::Core::Http::CurlTransportOptions CurlTransportOptionsFromTransportOptions
     curlOptions.SslOptions.PemEncodedExpectedRootCertificates
         = PemEncodeFromBase64(transportOptions.ExpectedTlsRootCertificate, "CERTIFICATE");
   }
+  curlOptions.SslVerifyPeer = transportOptions.SslVerifyPeer;
   return curlOptions;
 }
 

--- a/sdk/core/azure-core/src/http/transport_policy.cpp
+++ b/sdk/core/azure-core/src/http/transport_policy.cpp
@@ -32,7 +32,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies { namespa
               || transportOptions.ProxyUserName.HasValue()
               || transportOptions.EnableCertificateRevocationListCheck
               || !transportOptions.ExpectedTlsRootCertificate.empty())
-          || !transportOptions.SslVerifyPeer;
+          || transportOptions.DisableTlsCertificateValidation;
     }
   } // namespace
 

--- a/sdk/core/azure-core/src/http/transport_policy.cpp
+++ b/sdk/core/azure-core/src/http/transport_policy.cpp
@@ -28,11 +28,11 @@ namespace Azure { namespace Core { namespace Http { namespace Policies { namespa
      */
     bool AreAnyTransportOptionsSpecified(TransportOptions const& transportOptions)
     {
-      return (
-          transportOptions.HttpProxy.HasValue() || transportOptions.ProxyPassword.HasValue()
-          || transportOptions.ProxyUserName.HasValue()
-          || transportOptions.EnableCertificateRevocationListCheck
-          || !transportOptions.ExpectedTlsRootCertificate.empty());
+      return (transportOptions.HttpProxy.HasValue() || transportOptions.ProxyPassword.HasValue()
+              || transportOptions.ProxyUserName.HasValue()
+              || transportOptions.EnableCertificateRevocationListCheck
+              || !transportOptions.ExpectedTlsRootCertificate.empty())
+          || !transportOptions.SslVerifyPeer;
     }
   } // namespace
 

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -918,6 +918,16 @@ _detail::WinHttpRequest::WinHttpRequest(
     }
   }
 
+  if (options.IgnoreInvalidCertificateCommonName)
+  {
+    auto option = SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
+    if (!WinHttpSetOption(
+            m_requestHandle.get(), WINHTTP_OPTION_SECURITY_FLAGS, &option, sizeof(option)))
+    {
+      GetErrorAndThrow("Error while setting ignore invalid certificate common name.");
+    }
+  }
+
   if (options.EnableCertificateRevocationListCheck)
   {
     DWORD value = WINHTTP_ENABLE_SSL_REVOCATION;

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -765,6 +765,12 @@ WinHttpTransportOptions WinHttpTransportOptionsFromTransportOptions(
     httpOptions.IgnoreUnknownCertificateAuthority = true;
   }
 
+  if (!transportOptions.SslVerifyPeer)
+  {
+    httpOptions.IgnoreUnknownCertificateAuthority = true;
+    httpOptions.IgnoreInvalidCertificateCommonName = true;
+  }
+
   return httpOptions;
 }
 } // namespace

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -765,7 +765,7 @@ WinHttpTransportOptions WinHttpTransportOptionsFromTransportOptions(
     httpOptions.IgnoreUnknownCertificateAuthority = true;
   }
 
-  if (!transportOptions.SslVerifyPeer)
+  if (transportOptions.DisableTlsCertificateValidation)
   {
     httpOptions.IgnoreUnknownCertificateAuthority = true;
     httpOptions.IgnoreInvalidCertificateCommonName = true;


### PR DESCRIPTION
We need this feature when using storage library in Azure Storage server-side codebase. TLS certificate used for testing is self-signed. Service needs to be accessed via multiple hostnames including localhost, so we need to be able to ignore CN mismatch errors.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?

