### PR TITLE
Temporarily update platform-matrix.json to remove openssl_111n configuration

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -198,10 +198,6 @@
         },
         "included_release": {
           "CMAKE_BUILD_TYPE": "Release"
-        },
-        "openssl_111n": {
-          "CMAKE_BUILD_TYPE": "Release",
-          "VcpkgArgs": " -DVCPKG_MANIFEST_MODE=ON -DVCPKG_OVERLAY_PORTS=$(Build.SourcesDirectory)/vcpkg-custom-ports -DVCPKG_MANIFEST_DIR=$(Build.SourcesDirectory)"
         }
       }
     }


### PR DESCRIPTION
Stop-gap to unblock CI and check-ins to main while investigation on https://github.com/Azure/azure-sdk-for-cpp/issues/4485 is pending.

See previous discussion:
https://github.com/Azure/azure-sdk-for-cpp/pull/4491#issuecomment-1489521509