### PR TITLE
Fix clang format issue with multiple gtest includes in etag_test due to merge conflict resolution.

### DIFF
--- a/sdk/core/azure-core/test/ut/etag_test.cpp
+++ b/sdk/core/azure-core/test/ut/etag_test.cpp
@@ -5,8 +5,6 @@
 
 #include <azure/core/etag.hpp>
 
-#include <gtest/gtest.h>
-
 #include <limits>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
A clang-format issue got introduced in one of the recent changes to `etag_test.cpp`:
Looks like these two PRs conflicted with each other, on merge, and caused the double header include for `gtest.h`:
https://github.com/Azure/azure-sdk-for-cpp/pull/4656
https://github.com/Azure/azure-sdk-for-cpp/pull/4632

Discovered in:
https://github.com/Azure/azure-sdk-for-cpp/pull/4672#issuecomment-1569360117
