### PR TITLE
Fail C++ CI and release pipeline if API review is not approved for a …

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -129,7 +129,6 @@ jobs:
               pwsh: true
               workingDirectory: $(Pipeline.Workspace)
             displayName: Create API Review for ${{ artifact.name }}
-            continueOnError: true
             condition: >-
               and(
                 succeeded(),


### PR DESCRIPTION
C++ pipeline ignores API review status even for GA package release. This change is to ensure that C++ package has an approved API review to release a GA version.