### PR TITLE
Fixed the user-agent string sent to the service to include the "keys" suffix in the value, when using `CryptographyClient`.

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- [3366](https://github.com/Azure/azure-sdk-for-cpp/issues/4466) Fixed the user-agent string sent to the service to include the "keys" suffix in the value, when using `CryptographyClient`.
+
 ### Other Changes
 
 ## 4.3.0 (2022-10-11)

--- a/sdk/keyvault/azure-security-keyvault-keys/src/cryptography/cryptography_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/cryptography/cryptography_client.cpp
@@ -111,7 +111,7 @@ CryptographyClient::CryptographyClient(
 
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       options,
-      "KeyVault",
+      KeyVaultServicePackageName,
       PackageVersion::ToString(),
       std::move(perRetrypolicies),
       std::move(perCallpolicies));

--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -29,7 +29,6 @@ using namespace Azure::Core::Http::Policies::_internal;
 using namespace Azure::Core::Http::_internal;
 
 namespace {
-constexpr static const char KeyVaultServicePackageName[] = "keyvault-keys";
 constexpr static const char CreateValue[] = "create";
 } // namespace
 

--- a/sdk/keyvault/azure-security-keyvault-keys/src/private/key_constants.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/private/key_constants.hpp
@@ -10,6 +10,8 @@
 #pragma once
 
 namespace Azure { namespace Security { namespace KeyVault { namespace Keys { namespace _detail {
+  constexpr static const char KeyVaultServicePackageName[] = "keyvault-keys";
+  
   /***************** KeyVault Key *****************/
   constexpr static const char KeyPropertyName[] = "key";
 

--- a/sdk/keyvault/azure-security-keyvault-keys/src/private/key_constants.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/private/key_constants.hpp
@@ -11,7 +11,7 @@
 
 namespace Azure { namespace Security { namespace KeyVault { namespace Keys { namespace _detail {
   constexpr static const char KeyVaultServicePackageName[] = "keyvault-keys";
-  
+
   /***************** KeyVault Key *****************/
   constexpr static const char KeyPropertyName[] = "key";
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/4466