### PR TITLE
Added missing headers for cstdint and added a CMake preset for Linux.^

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -283,6 +283,20 @@
         "BUILD_PERFORMANCE_TESTS": true,
         "BUILD_SAMPLES": true
       }
-    }
+    },
+    {
+      "name": "linux-default",
+      "displayName": "Linux",
+      "description": "Using compilers: C = /usr/bin/gcc, CXX = /usr/bin/g++",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "cacheVariables": {
+          "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+          "CMAKE_C_COMPILER": "/usr/bin/gcc",
+          "CMAKE_CXX_COMPILER": "/usr/bin/g++",
+          "CMAKE_BUILD_TYPE": "Debug",
+          "VCPKG_TARGET_TRIPLET": "x64-linux",
+          "VCPKG_MANIFEST_MODE": true
+      }
+  }
   ]
 }

--- a/sdk/core/azure-core/inc/azure/core/base64.hpp
+++ b/sdk/core/azure-core/inc/azure/core/base64.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -11,6 +11,7 @@
 #include "azure/core/platform.hpp"
 
 #include <cstring>
+#include <cstdint>
 #include <string>
 
 namespace Azure { namespace Core {


### PR DESCRIPTION
Though the SDK is supported on Linux, there is no cmake preset to build on linux. I added a preset and found minor compilation issue of missing a header. So fixed it as well.

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
