### PR TITLE
Fix memory leak in xml_wrapper

### DIFF
--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 namespace Azure { namespace Storage { namespace _internal {

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -35,7 +35,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   class XmlReader final {
   public:
-    XmlReader(const char* data, size_t length);
+    XmlReader(uint8_t const* data, size_t length);
     XmlReader(const XmlReader& other) = delete;
     XmlReader& operator=(const XmlReader& other) = delete;
     XmlReader(XmlReader&& other) noexcept;

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -47,7 +47,6 @@ namespace Azure { namespace Storage { namespace _internal {
   private:
     struct XmlReaderContext;
     std::unique_ptr<XmlReaderContext> m_context;
-
   };
 
   class XmlWriter final {

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -19,54 +19,43 @@ namespace Azure { namespace Storage { namespace _internal {
 
   struct XmlNode final
   {
-    explicit XmlNode(XmlNodeType type, std::string name = std::string())
-        : Type(type), Name(std::move(name))
-    {
-    }
-
-    explicit XmlNode(XmlNodeType type, std::string name, std::string value)
-        : Type(type), Name(std::move(name)), Value(std::move(value)), HasValue(true)
+    explicit XmlNode(
+        XmlNodeType type,
+        std::string name = std::string(),
+        std::string value = std::string())
+        : Type(type), Name(std::move(name)), Value(std::move(value))
     {
     }
 
     XmlNodeType Type;
     std::string Name;
     std::string Value;
-    bool HasValue = false;
   };
 
   class XmlReader final {
   public:
-    explicit XmlReader(const char* data, size_t length);
+    XmlReader(const char* data, size_t length);
     XmlReader(const XmlReader& other) = delete;
     XmlReader& operator=(const XmlReader& other) = delete;
-    XmlReader(XmlReader&& other) noexcept { *this = std::move(other); }
-    XmlReader& operator=(XmlReader&& other) noexcept
-    {
-      m_context = other.m_context;
-      other.m_context = nullptr;
-      return *this;
-    }
+    XmlReader(XmlReader&& other) noexcept;
+    XmlReader& operator=(XmlReader&& other) noexcept;
     ~XmlReader();
 
     XmlNode Read();
 
   private:
-    void* m_context = nullptr;
+    struct XmlReaderContext;
+    std::unique_ptr<XmlReaderContext> m_context;
+
   };
 
   class XmlWriter final {
   public:
-    explicit XmlWriter();
+    XmlWriter();
     XmlWriter(const XmlWriter& other) = delete;
     XmlWriter& operator=(const XmlWriter& other) = delete;
-    XmlWriter(XmlWriter&& other) noexcept { *this = std::move(other); }
-    XmlWriter& operator=(XmlWriter&& other) noexcept
-    {
-      m_context = other.m_context;
-      other.m_context = nullptr;
-      return *this;
-    }
+    XmlWriter(XmlWriter&& other) noexcept;
+    XmlWriter& operator=(XmlWriter&& other) noexcept;
     ~XmlWriter();
 
     void Write(XmlNode node);
@@ -74,7 +63,11 @@ namespace Azure { namespace Storage { namespace _internal {
     std::string GetDocument();
 
   private:
-    void* m_context = nullptr;
+    struct XmlWriterContext;
+    std::unique_ptr<XmlWriterContext> m_context;
   };
+
+  void XmlGlobalInitialize();
+  void XmlGlobalDeinitialize();
 
 }}} // namespace Azure::Storage::_internal

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -23,7 +23,7 @@ namespace Azure { namespace Storage { namespace _internal {
     explicit XmlNode(
         XmlNodeType type,
         std::string name = std::string(),
-        std::string value = std::string())
+        std::string value = {}))
         : Type(type), Name(std::move(name)), Value(std::move(value))
     {
     }

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -6,8 +6,8 @@
 #include <cstring>
 #include <limits>
 #include <memory>
-#include <stdexcept>
 #include <mutex>
+#include <stdexcept>
 
 #include <azure/core/platform.hpp>
 
@@ -81,7 +81,12 @@ namespace Azure { namespace Storage { namespace _internal {
     textEncoding.encoding.encodingType = WS_XML_READER_ENCODING_TYPE_TEXT;
     textEncoding.charSet = WS_CHARSET_AUTO;
     HRESULT ret = WsSetInput(
-        m_context->reader, &textEncoding.encoding, &bufferInput.input, nullptr, 0, m_context->error);
+        m_context->reader,
+        &textEncoding.encoding,
+        &bufferInput.input,
+        nullptr,
+        0,
+        m_context->error);
     if (ret != S_OK)
     {
       throw std::runtime_error("Failed to initialize xml reader.");
@@ -89,7 +94,11 @@ namespace Azure { namespace Storage { namespace _internal {
 
     WS_CHARSET charSet;
     ret = WsGetReaderProperty(
-        m_context->reader, WS_XML_READER_PROPERTY_CHARSET, &charSet, sizeof(charSet), m_context->error);
+        m_context->reader,
+        WS_XML_READER_PROPERTY_CHARSET,
+        &charSet,
+        sizeof(charSet),
+        m_context->error);
     if (ret != S_OK)
     {
       throw std::runtime_error("Failed to get xml encoding.");
@@ -98,7 +107,6 @@ namespace Azure { namespace Storage { namespace _internal {
     {
       throw std::runtime_error("Unsupported xml encoding.");
     }
-
   }
 
   XmlReader::~XmlReader() = default;
@@ -255,7 +263,8 @@ namespace Azure { namespace Storage { namespace _internal {
   {
     m_context = std::make_unique<XmlWriterContext>();
 
-    HRESULT ret = WsCreateXmlBuffer(m_context->heap, nullptr, 0, &m_context->buffer, m_context->error);
+    HRESULT ret
+        = WsCreateXmlBuffer(m_context->heap, nullptr, 0, &m_context->buffer, m_context->error);
     if (ret != NO_ERROR)
     {
       throw std::runtime_error("Failed to initialize xml writer.");
@@ -394,9 +403,7 @@ namespace Azure { namespace Storage { namespace _internal {
   using ReaderPtr = std::unique_ptr<xmlTextReader, decltype(&xmlFreeTextReader)>;
   struct XmlReader::XmlReaderContext
   {
-    explicit XmlReaderContext(ReaderPtr && reader_)
-      : reader(std::move(reader_))
-    {}
+    explicit XmlReaderContext(ReaderPtr&& reader_) : reader(std::move(reader_)) {}
     ReaderPtr reader;
     bool readingAttributes = false;
     bool readingEmptyTag = false;
@@ -411,8 +418,8 @@ namespace Azure { namespace Storage { namespace _internal {
       throw std::runtime_error("Xml data too big.");
     }
 
-    auto reader
-        = ReaderPtr(xmlReaderForMemory(data, static_cast<int>(length), nullptr, nullptr, 0), xmlFreeTextReader);
+    auto reader = ReaderPtr(
+        xmlReaderForMemory(data, static_cast<int>(length), nullptr, nullptr, 0), xmlFreeTextReader);
 
     if (!reader)
     {
@@ -432,8 +439,10 @@ namespace Azure { namespace Storage { namespace _internal {
       int ret = xmlTextReaderMoveToNextAttribute(context->reader.get());
       if (ret == 1)
       {
-        const char* name = reinterpret_cast<const char*>(xmlTextReaderConstName(context->reader.get()));
-        const char* value = reinterpret_cast<const char*>(xmlTextReaderConstValue(context->reader.get()));
+        const char* name
+            = reinterpret_cast<const char*>(xmlTextReaderConstName(context->reader.get()));
+        const char* value
+            = reinterpret_cast<const char*>(xmlTextReaderConstValue(context->reader.get()));
         return XmlNode{XmlNodeType::Attribute, name, value};
       }
       else if (ret == 0)
@@ -467,7 +476,8 @@ namespace Azure { namespace Storage { namespace _internal {
     bool has_attributes = xmlTextReaderHasAttributes(context->reader.get()) == 1;
 
     const char* name = reinterpret_cast<const char*>(xmlTextReaderConstName(context->reader.get()));
-    const char* value = reinterpret_cast<const char*>(xmlTextReaderConstValue(context->reader.get()));
+    const char* value
+        = reinterpret_cast<const char*>(xmlTextReaderConstValue(context->reader.get()));
 
     if (has_attributes)
     {
@@ -510,10 +520,10 @@ namespace Azure { namespace Storage { namespace _internal {
   using WriterPtr = std::unique_ptr<xmlTextWriter, decltype(&xmlFreeTextWriter)>;
   struct XmlWriter::XmlWriterContext
   {
-    XmlWriterContext(BufferPtr && buffer_, WriterPtr && writer_)
-      : buffer(std::move(buffer_))
-      , writer(std::move(writer_))
-    {}
+    XmlWriterContext(BufferPtr&& buffer_, WriterPtr&& writer_)
+        : buffer(std::move(buffer_)), writer(std::move(writer_))
+    {
+    }
     BufferPtr buffer;
     WriterPtr writer;
   };
@@ -596,7 +606,8 @@ namespace Azure { namespace Storage { namespace _internal {
 
   std::string XmlWriter::GetDocument()
   {
-    return std::string(reinterpret_cast<const char*>(m_context->buffer->content), m_context->buffer->use);
+    return std::string(
+        reinterpret_cast<const char*>(m_context->buffer->content), m_context->buffer->use);
   }
 
 #endif


### PR DESCRIPTION
Backport memory fixes from https://github.com/ClickHouse/azure-sdk-for-cpp
This is effectively silencing address sanitizers warnings we've been observing.

Includes the following PRs:
https://github.com/ClickHouse/azure-sdk-for-cpp/pull/4
https://github.com/ClickHouse/azure-sdk-for-cpp/pull/5
https://github.com/ClickHouse/azure-sdk-for-cpp/pull/6


# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
