### PR TITLE
Use 1ES pool in platform-matrix.json

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -79,7 +79,7 @@
       "StaticConfigs": {
         "Win2022": {
           "OSVmImage": "windows-2022",
-          "Pool": "Azure Pipelines",
+          "Pool": "azsdk-pool-mms-win-2022-general",
           "RunProxyTests": true,
           "CMAKE_GENERATOR": "Visual Studio 17 2022"
         }


### PR DESCRIPTION
All Windows and Linux pipelines should use 1ES pools by default, unless they need to run in the DevOps Pool for a specific reason.

However, it appears these jobs need to run in the DevOps pool.  Step "Install WSL on Windows hosts when proxy tests are enabled" fails in the 1ES pool, but it succeeds in the DevOps pool (#4215).

In #4215, we thought the issue was the 1ES images were behind the DevOps images, but if this was working in DevOps as of 12/30/22, I would expect it to be working in 1ES by now.