### PR TITLE
Merge main into feature/amqp. (#4491)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,10 +23,10 @@
 ###########
 
 # PRLabel: %Attestation
-/sdk/attestation/        @LarryOsterman @gkostal @anilba06 @kroshkina-ms @ahmadmsft @rickwinter @ahsonkhan @antkmsft @vhvb1989 @gearama
+/sdk/attestation/        @LarryOsterman @gkostal @anilba06 @ahmadmsft @rickwinter @ahsonkhan @antkmsft @vhvb1989 @gearama
 
 # PRLabel: %KeyVault
-/sdk/keyvault/           @vhvb1989 @gearama @antkmsft @rickwinter
+/sdk/keyvault/           @gearama @antkmsft @rickwinter @LarryOsterman
 
 # PRLabel: %Storage
 /sdk/storage/            @vinjiang @Jinming-Hu @EmmaZhu @antkmsft @vhvb1989 @gearama @LarryOsterman @microzchang

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -12,7 +12,6 @@
     "*.a",
     "*.lib",
     "*.yaml",
-    "**/libcurl-stress-test/README.md",
     ".github/CODEOWNERS",
     ".gitignore",
     ".vscode/cspell.json",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,3 +257,23 @@ If the coverage data has been previously generated (for example, if you manually
 ### Visual Studio 2019
 
 You can also build the project by simply opening the repo directory in Visual Studio. Visual Studio will detect the `CMake` file and will configure itself to generate, build and run tests.
+
+## Samples
+
+### Third-party dependencies
+
+Third party libraries should only be included in samples when necessary to demonstrate usage of an Azure SDK package; they should not be suggested or endorsed as alternatives to the Azure SDK.
+
+When code samples take dependencies, readers should be able to use the material without significant license burden or research on terms. This goal requires restricting dependencies to certain types of open source or commercial licenses.
+
+Samples may take the following categories of dependencies:
+
+- **Open-source** : Open source offerings that use an [Open Source Initiative (OSI) approved license](https://opensource.org/licenses). Any component whose license isn't OSI-approved is considered a commercial offering. Prefer OSS projects that are members of any of the [OSS foundations that Microsoft is part of](https://opensource.microsoft.com/ecosystem/). Prefer permissive licenses for libraries, like [MIT](https://opensource.org/licenses/MIT) and [Apache 2](https://opensource.org/licenses/Apache-2.0). Copy-left licenses like [GPL](https://opensource.org/licenses/gpl-license) are acceptable for tools, and OSs. [Kubernetes](https://github.com/kubernetes/kubernetes), [Linux](https://github.com/torvalds/linux), and [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) are examples of this license type. Links to open source components should be to where the source is hosted, including any applicable license, such as a GitHub repository (or similar).
+
+- **Commercial**: Commercial offerings that enable readers to learn from our content without unnecessary extra costs. Typically, the offering has some form of a community edition, or a free trial sufficient for its use in content. A commercial license may be a form of dual-license, or tiered license. Links to commercial components should be to the commercial site for the software, even if the source software is hosted publicly on GitHub (or similar).
+
+- **Dual licensed**: Commercial offerings that enable readers to choose either license based on their needs. For example, if the offering has an OSS and commercial license, readers can  choose between them. [MySql](https://github.com/mysql/mysql-server) is an example of this license type.
+
+- **Tiered licensed**: Offerings that enable readers to use the license tier that corresponds to their characteristics. For example, tiers may be available for students, hobbyists, or companies with defined revenue  thresholds. For offerings with tiered licenses, strive to limit our use in tutorials to the features available in the lowest tier. This policy enables the widest audience for the article. [Docker](https://www.docker.com/), [IdentityServer](https://duendesoftware.com/products/identityserver), [ImageSharp](https://sixlabors.com/products/imagesharp/), and [Visual Studio](https://visualstudio.com) are examples of this license type.
+
+In general, we prefer taking dependencies on licensed components in the order of the listed categories. In cases where the category may not be well known, we'll document the category so that readers understand the choice that they're making by using that dependency.

--- a/eng/common/pipelines/templates/steps/check-spelling.yml
+++ b/eng/common/pipelines/templates/steps/check-spelling.yml
@@ -18,8 +18,8 @@ steps:
     - task: NodeTool@0
       condition: and(succeededOrFailed(), ne(variables['Skip.SpellCheck'],'true'))
       inputs:
-        versionSpec: 18.13.0
-      displayName: Use Node.js 18.13.0
+        versionSpec: 18.x
+      displayName: Use Node.js 18.x
 
     - task: PowerShell@2
       displayName: Check spelling (cspell)

--- a/eng/common/scripts/Test-SampleMetadata.ps1
+++ b/eng/common/scripts/Test-SampleMetadata.ps1
@@ -202,6 +202,7 @@ begin {
         "azure-genomics",
         "azure-hdinsight",
         "azure-hdinsight-rserver",
+        "azure-health-insights",
         "azure-hpc-cache",
         "azure-immersive-reader",
         "azure-information-protection",

--- a/eng/common/scripts/TypeSpec-Project-Generate.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Generate.ps1
@@ -1,0 +1,101 @@
+# For details see https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/TypeSpec-Project-Scripts.md
+
+[CmdletBinding()]
+param (
+    [Parameter(Position=0)]
+    [ValidateNotNullOrEmpty()]
+    [string] $ProjectDirectory,
+    [Parameter(Position=1)]
+    [string] $typespecAdditionalOptions ## addtional typespec emitter options, separated by semicolon if more than one, e.g. option1=value1;option2=value2
+)
+
+$ErrorActionPreference = "Stop"
+. $PSScriptRoot/Helpers/PSModule-Helpers.ps1
+. $PSScriptRoot/common.ps1
+Install-ModuleIfNotInstalled "powershell-yaml" "0.4.1" | Import-Module
+
+function NpmInstallForProject([string]$workingDirectory) {
+    Push-Location $workingDirectory
+    try {
+        $currentDur = Resolve-Path "."
+        Write-Host "Generating from $currentDur"
+
+        if (Test-Path "package.json") {
+            Remove-Item -Path "package.json" -Force
+        }
+
+        if (Test-Path ".npmrc") {
+            Remove-Item -Path ".npmrc" -Force
+        }
+
+        if (Test-Path "node_modules") {
+            Remove-Item -Path "node_modules" -Force -Recurse
+        }
+
+        if (Test-Path "package-lock.json") {
+            Remove-Item -Path "package-lock.json" -Force
+        }
+
+        #default to root/eng/emitter-package.json but you can override by writing
+        #Get-${Language}-EmitterPackageJsonPath in your Language-Settings.ps1
+        $replacementPackageJson = "$PSScriptRoot/../../emitter-package.json"
+        if (Test-Path "Function:$GetEmitterPackageJsonPathFn") {
+            $replacementPackageJson = &$GetEmitterPackageJsonPathFn
+        }
+
+        Write-Host("Copying package.json from $replacementPackageJson")
+        Copy-Item -Path $replacementPackageJson -Destination "package.json" -Force
+        npm install --no-lock-file
+        if ($LASTEXITCODE) { exit $LASTEXITCODE }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+$resolvedProjectDirectory = Resolve-Path $ProjectDirectory
+$emitterName = &$GetEmitterNameFn
+$typespecConfigurationFile = Resolve-Path "$ProjectDirectory/tsp-location.yaml"
+
+Write-Host "Reading configuration from $typespecConfigurationFile"
+$configuration = Get-Content -Path $typespecConfigurationFile -Raw | ConvertFrom-Yaml
+
+$specSubDirectory = $configuration["directory"]
+$innerFolder = Split-Path $specSubDirectory -Leaf
+
+$tempFolder = "$ProjectDirectory/TempTypeSpecFiles"
+$npmWorkingDir = Resolve-Path $tempFolder/$innerFolder
+$mainTypeSpecFile = If (Test-Path "$npmWorkingDir/client.*") { Resolve-Path "$npmWorkingDir/client.*" } Else { Resolve-Path "$npmWorkingDir/main.*"}
+
+try {
+    Push-Location $npmWorkingDir
+    NpmInstallForProject $npmWorkingDir
+
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+    if (Test-Path "Function:$GetEmitterAdditionalOptionsFn") {
+        $emitterAdditionalOptions = &$GetEmitterAdditionalOptionsFn $resolvedProjectDirectory
+        if ($emitterAdditionalOptions.Length -gt 0) {
+            $emitterAdditionalOptions = " $emitterAdditionalOptions"
+        }
+    }
+    $typespecCompileCommand = "npx tsp compile $mainTypeSpecFile --emit $emitterName$emitterAdditionalOptions"
+    if ($typespecAdditionalOptions) {
+        $options = $typespecAdditionalOptions.Split(";");
+        foreach ($option in $options) {
+            $typespecCompileCommand += " --option $emitterName.$option"
+        }
+    }
+    Write-Host($typespecCompileCommand)
+    Invoke-Expression $typespecCompileCommand
+
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+}
+finally {
+    Pop-Location
+}
+
+$shouldCleanUp = $configuration["cleanup"] ?? $true
+if ($shouldCleanUp) {
+    Remove-Item $tempFolder -Recurse -Force
+}

--- a/eng/common/scripts/TypeSpec-Project-Sync.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Sync.ps1
@@ -1,0 +1,127 @@
+# For details see https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/TypeSpec-Project-Scripts.md
+
+[CmdletBinding()]
+param (
+    [Parameter(Position=0)]
+    [ValidateNotNullOrEmpty()]
+    [string] $ProjectDirectory
+)
+
+$ErrorActionPreference = "Stop"
+. $PSScriptRoot/Helpers/PSModule-Helpers.ps1
+Install-ModuleIfNotInstalled "powershell-yaml" "0.4.1" | Import-Module
+$sparseCheckoutFile = ".git/info/sparse-checkout"
+
+function AddSparseCheckoutPath([string]$subDirectory) {
+    if (!(Test-Path $sparseCheckoutFile) -or !((Get-Content $sparseCheckoutFile).Contains($subDirectory))) {
+        Write-Output $subDirectory >> .git/info/sparse-checkout
+    }
+}
+
+function CopySpecToProjectIfNeeded([string]$specCloneRoot, [string]$mainSpecDir, [string]$dest, [string[]]$specAdditionalSubDirectories) {
+    $source = "$specCloneRoot/$mainSpecDir"
+    Copy-Item -Path $source -Destination $dest -Recurse -Force
+    Write-Host "Copying spec from $source to $dest"
+
+    foreach ($additionalDir in $specAdditionalSubDirectories) {
+        $source = "$specCloneRoot/$additionalDir"
+        Write-Host "Copying spec from $source to $dest"
+        Copy-Item -Path $source -Destination $dest -Recurse -Force
+    }
+}
+
+function UpdateSparseCheckoutFile([string]$mainSpecDir, [string[]]$specAdditionalSubDirectories) {
+    AddSparseCheckoutPath $mainSpecDir
+    foreach ($subDir in $specAdditionalSubDirectories) {
+        AddSparseCheckoutPath $subDir
+    }
+}
+
+function GetGitRemoteValue([string]$repo) {
+    Push-Location $ProjectDirectory
+    $result = ""
+    try {
+        $gitRemotes = (git remote -v)
+        foreach ($remote in $gitRemotes) {
+            if ($remote.StartsWith("origin")) {
+                if ($remote -match 'https://github.com/\S+') {
+                    $result = "https://github.com/$repo.git"
+                    break
+                } elseif ($remote -match "git@github.com:\S+"){
+                    $result = "git@github.com:$repo.git"
+                    break
+                } else {
+                    throw "Unknown git remote format found: $remote"
+                }
+            }
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    return $result
+}
+
+function InitializeSparseGitClone([string]$repo) {
+    git clone --no-checkout --filter=tree:0 $repo .
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+    git sparse-checkout init
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+    Remove-Item $sparseCheckoutFile -Force
+}
+
+function GetSpecCloneDir([string]$projectName) {
+    Push-Location $ProjectDirectory
+    try {
+        $root = git rev-parse --show-toplevel
+    }
+    finally {
+        Pop-Location
+    }
+
+    $sparseSpecCloneDir = "$root/../sparse-spec/$projectName"
+    New-Item $sparseSpecCloneDir -Type Directory -Force | Out-Null
+    $createResult = Resolve-Path $sparseSpecCloneDir
+    return $createResult
+}
+
+$typespecConfigurationFile = Resolve-Path "$ProjectDirectory/tsp-location.yaml"
+Write-Host "Reading configuration from $typespecConfigurationFile"
+$configuration = Get-Content -Path $typespecConfigurationFile -Raw | ConvertFrom-Yaml
+
+$pieces = $typespecConfigurationFile.Path.Replace("\","/").Split("/")
+$projectName = $pieces[$pieces.Count - 2]
+
+$specSubDirectory = $configuration["directory"]
+
+if ( $configuration["repo"] -and $configuration["commit"]) {
+    $specCloneDir = GetSpecCloneDir $projectName
+    $gitRemoteValue = GetGitRemoteValue $configuration["repo"]
+
+    Write-Host "Setting up sparse clone for $projectName at $specCloneDir"
+
+    Push-Location $specCloneDir.Path
+    try {
+        if (!(Test-Path ".git")) {
+            InitializeSparseGitClone $gitRemoteValue
+            UpdateSparseCheckoutFile $specSubDirectory $configuration["additionalDirectories"]
+        }
+        git checkout $configuration["commit"]
+        if ($LASTEXITCODE) { exit $LASTEXITCODE }
+    }
+    finally {
+        Pop-Location
+    }
+} elseif ( $configuration["spec-root-dir"] ) {
+    $specCloneDir = $configuration["spec-root-dir"]
+}
+
+
+$tempTypeSpecDir = "$ProjectDirectory/TempTypeSpecFiles"
+New-Item $tempTypeSpecDir -Type Directory -Force | Out-Null
+CopySpecToProjectIfNeeded `
+    -specCloneRoot $specCloneDir `
+    -mainSpecDir $specSubDirectory `
+    -dest $tempTypeSpecDir `
+    -specAdditionalSubDirectories $configuration["additionalDirectories"]

--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -37,6 +37,10 @@ param(
     [boolean] $AmendCommit = $false
 )
 
+# Explicit set arg parsing to Legacy mode because some of the git calls in this script depend on empty strings being empty and not passing a "" git.
+# more info https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.3#psnativecommandargumentpassing
+$PSNativeCommandArgumentPassing = "Legacy"
+
 # This is necessary because of the git command output writing to stderr.
 # Without explicitly setting the ErrorActionPreference to continue the script
 # would fail the first time git wrote command output.

--- a/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
+++ b/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
@@ -25,6 +25,8 @@ param(
     # Renders chart templates locally without deployment
     [Parameter(Mandatory=$False)][switch]$Template,
 
+    [Parameter(Mandatory=$False)][switch]$RetryFailedTests,
+
     # Matrix generation parameters
     [Parameter(Mandatory=$False)][string]$MatrixFileName,
     [Parameter(Mandatory=$False)][string]$MatrixSelection,

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -98,6 +98,7 @@ function DeployStressTests(
     })]
     [System.IO.FileInfo]$LocalAddonsPath,
     [Parameter(Mandatory=$False)][switch]$Template,
+    [Parameter(Mandatory=$False)][switch]$RetryFailedTests,
     [Parameter(Mandatory=$False)][string]$MatrixFileName,
     [Parameter(Mandatory=$False)][string]$MatrixSelection = "sparse",
     [Parameter(Mandatory=$False)][string]$MatrixDisplayNameFilter,
@@ -215,11 +216,16 @@ function DeployStressPackage(
     if ($LASTEXITCODE) {exit $LASTEXITCODE}
 
     $dockerBuildConfigs = @()
-    
-    $genValFile = Join-Path $pkg.Directory "generatedValues.yaml"
-    $genVal = Get-Content $genValFile -Raw | ConvertFrom-Yaml -Ordered
-    if (Test-Path $genValFile) {
-        $scenarios = $genVal.Scenarios
+
+    $generatedHelmValuesFilePath = Join-Path $pkg.Directory "generatedValues.yaml"
+    $generatedHelmValues = Get-Content $generatedHelmValuesFilePath -Raw | ConvertFrom-Yaml -Ordered
+    $releaseName = $pkg.ReleaseName
+    if ($RetryFailedTests) {
+        $releaseName, $generatedHelmValues = generateRetryTestsHelmValues $pkg $releaseName $generatedHelmValues
+    }
+
+    if (Test-Path $generatedHelmValuesFilePath) {
+        $scenarios = $generatedHelmValues.Scenarios
         foreach ($scenario in $scenarios) {
             if ("image" -in $scenario.keys) {
                 $dockerFilePath = Join-Path $pkg.Directory $scenario.image
@@ -286,7 +292,7 @@ function DeployStressPackage(
                 }
             }
         }
-        $genVal.scenarios = @( foreach ($scenario in $genVal.scenarios) {
+        $generatedHelmValues.scenarios = @( foreach ($scenario in $generatedHelmValues.scenarios) {
             $dockerPath = if ("image" -notin $scenario) {
                 $dockerFilePath
             } else {
@@ -298,15 +304,15 @@ function DeployStressPackage(
             $scenario
         } )
 
-        $genVal | ConvertTo-Yaml | Out-File -FilePath $genValFile
+        $generatedHelmValues | ConvertTo-Yaml | Out-File -FilePath $generatedHelmValuesFilePath
     }
 
-    Write-Host "Installing or upgrading stress test $($pkg.ReleaseName) from $($pkg.Directory)"
+    Write-Host "Installing or upgrading stress test $releaseName from $($pkg.Directory)"
 
     $generatedConfigPath = Join-Path $pkg.Directory generatedValues.yaml
     $subCommand = $Template ? "template" : "upgrade"
     $installFlag = $Template ? "" : "--install"
-    $helmCommandArg = "helm", $subCommand, $pkg.ReleaseName, $pkg.Directory, "-n", $pkg.Namespace, $installFlag, "--set", "stress-test-addons.env=$environment", "--values", $generatedConfigPath
+    $helmCommandArg = "helm", $subCommand, $releaseName, $pkg.Directory, "-n", $pkg.Namespace, $installFlag, "--set", "stress-test-addons.env=$environment", "--values", $generatedConfigPath
 
     $result = (Run @helmCommandArg) 2>&1 | Write-Host
 
@@ -322,7 +328,7 @@ function DeployStressPackage(
           # Issues like 'UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress'
           # can be the result of cancelled `upgrade` operations (e.g. ctrl-c).
           # See https://github.com/helm/helm/issues/4558
-          Write-Warning "The issue may be fixable by first running 'helm rollback -n $($pkg.Namespace) $($pkg.ReleaseName)'"
+          Write-Warning "The issue may be fixable by first running 'helm rollback -n $($pkg.Namespace) $releaseName'"
           return
         }
     }
@@ -333,7 +339,7 @@ function DeployStressPackage(
     if(!$Template) {
         $helmReleaseConfig = RunOrExitOnFailure kubectl get secrets `
                                                 -n $pkg.Namespace `
-                                                -l "status=deployed,name=$($pkg.ReleaseName)" `
+                                                -l "status=deployed,name=$releaseName" `
                                                 -o jsonpath='{.items[0].metadata.name}'
         Run kubectl label secret -n $pkg.Namespace --overwrite $helmReleaseConfig deployId=$deployId
     }
@@ -374,4 +380,73 @@ function CheckDependencies()
         exit 1
     }
 
+}
+
+function generateRetryTestsHelmValues ($pkg, $releaseName, $generatedHelmValues) {
+    $podOutput = RunOrExitOnFailure kubectl get pods -n $pkg.namespace -o json
+    $pods = $podOutput | ConvertFrom-Json
+
+    # Get all jobs within this helm release
+    
+    $helmStatusOutput = RunOrExitOnFailure helm status -n $pkg.Namespace $pkg.ReleaseName --show-resources
+    # -----Example output-----
+    # NAME: <Release Name>
+    # LAST DEPLOYED: Mon Jan 01 12:12:12 2020
+    # NAMESPACE: <namespace>
+    # STATUS: deployed
+    # REVISION: 10
+    # RESOURCES:
+    # ==> v1alpha1/Schedule
+    # NAME                          AGE
+    # <schedule resource name 1>    5h5m
+    # <schedule resource name 2>    5h5m
+
+    # ==> v1/SecretProviderClass
+    # <secret provider name 1>   7d4h
+
+    # ==> v1/Job
+    # NAME          COMPLETIONS   DURATION   AGE
+    # <job name 1>   0/1          5h5m       5h5m
+    # <job name 2>   0/1          5h5m       5h5m
+    $discoveredJob = $False
+    $jobs = @()
+    foreach ($line in $helmStatusOutput) {
+        if ($discoveredJob -and $line -match "==>") {break}
+        if ($discoveredJob) {
+            $jobs += ($line -split '\s+')[0] | Where-Object {($_ -ne "NAME") -and ($_)}
+        }
+        if ($line -match "==> v1/Job") {
+            $discoveredJob = $True
+        }
+    }
+
+    $failedJobsScenario = @()
+    $revision = 0
+    foreach ($job in $jobs) {
+        $jobRevision = [int]$job.split('-')[-1]
+        if ($jobRevision -gt $revision) {
+            $revision = $jobRevision
+        }
+
+        $jobOutput = RunOrExitOnFailure kubectl describe jobs -n $pkg.Namespace $job
+        $podPhase = $jobOutput | Select-String "0 Failed"
+        if ([System.String]::IsNullOrEmpty($podPhase)) {
+            $failedJobsScenario += $job.split("-$($pkg.ReleaseName)")[0]
+        }
+    }
+    
+    $releaseName = "$($pkg.ReleaseName)-$revision-retry"
+
+    $retryTestsHelmVal = @{"scenarios"=@()}
+    foreach ($failedScenario in $failedJobsScenario) {
+        $failedScenarioObject = $generatedHelmValues.scenarios | Where {$_.Scenario -eq $failedScenario}
+        $retryTestsHelmVal.scenarios += $failedScenarioObject
+    }
+
+    if (!$retryTestsHelmVal.scenarios.length) {
+        Write-Host "There are no failed pods to retry."
+        return
+    }
+    $generatedHelmValues = $retryTestsHelmVal
+    return $releaseName, $generatedHelmValues
 }

--- a/eng/common/scripts/trust-proxy-certificate.ps1
+++ b/eng/common/scripts/trust-proxy-certificate.ps1
@@ -4,3 +4,7 @@ if ($TestProxyTrustCertFn -and (Test-Path "Function:$TestProxyTrustCertFn"))
 {
     &$TestProxyTrustCertFn
 }
+else 
+{
+    Write-Host "No implementation of Import-Dev-Cert-<language> provided in eng/scripts/Language-Settings.ps1."
+}

--- a/sdk/attestation/azure-security-attestation/samples/policy-certificates/cryptohelpers.hpp
+++ b/sdk/attestation/azure-security-attestation/samples/policy-certificates/cryptohelpers.hpp
@@ -18,7 +18,7 @@
 #include <utility>
 #include <vector>
 /**
- * @brief THe Cryptography class provides a set of basic cryptographic primatives required
+ * @brief The Cryptography class provides a set of basic cryptographic primatives required
  * by the attestation samples.
  */
 

--- a/sdk/attestation/azure-security-attestation/test/ut/token_test.cpp
+++ b/sdk/attestation/azure-security-attestation/test/ut/token_test.cpp
@@ -431,7 +431,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
       auto serializedObject = TestObjectSerializer::Serialize(testObject);
 
       auto targetObject = TestObjectSerializer::Deserialize(json::parse(serializedObject));
-      EXPECT_TRUE(testObject == targetObject);
+      EXPECT_EQ(testObject, targetObject);
     }
   }
 

--- a/sdk/core/azure-core-test/inc/azure/core/test/test_proxy_manager.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_proxy_manager.hpp
@@ -31,6 +31,8 @@ namespace Azure { namespace Core { namespace Test {
 
   class TestNonExpiringCredential final : public Core::Credentials::TokenCredential {
   public:
+    TestNonExpiringCredential() : TokenCredential("TestNonExpiringCredential") {}
+
     Core::Credentials::AccessToken GetToken(
         Core::Credentials::TokenRequestContext const& tokenRequestContext,
         Core::Context const& context) const override

--- a/sdk/core/azure-core-tracing-opentelemetry/test/ut/service_support_test.cpp
+++ b/sdk/core/azure-core-tracing-opentelemetry/test/ut/service_support_test.cpp
@@ -194,14 +194,14 @@ protected:
       // Make sure that every expected attribute is somewhere in the actual attributes.
       for (auto const& expectedAttribute : expectedAttributes.items())
       {
-        EXPECT_TRUE(
+        EXPECT_NE(
             std::find_if(
                 attributes.begin(),
                 attributes.end(),
                 [&](std::pair<const std::string, RecordedSpan::Attribute>& item) {
                   return item.first == expectedAttribute.key();
-                })
-            != attributes.end());
+                }),
+            attributes.end());
       }
 
       for (auto const& foundAttribute : attributes)

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 - Added the ability to ignore invalid certificate common name for TLS connections in WinHTTP transport.
 - Added `DisableTlsCertificateValidation` in `TransportOptions`.
+- Added `TokenCredential::GetCredentialName()` to be utilized in diagnostic messages. If you have any custom implementations of `TokenCredential`, it is recommended to pass the name of your credential to `TokenCredential` constructor. The old parameterless constructor is deprecated.
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
-- Fixed a bug where `Host` request header is not set for non-default port (80, 443).
+- [[#4213]](https://github.com/Azure/azure-sdk-for-cpp/issues/4213) Fixed a bug where `Host` request header is not set for non-default port (80, 443).
+- [[#4443]](https://github.com/Azure/azure-sdk-for-cpp/issues/4443) Fixed potentially high CPU usage on Windows.
 
 ### Other Changes
 

--- a/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
+++ b/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
@@ -60,6 +60,9 @@ namespace Azure { namespace Core { namespace Credentials {
    * @brief A base type of credential that uses Azure::Core::AccessToken to authenticate requests.
    */
   class TokenCredential {
+  private:
+    std::string m_credentialName;
+
   public:
     /**
      * @brief Gets an authentication token.
@@ -76,6 +79,12 @@ namespace Azure { namespace Core { namespace Credentials {
         Context const& context) const = 0;
 
     /**
+     * @brief Gets the name of the credential.
+     *
+     */
+    std::string const& GetCredentialName() const { return m_credentialName; }
+
+    /**
      * @brief Destructs `%TokenCredential`.
      *
      */
@@ -83,10 +92,24 @@ namespace Azure { namespace Core { namespace Credentials {
 
   protected:
     /**
+     * @brief Constructs an instance of `%TokenCredential`.
+     *
+     * @param credentialName Name of the credential for diagnostic messages.
+     */
+    TokenCredential(std::string const& credentialName)
+        : m_credentialName(credentialName.empty() ? "Custom Credential" : credentialName)
+    {
+    }
+
+    /**
      * @brief Constructs a default instance of `%TokenCredential`.
      *
+     * @deprecated Use the constructor with parameter.
      */
-    TokenCredential() {}
+    [[deprecated("Use the constructor with parameter.")]] TokenCredential()
+        : TokenCredential(std::string{})
+    {
+    }
 
   private:
     /**

--- a/sdk/core/azure-core/inc/azure/core/internal/strings.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/strings.hpp
@@ -30,6 +30,22 @@ namespace Azure { namespace Core { namespace _internal {
       return (c < 'A' || c > 'Z') ? c : c + ('a' - 'A');
     }
 
+    static constexpr bool IsDigit(char c) noexcept { return c >= '0' && c <= '9'; }
+
+    static constexpr bool IsHexDigit(char c) noexcept
+    {
+      return IsDigit(c) || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+    }
+
+    static constexpr bool IsAlphaNumeric(char c) noexcept
+    {
+      return IsDigit(c) || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    }
+
+    static constexpr bool IsSpace(char c) noexcept { return c == ' ' || (c >= '\t' && c <= '\r'); }
+
+    static constexpr bool IsPrintable(char c) noexcept { return c >= ' ' && c <= '~'; }
+
     struct CaseInsensitiveComparator final
     {
       bool operator()(std::string const& lhs, std::string const& rhs) const

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 #include "azure/core/datetime.hpp"
+#include "azure/core/internal/strings.hpp"
 #include "azure/core/platform.hpp"
 
 #include <algorithm>
 #include <ctime>
 #include <iomanip>
 #include <limits>
-#include <locale>
 #include <sstream>
 #include <stdexcept>
 
@@ -320,7 +320,7 @@ T ParseNumber(
     for (; i < MaxChars; ++i)
     {
       auto const ch = str[*cursor + i];
-      if (std::isdigit(ch, std::locale::classic()))
+      if (Core::_internal::StringExtensions::IsDigit(ch))
       {
         value = (value * 10) + (static_cast<decltype(value)>(static_cast<unsigned char>(ch)) - '0');
         continue;
@@ -655,7 +655,7 @@ DateTime DateTime::Parse(std::string const& dateTime, DateFormat format)
             if (charsRead == 7 && (DateTimeLength - cursor) > 0)
             {
               auto const ch = dateTime[cursor];
-              if (std::isdigit(ch, std::locale::classic()))
+              if (Core::_internal::StringExtensions::IsDigit(ch))
               {
                 auto const num = static_cast<int>(static_cast<unsigned char>(ch) - '0');
                 if (num > 4)
@@ -677,7 +677,7 @@ DateTime DateTime::Parse(std::string const& dateTime, DateFormat format)
 
           for (auto i = DateTimeLength - cursor; i > 0; --i)
           {
-            if (std::isdigit(dateTime[cursor], std::locale::classic()))
+            if (Core::_internal::StringExtensions::IsDigit(dateTime[cursor]))
             {
               ++minDateTimeLength;
               ++cursor;

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -30,6 +30,7 @@
 #include "azure/core/http/policies/policy.hpp"
 #include "azure/core/http/transport.hpp"
 #include "azure/core/internal/diagnostics/log.hpp"
+#include "azure/core/internal/strings.hpp"
 
 // Private include
 #include "curl_connection_pool_private.hpp"
@@ -70,7 +71,6 @@
 #include <algorithm>
 #include <chrono>
 #include <iomanip>
-#include <locale>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -1340,7 +1340,7 @@ void DumpCurlInfoToLog(std::string const& text, uint8_t* ptr, size_t size)
       // Log the contents of the buffer as text, if it's printable, print the character, otherwise
       // print '.'
       auto const ch = static_cast<char>(ptr[i + c]);
-      if (std::isprint(ch, std::locale::classic()))
+      if (Azure::Core::_internal::StringExtensions::IsPrintable(ch))
       {
         ss << ch;
       }

--- a/sdk/core/azure-core/src/http/http.cpp
+++ b/sdk/core/azure-core/src/http/http.cpp
@@ -3,10 +3,10 @@
 
 #include "azure/core/http/http.hpp"
 #include "azure/core/http/policies/policy.hpp"
+#include "azure/core/internal/strings.hpp"
 #include "azure/core/url.hpp"
 
 #include <algorithm>
-#include <locale>
 #include <unordered_set>
 #include <utility>
 
@@ -32,7 +32,7 @@ bool IsInvalidHeaderNameChar(char c)
   static std::unordered_set<char> const HeaderNameExtraValidChars
       = {' ', '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~'};
 
-  return !std::isalnum(c, std::locale::classic())
+  return !Azure::Core::_internal::StringExtensions::IsAlphaNumeric(c)
       && HeaderNameExtraValidChars.find(c) == HeaderNameExtraValidChars.end();
 }
 } // namespace

--- a/sdk/core/azure-core/src/http/url.cpp
+++ b/sdk/core/azure-core/src/http/url.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <limits>
-#include <locale>
 #include <stdexcept>
 #include <unordered_set>
 
@@ -22,7 +21,7 @@ Url::Url(std::string const& url)
 
     if (schemePos != std::string::npos)
     {
-      m_scheme = Azure::Core::_internal::StringExtensions::ToLower(url.substr(0, schemePos));
+      m_scheme = _internal::StringExtensions::ToLower(url.substr(0, schemePos));
       urlIter += schemePos + SchemeEnd.length();
     }
   }
@@ -43,8 +42,8 @@ Url::Url(std::string const& url)
   if (*urlIter == ':')
   {
     ++urlIter;
-    auto const portIter = std::find_if_not(
-        urlIter, url.end(), [](auto c) { return std::isdigit(c, std::locale::classic()); });
+    auto const portIter
+        = std::find_if_not(urlIter, url.end(), _internal::StringExtensions::IsDigit);
 
     auto const portNumber = std::stoi(std::string(urlIter, portIter));
 
@@ -105,8 +104,8 @@ std::string Url::Decode(std::string const& value)
     {
       case '%':
         if ((valueSize - i) < 3 // need at least 3 characters: "%XY"
-            || !std::isxdigit(value[i + 1], std::locale::classic())
-            || !std::isxdigit(value[i + 2], std::locale::classic()))
+            || !_internal::StringExtensions::IsHexDigit(value[i + 1])
+            || !_internal::StringExtensions::IsHexDigit(value[i + 2]))
         {
           throw std::runtime_error("failed when decoding URL component");
         }
@@ -133,7 +132,7 @@ bool ShouldEncode(char c)
 {
   static std::unordered_set<char> const ExtraNonEncodableChars = {'-', '.', '_', '~'};
 
-  return !std::isalnum(c, std::locale::classic())
+  return !_internal::StringExtensions::IsAlphaNumeric(c)
       && ExtraNonEncodableChars.find(c) == ExtraNonEncodableChars.end();
 }
 } // namespace

--- a/sdk/core/azure-core/src/http/user_agent.cpp
+++ b/sdk/core/azure-core/src/http/user_agent.cpp
@@ -11,9 +11,9 @@
 
 #include "azure/core/context.hpp"
 #include "azure/core/http/policies/policy.hpp"
+#include "azure/core/internal/strings.hpp"
 #include "azure/core/internal/tracing/service_tracing.hpp"
 #include "azure/core/platform.hpp"
-#include <locale>
 #include <sstream>
 
 #if defined(AZ_PLATFORM_WINDOWS)
@@ -133,10 +133,14 @@ std::string GetOSVersion()
 
 std::string TrimString(std::string s)
 {
-  auto const isNotSpace = [](char c) { return !std::isspace(c, std::locale::classic()); };
+  s.erase(
+      s.begin(),
+      std::find_if_not(s.begin(), s.end(), Azure::Core::_internal::StringExtensions::IsSpace));
 
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(), isNotSpace));
-  s.erase(std::find_if(s.rbegin(), s.rend(), isNotSpace).base(), s.end());
+  s.erase(
+      std::find_if_not(s.rbegin(), s.rend(), Azure::Core::_internal::StringExtensions::IsSpace)
+          .base(),
+      s.end());
 
   return s;
 }

--- a/sdk/core/azure-core/test/libcurl-stress-test/README.md
+++ b/sdk/core/azure-core/test/libcurl-stress-test/README.md
@@ -5,24 +5,24 @@ This is work in progress. It's a prototype of how a stress test would look. This
 The cpp file represents the code for the test, it will generate a number of invalid URLs and then issue CURL send commands. The requests are expected to fail. The point was that it exposes memory leaks in handling the error cases, which we fixed since. 
 
 ### Dockerfile (https://www.docker.com/)
-Represents the build file for the container in which the test runs, it is based on ubuntu 22.04 , from mcr. 
-The main change from default ubuntu is making sure we have the valgrind tool installed. Valgrind is a heap monitoring tool that helps identify potential stack traces that might leak memory. While not 100% effective is is great at reducing the surface are for investigations. 
+Represents the build file for the container in which the test runs, it is based on Ubuntu 22.04 , from MCR. 
+The main change from default Ubuntu is making sure we have the Valgrind tool installed. Valgrind is a heap monitoring tool that helps identify potential stack traces that might leak memory. While not 100% effective is great at reducing the surface are for investigations. 
 
 ### Helm chart (https://helm.sh/)
 Chart.yaml together with the bicep file(https://docs.microsoft.com/azure/azure-resource-manager/bicep/overview?tabs=bicep) and the deploy job file , represent the helm chart needed to deploy to the docker image built from the dockerfile to the stress cluster and execute the stress test. 
 
-The helm chart creates a pod with a container based on the docker image, and executes the test under valgrind. 
+The helm chart creates a pod with a container based on the docker image, and executes the test under Valgrind. 
 
 To deploy the chart you will need to run "azure-sdk-for-cpp\eng\common\scripts\stress-testing> .\deploy-stress-tests.ps1 -Namespace azuresdkforcpp -SearchDirectory E:\src\azure-sdk-for-cpp\sdk\core\azure-core\test -PushImage"
 
-Where namaspace will be created if missing , search directory can be any folder where it will search for charts in it and all it's sub dirs, push image will call it to build the docker image. 
+Where namespace will be created if missing , search directory can be any folder where it will search for charts in it and all it's sub dirs, push image will call it to build the docker image. 
 
-ATM the docker image is build by hand and harcoded in the chart to simplify matters.  
+ATM the docker image is build by hand and hard-coded in the chart to simplify matters.  
 
-To build the image run "docker build -t stresstesttbiruti6oi24k.acr.io/azuresdkforcpp/curlstress:v8  --build-arg targetTest=azure-core-libcurl-stress-test --build-arg build=on  ."
+To build the image run "docker build -t <acr>/azuresdkforcpp/curlstress:v8  --build-arg targetTest=azure-core-libcurl-stress-test --build-arg build=on  ."
 
-To push to mcr : "docker push stresstesttbiruti6oi24k.acr.io/azuresdkforcpp/curlstress:v8"
-Obviously after logging in to the acr "az acr login -n stresspgs7b6dif73rup6.azurecr.io"
+To push to mcr : "docker push <acr>/azuresdkforcpp/curlstress:v8"
+Obviously after logging in to the acr "az acr login -n <acr>"
 
 To use another image you will need to go to line 12 in deploy job and update with your new file. 
 

--- a/sdk/core/azure-core/test/ut/bearer_token_authentication_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/bearer_token_authentication_policy_test.cpp
@@ -16,7 +16,7 @@ private:
 public:
   explicit TestTokenCredential(
       std::shared_ptr<Azure::Core::Credentials::AccessToken const> accessToken)
-      : m_accessToken(accessToken)
+      : TokenCredential("TestTokenCredential"), m_accessToken(accessToken)
   {
   }
 

--- a/sdk/core/azure-core/test/ut/context_test.cpp
+++ b/sdk/core/azure-core/test/ut/context_test.cpp
@@ -33,7 +33,7 @@ TEST(Context, BasicBool)
   auto c2 = context.WithValue(key, true);
   bool value{};
   EXPECT_TRUE(c2.TryGetValue<bool>(key, value));
-  EXPECT_TRUE(value == true);
+  EXPECT_TRUE(value);
 
   Context::Key const anotherKey;
   auto c3 = c2.WithValue(anotherKey, std::make_shared<bool>(true));
@@ -56,7 +56,7 @@ TEST(Context, BasicInt)
   auto c2 = context.WithValue(key, 123);
   int value;
   EXPECT_TRUE(c2.TryGetValue<int>(key, value));
-  EXPECT_TRUE(value == 123);
+  EXPECT_EQ(value, 123);
 }
 
 TEST(Context, BasicStdString)
@@ -70,7 +70,7 @@ TEST(Context, BasicStdString)
   auto c2 = context.WithValue(key, s);
   std::string value;
   EXPECT_TRUE(c2.TryGetValue<std::string>(key, value));
-  EXPECT_TRUE(value == s);
+  EXPECT_EQ(value, s);
 }
 
 TEST(Context, BasicChar)
@@ -85,8 +85,8 @@ TEST(Context, BasicChar)
   auto c2 = context.WithValue(key, str);
   const char* value;
   EXPECT_TRUE(c2.TryGetValue<const char*>(key, value));
-  EXPECT_TRUE(value == s);
-  EXPECT_TRUE(value == str);
+  EXPECT_EQ(value, s);
+  EXPECT_EQ(value, str);
 }
 
 TEST(Context, IsCancelled)
@@ -206,13 +206,13 @@ TEST(Context, Chain)
   const char* valueT8;
   EXPECT_TRUE(finalContext.TryGetValue<const char*>(keyFinal, valueT8));
 
-  EXPECT_TRUE(valueT2 == 123);
-  EXPECT_TRUE(valueT3 == 456);
-  EXPECT_TRUE(valueT4 == 789);
-  EXPECT_TRUE(valueT5 == std::string("5"));
-  EXPECT_TRUE(valueT6 == std::string("6"));
-  EXPECT_TRUE(valueT7 == std::string("7"));
-  EXPECT_TRUE(valueT8 == std::string("Final"));
+  EXPECT_EQ(valueT2, 123);
+  EXPECT_EQ(valueT3, 456);
+  EXPECT_EQ(valueT4, 789);
+  EXPECT_EQ(valueT5, std::string("5"));
+  EXPECT_EQ(valueT6, std::string("6"));
+  EXPECT_EQ(valueT7, std::string("7"));
+  EXPECT_EQ(valueT8, std::string("Final"));
 }
 
 TEST(Context, MatchingKeys)
@@ -229,8 +229,8 @@ TEST(Context, MatchingKeys)
   int valueT3;
   EXPECT_TRUE(c3.TryGetValue<int>(key, valueT3));
 
-  EXPECT_TRUE(valueT2 == 123);
-  EXPECT_TRUE(valueT3 == 456);
+  EXPECT_EQ(valueT2, 123);
+  EXPECT_EQ(valueT3, 456);
 }
 
 struct SomeStructForContext final
@@ -492,10 +492,10 @@ TEST(Context, KeyTypePairPrecondition)
 #endif
 #endif
 
-  EXPECT_TRUE(strValue == "previous value");
+  EXPECT_EQ(strValue, "previous value");
 
   EXPECT_TRUE(c2.TryGetValue<int>(key, intValue));
-  EXPECT_TRUE(intValue == 123);
+  EXPECT_EQ(intValue, 123);
 
 #if GTEST_HAS_DEATH_TEST
 // Type-safe assert requires RTTI build
@@ -509,8 +509,8 @@ TEST(Context, KeyTypePairPrecondition)
 #endif
 #endif
 
-  EXPECT_TRUE(intValue == 123);
+  EXPECT_EQ(intValue, 123);
 
   EXPECT_TRUE(c3.TryGetValue<std::string>(key, strValue));
-  EXPECT_TRUE(strValue == s);
+  EXPECT_EQ(strValue, s);
 }

--- a/sdk/core/azure-core/test/ut/nullable_test.cpp
+++ b/sdk/core/azure-core/test/ut/nullable_test.cpp
@@ -12,15 +12,15 @@ TEST(Nullable, Basic)
 {
   Nullable<std::string> testString{"hello world"};
   EXPECT_TRUE(testString.HasValue());
-  EXPECT_TRUE(testString.Value() == "hello world");
+  EXPECT_EQ(testString.Value(), "hello world");
 
   Nullable<int> testInt{54321};
   EXPECT_TRUE(testInt.HasValue());
-  EXPECT_TRUE(testInt.Value() == 54321);
+  EXPECT_EQ(testInt.Value(), 54321);
 
   Nullable<double> testDouble{10.0};
   EXPECT_TRUE(testDouble.HasValue());
-  EXPECT_TRUE(testDouble.Value() == 10.0);
+  EXPECT_EQ(testDouble.Value(), 10.0);
 }
 
 TEST(Nullable, Empty)
@@ -55,18 +55,18 @@ TEST(Nullable, Assignment)
   Nullable<std::string> instance{"hello world"};
   auto instance2 = instance;
   EXPECT_TRUE(instance2.HasValue());
-  EXPECT_TRUE(instance2.Value() == "hello world");
+  EXPECT_EQ(instance2.Value(), "hello world");
 
   auto instance3 = std::move(instance);
   EXPECT_TRUE(instance3.HasValue());
-  EXPECT_TRUE(instance3.Value() == "hello world");
+  EXPECT_EQ(instance3.Value(), "hello world");
 
   EXPECT_TRUE(instance.HasValue());
 
   // This is not a guarantee that the string will be empty
   //  It is an implementation detail that the contents are moved
   //  Should a future compiler change this assumption this test will need updates
-  EXPECT_TRUE(instance.Value() == "");
+  EXPECT_EQ(instance.Value(), "");
   EXPECT_TRUE(instance.HasValue());
 }
 
@@ -76,22 +76,22 @@ TEST(Nullable, ValueAssignment)
   EXPECT_FALSE(intVal.HasValue());
   intVal = 7;
   EXPECT_TRUE(intVal.HasValue());
-  EXPECT_TRUE(intVal.Value() == 7);
+  EXPECT_EQ(intVal.Value(), 7);
 
   Nullable<double> doubleVal;
   EXPECT_FALSE(doubleVal.HasValue());
   doubleVal = 10.12345;
   EXPECT_TRUE(doubleVal.HasValue());
-  EXPECT_TRUE(doubleVal.Value() == 10.12345);
+  EXPECT_EQ(doubleVal.Value(), 10.12345);
 
   Nullable<std::string> strVal;
   EXPECT_FALSE(strVal.HasValue());
   strVal = std::string("Hello World");
   EXPECT_TRUE(strVal.HasValue());
-  EXPECT_TRUE(strVal.Value() == "Hello World");
+  EXPECT_EQ(strVal.Value(), "Hello World");
 
   strVal = "New String";
-  EXPECT_TRUE(strVal.Value() == "New String");
+  EXPECT_EQ(strVal.Value(), "New String");
 
   strVal.Reset();
   EXPECT_FALSE(strVal.HasValue());
@@ -111,13 +111,13 @@ TEST(Nullable, Swap)
   val3.Swap(val4);
   EXPECT_TRUE(val3);
   EXPECT_TRUE(val4);
-  EXPECT_TRUE(val3.Value() == 678910);
-  EXPECT_TRUE(val4.Value() == 12345);
+  EXPECT_EQ(val3.Value(), 678910);
+  EXPECT_EQ(val4.Value(), 12345);
 
   val1.Swap(val3);
   EXPECT_TRUE(val1);
   EXPECT_FALSE(val3);
-  EXPECT_TRUE(val1.Value() == 678910);
+  EXPECT_EQ(val1.Value(), 678910);
   EXPECT_FALSE(val3.HasValue());
 }
 
@@ -134,19 +134,19 @@ TEST(Nullable, CopyConstruction)
   Nullable<int> val4(val3);
   EXPECT_TRUE(val3);
   EXPECT_TRUE(val4);
-  EXPECT_TRUE(val3.Value() == 12345);
-  EXPECT_TRUE(val4.Value() == 12345);
+  EXPECT_EQ(val3.Value(), 12345);
+  EXPECT_EQ(val4.Value(), 12345);
 
   // Literal
   Nullable<int> val5 = 54321;
   EXPECT_TRUE(val5);
-  EXPECT_TRUE(val5.Value() == 54321);
+  EXPECT_EQ(val5.Value(), 54321);
 
   // Value
   const int i = 1;
   Nullable<int> val6(i);
   EXPECT_TRUE(val6);
-  EXPECT_TRUE(val6.Value() == 1);
+  EXPECT_EQ(val6.Value(), 1);
 }
 
 TEST(Nullable, Disengage)
@@ -162,12 +162,12 @@ TEST(Nullable, ValueOr)
   Nullable<int> val2;
 
   EXPECT_TRUE(val1);
-  EXPECT_TRUE(val1.ValueOr(678910) == 12345);
+  EXPECT_EQ(val1.ValueOr(678910), 12345);
   // Ensure the value was unmodified in ValueOr
-  EXPECT_TRUE(val1.Value() == 12345);
+  EXPECT_EQ(val1.Value(), 12345);
 
   EXPECT_FALSE(val2);
-  EXPECT_TRUE(val2.ValueOr(678910) == 678910);
+  EXPECT_EQ(val2.ValueOr(678910), 678910);
   // Ensure val2 is still disengaged after call to ValueOr
   EXPECT_FALSE(val2);
 }

--- a/sdk/core/azure-core/test/ut/operation_test.cpp
+++ b/sdk/core/azure-core/test/ut/operation_test.cpp
@@ -51,7 +51,7 @@ TEST(Operation, PollUntilDone)
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double, std::milli> elapsed = end - start;
   // StringOperation test code is implemented to poll 2 times
-  EXPECT_TRUE(elapsed >= 1s);
+  EXPECT_GE(elapsed, 1s);
 
   EXPECT_TRUE(operation.IsDone());
   EXPECT_TRUE(operation.HasValue());

--- a/sdk/core/azure-core/test/ut/string_test.cpp
+++ b/sdk/core/azure-core/test/ut/string_test.cpp
@@ -16,6 +16,7 @@ TEST(String, invariantCompare)
   EXPECT_TRUE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("AA", "aa"));
   EXPECT_TRUE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("aA", "aa"));
   EXPECT_TRUE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("ABC", "abc"));
+
   EXPECT_FALSE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("", "a"));
   EXPECT_FALSE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("a", ""));
   EXPECT_FALSE(StringExtensions::LocaleInvariantCaseInsensitiveEqual("A", "aA"));
@@ -28,7 +29,7 @@ TEST(String, toLowerC)
   for (unsigned i = 0; i <= 255; ++i)
   {
     auto const c = static_cast<char>(static_cast<unsigned char>(i));
-    EXPECT_TRUE(StringExtensions::ToLower(c) == std::tolower(c, std::locale::classic()));
+    EXPECT_EQ(StringExtensions::ToLower(c), std::tolower(c, std::locale::classic()));
   }
 }
 
@@ -38,46 +39,94 @@ TEST(String, toUpperC)
   for (unsigned i = 0; i <= 255; ++i)
   {
     auto const c = static_cast<char>(static_cast<unsigned char>(i));
-    EXPECT_TRUE(StringExtensions::ToUpper(c) == std::toupper(c, std::locale::classic()));
+    EXPECT_EQ(StringExtensions::ToUpper(c), std::toupper(c, std::locale::classic()));
+  }
+}
+
+TEST(String, isDigit)
+{
+  using Azure::Core::_internal::StringExtensions;
+  for (unsigned i = 0; i <= 255; ++i)
+  {
+    auto const c = static_cast<char>(static_cast<unsigned char>(i));
+    EXPECT_EQ(StringExtensions::IsDigit(c), std::isdigit(c, std::locale::classic()));
+  }
+}
+
+TEST(String, isHexDigit)
+{
+  using Azure::Core::_internal::StringExtensions;
+  for (unsigned i = 0; i <= 255; ++i)
+  {
+    auto const c = static_cast<char>(static_cast<unsigned char>(i));
+    EXPECT_EQ(StringExtensions::IsHexDigit(c), std::isxdigit(c, std::locale::classic()));
+  }
+}
+
+TEST(String, isAlphaNumeric)
+{
+  using Azure::Core::_internal::StringExtensions;
+  for (unsigned i = 0; i <= 255; ++i)
+  {
+    auto const c = static_cast<char>(static_cast<unsigned char>(i));
+    EXPECT_EQ(StringExtensions::IsAlphaNumeric(c), std::isalnum(c, std::locale::classic()));
+  }
+}
+
+TEST(String, isSpace)
+{
+  using Azure::Core::_internal::StringExtensions;
+  for (unsigned i = 0; i <= 255; ++i)
+  {
+    auto const c = static_cast<char>(static_cast<unsigned char>(i));
+    EXPECT_EQ(StringExtensions::IsSpace(c), std::isspace(c, std::locale::classic()));
+  }
+}
+
+TEST(String, isPrintable)
+{
+  using Azure::Core::_internal::StringExtensions;
+  for (unsigned i = 0; i <= 255; ++i)
+  {
+    auto const c = static_cast<char>(static_cast<unsigned char>(i));
+    EXPECT_EQ(StringExtensions::IsPrintable(c), std::isprint(c, std::locale::classic()));
   }
 }
 
 TEST(String, toLower)
 {
   using Azure::Core::_internal::StringExtensions;
-  EXPECT_TRUE(StringExtensions::ToLower("") == "");
-  EXPECT_TRUE(StringExtensions::ToLower("a") == "a");
-  EXPECT_TRUE(StringExtensions::ToLower("A") == "a");
-  EXPECT_TRUE(StringExtensions::ToLower("AA") == "aa");
-  EXPECT_TRUE(StringExtensions::ToLower("aA") == "aa");
-  EXPECT_TRUE(StringExtensions::ToLower("ABC") == "abc");
-  EXPECT_TRUE(
-      StringExtensions::ToLower("abcdefghijklmnopqrstuvwxyz") == "abcdefghijklmnopqrstuvwxyz");
-  EXPECT_TRUE(
-      StringExtensions::ToLower("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == "abcdefghijklmnopqrstuvwxyz");
-  EXPECT_TRUE(StringExtensions::ToLower("ABC-1-,!@#$%^&*()_+=ABC") == "abc-1-,!@#$%^&*()_+=abc");
-  EXPECT_FALSE(StringExtensions::ToLower("") == "a");
-  EXPECT_FALSE(StringExtensions::ToLower("a") == "");
-  EXPECT_FALSE(StringExtensions::ToLower("a") == "aA");
-  EXPECT_FALSE(StringExtensions::ToLower("abc") == "abcd");
+  EXPECT_EQ(StringExtensions::ToLower(""), "");
+  EXPECT_EQ(StringExtensions::ToLower("a"), "a");
+  EXPECT_EQ(StringExtensions::ToLower("A"), "a");
+  EXPECT_EQ(StringExtensions::ToLower("AA"), "aa");
+  EXPECT_EQ(StringExtensions::ToLower("aA"), "aa");
+  EXPECT_EQ(StringExtensions::ToLower("ABC"), "abc");
+  EXPECT_EQ(StringExtensions::ToLower("abcdefghijklmnopqrstuvwxyz"), "abcdefghijklmnopqrstuvwxyz");
+  EXPECT_EQ(StringExtensions::ToLower("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "abcdefghijklmnopqrstuvwxyz");
+  EXPECT_EQ(StringExtensions::ToLower("ABC-1-,!@#$%^&*()_+=ABC"), "abc-1-,!@#$%^&*()_+=abc");
+
+  EXPECT_NE(StringExtensions::ToLower(""), "a");
+  EXPECT_NE(StringExtensions::ToLower("a"), "");
+  EXPECT_NE(StringExtensions::ToLower("a"), "aA");
+  EXPECT_NE(StringExtensions::ToLower("abc"), "abcd");
 }
 
 TEST(String, toUpper)
 {
   using Azure::Core::_internal::StringExtensions;
-  EXPECT_TRUE(StringExtensions::ToUpper("") == "");
-  EXPECT_TRUE(StringExtensions::ToUpper("a") == "A");
-  EXPECT_TRUE(StringExtensions::ToUpper("A") == "A");
-  EXPECT_TRUE(StringExtensions::ToUpper("AA") == "AA");
-  EXPECT_TRUE(StringExtensions::ToUpper("aA") == "AA");
-  EXPECT_TRUE(
-      StringExtensions::ToUpper("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
-  EXPECT_TRUE(StringExtensions::ToUpper("ABC") == "ABC");
-  EXPECT_TRUE(
-      StringExtensions::ToUpper("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
-  EXPECT_TRUE(StringExtensions::ToUpper("ABC-1-,!@#$%^&*()_+=ABC") == "ABC-1-,!@#$%^&*()_+=ABC");
-  EXPECT_FALSE(StringExtensions::ToUpper("") == "A");
-  EXPECT_FALSE(StringExtensions::ToUpper("a") == "");
-  EXPECT_FALSE(StringExtensions::ToUpper("a") == "aA");
-  EXPECT_FALSE(StringExtensions::ToUpper("abc") == "abcd");
+  EXPECT_EQ(StringExtensions::ToUpper(""), "");
+  EXPECT_EQ(StringExtensions::ToUpper("a"), "A");
+  EXPECT_EQ(StringExtensions::ToUpper("A"), "A");
+  EXPECT_EQ(StringExtensions::ToUpper("AA"), "AA");
+  EXPECT_EQ(StringExtensions::ToUpper("aA"), "AA");
+  EXPECT_EQ(StringExtensions::ToUpper("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  EXPECT_EQ(StringExtensions::ToUpper("ABC"), "ABC");
+  EXPECT_EQ(StringExtensions::ToUpper("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  EXPECT_EQ(StringExtensions::ToUpper("ABC-1-,!@#$%^&*()_+=ABC"), "ABC-1-,!@#$%^&*()_+=ABC");
+
+  EXPECT_NE(StringExtensions::ToUpper(""), "A");
+  EXPECT_NE(StringExtensions::ToUpper("a"), "");
+  EXPECT_NE(StringExtensions::ToUpper("a"), "aA");
+  EXPECT_NE(StringExtensions::ToUpper("abc"), "abcd");
 }

--- a/sdk/core/azure-core/test/ut/transport_adapter_base_test.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base_test.cpp
@@ -84,7 +84,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // Check content-length header to be greater than 0
     int64_t contentLengthHeader = std::stoull(response->GetHeaders().at("content-length"));
-    EXPECT_TRUE(contentLengthHeader > 0);
+    EXPECT_GT(contentLengthHeader, 0);
   }
 
   TEST_P(TransportAdapter, put)
@@ -221,7 +221,7 @@ namespace Azure { namespace Core { namespace Test {
 
     // Check content-length header to be greater than 0
     int64_t contentLengthHeader = std::stoull(response->GetHeaders().at("content-length"));
-    EXPECT_TRUE(contentLengthHeader > 0);
+    EXPECT_GT(contentLengthHeader, 0);
   }
 
   TEST_P(TransportAdapter, putWithStream)
@@ -301,7 +301,7 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Response<std::string> responseT(expectedType, std::move(response));
     auto& r = responseT.RawResponse;
 
-    EXPECT_TRUE(r->GetStatusCode() == Azure::Core::Http::HttpStatusCode::Ok);
+    EXPECT_EQ(r->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
     auto expectedResponseBodySize = std::stoull(r->GetHeaders().at("content-length"));
     CheckBodyFromBuffer(*r, expectedResponseBodySize);
 

--- a/sdk/core/azure-core/test/ut/uuid_test.cpp
+++ b/sdk/core/azure-core/test/ut/uuid_test.cpp
@@ -11,7 +11,7 @@ using namespace Azure::Core;
 TEST(Uuid, Basic)
 {
   auto uuid = Uuid::CreateUuid();
-  EXPECT_TRUE(uuid.ToString().length() == 36);
+  EXPECT_EQ(uuid.ToString().length(), 36);
 }
 
 TEST(Uuid, Randomness)
@@ -25,7 +25,7 @@ TEST(Uuid, Randomness)
     // ret.second == false means the insert failed.
     EXPECT_TRUE(ret.second);
   }
-  EXPECT_TRUE(uuids.size() == size);
+  EXPECT_EQ(uuids.size(), size);
 }
 
 TEST(Uuid, separatorPosition)

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Bugs Fixed
 
+- [[#4443]](https://github.com/Azure/azure-sdk-for-cpp/issues/4443) Fixed potentially high CPU usage on Windows.
+
 ### Other Changes
+
+- Improved diagnostics to utilize `Azure::Core::Credentials::TokenCredential::GetCredentialName()`.
 
 ## 1.5.0-beta.1 (2023-03-07)
 

--- a/sdk/identity/azure-identity/CMakeLists.txt
+++ b/sdk/identity/azure-identity/CMakeLists.txt
@@ -62,6 +62,8 @@ set(
 
 set(
   AZURE_IDENTITY_SOURCE
+    src/private/chained_token_credential_impl.hpp
+    src/private/identity_log.hpp
     src/private/managed_identity_source.hpp
     src/private/package_version.hpp
     src/private/token_credential_impl.hpp

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -58,7 +58,7 @@ The `DefaultAzureCredential` attempts to authenticate via the following mechanis
 1. **Azure CLI** - If the developer has authenticated an account via the Azure CLI `az login` command, the `DefaultAzureCredential` will authenticate with that account.
 1. **Managed Identity** - If the application is deployed to an Azure host with Managed Identity enabled, the `DefaultAzureCredential` will authenticate with that account.
 
-`DefaultAzureCredential` uses [`ChainedTokenCredential`](#chained-token-credential) that consists of a chain of `EnvironmentCredential`, `AzureCliCredential`, and `ManagedIdentityCredential`. Implementation, including the order in which credentials are applied is documented, but it may change from release to release.
+Even though the credentials being used and their order is documented, it may change from release to release.
 
 `DefaultAzureCredential` intends to provide a credential that "just works out of the box and without requiring any information", if only the environment is set up sufficiently for the credential to work.
 Therefore, it could be simple to use, but since it uses a chain of credentials, it could be a bit complicated to diagnose if the environment setup is not sufficient.

--- a/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
@@ -58,6 +58,8 @@ namespace Azure { namespace Identity {
         DateTime::duration cliProcessTimeout,
         Core::Credentials::TokenCredentialOptions const& options);
 
+    void ThrowIfNotSafeCmdLineInput(std::string const& input, std::string const& description) const;
+
   public:
     /**
      * @brief Constructs an Azure CLI Credential.

--- a/sdk/identity/azure-identity/inc/azure/identity/chained_token_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/chained_token_credential.hpp
@@ -15,7 +15,9 @@
 #include <vector>
 
 namespace Azure { namespace Identity {
-  class DefaultAzureCredential;
+  namespace _detail {
+    class ChainedTokenCredentialImpl;
+  }
 
   /**
    * @brief Chained Token Credential provides a token credential implementation which chains
@@ -24,10 +26,6 @@ namespace Azure { namespace Identity {
    *
    */
   class ChainedTokenCredential final : public Core::Credentials::TokenCredential {
-    // Friend declaration is needed for DefaultAzureCredential to access ChainedTokenCredential's
-    // private constructor built to be used specifically by it.
-    friend class DefaultAzureCredential;
-
   public:
     /**
      * @brief A container type to store the ordered chain of credentials.
@@ -62,14 +60,7 @@ namespace Azure { namespace Identity {
         Core::Context const& context) const override;
 
   private:
-    explicit ChainedTokenCredential(
-        Sources sources,
-        std::string const& enclosingCredential,
-        std::vector<std::string> sourcesFriendlyNames);
-
-    Sources m_sources;
-    std::vector<std::string> m_sourcesFriendlyNames;
-    std::string m_logPrefix;
+    std::unique_ptr<_detail::ChainedTokenCredentialImpl> m_impl;
   };
 
 }} // namespace Azure::Identity

--- a/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
@@ -8,13 +8,15 @@
 
 #pragma once
 
+#include <azure/core/credentials/credentials.hpp>
 #include <azure/core/credentials/token_credential_options.hpp>
-
-#include <azure/identity/chained_token_credential.hpp>
 
 #include <memory>
 
 namespace Azure { namespace Identity {
+  namespace _detail {
+    class ChainedTokenCredentialImpl;
+  }
 
   /**
    * @brief Default Azure Credential combines multiple credentials that depend on the setup
@@ -22,7 +24,7 @@ namespace Azure { namespace Identity {
    * sufficiently for at least one of such credentials to work, `DefaultAzureCredential` will work
    * as well.
    *
-   * @details This credential is using the #ChainedTokenCredential of 3 credentials in the order:
+   * @details This credential is using several credentials in the following order:
    * #EnvironmentCredential, #AzureCliCredential, and #ManagedIdentityCredential. Even though the
    * credentials being used and their order is documented, it may be changed in the future versions
    * of the SDK, potentially bringing breaking changes in its behavior.
@@ -68,7 +70,7 @@ namespace Azure { namespace Identity {
         Core::Context const& context) const override;
 
   private:
-    std::shared_ptr<ChainedTokenCredential> m_credentials;
+    std::unique_ptr<_detail::ChainedTokenCredentialImpl> m_impl;
   };
 
 }} // namespace Azure::Identity

--- a/sdk/identity/azure-identity/samples/default_azure_credential.cpp
+++ b/sdk/identity/azure-identity/samples/default_azure_credential.cpp
@@ -14,8 +14,7 @@ int main()
     // Step 1: Initialize Default Azure Credential.
     // Default Azure Credential is good for samples and initial development stages only.
     // It is not recommended used it in a production environment.
-    // To diagnose, see
-    // https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity#troubleshooting
+    // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
 
     auto defaultAzureCredential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
 

--- a/sdk/identity/azure-identity/src/client_certificate_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_certificate_credential.cpp
@@ -80,7 +80,8 @@ ClientCertificateCredential::ClientCertificateCredential(
     std::string const& clientCertificatePath,
     std::string const& authorityHost,
     TokenCredentialOptions const& options)
-    : m_clientCredentialCore(tenantId, authorityHost),
+    : TokenCredential("ClientCertificateCredential"),
+      m_clientCredentialCore(tenantId, authorityHost),
       m_tokenCredentialImpl(std::make_unique<TokenCredentialImpl>(options)),
       m_requestBody(
           std::string(

--- a/sdk/identity/azure-identity/src/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_secret_credential.cpp
@@ -21,7 +21,7 @@ ClientSecretCredential::ClientSecretCredential(
     std::string const& clientSecret,
     std::string const& authorityHost,
     TokenCredentialOptions const& options)
-    : m_clientCredentialCore(tenantId, authorityHost),
+    : TokenCredential("ClientSecretCredential"), m_clientCredentialCore(tenantId, authorityHost),
       m_tokenCredentialImpl(std::make_unique<TokenCredentialImpl>(options)),
       m_requestBody(
           std::string("grant_type=client_credentials&client_id=") + Url::Encode(clientId)

--- a/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "azure/identity/chained_token_credential.hpp"
+
+namespace Azure { namespace Identity { namespace _detail {
+
+  class ChainedTokenCredentialImpl final {
+  public:
+    ChainedTokenCredentialImpl(
+        std::string const& credentialName,
+        ChainedTokenCredential::Sources&& sources);
+
+    Core::Credentials::AccessToken GetToken(
+        std::string const& credentialName,
+        Core::Credentials::TokenRequestContext const& tokenRequestContext,
+        Core::Context const& context) const;
+
+  private:
+    ChainedTokenCredential::Sources m_sources;
+  };
+
+}}} // namespace Azure::Identity::_detail

--- a/sdk/identity/azure-identity/src/private/identity_log.hpp
+++ b/sdk/identity/azure-identity/src/private/identity_log.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <azure/core/internal/diagnostics/log.hpp>
+
+namespace Azure { namespace Identity { namespace _detail {
+
+  class IdentityLog final {
+  public:
+    using Level = Core::Diagnostics::Logger::Level;
+
+    static void Write(Level level, std::string const& message)
+    {
+      Core::Diagnostics::_internal::Log::Write(level, "Identity: " + message);
+    }
+
+    static bool ShouldWrite(Level level)
+    {
+      return Core::Diagnostics::_internal::Log::ShouldWrite(level);
+    }
+
+  private:
+    IdentityLog() = delete;
+    ~IdentityLog() = delete;
+  };
+
+}}} // namespace Azure::Identity::_detail

--- a/sdk/identity/azure-identity/src/private/managed_identity_source.hpp
+++ b/sdk/identity/azure-identity/src/private/managed_identity_source.hpp
@@ -30,6 +30,7 @@ namespace Azure { namespace Identity { namespace _detail {
     _detail::TokenCache m_tokenCache;
 
     static Core::Url ParseEndpointUrl(
+        std::string const& credName,
         std::string const& url,
         char const* envVarName,
         std::string const& credSource);
@@ -63,6 +64,7 @@ namespace Azure { namespace Identity { namespace _detail {
 
     template <typename T>
     static std::unique_ptr<ManagedIdentitySource> Create(
+        std::string const& credName,
         std::string const& clientId,
         Core::Credentials::TokenCredentialOptions const& options,
         char const* endpointVarName,
@@ -97,6 +99,7 @@ namespace Azure { namespace Identity { namespace _detail {
 
   public:
     static std::unique_ptr<ManagedIdentitySource> Create(
+        std::string const& credName,
         std::string const& clientId,
         Core::Credentials::TokenCredentialOptions const& options);
   };
@@ -123,6 +126,7 @@ namespace Azure { namespace Identity { namespace _detail {
 
   public:
     static std::unique_ptr<ManagedIdentitySource> Create(
+        std::string const& credName,
         std::string const& clientId,
         Core::Credentials::TokenCredentialOptions const& options);
   };
@@ -139,6 +143,7 @@ namespace Azure { namespace Identity { namespace _detail {
 
   public:
     static std::unique_ptr<ManagedIdentitySource> Create(
+        std::string const& credName,
         std::string const& clientId,
         Core::Credentials::TokenCredentialOptions const& options);
 
@@ -157,6 +162,7 @@ namespace Azure { namespace Identity { namespace _detail {
 
   public:
     static std::unique_ptr<ManagedIdentitySource> Create(
+        std::string const& credName,
         std::string const& clientId,
         Core::Credentials::TokenCredentialOptions const& options);
 
@@ -175,6 +181,7 @@ namespace Azure { namespace Identity { namespace _detail {
 
   public:
     static std::unique_ptr<ManagedIdentitySource> Create(
+        std::string const& credName,
         std::string const& clientId,
         Core::Credentials::TokenCredentialOptions const& options);
 

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -158,6 +158,12 @@ TEST(AzureCliCredential, Error)
   Logger::SetListener(nullptr);
 }
 
+TEST(AzureCliCredential, GetCredentialName)
+{
+  AzureCliTestCredential const cred(EmptyOutputCommand);
+  EXPECT_EQ(cred.GetCredentialName(), "AzureCliCredential");
+}
+
 TEST(AzureCliCredential, EmptyOutput)
 {
   AzureCliTestCredential const azCliCred(EmptyOutputCommand);

--- a/sdk/identity/azure-identity/test/ut/client_certificate_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/client_certificate_credential_test.cpp
@@ -30,9 +30,20 @@ std::vector<std::string> SplitString(const std::string& s, char separator);
 std::string ToString(std::vector<uint8_t> const& vec);
 } // namespace
 
+TEST(ClientCertificateCredential, GetCredentialName)
+{
+  TempCertFile const tempCertFile;
+  ClientCertificateCredential const cred(
+      "01234567-89ab-cdef-fedc-ba8976543210",
+      "fedcba98-7654-3210-0123-456789abcdef",
+      TempCertFile::Path);
+
+  EXPECT_EQ(cred.GetCredentialName(), "ClientCertificateCredential");
+}
+
 TEST(ClientCertificateCredential, Regular)
 {
-  TempCertFile tempCertFile;
+  TempCertFile const tempCertFile;
 
   auto const actual = CredentialTestHelper::SimulateTokenRequest(
       [](auto transport) {
@@ -167,7 +178,7 @@ TEST(ClientCertificateCredential, Regular)
 
 TEST(ClientCertificateCredential, AzureStack)
 {
-  TempCertFile tempCertFile;
+  TempCertFile const tempCertFile;
 
   auto const actual = CredentialTestHelper::SimulateTokenRequest(
       [](auto transport) {
@@ -294,7 +305,7 @@ TEST(ClientCertificateCredential, AzureStack)
 
 TEST(ClientCertificateCredential, Authority)
 {
-  TempCertFile tempCertFile;
+  TempCertFile const tempCertFile;
 
   auto const actual = CredentialTestHelper::SimulateTokenRequest(
       [](auto transport) {

--- a/sdk/identity/azure-identity/test/ut/client_secret_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/client_secret_credential_test.cpp
@@ -12,6 +12,16 @@ using Azure::Identity::ClientSecretCredential;
 using Azure::Identity::ClientSecretCredentialOptions;
 using Azure::Identity::Test::_detail::CredentialTestHelper;
 
+TEST(ClientSecretCredential, GetCredentialName)
+{
+  ClientSecretCredential const cred(
+      "01234567-89ab-cdef-fedc-ba8976543210",
+      "fedcba98-7654-3210-0123-456789abcdef",
+      "CLIENTSECRET");
+
+  EXPECT_EQ(cred.GetCredentialName(), "ClientSecretCredential");
+}
+
 TEST(ClientSecretCredential, Regular)
 {
   auto const actual = CredentialTestHelper::SimulateTokenRequest(

--- a/sdk/identity/azure-identity/test/ut/default_azure_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/default_azure_credential_test.cpp
@@ -17,6 +17,28 @@ using Azure::Identity::Test::_detail::CredentialTestHelper;
 namespace {
 } // namespace
 
+TEST(DefaultAzureCredential, GetCredentialName)
+{
+  CredentialTestHelper::EnvironmentOverride const env({
+      {"AZURE_TENANT_ID", "01234567-89ab-cdef-fedc-ba8976543210"},
+      {"AZURE_CLIENT_ID", "fedcba98-7654-3210-0123-456789abcdef"},
+      {"AZURE_CLIENT_SECRET", "CLIENTSECRET"},
+      {"AZURE_AUTHORITY_HOST", ""},
+      {"AZURE_USERNAME", ""},
+      {"AZURE_PASSWORD", ""},
+      {"AZURE_CLIENT_CERTIFICATE_PATH", ""},
+      {"MSI_ENDPOINT", ""},
+      {"MSI_SECRET", ""},
+      {"IDENTITY_ENDPOINT", "https://visualstudio.com/"},
+      {"IMDS_ENDPOINT", ""},
+      {"IDENTITY_HEADER", "CLIENTSECRET"},
+      {"IDENTITY_SERVER_THUMBPRINT", ""},
+  });
+
+  DefaultAzureCredential const cred;
+  EXPECT_EQ(cred.GetCredentialName(), "DefaultAzureCredential");
+}
+
 TEST(DefaultAzureCredential, LogMessages)
 {
   using LogMsgVec = std::vector<std::pair<Logger::Level, std::string>>;
@@ -47,70 +69,73 @@ TEST(DefaultAzureCredential, LogMessages)
 
         auto credential = std::make_unique<DefaultAzureCredential>(options);
 
-        EXPECT_EQ(log.size(), LogMsgVec::size_type(9));
+        EXPECT_EQ(log.size(), LogMsgVec::size_type(10));
 
         EXPECT_EQ(log[0].first, Logger::Level::Verbose);
         EXPECT_EQ(
             log[0].second,
-            "Identity: Creating DefaultAzureCredential which combines mutiple parameterless "
-            "credentials "
-            "into a single one (by using ChainedTokenCredential)."
+            "Identity: Creating DefaultAzureCredential which combines "
+            "mutiple parameterless credentials into a single one."
             "\nDefaultAzureCredential is only recommended for the early stages of development, "
             "and not for usage in production environment."
             "\nOnce the developer focuses on the Credentials and Authentication aspects of their "
             "application, DefaultAzureCredential needs to be replaced with the credential that "
             "is the better fit for the application.");
 
-        EXPECT_EQ(log[1].first, Logger::Level::Verbose);
+        EXPECT_EQ(log[1].first, Logger::Level::Informational);
         EXPECT_EQ(
             log[1].second,
+            "Identity: EnvironmentCredential gets created with ClientSecretCredential.");
+
+        EXPECT_EQ(log[2].first, Logger::Level::Verbose);
+        EXPECT_EQ(
+            log[2].second,
             "Identity: EnvironmentCredential: 'AZURE_TENANT_ID', 'AZURE_CLIENT_ID', "
             "'AZURE_CLIENT_SECRET', and 'AZURE_AUTHORITY_HOST' environment variables are set, so "
             "ClientSecretCredential with corresponding tenantId, clientId, clientSecret, and "
             "authorityHost gets created.");
 
-        EXPECT_EQ(log[2].first, Logger::Level::Informational);
-        EXPECT_EQ(
-            log[2].second,
-            "Identity: AzureCliCredential created."
-            "\nSuccessful creation does not guarantee further successful token retrieval.");
-
-        EXPECT_EQ(log[3].first, Logger::Level::Verbose);
+        EXPECT_EQ(log[3].first, Logger::Level::Informational);
         EXPECT_EQ(
             log[3].second,
-            "Identity: ManagedIdentityCredential: Environment is not set up for the credential "
-            "to be created with App Service 2019 source.");
+            "Identity: AzureCliCredential created."
+            "\nSuccessful creation does not guarantee further successful token retrieval.");
 
         EXPECT_EQ(log[4].first, Logger::Level::Verbose);
         EXPECT_EQ(
             log[4].second,
             "Identity: ManagedIdentityCredential: Environment is not set up for the credential "
-            "to be created with App Service 2017 source.");
+            "to be created with App Service 2019 source.");
 
         EXPECT_EQ(log[5].first, Logger::Level::Verbose);
         EXPECT_EQ(
             log[5].second,
             "Identity: ManagedIdentityCredential: Environment is not set up for the credential "
-            "to be created with Cloud Shell source.");
+            "to be created with App Service 2017 source.");
 
         EXPECT_EQ(log[6].first, Logger::Level::Verbose);
         EXPECT_EQ(
             log[6].second,
             "Identity: ManagedIdentityCredential: Environment is not set up for the credential "
-            "to be created with Azure Arc source.");
+            "to be created with Cloud Shell source.");
 
-        EXPECT_EQ(log[7].first, Logger::Level::Informational);
+        EXPECT_EQ(log[7].first, Logger::Level::Verbose);
         EXPECT_EQ(
             log[7].second,
-            "Identity: ManagedIdentityCredential will be created "
-            "with Azure Instance Metadata Service source."
-            "\nSuccessful creation does not guarantee further successful token retrieval.");
+            "Identity: ManagedIdentityCredential: Environment is not set up for the credential "
+            "to be created with Azure Arc source.");
 
         EXPECT_EQ(log[8].first, Logger::Level::Informational);
         EXPECT_EQ(
             log[8].second,
-            "Identity: DefaultAzureCredential: Created ChainedTokenCredential "
-            "with the following credentials: "
+            "Identity: ManagedIdentityCredential will be created "
+            "with Azure Instance Metadata Service source."
+            "\nSuccessful creation does not guarantee further successful token retrieval.");
+
+        EXPECT_EQ(log[9].first, Logger::Level::Informational);
+        EXPECT_EQ(
+            log[9].second,
+            "Identity: DefaultAzureCredential: Created with the following credentials: "
             "EnvironmentCredential, AzureCliCredential, ManagedIdentityCredential.");
 
         log.clear();
@@ -127,8 +152,7 @@ TEST(DefaultAzureCredential, LogMessages)
   EXPECT_EQ(log[3].first, Logger::Level::Informational);
   EXPECT_EQ(
       log[3].second,
-      "Identity: DefaultAzureCredential -> ChainedTokenCredential: "
-      "Successfully got token from EnvironmentCredential.");
+      "Identity: DefaultAzureCredential: Successfully got token from EnvironmentCredential.");
 
   Logger::SetListener(nullptr);
 }

--- a/sdk/identity/azure-identity/test/ut/managed_identity_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/managed_identity_credential_test.cpp
@@ -16,6 +16,21 @@ using Azure::Core::Http::HttpStatusCode;
 using Azure::Identity::ManagedIdentityCredential;
 using Azure::Identity::Test::_detail::CredentialTestHelper;
 
+TEST(ManagedIdentityCredential, GetCredentialName)
+{
+  CredentialTestHelper::EnvironmentOverride const env({
+      {"MSI_ENDPOINT", ""},
+      {"MSI_SECRET", ""},
+      {"IDENTITY_ENDPOINT", "https://visualstudio.com/"},
+      {"IMDS_ENDPOINT", ""},
+      {"IDENTITY_HEADER", "CLIENTSECRET"},
+      {"IDENTITY_SERVER_THUMBPRINT", ""},
+  });
+
+  ManagedIdentityCredential const cred;
+  EXPECT_EQ(cred.GetCredentialName(), "ManagedIdentityCredential");
+}
+
 TEST(ManagedIdentityCredential, AppServiceV2019)
 {
   using Azure::Core::Diagnostics::Logger;

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_cryptographic_client_test_live.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_cryptographic_client_test_live.cpp
@@ -37,7 +37,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteEncrypt)
         = cryptoClient->Encrypt(EncryptParameters::RsaOaepParameters(plaintext)).Value;
     EXPECT_EQ(encryptResult.Algorithm.ToString(), EncryptionAlgorithm::RsaOaep.ToString());
     EXPECT_EQ(encryptResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(encryptResult.Ciphertext.size() > 0);
+    EXPECT_GT(encryptResult.Ciphertext.size(), 0u);
 
     auto decryptResult
         = cryptoClient->Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext))
@@ -68,7 +68,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteWrap)
     auto wrapResult = cryptoClient->WrapKey(KeyWrapAlgorithm::RsaOaep256, plaintext).Value;
     EXPECT_EQ(wrapResult.Algorithm.ToString(), KeyWrapAlgorithm::RsaOaep256.ToString());
     EXPECT_EQ(wrapResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(wrapResult.EncryptedKey.size() > 0);
+    EXPECT_GT(wrapResult.EncryptedKey.size(), 0u);
 
     auto unwrapResult
         = cryptoClient->UnwrapKey(wrapResult.Algorithm, wrapResult.EncryptedKey).Value;
@@ -102,7 +102,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyRSA256)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0u);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -121,7 +121,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyRSA256)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0u);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -152,7 +152,7 @@ TEST_F(KeyVaultKeyClient, RemoteSignVerifyES256)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, ecKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0u);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -176,7 +176,7 @@ TEST_F(KeyVaultKeyClient, RemoteSignVerifyES256)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, ecKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0u);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -210,7 +210,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyRSA384)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0u);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -229,7 +229,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyRSA384)
     auto signResult = cryptoClient->Sign(signatureAlgorithm, digest).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0u);
 
     auto verifyResult
         = cryptoClient->Verify(signResult.Algorithm, digest, signResult.Signature).Value;
@@ -260,7 +260,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyDataRSA256)
     auto signResult = cryptoClient->SignData(signatureAlgorithm, data).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0u);
 
     auto verifyResult
         = cryptoClient->VerifyData(signResult.Algorithm, data, signResult.Signature).Value;
@@ -275,7 +275,7 @@ TEST_P(KeyVaultKeyClientWithParam, RemoteSignVerifyDataRSA256)
     auto signResult = cryptoClient->SignData(signatureAlgorithm, data).Value;
     EXPECT_EQ(signResult.Algorithm.ToString(), signatureAlgorithm.ToString());
     EXPECT_EQ(signResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(signResult.Signature.size() > 0);
+    EXPECT_GT(signResult.Signature.size(), 0u);
 
     auto verifyResult
         = cryptoClient->VerifyData(signResult.Algorithm, data, signResult.Signature).Value;
@@ -305,7 +305,7 @@ TEST_P(KeyVaultKeyClientWithParam, GetCryptoFromKeyRemoteEncrypt)
         = cryptoClient.Encrypt(EncryptParameters::RsaOaepParameters(plaintext)).Value;
     EXPECT_EQ(encryptResult.Algorithm.ToString(), EncryptionAlgorithm::RsaOaep.ToString());
     EXPECT_EQ(encryptResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(encryptResult.Ciphertext.size() > 0);
+    EXPECT_GT(encryptResult.Ciphertext.size(), 0u);
 
     auto decryptResult
         = cryptoClient.Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext))
@@ -336,7 +336,7 @@ TEST_P(KeyVaultKeyClientWithParam, GetCryptoFromKeyVersionRemoteEncrypt)
         = cryptoClient.Encrypt(EncryptParameters::RsaOaepParameters(plaintext)).Value;
     EXPECT_EQ(encryptResult.Algorithm.ToString(), EncryptionAlgorithm::RsaOaep.ToString());
     EXPECT_EQ(encryptResult.KeyId, rsaKey.Id());
-    EXPECT_TRUE(encryptResult.Ciphertext.size() > 0);
+    EXPECT_GT(encryptResult.Ciphertext.size(), 0u);
 
     auto decryptResult
         = cryptoClient.Decrypt(DecryptParameters::RsaOaepParameters(encryptResult.Ciphertext))

--- a/sdk/storage/MigrationGuide.md
+++ b/sdk/storage/MigrationGuide.md
@@ -81,7 +81,7 @@ cloud_blob_client blob_client(storage_uri(blob_url), storage_credentials(sas_tok
 ```
 
 ```C++
-cloud_blob_client blob_client(storage_uri(blob_url_with_sas);
+cloud_blob_client blob_client(storage_uri(blob_url_with_sas));
 ```
 
 v12

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -1737,23 +1737,14 @@ namespace Azure { namespace Storage { namespace Test {
 
     for (int c : {1, 2, 4})
     {
-      std::vector<std::future<void>> futures;
-      // random range
       for (int i = 0; i < 16; ++i)
       {
+        // random range
         int64_t fileSize = RandomInt(1, 1_MB);
-        futures.emplace_back(
-            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 4_KB, 47_KB));
-        futures.emplace_back(
-            std::async(std::launch::async, testUploadFromFile, c, fileSize, 2_KB, 185_KB));
-        futures.emplace_back(
-            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 0, 117_KB));
-        futures.emplace_back(
-            std::async(std::launch::async, testUploadFromFile, c, fileSize, 0, 259_KB));
-      }
-      for (auto& f : futures)
-      {
-        f.get();
+        testUploadFromBuffer(c, fileSize, 4_KB, 47_KB);
+        testUploadFromFile(c, fileSize, 2_KB, 185_KB);
+        testUploadFromBuffer(c, fileSize, 0, 117_KB);
+        testUploadFromFile(c, fileSize, 0, 259_KB);
       }
     }
   }

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
@@ -868,23 +868,14 @@ namespace Azure { namespace Storage { namespace Test {
 
     for (int c : {1, 2, 4})
     {
-      std::vector<std::future<void>> futures;
-      // random range
       for (int i = 0; i < 16; ++i)
       {
+        // random range
         int64_t fileSize = RandomInt(1, 1_MB);
-        futures.emplace_back(
-            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 4_KB, 56_KB));
-        futures.emplace_back(
-            std::async(std::launch::async, testUploadFromFile, c, fileSize, 2_KB, 172_KB));
-        futures.emplace_back(
-            std::async(std::launch::async, testUploadFromBuffer, c, fileSize, 0, 109_KB));
-        futures.emplace_back(
-            std::async(std::launch::async, testUploadFromFile, c, fileSize, 0, 256_KB));
-      }
-      for (auto& f : futures)
-      {
-        f.get();
+        testUploadFromBuffer(c, fileSize, 4_KB, 56_KB);
+        testUploadFromFile(c, fileSize, 2_KB, 172_KB);
+        testUploadFromBuffer(c, fileSize, 0, 109_KB);
+        testUploadFromFile(c, fileSize, 0, 256_KB);
       }
     }
   }

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_client_test.cpp
@@ -301,12 +301,12 @@ namespace Azure { namespace Storage { namespace Test {
       Files::Shares::ShareLeaseClient leaseClient(*m_shareClient, leaseId1);
       auto aLease = leaseClient.Acquire(leaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
       lastModified = m_shareClient->GetProperties().Value.LastModified;
       aLease = leaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
 
       auto properties = m_shareClient->GetProperties().Value;
@@ -316,7 +316,7 @@ namespace Azure { namespace Storage { namespace Test {
       lastModified = m_shareClient->GetProperties().Value.LastModified;
       auto rLease = leaseClient.Renew().Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(rLease.LeaseId, leaseId1);
 
       lastModified = m_shareClient->GetProperties().Value.LastModified;
@@ -324,14 +324,14 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NE(leaseId1, leaseId2);
       auto cLease = leaseClient.Change(leaseId2).Value;
       EXPECT_TRUE(cLease.ETag.HasValue());
-      EXPECT_TRUE(cLease.LastModified >= lastModified);
+      EXPECT_GE(cLease.LastModified, lastModified);
       EXPECT_EQ(cLease.LeaseId, leaseId2);
       EXPECT_EQ(leaseClient.GetLeaseId(), leaseId2);
 
       lastModified = m_shareClient->GetProperties().Value.LastModified;
       auto relLease = leaseClient.Release().Value;
       EXPECT_TRUE(relLease.ETag.HasValue());
-      EXPECT_TRUE(relLease.LastModified >= lastModified);
+      EXPECT_GE(relLease.LastModified, lastModified);
     }
 
     {
@@ -343,7 +343,7 @@ namespace Azure { namespace Storage { namespace Test {
           Files::Shares::Models::LeaseDurationType::Infinite, properties.LeaseDuration.Value());
       auto brokenLease = leaseClient.Break().Value;
       EXPECT_TRUE(brokenLease.ETag.HasValue());
-      EXPECT_TRUE(brokenLease.LastModified >= properties.LastModified);
+      EXPECT_GE(brokenLease.LastModified, properties.LastModified);
     }
   }
 
@@ -358,14 +358,14 @@ namespace Azure { namespace Storage { namespace Test {
       Files::Shares::ShareLeaseClient shareSnapshotLeaseClient(shareSnapshot, leaseId1);
       auto aLease = shareSnapshotLeaseClient.Acquire(leaseDuration).Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
       lastModified = shareSnapshot.GetProperties().Value.LastModified;
       aLease
           = shareSnapshotLeaseClient.Acquire(Files::Shares::ShareLeaseClient::InfiniteLeaseDuration)
                 .Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(aLease.LeaseId, leaseId1);
 
       auto properties = shareSnapshot.GetProperties().Value;
@@ -375,7 +375,7 @@ namespace Azure { namespace Storage { namespace Test {
       lastModified = shareSnapshot.GetProperties().Value.LastModified;
       auto rLease = shareSnapshotLeaseClient.Renew().Value;
       EXPECT_TRUE(aLease.ETag.HasValue());
-      EXPECT_TRUE(aLease.LastModified >= lastModified);
+      EXPECT_GE(aLease.LastModified, lastModified);
       EXPECT_EQ(rLease.LeaseId, leaseId1);
 
       lastModified = shareSnapshot.GetProperties().Value.LastModified;
@@ -383,14 +383,14 @@ namespace Azure { namespace Storage { namespace Test {
       EXPECT_NE(leaseId1, leaseId2);
       auto cLease = shareSnapshotLeaseClient.Change(leaseId2).Value;
       EXPECT_TRUE(cLease.ETag.HasValue());
-      EXPECT_TRUE(cLease.LastModified >= lastModified);
+      EXPECT_GE(cLease.LastModified, lastModified);
       EXPECT_EQ(cLease.LeaseId, leaseId2);
       EXPECT_EQ(shareSnapshotLeaseClient.GetLeaseId(), leaseId2);
 
       lastModified = shareSnapshot.GetProperties().Value.LastModified;
       auto relLease = shareSnapshotLeaseClient.Release().Value;
       EXPECT_TRUE(relLease.ETag.HasValue());
-      EXPECT_TRUE(relLease.LastModified >= lastModified);
+      EXPECT_GE(relLease.LastModified, lastModified);
     }
 
     {
@@ -403,7 +403,7 @@ namespace Azure { namespace Storage { namespace Test {
           Files::Shares::Models::LeaseDurationType::Infinite, properties.LeaseDuration.Value());
       auto brokenLease = shareSnapshotLeaseClient.Break().Value;
       EXPECT_TRUE(brokenLease.ETag.HasValue());
-      EXPECT_TRUE(brokenLease.LastModified >= properties.LastModified);
+      EXPECT_GE(brokenLease.LastModified, properties.LastModified);
       shareSnapshotLeaseClient.Release();
     }
 


### PR DESCRIPTION
* Add GetCredentialName() (#4428)

* Add GetCredentialName()

* Update

* Undo accidental change

* Clang-format

* Call GetCredentialName() instead of using constant; Return in-place constructed name; Explicit tests for GetCredentialName()

* PR feedback

* constructor parameter + non-virtual GetCredentialName()

* Update sdk/core/azure-core/CMakeLists.txt

* Update sdk/identity/azure-identity/test/ut/client_secret_credential_test.cpp

* Update sdk/identity/azure-identity/test/ut/client_certificate_credential_test.cpp

* GCC and Clang warnings

* Promote ThrowIfNotSafeCmdLineInput() to private member; avoid copies when calling GetCredentialName()

* Spelling

* Fix deprecated usage

* Fix iteration

* Clang-format

---------



* Sync eng/common directory with azure-sdk-tools for PR 5702 (#4453)

* add healthinsights to Test-SampleMetadata script

* spacing

* update productSlug to azure-health-insights

---------



* Use aka.ms link to Identity troubleshooting (#4449)

* Use aka.ms link to Identity troubleshooting

* Update default_azure_credential.cpp

* Update default_azure_credential.cpp

---------



* Undocument ChainedCred usage by DefaultAzCred & remove friend and private ctor (#4447)

* Undocument ChainedCred usage by DefaultAzCred & remove friend and private ctor

* Clang warning fix

---------



* Sync eng/common directory with azure-sdk-tools for PR 5691 (#4450)

* typespec renaming

* add back scripts for cadl

* support .cadl and .tsp

* rename

* add newline at the end of file

---------



* fix cspell for readme.ms in libcurl sterss test (#4441)

* fix cspell

* capitalize Valgrind and ubuntu

* sdada

* fix2

* Simpler identity logging (#4455)

* Simpler identity logging

* Even simpler

* Remove refactoring artifact

* Cosmetic change

* foreach

---------



* 3rd Party Libs in Samples (#4408)

Adding guidance on the proper usage of 3rd Party Libraries in our samples.

* Update changelog with issue link (#4458)



* Tests: replace most `EXPECT_TRUE(a OP b)` with `EXPECT_OP(a, b)` (#4457)

* Tests: replace most `EXPECT_TRUE(a OP b)` with `EXPECT_OP(a, b)`

* Undo unnecessary change

---------



* Revert "[check-spelling] Temporarily pin Node 18 to 18.13.0 (#5537)" (#4456)

This reverts commit 8a02e02adfc0d213509fce2764132afa74bd4ba4.



* Fix potentially high CPU usage on Windows (#4448)

* Fix potentially high CPU usage on Windows

* Undo unnecessary formatting

* Undo unnecessary changelog

* Undo unnecessary formatting

* Undo unnecessary formatting

* Uninclude locale

* Add issue link to changelog

* EXPECT_TRUE(a == b) => EXPECT_EQ(a, b)

* Update second changelog with link as well

---------



* Ensure the comparison is unsigned to unsigned (#4464)

* Ensure the comparison is unsigned to unsigned

* Remove cast

* Sync eng/common directory with azure-sdk-tools for PR 5742 (#4465)

* add some default output to see about minimizing any occurrence of the task failing for no reason. perhaps having some output will allow devops to have an easier time with the invocation

* update message

* Update eng/common/scripts/trust-proxy-certificate.ps1



* Update CODEOWNERS (#4461)

Fixup an invalid user

* Organize applying Identity log prefix (#4459)

* Organize applying Identity log prefix

* logLevel

* Cosmetic changes

---------



* Explicitly set PSNativeCommandArgumentPassing to Legacy for git push script (#4481)

https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.3#psnativecommandargumentpassing Do to that breaking change in PS 7.3 we need to opt into the legacy arg parsing.



* Fix unmatched parenthesis in doc (#4482)

* fix concurrent upload failures (#4484)

* Sync eng/common directory with azure-sdk-tools for PR 5726 (#4488)

* rerun flag

* rerun failed stress test

* naming & commenting

* update

* function and var renaming for better readability

* readability & exit on error

---------



---------

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
