### PR TITLE
Remove -Login and -PushImages parameters from stress helper

### DIFF
--- a/sdk/core/azure-core/test/libcurl-stress-test/deploy.ps1
+++ b/sdk/core/azure-core/test/libcurl-stress-test/deploy.ps1
@@ -1,2 +1,2 @@
 Set-Location $PSScriptRoot
-pwsh "../../../../../eng/common/scripts/stress-testing/deploy-stress-tests.ps1" -Login -PushImages
+pwsh "../../../../../eng/common/scripts/stress-testing/deploy-stress-tests.ps1"


### PR DESCRIPTION
Relies on https://github.com/Azure/azure-sdk-tools/pull/6103
