### PR TITLE
Fixed the UUID generation logic so that the variant digit is RFC 4122 conforming.

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -12,6 +12,7 @@ This is useful when the UUID was generated outside the Azure SDK, or needs to be
 ### Bugs Fixed
 
 - [[#4490]](https://github.com/Azure/azure-sdk-for-cpp/issues/4490) Fixed WinHTTP memory leak during failed requests.
+- Fixed the UUID generation so the variant is RFC 4122 conforming.
 
 ### Other Changes
 

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -24,11 +24,6 @@ namespace Azure { namespace Core {
     static constexpr size_t UuidSize = 16;
 
     std::array<uint8_t, UuidSize> m_uuid;
-    // The UUID reserved variants.
-    static constexpr uint8_t ReservedNCS = 0x80;
-    static constexpr uint8_t ReservedRFC4122 = 0x40;
-    static constexpr uint8_t ReservedMicrosoft = 0x20;
-    static constexpr uint8_t ReservedFuture = 0x00;
 
   private:
     Uuid(uint8_t const uuid[UuidSize]) { std::memcpy(m_uuid.data(), uuid, UuidSize); }

--- a/sdk/core/azure-core/src/uuid.cpp
+++ b/sdk/core/azure-core/src/uuid.cpp
@@ -67,8 +67,15 @@ namespace Azure { namespace Core {
       std::memcpy(uuid + i, &x, 4);
     }
 
-    // SetVariant to ReservedRFC4122
-    uuid[8] = (uuid[8] | ReservedRFC4122) & 0x7F;
+    // The variant field consists of a variable number of the most significant bits of octet 8 of
+    // the UUID.
+    // https://www.rfc-editor.org/rfc/rfc4122.html#section-4.1.1
+    // For setting the variant to conform to RFC4122, the high bits need to be of the form 10xx,
+    // which means the hex value of the first 4 bits can only be either 8, 9, A|a, B|b. The 0-7
+    // values are reserved for backward compatibility. The C|c, D|d values are reserved for
+    // Microsoft, and the E|e, F|f values are reserved for future use.
+    // Therefore, we have to zero out the two high bits, and then set the highest bit to 1.
+    uuid[8] = (uuid[8] & 0x3F) | 0x80;
 
     constexpr uint8_t version = 4; // Version 4: Pseudo-random number
 

--- a/sdk/core/azure-core/test/ut/uuid_test.cpp
+++ b/sdk/core/azure-core/test/ut/uuid_test.cpp
@@ -36,6 +36,33 @@ TEST(Uuid, Randomness)
   EXPECT_EQ(uuids.size(), size);
 }
 
+TEST(Uuid, Rfc4122Conforming)
+{
+  const int size = 100;
+  for (int i = 0; i < size; i++)
+  {
+    auto uuid = Uuid::CreateUuid();
+    auto uuidStr = uuid.ToString();
+    auto version = uuidStr[14];
+    EXPECT_EQ(version, '4'); // Version 4: Pseudo-random number
+
+    // The variant field consists of a variable number of the most significant bits of octet 8 of
+    // the UUID.
+    // https://www.rfc-editor.org/rfc/rfc4122.html#section-4.1.1
+    // The high bits of the variant need to be of the form 10xx, which means they can only be either
+    // 8, 9, A|a, B|b. The 0-7 values are reserved for backward compatibility. The C|c, D|d values
+    // are reserved for Microsoft, and the E|e, F|f values are reserved for future use.
+    auto variant = uuidStr[19];
+
+    // The test is written this way to improve logging IF it was to fail, so we can see the value
+    // of the incorrect variant.
+    EXPECT_TRUE(
+        (variant == '8' || variant == '9' || variant == 'A' || variant == 'B' || variant == 'a'
+         || variant == 'b'))
+        << variant << " is not one of the expected values of 8, 9, A, B, a, b";
+  }
+}
+
 TEST(Uuid, separatorPosition)
 {
   auto uuidKey = Uuid::CreateUuid().ToString();


### PR DESCRIPTION
This line isn’t doing what is says it is supposed to be doing, from my reading of it (unless I got the endianness/bit order wrong).
https://www.rfc-editor.org/rfc/rfc4122.html#section-4.1.1

```C++
// SetVariant to ReservedRFC4122
uuid[8] = (uuid[8] | ReservedRFC4122) & 0x7F;
```

Incorrect: (X | 0100 000) & (0111 1111)

It is setting the high bits to `01xx xxxx` instead of what it should be `10xx xxxx`.

Correct: (X & 0011 1111) | (1000 000)

**Additional references:**
https://www.famkruithof.net/guid-uuid-make.html
https://stackoverflow.com/a/1709834
https://www.cryptosys.net/pki/uuid-rfc4122.html

Confirmed with .NET and GoLang's UUID implementations, they only produce values that have 8,9,A|a,B|b for the 17th hex digit in the form `8-4-4-4-12`

```golang
package main

import (
	"fmt"

	"github.com/google/uuid"
)

func main() {
	for i := 0; i < 10; i++ {
		id := uuid.New()
		fmt.Println(id.String())
	}
}
```
```C#
using System;
					
public class Program
{
	public static void Main()
	{
		for (int i = 0; i < 256; i++)
		{
			Console.WriteLine(Guid.NewGuid());
		}

	}
}
```

```text
eb5d6e43-8be3-4d83-a584-a9033c68788b
fe813296-b8bb-4565-9c7a-697d18dffc25
...
869f397c-27b1-4ec9-ae35-f4ce244d3fe7
31321838-d701-4280-8c5a-7affad82086b
927df9e6-26cb-4b0e-8291-be207e012043
49cd84e0-8cda-462c-913f-e352740d5520
```