### PR TITLE
Fix `Get-BinarySizes.ps1` to handle new `OsVMImage` names for Ubuntu

### DIFF
--- a/eng/scripts/Get-BinarySizes.ps1
+++ b/eng/scripts/Get-BinarySizes.ps1
@@ -56,15 +56,15 @@ function getTargetOs {
         return "win-2022"
     }
 
-    if ($OsVMImage -eq "MMSUbuntu18.04") {
+    if ($OsVMImage -in "MMSUbuntu18.04", "ubuntu-18.04") {
         return "ubuntu-18.04"
     }
 
-    if ($OsVMImage -eq "MMSUbuntu20.04") {
+    if ($OsVMImage -in "MMSUbuntu20.04", "ubuntu-20.04") {
         return "ubuntu-20.04"
     }
 
-    if ($OsVMImage -eq "MMSUbuntu22.04") {
+    if ($OsVMImage -in "MMSUbuntu22.04", "ubuntu-22.04") {
         return "ubuntu-22.04"
     }
 


### PR DESCRIPTION
This is internal Azure Engineering System Team PR, required per:

- https://github.com/Azure/azure-sdk-tools/pull/6004#issuecomment-1515183816

Related work: 
- https://github.com/Azure/azure-sdk-tools/issues/5472