### PR TITLE
Fix for the flaky curl test

### DIFF
--- a/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
@@ -29,102 +29,104 @@ namespace Azure { namespace Core { namespace Test {
   class CurlConnectionPool_connectionPoolTest_Test;
   class CurlConnectionPool_uniquePort_Test;
   class CurlConnectionPool_connectionClose_Test;
+  class SdkWithLibcurl_globalCleanUp_Test;
 }}} // namespace Azure::Core::Test
 #endif
 
 namespace Azure { namespace Core { namespace Http { namespace _detail {
 
-  /**
-   * @brief CURL HTTP connection pool makes it possible to re-use one curl connection to perform
-   * more than one request. Use this component when connections are not re-used by default.
-   *
-   * This pool offers static methods and it is allocated statically. There can be only one
-   * connection pool per application.
-   */
-  class CurlConnectionPool final {
+    /**
+     * @brief CURL HTTP connection pool makes it possible to re-use one curl connection to perform
+     * more than one request. Use this component when connections are not re-used by default.
+     *
+     * This pool offers static methods and it is allocated statically. There can be only one
+     * connection pool per application.
+     */
+    class CurlConnectionPool final {
 #if defined(TESTING_BUILD)
-    // Give access to private to this tests class
-    friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
-    friend class Azure::Core::Test::CurlConnectionPool_uniquePort_Test;
-    friend class Azure::Core::Test::CurlConnectionPool_connectionClose_Test;
+      // Give access to private to this tests class
+      friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
+      friend class Azure::Core::Test::CurlConnectionPool_uniquePort_Test;
+      friend class Azure::Core::Test::CurlConnectionPool_connectionClose_Test;
+      friend class Azure::Core::Test::SdkWithLibcurl_globalCleanUp_Test;
 #endif
 
-  public:
-    ~CurlConnectionPool()
-    {
-      using namespace Azure::Core::Http::_detail;
-      if (m_cleanThread.joinable())
+    public:
+      ~CurlConnectionPool()
       {
+        using namespace Azure::Core::Http::_detail;
+        if (m_cleanThread.joinable())
         {
-          std::unique_lock<std::mutex> lock(ConnectionPoolMutex);
-          // Remove all connections
-          g_curlConnectionPool.ConnectionPoolIndex.clear();
+          {
+            std::unique_lock<std::mutex> lock(ConnectionPoolMutex);
+            // Remove all connections
+            g_curlConnectionPool.ConnectionPoolIndex.clear();
+          }
+          // Signal clean thread to wake up
+          ConditionalVariableForCleanThread.notify_one();
+          // join thread
+          m_cleanThread.join();
         }
-        // Signal clean thread to wake up
-        ConditionalVariableForCleanThread.notify_one();
-        // join thread
-        m_cleanThread.join();
+        curl_global_cleanup();
       }
-      curl_global_cleanup();
-    }
 
-    /**
-     * @brief Finds a connection to be re-used from the connection pool.
-     * @remark If there is not any available connection, a new connection is created.
-     *
-     * @param request HTTP request to get #Azure::Core::Http::CurlNetworkConnection for.
-     * @param options The connection settings which includes host name and libcurl handle specific
-     * configuration.
-     * @param resetPool Request the pool to remove all current connections for the provided
-     * options to force the creation of a new connection.
-     *
-     * @return #Azure::Core::Http::CurlNetworkConnection to use.
-     */
-    std::unique_ptr<CurlNetworkConnection> ExtractOrCreateCurlConnection(
-        Request& request,
-        CurlTransportOptions const& options,
-        bool resetPool = false);
+      /**
+       * @brief Finds a connection to be re-used from the connection pool.
+       * @remark If there is not any available connection, a new connection is created.
+       *
+       * @param request HTTP request to get #Azure::Core::Http::CurlNetworkConnection for.
+       * @param options The connection settings which includes host name and libcurl handle specific
+       * configuration.
+       * @param resetPool Request the pool to remove all current connections for the provided
+       * options to force the creation of a new connection.
+       *
+       * @return #Azure::Core::Http::CurlNetworkConnection to use.
+       */
+      std::unique_ptr<CurlNetworkConnection> ExtractOrCreateCurlConnection(
+          Request& request,
+          CurlTransportOptions const& options,
+          bool resetPool = false);
 
-    /**
-     * @brief Moves a connection back to the pool to be re-used.
-     *
-     * @param connection CURL HTTP connection to add to the pool.
-     * @param lastStatusCode The most recent HTTP status code received from the \p connection.
-     */
-    void MoveConnectionBackToPool(
-        std::unique_ptr<CurlNetworkConnection> connection,
-        HttpStatusCode lastStatusCode);
+      /**
+       * @brief Moves a connection back to the pool to be re-used.
+       *
+       * @param connection CURL HTTP connection to add to the pool.
+       * @param lastStatusCode The most recent HTTP status code received from the \p connection.
+       */
+      void MoveConnectionBackToPool(
+          std::unique_ptr<CurlNetworkConnection> connection,
+          HttpStatusCode lastStatusCode);
 
-    /**
-     * @brief Keeps a unique key for each host and creates a connection pool for each key.
-     *
-     * @details This way getting a connection for a specific host can be done in O(1) instead of
-     * looping a single connection list to find the first connection for the required host.
-     *
-     * @remark There might be multiple connections for each host.
-     */
-    std::unordered_map<std::string, std::list<std::unique_ptr<CurlNetworkConnection>>>
-        ConnectionPoolIndex;
+      /**
+       * @brief Keeps a unique key for each host and creates a connection pool for each key.
+       *
+       * @details This way getting a connection for a specific host can be done in O(1) instead of
+       * looping a single connection list to find the first connection for the required host.
+       *
+       * @remark There might be multiple connections for each host.
+       */
+      std::unordered_map<std::string, std::list<std::unique_ptr<CurlNetworkConnection>>>
+          ConnectionPoolIndex;
 
-    std::mutex ConnectionPoolMutex;
+      std::mutex ConnectionPoolMutex;
 
-    // This is used to put the cleaning pool thread to sleep and yet to be able to wake it if the
-    // application finishes.
-    std::condition_variable ConditionalVariableForCleanThread;
+      // This is used to put the cleaning pool thread to sleep and yet to be able to wake it if the
+      // application finishes.
+      std::condition_variable ConditionalVariableForCleanThread;
 
-    AZ_CORE_DLLEXPORT static Azure::Core::Http::_detail::CurlConnectionPool g_curlConnectionPool;
+      AZ_CORE_DLLEXPORT static Azure::Core::Http::_detail::CurlConnectionPool g_curlConnectionPool;
 
-    bool IsCleanThreadRunning = false;
+      bool IsCleanThreadRunning = false;
 
-  private:
-    // private constructor to keep this as singleton.
-    CurlConnectionPool() { curl_global_init(CURL_GLOBAL_ALL); }
+    private:
+      // private constructor to keep this as singleton.
+      CurlConnectionPool() { curl_global_init(CURL_GLOBAL_ALL); }
 
-    // Makes possible to know the number of current connections in the connection pool for an
-    // index
-    size_t ConnectionsOnPool(std::string const& host) { return ConnectionPoolIndex[host].size(); }
+      // Makes possible to know the number of current connections in the connection pool for an
+      // index
+      size_t ConnectionsOnPool(std::string const& host) { return ConnectionPoolIndex[host].size(); }
 
-    std::thread m_cleanThread;
-  };
+      std::thread m_cleanThread;
+    };
 
 }}}} // namespace Azure::Core::Http::_detail

--- a/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
@@ -35,98 +35,98 @@ namespace Azure { namespace Core { namespace Test {
 
 namespace Azure { namespace Core { namespace Http { namespace _detail {
 
-    /**
-     * @brief CURL HTTP connection pool makes it possible to re-use one curl connection to perform
-     * more than one request. Use this component when connections are not re-used by default.
-     *
-     * This pool offers static methods and it is allocated statically. There can be only one
-     * connection pool per application.
-     */
-    class CurlConnectionPool final {
+  /**
+   * @brief CURL HTTP connection pool makes it possible to re-use one curl connection to perform
+   * more than one request. Use this component when connections are not re-used by default.
+   *
+   * This pool offers static methods and it is allocated statically. There can be only one
+   * connection pool per application.
+   */
+  class CurlConnectionPool final {
 #if defined(TESTING_BUILD)
-      // Give access to private to this tests class
-      friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
-      friend class Azure::Core::Test::CurlConnectionPool_uniquePort_Test;
-      friend class Azure::Core::Test::CurlConnectionPool_connectionClose_Test;
-      friend class Azure::Core::Test::SdkWithLibcurl_globalCleanUp_Test;
+    // Give access to private to this tests class
+    friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
+    friend class Azure::Core::Test::CurlConnectionPool_uniquePort_Test;
+    friend class Azure::Core::Test::CurlConnectionPool_connectionClose_Test;
+    friend class Azure::Core::Test::SdkWithLibcurl_globalCleanUp_Test;
 #endif
 
-    public:
-      ~CurlConnectionPool()
+  public:
+    ~CurlConnectionPool()
+    {
+      using namespace Azure::Core::Http::_detail;
+      if (m_cleanThread.joinable())
       {
-        using namespace Azure::Core::Http::_detail;
-        if (m_cleanThread.joinable())
         {
-          {
-            std::unique_lock<std::mutex> lock(ConnectionPoolMutex);
-            // Remove all connections
-            g_curlConnectionPool.ConnectionPoolIndex.clear();
-          }
-          // Signal clean thread to wake up
-          ConditionalVariableForCleanThread.notify_one();
-          // join thread
-          m_cleanThread.join();
+          std::unique_lock<std::mutex> lock(ConnectionPoolMutex);
+          // Remove all connections
+          g_curlConnectionPool.ConnectionPoolIndex.clear();
         }
-        curl_global_cleanup();
+        // Signal clean thread to wake up
+        ConditionalVariableForCleanThread.notify_one();
+        // join thread
+        m_cleanThread.join();
       }
+      curl_global_cleanup();
+    }
 
-      /**
-       * @brief Finds a connection to be re-used from the connection pool.
-       * @remark If there is not any available connection, a new connection is created.
-       *
-       * @param request HTTP request to get #Azure::Core::Http::CurlNetworkConnection for.
-       * @param options The connection settings which includes host name and libcurl handle specific
-       * configuration.
-       * @param resetPool Request the pool to remove all current connections for the provided
-       * options to force the creation of a new connection.
-       *
-       * @return #Azure::Core::Http::CurlNetworkConnection to use.
-       */
-      std::unique_ptr<CurlNetworkConnection> ExtractOrCreateCurlConnection(
-          Request& request,
-          CurlTransportOptions const& options,
-          bool resetPool = false);
+    /**
+     * @brief Finds a connection to be re-used from the connection pool.
+     * @remark If there is not any available connection, a new connection is created.
+     *
+     * @param request HTTP request to get #Azure::Core::Http::CurlNetworkConnection for.
+     * @param options The connection settings which includes host name and libcurl handle specific
+     * configuration.
+     * @param resetPool Request the pool to remove all current connections for the provided
+     * options to force the creation of a new connection.
+     *
+     * @return #Azure::Core::Http::CurlNetworkConnection to use.
+     */
+    std::unique_ptr<CurlNetworkConnection> ExtractOrCreateCurlConnection(
+        Request& request,
+        CurlTransportOptions const& options,
+        bool resetPool = false);
 
-      /**
-       * @brief Moves a connection back to the pool to be re-used.
-       *
-       * @param connection CURL HTTP connection to add to the pool.
-       * @param lastStatusCode The most recent HTTP status code received from the \p connection.
-       */
-      void MoveConnectionBackToPool(
-          std::unique_ptr<CurlNetworkConnection> connection,
-          HttpStatusCode lastStatusCode);
+    /**
+     * @brief Moves a connection back to the pool to be re-used.
+     *
+     * @param connection CURL HTTP connection to add to the pool.
+     * @param lastStatusCode The most recent HTTP status code received from the \p connection.
+     */
+    void MoveConnectionBackToPool(
+        std::unique_ptr<CurlNetworkConnection> connection,
+        HttpStatusCode lastStatusCode);
 
-      /**
-       * @brief Keeps a unique key for each host and creates a connection pool for each key.
-       *
-       * @details This way getting a connection for a specific host can be done in O(1) instead of
-       * looping a single connection list to find the first connection for the required host.
-       *
-       * @remark There might be multiple connections for each host.
-       */
-      std::unordered_map<std::string, std::list<std::unique_ptr<CurlNetworkConnection>>>
-          ConnectionPoolIndex;
+    /**
+     * @brief Keeps a unique key for each host and creates a connection pool for each key.
+     *
+     * @details This way getting a connection for a specific host can be done in O(1) instead of
+     * looping a single connection list to find the first connection for the required host.
+     *
+     * @remark There might be multiple connections for each host.
+     */
+    std::unordered_map<std::string, std::list<std::unique_ptr<CurlNetworkConnection>>>
+        ConnectionPoolIndex;
 
-      std::mutex ConnectionPoolMutex;
+    std::mutex ConnectionPoolMutex;
 
-      // This is used to put the cleaning pool thread to sleep and yet to be able to wake it if the
-      // application finishes.
-      std::condition_variable ConditionalVariableForCleanThread;
+    // This is used to put the cleaning pool thread to sleep and yet to be able to wake it if the
+    // application finishes.
+    std::condition_variable ConditionalVariableForCleanThread;
 
-      AZ_CORE_DLLEXPORT static Azure::Core::Http::_detail::CurlConnectionPool g_curlConnectionPool;
+    AZ_CORE_DLLEXPORT static Azure::Core::Http::_detail::CurlConnectionPool g_curlConnectionPool;
 
-      bool IsCleanThreadRunning = false;
+    bool IsCleanThreadRunning = false;
 
-    private:
-      // private constructor to keep this as singleton.
-      CurlConnectionPool() { curl_global_init(CURL_GLOBAL_ALL); }
+  private:
+    // private constructor to keep this as singleton.
+    CurlConnectionPool() { curl_global_init(CURL_GLOBAL_ALL); }
 
-      // Makes possible to know the number of current connections in the connection pool for an
-      // index
-      size_t ConnectionsOnPool(std::string const& host) { return ConnectionPoolIndex[host].size(); }
+    // Makes possible to know the number of current connections in the connection pool for an
+    // index
+    size_t ConnectionsOnPool(std::string const& host) { return ConnectionPoolIndex[host].size(); }
 
-      std::thread m_cleanThread;
-    };
+    std::thread m_cleanThread;
+  };
 
 }}}} // namespace Azure::Core::Http::_detail

--- a/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
+++ b/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
@@ -64,17 +64,16 @@ namespace Azure { namespace Core { namespace Test {
     // the same destructor also makes a call to start the cleanup thread
     // which will sleep for DefaultCleanerIntervalMilliseconds then loop through the connections
     // in the pool and check for the ones that are expired(DefaultConnectionExpiredMilliseconds) and
-    // remove them which will be the case here if we wait long enough. 
+    // remove them which will be the case here if we wait long enough.
     // without the calculations below test is flaky due to the
     // fact that tests in the CI pipeline might take longer than 90 sec to execute thus the cleanup
-    // thread strikes. to have this test be predictable we need to be aware of when we attempt to read 
-    // pool size, also we should let things run to completion and
-    // then check the pool size thus the sleep below plus another second to let the for loop in the
-    // cleanup thread do its thing.
+    // thread strikes. to have this test be predictable we need to be aware of when we attempt to
+    // read pool size, also we should let things run to completion and then check the pool size thus
+    // the sleep below plus another second to let the for loop in the cleanup thread do its thing.
 
     auto t2 = high_resolution_clock::now();
 
-    // Getting number of milliseconds as a double. 
+    // Getting number of milliseconds as a double.
     duration<double, std::milli> ms_double = t2 - t1;
     if (ms_double < duration<double, std::milli>(
             Azure::Core::Http::_detail::DefaultCleanerIntervalMilliseconds))

--- a/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
+++ b/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
@@ -72,9 +72,6 @@ namespace Azure { namespace Core { namespace Test {
 
     auto t2 = high_resolution_clock::now();
 
-    /* Getting number of milliseconds as an integer. */
-    auto ms_int = duration_cast<milliseconds>(t2 - t1);
-
     /* Getting number of milliseconds as a double. */
     duration<double, std::milli> ms_double = t2 - t1;
     if (ms_double < duration<double, std::milli>(
@@ -115,13 +112,13 @@ int main(int argc, char** argv)
 #if defined(AZ_PLATFORM_WINDOWS)
 // Ensure that all calls to abort() no longer pop up a modal dialog on Windows.
 #if defined(_DEBUG) && defined(_MSC_VER)
-_CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG);
+  _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG);
 #endif
 
-signal(SIGABRT, Azure::Core::Diagnostics::_internal::GlobalExceptionHandler::HandleSigAbort);
+  signal(SIGABRT, Azure::Core::Diagnostics::_internal::GlobalExceptionHandler::HandleSigAbort);
 #endif // AZ_PLATFORM_WINDOWS
 
-testing::InitGoogleTest(&argc, argv);
-auto r = RUN_ALL_TESTS();
-return r;
+  testing::InitGoogleTest(&argc, argv);
+  auto r = RUN_ALL_TESTS();
+  return r;
 }

--- a/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
+++ b/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
@@ -64,15 +64,17 @@ namespace Azure { namespace Core { namespace Test {
     // the same destructor also makes a call to start the cleanup thread
     // which will sleep for DefaultCleanerIntervalMilliseconds then loop through the connections
     // in the pool and check for the ones that are expired(DefaultConnectionExpiredMilliseconds) and
-    // remove them which will be the case here if we wait long enough. the test is flaky due to the
+    // remove them which will be the case here if we wait long enough. 
+    // without the calculations below test is flaky due to the
     // fact that tests in the CI pipeline might take longer than 90 sec to execute thus the cleanup
-    // thread strikes. to have this test be predictable we should let things run to completion and
+    // thread strikes. to have this test be predictable we need to be aware of when we attempt to read 
+    // pool size, also we should let things run to completion and
     // then check the pool size thus the sleep below plus another second to let the for loop in the
-    // thread do its thing.
+    // cleanup thread do its thing.
 
     auto t2 = high_resolution_clock::now();
 
-    /* Getting number of milliseconds as a double. */
+    // Getting number of milliseconds as a double. 
     duration<double, std::milli> ms_double = t2 - t1;
     if (ms_double < duration<double, std::milli>(
             Azure::Core::Http::_detail::DefaultCleanerIntervalMilliseconds))

--- a/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
+++ b/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
@@ -26,6 +26,7 @@
 
 #include <csignal>
 #include <cstdlib>
+#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -34,7 +35,12 @@ namespace Azure { namespace Core { namespace Test {
   {
     Azure::Core::Http::Request req(
         Azure::Core::Http::HttpMethod::Get, Azure::Core::Url("https://httpbin.org/get"));
+    using std::chrono::duration;
+    using std::chrono::duration_cast;
+    using std::chrono::high_resolution_clock;
+    using std::chrono::milliseconds;
 
+    auto t1 = high_resolution_clock::now();
     {
       // Creating a new connection with default options
       Azure::Core::Http::CurlTransportOptions options;
@@ -52,22 +58,53 @@ namespace Azure { namespace Core { namespace Test {
       EXPECT_TRUE(session->IsEOF());
       EXPECT_TRUE(session->m_keepAlive);
       EXPECT_FALSE(session->m_connectionUpgraded);
+      t1 = high_resolution_clock::now();
     }
     // here the session is destroyed and the connection is moved to the pool
     // the same destructor also makes a call to start the cleanup thread
     // which will sleep for DefaultCleanerIntervalMilliseconds then loop through the connections
-    // in the pool and check for the ones that are expired(DefaultConnectionExpiredMilliseconds) and remove them
-    // which will be the case here if we wait long enough. 
-    // the test is flaky due to the fact that tests in the CI pipeline might take longer than 90 sec to execute 
-    // thus the cleanup thread strikes. 
-    // to have this test be predictable we should let things run to completion and then check the pool size
-    // thus the sleep below plus another second to let the for loop in the thread do its thing. 
-    Sleep(Azure::Core::Http::_detail::DefaultCleanerIntervalMilliseconds+1000);
-    // Check that after the connection is gone, it is moved back to the pool
-    EXPECT_EQ(
-        Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool.ConnectionPoolIndex
-            .size(),
+    // in the pool and check for the ones that are expired(DefaultConnectionExpiredMilliseconds) and
+    // remove them which will be the case here if we wait long enough. the test is flaky due to the
+    // fact that tests in the CI pipeline might take longer than 90 sec to execute thus the cleanup
+    // thread strikes. to have this test be predictable we should let things run to completion and
+    // then check the pool size thus the sleep below plus another second to let the for loop in the
+    // thread do its thing.
+
+    auto t2 = high_resolution_clock::now();
+
+    /* Getting number of milliseconds as an integer. */
+    auto ms_int = duration_cast<milliseconds>(t2 - t1);
+
+    /* Getting number of milliseconds as a double. */
+    duration<double, std::milli> ms_double = t2 - t1;
+    if (ms_double < duration<double, std::milli>(
+            Azure::Core::Http::_detail::DefaultCleanerIntervalMilliseconds))
+    {
+      // if the destructor execution took less than the cleanup thread sleep the size should be 1
+      EXPECT_EQ(
+          Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool.ConnectionPoolIndex
+              .size(),
+          1);
+      // let the thread cleanup thread hit
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(
+              Azure::Core::Http::_detail::DefaultCleanerIntervalMilliseconds + 1000)
+          - ms_double);
+      // Check that after the connection is gone and cleaned up, the pool is empty
+      EXPECT_EQ(
+          Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool.ConnectionPoolIndex
+              .size(),
           0);
+    }
+    else
+    {
+      // we got back from the destructor and thread creation after the cleanup thread hit thus it
+      // will be empty
+      EXPECT_EQ(
+          Azure::Core::Http::_detail::CurlConnectionPool::g_curlConnectionPool.ConnectionPoolIndex
+              .size(),
+          0);
+    }
   }
 }}} // namespace Azure::Core::Test
 
@@ -78,13 +115,13 @@ int main(int argc, char** argv)
 #if defined(AZ_PLATFORM_WINDOWS)
 // Ensure that all calls to abort() no longer pop up a modal dialog on Windows.
 #if defined(_DEBUG) && defined(_MSC_VER)
-  _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG);
+_CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG);
 #endif
 
-  signal(SIGABRT, Azure::Core::Diagnostics::_internal::GlobalExceptionHandler::HandleSigAbort);
+signal(SIGABRT, Azure::Core::Diagnostics::_internal::GlobalExceptionHandler::HandleSigAbort);
 #endif // AZ_PLATFORM_WINDOWS
 
-  testing::InitGoogleTest(&argc, argv);
-  auto r = RUN_ALL_TESTS();
-  return r;
+testing::InitGoogleTest(&argc, argv);
+auto r = RUN_ALL_TESTS();
+return r;
 }


### PR DESCRIPTION
See the comments in the code. 
The bottom line is that there is a race condition between EXPECT_EQ and the execution of the cleanup thread started by the curl session destruction which moves the connection to the pool then starts the cleanup thread. 

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
