### PR TITLE
fix unstable storage tests

### DIFF
--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -1699,7 +1699,10 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(
           blobClient.UploadFrom(blobContent.data(), static_cast<size_t>(bufferSize), options));
       std::vector<uint8_t> downloadBuffer(static_cast<size_t>(bufferSize), '\x00');
-      blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      Blobs::DownloadBlobToOptions downloadOptions;
+      downloadOptions.TransferOptions.Concurrency = 1;
+      ASSERT_NO_THROW(
+          blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), downloadOptions));
       std::vector<uint8_t> expectedData(
           blobContent.begin(), blobContent.begin() + static_cast<size_t>(bufferSize));
       EXPECT_EQ(downloadBuffer, expectedData);
@@ -1729,7 +1732,10 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(blobClient.UploadFrom(tempFileName, options));
       DeleteFile(tempFileName);
       std::vector<uint8_t> downloadBuffer(static_cast<size_t>(fileSize), '\x00');
-      blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      Blobs::DownloadBlobToOptions downloadOptions;
+      downloadOptions.TransferOptions.Concurrency = 1;
+      ASSERT_NO_THROW(
+          blobClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), downloadOptions));
       std::vector<uint8_t> expectedData(
           blobContent.begin(), blobContent.begin() + static_cast<size_t>(fileSize));
       EXPECT_EQ(downloadBuffer, expectedData);

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
@@ -830,7 +830,10 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(
           fileClient.UploadFrom(blobContent.data(), static_cast<size_t>(bufferSize), options));
       std::vector<uint8_t> downloadBuffer(static_cast<size_t>(bufferSize), '\x00');
-      fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      Files::DataLake::DownloadFileToOptions downloadOptions;
+      downloadOptions.TransferOptions.Concurrency = 1;
+      ASSERT_NO_THROW(
+          fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), downloadOptions));
       std::vector<uint8_t> expectedData(
           blobContent.begin(), blobContent.begin() + static_cast<size_t>(bufferSize));
       EXPECT_EQ(downloadBuffer, expectedData);
@@ -860,7 +863,10 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(fileClient.UploadFrom(tempFileName, options));
       DeleteFile(tempFileName);
       std::vector<uint8_t> downloadBuffer(static_cast<size_t>(fileSize), '\x00');
-      fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      Files::DataLake::DownloadFileToOptions downloadOptions;
+      downloadOptions.TransferOptions.Concurrency = 1;
+      ASSERT_NO_THROW(
+          fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), downloadOptions));
       std::vector<uint8_t> expectedData(
           blobContent.begin(), blobContent.begin() + static_cast<size_t>(fileSize));
       EXPECT_EQ(downloadBuffer, expectedData);

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
@@ -392,7 +392,10 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(
           fileClient.UploadFrom(blobContent.data(), static_cast<size_t>(bufferSize), options));
       std::vector<uint8_t> downloadBuffer(static_cast<size_t>(bufferSize), '\x00');
-      fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      Files::Shares::DownloadFileToOptions downloadOptions;
+      downloadOptions.TransferOptions.Concurrency = 1;
+      ASSERT_NO_THROW(
+          fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), downloadOptions));
       std::vector<uint8_t> expectedData(
           blobContent.begin(), blobContent.begin() + static_cast<size_t>(bufferSize));
       EXPECT_EQ(downloadBuffer, expectedData);
@@ -422,7 +425,10 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NO_THROW(fileClient.UploadFrom(tempFileName, options));
       DeleteFile(tempFileName);
       std::vector<uint8_t> downloadBuffer(static_cast<size_t>(fileSize), '\x00');
-      fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size());
+      Files::Shares::DownloadFileToOptions downloadOptions;
+      downloadOptions.TransferOptions.Concurrency = 1;
+      ASSERT_NO_THROW(
+          fileClient.DownloadTo(downloadBuffer.data(), downloadBuffer.size(), downloadOptions));
       std::vector<uint8_t> expectedData(
           blobContent.begin(), blobContent.begin() + static_cast<size_t>(fileSize));
       EXPECT_EQ(downloadBuffer, expectedData);


### PR DESCRIPTION
Reduce number of concurrent requests during testing.
This hopefully fixes https://github.com/Azure/azure-sdk-for-cpp/issues/4405

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
