### PR TITLE
Tests: replace most `EXPECT_TRUE(a OP b)` with `EXPECT_OP(a, b)`

### DIFF
--- a/sdk/attestation/azure-security-attestation/test/ut/token_test.cpp
+++ b/sdk/attestation/azure-security-attestation/test/ut/token_test.cpp
@@ -431,7 +431,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
       auto serializedObject = TestObjectSerializer::Serialize(testObject);
 
       auto targetObject = TestObjectSerializer::Deserialize(json::parse(serializedObject));
-      EXPECT_TRUE(testObject == targetObject);
+      EXPECT_EQ(testObject, targetObject);
     }
   }
 

--- a/sdk/core/azure-core-tracing-opentelemetry/test/ut/service_support_test.cpp
+++ b/sdk/core/azure-core-tracing-opentelemetry/test/ut/service_support_test.cpp
@@ -194,14 +194,14 @@ protected:
       // Make sure that every expected attribute is somewhere in the actual attributes.
       for (auto const& expectedAttribute : expectedAttributes.items())
       {
-        EXPECT_TRUE(
+        EXPECT_NE(
             std::find_if(
                 attributes.begin(),
                 attributes.end(),
                 [&](std::pair<const std::string, RecordedSpan::Attribute>& item) {
                   return item.first == expectedAttribute.key();
-                })
-            != attributes.end());
+                }),
+            attributes.end());
       }
 
       for (auto const& foundAttribute : attributes)

--- a/sdk/core/azure-core/test/ut/context_test.cpp
+++ b/sdk/core/azure-core/test/ut/context_test.cpp
@@ -33,7 +33,7 @@ TEST(Context, BasicBool)
   auto c2 = context.WithValue(key, true);
   bool value{};
   EXPECT_TRUE(c2.TryGetValue<bool>(key, value));
-  EXPECT_TRUE(value == true);
+  EXPECT_TRUE(value);
 
   Context::Key const anotherKey;
   auto c3 = c2.WithValue(anotherKey, std::make_shared<bool>(true));
@@ -56,7 +56,7 @@ TEST(Context, BasicInt)
   auto c2 = context.WithValue(key, 123);
   int value;
   EXPECT_TRUE(c2.TryGetValue<int>(key, value));
-  EXPECT_TRUE(value == 123);
+  EXPECT_EQ(value, 123);
 }
 
 TEST(Context, BasicStdString)
@@ -67,10 +67,10 @@ TEST(Context, BasicStdString)
   Context::Key const key;
 
   // New context from previous
-  auto c2 = context.WithValue(key, s);
+  auto c2 = context.WithValue<std::string&>(key, s);
   std::string value;
   EXPECT_TRUE(c2.TryGetValue<std::string>(key, value));
-  EXPECT_TRUE(value == s);
+  EXPECT_EQ(value, s);
 }
 
 TEST(Context, BasicChar)
@@ -85,8 +85,8 @@ TEST(Context, BasicChar)
   auto c2 = context.WithValue(key, str);
   const char* value;
   EXPECT_TRUE(c2.TryGetValue<const char*>(key, value));
-  EXPECT_TRUE(value == s);
-  EXPECT_TRUE(value == str);
+  EXPECT_EQ(value, s);
+  EXPECT_EQ(value, str);
 }
 
 TEST(Context, IsCancelled)
@@ -206,13 +206,13 @@ TEST(Context, Chain)
   const char* valueT8;
   EXPECT_TRUE(finalContext.TryGetValue<const char*>(keyFinal, valueT8));
 
-  EXPECT_TRUE(valueT2 == 123);
-  EXPECT_TRUE(valueT3 == 456);
-  EXPECT_TRUE(valueT4 == 789);
-  EXPECT_TRUE(valueT5 == std::string("5"));
-  EXPECT_TRUE(valueT6 == std::string("6"));
-  EXPECT_TRUE(valueT7 == std::string("7"));
-  EXPECT_TRUE(valueT8 == std::string("Final"));
+  EXPECT_EQ(valueT2, 123);
+  EXPECT_EQ(valueT3, 456);
+  EXPECT_EQ(valueT4, 789);
+  EXPECT_EQ(valueT5, std::string("5"));
+  EXPECT_EQ(valueT6, std::string("6"));
+  EXPECT_EQ(valueT7, std::string("7"));
+  EXPECT_EQ(valueT8, std::string("Final"));
 }
 
 TEST(Context, MatchingKeys)
@@ -229,8 +229,8 @@ TEST(Context, MatchingKeys)
   int valueT3;
   EXPECT_TRUE(c3.TryGetValue<int>(key, valueT3));
 
-  EXPECT_TRUE(valueT2 == 123);
-  EXPECT_TRUE(valueT3 == 456);
+  EXPECT_EQ(valueT2, 123);
+  EXPECT_EQ(valueT3, 456);
 }
 
 struct SomeStructForContext final
@@ -492,10 +492,10 @@ TEST(Context, KeyTypePairPrecondition)
 #endif
 #endif
 
-  EXPECT_TRUE(strValue == "previous value");
+  EXPECT_EQ(strValue, "previous value");
 
   EXPECT_TRUE(c2.TryGetValue<int>(key, intValue));
-  EXPECT_TRUE(intValue == 123);
+  EXPECT_EQ(intValue, 123);
 
 #if GTEST_HAS_DEATH_TEST
 // Type-safe assert requires RTTI build
@@ -509,8 +509,8 @@ TEST(Context, KeyTypePairPrecondition)
 #endif
 #endif
 
-  EXPECT_TRUE(intValue == 123);
+  EXPECT_EQ(intValue, 123);
 
   EXPECT_TRUE(c3.TryGetValue<std::string>(key, strValue));
-  EXPECT_TRUE(strValue == s);
+  EXPECT_EQ(strValue, s);
 }

--- a/sdk/core/azure-core/test/ut/context_test.cpp
+++ b/sdk/core/azure-core/test/ut/context_test.cpp
@@ -67,7 +67,7 @@ TEST(Context, BasicStdString)
   Context::Key const key;
 
   // New context from previous
-  auto c2 = context.WithValue<std::string&>(key, s);
+  auto c2 = context.WithValue(key, s);
   std::string value;
   EXPECT_TRUE(c2.TryGetValue<std::string>(key, value));
   EXPECT_EQ(value, s);

--- a/sdk/core/azure-core/test/ut/nullable_test.cpp
+++ b/sdk/core/azure-core/test/ut/nullable_test.cpp
@@ -12,15 +12,15 @@ TEST(Nullable, Basic)
 {
   Nullable<std::string> testString{"hello world"};
   EXPECT_TRUE(testString.HasValue());
-  EXPECT_TRUE(testString.Value() == "hello world");
+  EXPECT_EQ(testString.Value(), "hello world");
 
   Nullable<int> testInt{54321};
   EXPECT_TRUE(testInt.HasValue());
-  EXPECT_TRUE(testInt.Value() == 54321);
+  EXPECT_EQ(testInt.Value(), 54321);
 
   Nullable<double> testDouble{10.0};
   EXPECT_TRUE(testDouble.HasValue());
-  EXPECT_TRUE(testDouble.Value() == 10.0);
+  EXPECT_EQ(testDouble.Value(), 10.0);
 }
 
 TEST(Nullable, Empty)
@@ -55,18 +55,18 @@ TEST(Nullable, Assignment)
   Nullable<std::string> instance{"hello world"};
   auto instance2 = instance;
   EXPECT_TRUE(instance2.HasValue());
-  EXPECT_TRUE(instance2.Value() == "hello world");
+  EXPECT_EQ(instance2.Value(), "hello world");
 
   auto instance3 = std::move(instance);
   EXPECT_TRUE(instance3.HasValue());
-  EXPECT_TRUE(instance3.Value() == "hello world");
+  EXPECT_EQ(instance3.Value(), "hello world");
 
   EXPECT_TRUE(instance.HasValue());
 
   // This is not a guarantee that the string will be empty
   //  It is an implementation detail that the contents are moved
   //  Should a future compiler change this assumption this test will need updates
-  EXPECT_TRUE(instance.Value() == "");
+  EXPECT_EQ(instance.Value(), "");
   EXPECT_TRUE(instance.HasValue());
 }
 
@@ -76,22 +76,22 @@ TEST(Nullable, ValueAssignment)
   EXPECT_FALSE(intVal.HasValue());
   intVal = 7;
   EXPECT_TRUE(intVal.HasValue());
-  EXPECT_TRUE(intVal.Value() == 7);
+  EXPECT_EQ(intVal.Value(), 7);
 
   Nullable<double> doubleVal;
   EXPECT_FALSE(doubleVal.HasValue());
   doubleVal = 10.12345;
   EXPECT_TRUE(doubleVal.HasValue());
-  EXPECT_TRUE(doubleVal.Value() == 10.12345);
+  EXPECT_EQ(doubleVal.Value(), 10.12345);
 
   Nullable<std::string> strVal;
   EXPECT_FALSE(strVal.HasValue());
   strVal = std::string("Hello World");
   EXPECT_TRUE(strVal.HasValue());
-  EXPECT_TRUE(strVal.Value() == "Hello World");
+  EXPECT_EQ(strVal.Value(), "Hello World");
 
   strVal = "New String";
-  EXPECT_TRUE(strVal.Value() == "New String");
+  EXPECT_EQ(strVal.Value(), "New String");
 
   strVal.Reset();
   EXPECT_FALSE(strVal.HasValue());
@@ -111,13 +111,13 @@ TEST(Nullable, Swap)
   val3.Swap(val4);
   EXPECT_TRUE(val3);
   EXPECT_TRUE(val4);
-  EXPECT_TRUE(val3.Value() == 678910);
-  EXPECT_TRUE(val4.Value() == 12345);
+  EXPECT_EQ(val3.Value(), 678910);
+  EXPECT_EQ(val4.Value(), 12345);
 
   val1.Swap(val3);
   EXPECT_TRUE(val1);
   EXPECT_FALSE(val3);
-  EXPECT_TRUE(val1.Value() == 678910);
+  EXPECT_EQ(val1.Value(), 678910);
   EXPECT_FALSE(val3.HasValue());
 }
 
@@ -134,19 +134,19 @@ TEST(Nullable, CopyConstruction)
   Nullable<int> val4(val3);
   EXPECT_TRUE(val3);
   EXPECT_TRUE(val4);
-  EXPECT_TRUE(val3.Value() == 12345);
-  EXPECT_TRUE(val4.Value() == 12345);
+  EXPECT_EQ(val3.Value(), 12345);
+  EXPECT_EQ(val4.Value(), 12345);
 
   // Literal
   Nullable<int> val5 = 54321;
   EXPECT_TRUE(val5);
-  EXPECT_TRUE(val5.Value() == 54321);
+  EXPECT_EQ(val5.Value(), 54321);
 
   // Value
   const int i = 1;
   Nullable<int> val6(i);
   EXPECT_TRUE(val6);
-  EXPECT_TRUE(val6.Value() == 1);
+  EXPECT_EQ(val6.Value(), 1);
 }
 
 TEST(Nullable, Disengage)
@@ -162,12 +162,12 @@ TEST(Nullable, ValueOr)
   Nullable<int> val2;
 
   EXPECT_TRUE(val1);
-  EXPECT_TRUE(val1.ValueOr(678910) == 12345);
+  EXPECT_EQ(val1.ValueOr(678910), 12345);
   // Ensure the value was unmodified in ValueOr
-  EXPECT_TRUE(val1.Value() == 12345);
+  EXPECT_EQ(val1.Value(), 12345);
 
   EXPECT_FALSE(val2);
-  EXPECT_TRUE(val2.ValueOr(678910) == 678910);
+  EXPECT_EQ(val2.ValueOr(678910), 678910);
   // Ensure val2 is still disengaged after call to ValueOr
   EXPECT_FALSE(val2);
 }

--- a/sdk/core/azure-core/test/ut/operation_test.cpp
+++ b/sdk/core/azure-core/test/ut/operation_test.cpp
@@ -51,7 +51,7 @@ TEST(Operation, PollUntilDone)
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double, std::milli> elapsed = end - start;
   // StringOperation test code is implemented to poll 2 times
-  EXPECT_TRUE(elapsed >= 1s);
+  EXPECT_GE(elapsed, 1s);
 
   EXPECT_TRUE(operation.IsDone());
   EXPECT_TRUE(operation.HasValue());

--- a/sdk/core/azure-core/test/ut/string_test.cpp
+++ b/sdk/core/azure-core/test/ut/string_test.cpp
@@ -16,6 +16,7 @@ TEST(String, invariantCompare)
   EXPECT_TRUE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("AA", "aa"));
   EXPECT_TRUE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("aA", "aa"));
   EXPECT_TRUE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("ABC", "abc"));
+
   EXPECT_FALSE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("", "a"));
   EXPECT_FALSE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("a", ""));
   EXPECT_FALSE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("A", "aA"));
@@ -28,7 +29,7 @@ TEST(String, toLowerC)
   for (unsigned i = 0; i <= 255; ++i)
   {
     auto const c = static_cast<char>(static_cast<unsigned char>(i));
-    EXPECT_TRUE(StringExtensions::ToLower(c) == std::tolower(c, std::locale::classic()));
+    EXPECT_EQ(StringExtensions::ToLower(c), std::tolower(c, std::locale::classic()));
   }
 }
 
@@ -38,46 +39,44 @@ TEST(String, toUpperC)
   for (unsigned i = 0; i <= 255; ++i)
   {
     auto const c = static_cast<char>(static_cast<unsigned char>(i));
-    EXPECT_TRUE(StringExtensions::ToUpper(c) == std::toupper(c, std::locale::classic()));
+    EXPECT_EQ(StringExtensions::ToUpper(c), std::toupper(c, std::locale::classic()));
   }
 }
 
 TEST(String, toLower)
 {
   using Azure::Core::_internal::StringExtensions;
-  EXPECT_TRUE(StringExtensions::ToLower("") == "");
-  EXPECT_TRUE(StringExtensions::ToLower("a") == "a");
-  EXPECT_TRUE(StringExtensions::ToLower("A") == "a");
-  EXPECT_TRUE(StringExtensions::ToLower("AA") == "aa");
-  EXPECT_TRUE(StringExtensions::ToLower("aA") == "aa");
-  EXPECT_TRUE(StringExtensions::ToLower("ABC") == "abc");
-  EXPECT_TRUE(
-      StringExtensions::ToLower("abcdefghijklmnopqrstuvwxyz") == "abcdefghijklmnopqrstuvwxyz");
-  EXPECT_TRUE(
-      StringExtensions::ToLower("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == "abcdefghijklmnopqrstuvwxyz");
-  EXPECT_TRUE(StringExtensions::ToLower("ABC-1-,!@#$%^&*()_+=ABC") == "abc-1-,!@#$%^&*()_+=abc");
-  EXPECT_FALSE(StringExtensions::ToLower("") == "a");
-  EXPECT_FALSE(StringExtensions::ToLower("a") == "");
-  EXPECT_FALSE(StringExtensions::ToLower("a") == "aA");
-  EXPECT_FALSE(StringExtensions::ToLower("abc") == "abcd");
+  EXPECT_EQ(StringExtensions::ToLower(""), "");
+  EXPECT_EQ(StringExtensions::ToLower("a"), "a");
+  EXPECT_EQ(StringExtensions::ToLower("A"), "a");
+  EXPECT_EQ(StringExtensions::ToLower("AA"), "aa");
+  EXPECT_EQ(StringExtensions::ToLower("aA"), "aa");
+  EXPECT_EQ(StringExtensions::ToLower("ABC"), "abc");
+  EXPECT_EQ(StringExtensions::ToLower("abcdefghijklmnopqrstuvwxyz"), "abcdefghijklmnopqrstuvwxyz");
+  EXPECT_EQ(StringExtensions::ToLower("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "abcdefghijklmnopqrstuvwxyz");
+  EXPECT_EQ(StringExtensions::ToLower("ABC-1-,!@#$%^&*()_+=ABC"), "abc-1-,!@#$%^&*()_+=abc");
+
+  EXPECT_NE(StringExtensions::ToLower(""), "a");
+  EXPECT_NE(StringExtensions::ToLower("a"), "");
+  EXPECT_NE(StringExtensions::ToLower("a"), "aA");
+  EXPECT_NE(StringExtensions::ToLower("abc"), "abcd");
 }
 
 TEST(String, toUpper)
 {
   using Azure::Core::_internal::StringExtensions;
-  EXPECT_TRUE(StringExtensions::ToUpper("") == "");
-  EXPECT_TRUE(StringExtensions::ToUpper("a") == "A");
-  EXPECT_TRUE(StringExtensions::ToUpper("A") == "A");
-  EXPECT_TRUE(StringExtensions::ToUpper("AA") == "AA");
-  EXPECT_TRUE(StringExtensions::ToUpper("aA") == "AA");
-  EXPECT_TRUE(
-      StringExtensions::ToUpper("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
-  EXPECT_TRUE(StringExtensions::ToUpper("ABC") == "ABC");
-  EXPECT_TRUE(
-      StringExtensions::ToUpper("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
-  EXPECT_TRUE(StringExtensions::ToUpper("ABC-1-,!@#$%^&*()_+=ABC") == "ABC-1-,!@#$%^&*()_+=ABC");
-  EXPECT_FALSE(StringExtensions::ToUpper("") == "A");
-  EXPECT_FALSE(StringExtensions::ToUpper("a") == "");
-  EXPECT_FALSE(StringExtensions::ToUpper("a") == "aA");
-  EXPECT_FALSE(StringExtensions::ToUpper("abc") == "abcd");
+  EXPECT_EQ(StringExtensions::ToUpper(""), "");
+  EXPECT_EQ(StringExtensions::ToUpper("a"), "A");
+  EXPECT_EQ(StringExtensions::ToUpper("A"), "A");
+  EXPECT_EQ(StringExtensions::ToUpper("AA"), "AA");
+  EXPECT_EQ(StringExtensions::ToUpper("aA"), "AA");
+  EXPECT_EQ(StringExtensions::ToUpper("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  EXPECT_EQ(StringExtensions::ToUpper("ABC"), "ABC");
+  EXPECT_EQ(StringExtensions::ToUpper("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  EXPECT_EQ(StringExtensions::ToUpper("ABC-1-,!@#$%^&*()_+=ABC"), "ABC-1-,!@#$%^&*()_+=ABC");
+
+  EXPECT_NE(StringExtensions::ToUpper(""), "A");
+  EXPECT_NE(StringExtensions::ToUpper("a"), "");
+  EXPECT_NE(StringExtensions::ToUpper("a"), "aA");
+  EXPECT_NE(StringExtensions::ToUpper("abc"), "abcd");
 }

--- a/sdk/core/azure-core/test/ut/transport_adapter_base_test.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base_test.cpp
@@ -84,7 +84,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // Check content-length header to be greater than 0
     int64_t contentLengthHeader = std::stoull(response->GetHeaders().at("content-length"));
-    EXPECT_TRUE(contentLengthHeader > 0);
+    EXPECT_GT(contentLengthHeader, 0);
   }
 
   TEST_P(TransportAdapter, put)
@@ -221,7 +221,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // Check content-length header to be greater than 0
     int64_t contentLengthHeader = std::stoull(response->GetHeaders().at("content-length"));
-    EXPECT_TRUE(contentLengthHeader > 0);
+    EXPECT_GT(contentLengthHeader, 0);
   }
 
   TEST_P(TransportAdapter, putWithStream)
@@ -301,7 +301,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Response<std::string> responseT(expectedType, std::move(response));
     auto& r = responseT.RawResponse;
 
-    EXPECT_TRUE(r->GetStatusCode() == Azure::Core::Http::HttpStatusCode::Ok);
+    EXPECT_EQ(r->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
     auto expectedResponseBodySize = std::stoull(r->GetHeaders().at("content-length"));
     CheckBodyFromBuffer(*r, expectedResponseBodySize);
 

--- a/sdk/core/azure-core/test/ut/uuid_test.cpp
+++ b/sdk/core/azure-core/test/ut/uuid_test.cpp
@@ -11,7 +11,7 @@ using namespace Azure::Core;
 TEST(Uuid, Basic)
 {
   auto uuid = Uuid::CreateUuid();
-  EXPECT_TRUE(uuid.ToString().length() == 36);
+  EXPECT_EQ(uuid.ToString().length(), 36);
 }
 
 TEST(Uuid, Randomness)
@@ -25,7 +25,7 @@ TEST(Uuid, Randomness)
     // ret.second == false means the insert failed.
     EXPECT_TRUE(ret.second);
   }
-  EXPECT_TRUE(uuids.size() == size);
+  EXPECT_EQ(uuids.size(), size);
 }
 
 TEST(Uuid, separatorPosition)

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_cryptographic_client_test_live.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_cryptographic_client_test_live.cpp
@@ -37,7 +37,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteEncrypt)
         = cryptoClient->Encrypt(EncryptParameters::RsaOaepParameters(plaintext)).Value;
     EXPECT_EQ(encryptResult.Algorithm.ToString(), EncryptionAlgorithm::RsaOaep.ToString());
     EXPECT_EQ(encryptResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(encryptResult.Ciphertext.size() > 0);
+    EXPECT_GT(encryptResult.Ciphertext.size(), 0);
 
     auto decryptResult
         = cryptoClient->Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext))
@@ -68,7 +68,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteWrap)
     auto wrapResult = cryptoClient->WrapKey(KeyWrapAlgorithm::RsaOaep256, plaintext).Value;
     EXPECT_EQ(wrapResult.Algorithm.ToString(), KeyWrapAlgorithm::RsaOaep256.ToString());
     EXPECT_EQ(wrapResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(wrapResult.EncryptedKey.size() > 0);
+    EXPECT_GT(wrapResult.EncryptedKey.size(), 0);
 
     auto unwrapResult
         = cryptoClient->UnwrapKey(wrapResult.Algorithm, wrapResult.EncryptedKey).Value;
@@ -102,7 +102,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyRSA256)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -121,7 +121,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyRSA256)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -152,7 +152,7 @@ TEST_F(KeyVaultKeyClient, RemoteSignVerifyES256)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, ecKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -176,7 +176,7 @@ TEST_F(KeyVaultKeyClient, RemoteSignVerifyES256)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, ecKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -210,7 +210,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyRSA384)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -229,7 +229,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyRSA384)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -260,7 +260,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyDataRSA256)
     auto signResult = cryptoClient->SignData(signatureAlgorithm, data).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0);
 
     auto verifyResult
         = cryptoClient->VerifyData(signResult.Algorithm, data, signResult.Signature).Value;
@@ -275,7 +275,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyDataRSA256)
     auto signResult = cryptoClient->SignData(signatureAlgorithm, data).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0);
 
     auto verifyResult
         = cryptoClient->VerifyData(signResult.Algorithm, data, signResult.Signature).Value;
@@ -305,7 +305,7 @@ TEST_P(KeyVaultKeyClientWithParam, GetCryptoFromKeyRemoteEncrypt)
         = cryptoClient.Encrypt(EncryptParameters::RsaOaepParameters(plaintext)).Value;
     EXPECT_EQ(encryptResult.Algorithm.ToString(), EncryptionAlgorithm::RsaOaep.ToString());
     EXPECT_EQ(encryptResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(encryptResult.Ciphertext.size() > 0);
+    EXPECT_GT(encryptResult.Ciphertext.size(), 0);
 
     auto decryptResult
         = cryptoClient.Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext))
@@ -336,7 +336,7 @@ TEST_P(KeyVaultKeyClientWithParam, GetCryptoFromKeyVersionRemoteEncrypt)
         = cryptoClient.Encrypt(EncryptParameters::RsaOaepParameters(plaintext)).Value;
     EXPECT_EQ(encryptResult.Algorithm.ToString(), EncryptionAlgorithm::RsaOaep.ToString());
     EXPECT_EQ(encryptResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(encryptResult.Ciphertext.size() > 0);
+    EXPECT_GT(encryptResult.Ciphertext.size(), 0);
 
     auto decryptResult
         = cryptoClient.Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext))

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.cpp
@@ -301,12 +301,12 @@ namespace Azure { namespace Storage { namespace Test {
       Files::Shares::ShareLeaseClient leaseClient(*m_shareClient, leaseId1);
       auto aLease = leaseClient.Acquire(leaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
       lastModified = m_shareClient->GetProperties().Value.LastModified;
       aLease = leaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
 
       auto properties = m_shareClient->GetProperties().Value;
@@ -316,7 +316,7 @@ namespace Azure { namespace Storage { namespace Test {
       lastModified = m_shareClient->GetProperties().Value.LastModified;
       auto rLease = leaseClient.Renew().Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(rLease.LeaseId, leaseId1);
 
       lastModified = m_shareClient->GetProperties().Value.LastModified;
@@ -324,14 +324,14 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NE(leaseId1, leaseId2);
       auto cLease = leaseClient.Change(leaseId2).Value;
       EXPECT_TRUE(cLease.ETag.HasValue());
-      EXPECT_TRUE(cLease.LastModified >= lastModified);
+      EXPECT_GE(cLease.LastModified, lastModified);
       EXPECT_EQ(cLease.LeaseId, leaseId2);
       EXPECT_EQ(leaseClient.GetLeaseId(), leaseId2);
 
       lastModified = m_shareClient->GetProperties().Value.LastModified;
       auto relLease = leaseClient.Release().Value;
       EXPECT_TRUE(relLease.ETag.HasValue());
-      EXPECT_TRUE(relLease.LastModified >= lastModified);
+      EXPECT_GE(relLease.LastModified, lastModified);
     }
 
     {
@@ -343,7 +343,7 @@ namespace Azure { namespace Storage { namespace Test {
           Files::Shares::Models::LeaseDurationType::Infinite, properties.LeaseDuration.Value());
       auto brokenLease = leaseClient.Break().Value;
       EXPECT_TRUE(brokenLease.ETag.HasValue());
-      EXPECT_TRUE(brokenLease.LastModified >= properties.LastModified);
+      EXPECT_GE(brokenLease.LastModified, properties.LastModified);
     }
   }
 
@@ -358,14 +358,14 @@ namespace Azure { namespace Storage { namespace Test {
       Files::Shares::ShareLeaseClient shareSnapshotLeaseClient(shareSnapshot, leaseId1);
       auto aLease = shareSnapshotLeaseClient.Acquire(leaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
       lastModified = shareSnapshot.GetProperties().Value.LastModified;
       aLease
           = shareSnapshotLeaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration)
                 .Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
 
       auto properties = shareSnapshot.GetProperties().Value;
@@ -375,7 +375,7 @@ namespace Azure { namespace Storage { namespace Test {
       lastModified = shareSnapshot.GetProperties().Value.LastModified;
       auto rLease = shareSnapshotLeaseClient.Renew().Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(rLease.LeaseId, leaseId1);
 
       lastModified = shareSnapshot.GetProperties().Value.LastModified;
@@ -383,14 +383,14 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NE(leaseId1, leaseId2);
       auto cLease = shareSnapshotLeaseClient.Change(leaseId2).Value;
       EXPECT_TRUE(cLease.ETag.HasValue());
-      EXPECT_TRUE(cLease.LastModified >= lastModified);
+      EXPECT_GE(cLease.LastModified, lastModified);
       EXPECT_EQ(cLease.LeaseId, leaseId2);
       EXPECT_EQ(shareSnapshotLeaseClient.GetLeaseId(), leaseId2);
 
       lastModified = shareSnapshot.GetProperties().Value.LastModified;
       auto relLease = shareSnapshotLeaseClient.Release().Value;
       EXPECT_TRUE(relLease.ETag.HasValue());
-      EXPECT_TRUE(relLease.LastModified >= lastModified);
+      EXPECT_GE(relLease.LastModified, lastModified);
     }
 
     {
@@ -403,7 +403,7 @@ namespace Azure { namespace Storage { namespace Test {
           Files::Shares::Models::LeaseDurationType::Infinite, properties.LeaseDuration.Value());
       auto brokenLease = shareSnapshotLeaseClient.Break().Value;
       EXPECT_TRUE(brokenLease.ETag.HasValue());
-      EXPECT_TRUE(brokenLease.LastModified >= properties.LastModified);
+      EXPECT_GE(brokenLease.LastModified, properties.LastModified);
       shareSnapshotLeaseClient.Release();
     }
 

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
@@ -330,12 +330,12 @@ namespace Azure { namespace Storage { namespace Test {
       auto aLease
           = leaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
       lastModified = m_fileClient->GetProperties().Value.LastModified;
       aLease = leaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
 
       auto properties = m_fileClient->GetProperties().Value;
@@ -347,14 +347,14 @@ namespace Azure { namespace Storage { namespace Test {
       lastModified = m_fileClient->GetProperties().Value.LastModified;
       auto cLease = leaseClient.Change(leaseId2).Value;
       EXPECT_TRUE(cLease.ETag.HasValue());
-      EXPECT_TRUE(cLease.LastModified >= lastModified);
+      EXPECT_GE(cLease.LastModified, lastModified);
       EXPECT_EQ(cLease.LeaseId, leaseId2);
       EXPECT_EQ(leaseClient.GetLeaseId(), leaseId2);
 
       lastModified = m_fileClient->GetProperties().Value.LastModified;
       auto fileInfo = leaseClient.Release().Value;
       EXPECT_TRUE(fileInfo.ETag.HasValue());
-      EXPECT_TRUE(fileInfo.LastModified >= lastModified);
+      EXPECT_GE(fileInfo.LastModified, lastModified);
     }
 
     {
@@ -365,7 +365,7 @@ namespace Azure { namespace Storage { namespace Test {
       auto lastModified = m_fileClient->GetProperties().Value.LastModified;
       auto brokenLease = leaseClient.Break().Value;
       EXPECT_TRUE(brokenLease.ETag.HasValue());
-      EXPECT_TRUE(brokenLease.LastModified >= lastModified);
+      EXPECT_GE(brokenLease.LastModified, lastModified);
     }
   }
 


### PR DESCRIPTION
This gives better log messages for the test failure logs (puts both the values as actual/expected).
In couple of places, the tests are clearly testing overloaded `==`/`!=` operator semantics, I didn't update these.