### PR TITLE
Merge forked changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The following SDK library releases are available on [vcpkg](https://github.com/m
 * `azure-storage-files-shares-cpp`
 * `azure-storage-queues-cpp`
 
-> NOTE: In case of getting linker errors when consuming the SDK on Windows, make sure that [vcpkg triplet](https://vcpkg.readthedocs.io/en/latest/users/triplets/) being consumed matches the [CRT link flags](https://docs.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-160) being set for your app or library build. See also `MSVC_USE_STATIC_CRT` build flag.
+> NOTE: In case of getting linker errors when consuming the SDK on Windows, make sure that [vcpkg triplet](https://learn.microsoft.com/vcpkg/users/triplets) being consumed matches the [CRT link flags](https://docs.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-160) being set for your app or library build. See also `MSVC_USE_STATIC_CRT` build flag.
 
 ## OpenSSL Version
 

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2,6 +2,13 @@
 // SPDX-License-Identifier: MIT
 // cspell:words OCSP crls
 
+// Some macros (e.g. BIO_set_conn_port, or BIO_get_mem_data) include a (char*) cast. This causes a warning when building on Debian 9.
+// Let's temporarily disable this warning here
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 #include "azure/core/base64.hpp"
 #include "azure/core/platform.hpp"
 
@@ -1500,12 +1507,6 @@ namespace Azure { namespace Core {
           return nullptr;
         }
 
-        // BIO_set_conn_port is a macro that defines a (char*) cast. This causes a warning when building on Debian 9.
-        // Let's temporarily disable this warning here
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif
         if (!BIO_set_conn_port(bio.get(), const_cast<char*>(port.c_str())))
         {
           Log::Write(
@@ -1513,9 +1514,6 @@ namespace Azure { namespace Core {
               "BIO_set_conn_port failed" + _detail::GetOpenSSLError("Load CRL"));
           return nullptr;
         }
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
         auto requestContext
             = Azure::Core::_internal::MakeUniqueHandle(OCSP_REQ_CTX_new, bio.get(), 1024 * 1024);
@@ -2443,3 +2441,7 @@ CurlConnection::CurlConnection(
         + std::string(curl_easy_strerror(result)));
   }
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -1500,11 +1500,10 @@ namespace Azure { namespace Core {
           return nullptr;
         }
 
-#ifdef __GNUC__
-        // BIO_set_conn_port is a macro that defines a (char*) cast. This causes a warning when building on Debian 9
-        // so let's suppress that here
-_Pragma("GCC diagnostic push")
-_Pragma("GCC diagnostic ignored \"-Werror=old-style-cast\"")
+        // BIO_set_conn_port is a macro that defines a (char*) cast. This causes a warning when building on Debian 9.
+        // Let's temporarily disable this warning here
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
         if (!BIO_set_conn_port(bio.get(), const_cast<char*>(port.c_str())))
         {
@@ -1514,7 +1513,7 @@ _Pragma("GCC diagnostic ignored \"-Werror=old-style-cast\"")
           return nullptr;
         }
 #ifdef __GNUC__
-_Pragma("GCC diagnostic pop")
+#pragma GCC diagnostic pop
 #endif
 
         auto requestContext

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -1502,6 +1502,7 @@ namespace Azure { namespace Core {
 
         // BIO_set_conn_port is a macro that defines a (char*) cast. This causes a warning when building on Debian 9.
         // Let's temporarily disable this warning here
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2,13 +2,6 @@
 // SPDX-License-Identifier: MIT
 // cspell:words OCSP crls
 
-// Some macros (e.g. BIO_set_conn_port, or BIO_get_mem_data) include a (char*) cast. This causes a warning when building on Debian 9.
-// Let's temporarily disable this warning here
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif
-
 #include "azure/core/base64.hpp"
 #include "azure/core/platform.hpp"
 
@@ -1507,6 +1500,12 @@ namespace Azure { namespace Core {
           return nullptr;
         }
 
+        // BIO_set_conn_port is a macro that defines a (char*) cast. This causes a warning when building on Debian 9.
+        // Let's temporarily disable this warning here
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
         if (!BIO_set_conn_port(bio.get(), const_cast<char*>(port.c_str())))
         {
           Log::Write(
@@ -1514,6 +1513,9 @@ namespace Azure { namespace Core {
               "BIO_set_conn_port failed" + _detail::GetOpenSSLError("Load CRL"));
           return nullptr;
         }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
         auto requestContext
             = Azure::Core::_internal::MakeUniqueHandle(OCSP_REQ_CTX_new, bio.get(), 1024 * 1024);
@@ -2441,7 +2443,3 @@ CurlConnection::CurlConnection(
         + std::string(curl_easy_strerror(result)));
   }
 }
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2290,7 +2290,7 @@ CurlConnection::CurlConnection(
   {
     // curl_blob is defined in Curl version 7.77 or newer. Since we prefer to use the OS version of Curl
     // some may not be up to date enough (e.g. Ubuntu 18.04 uses Curl 7.58)
-#if LIBCURL_VERSION_MAJOR >= 7 && LIBCURL_VERSION_MINOR >= 77
+#if LIBCURL_VERSION_MAJOR > 7 || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 77)
     curl_blob rootCertBlob
         = {const_cast<void*>(reinterpret_cast<const void*>(
                options.SslOptions.PemEncodedExpectedRootCertificates.c_str())),

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -1502,7 +1502,6 @@ namespace Azure { namespace Core {
 
         // BIO_set_conn_port is a macro that defines a (char*) cast. This causes a warning when building on Debian 9.
         // Let's temporarily disable this warning here
-#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -1434,7 +1434,7 @@ namespace Azure { namespace Core {
       {
         auto bio(Azure::Core::_internal::MakeUniqueHandle(BIO_new, BIO_s_mem()));
 
-        BIO_printf(bio.get(), "Error in %s: ", what.c_str());
+        BIO_printf(bio.get(), "Error in %hs: ", what.c_str());
         if (ERR_peek_error() != 0)
         {
           ERR_print_errors(bio.get());
@@ -1499,13 +1499,6 @@ namespace Azure { namespace Core {
               "BIO_new_connect failed" + _detail::GetOpenSSLError("Load CRL"));
           return nullptr;
         }
-
-#ifdef __GNUC__
-        // BIO_set_conn_port is a macro that defines a (char*) cast. This causes a warning when building on Debian 9
-        // so let's suppress that here
-_Pragma("GCC diagnostic push")
-_Pragma("GCC diagnostic ignored \"-Werror=old-style-cast\"")
-#endif
         if (!BIO_set_conn_port(bio.get(), const_cast<char*>(port.c_str())))
         {
           Log::Write(
@@ -1513,9 +1506,6 @@ _Pragma("GCC diagnostic ignored \"-Werror=old-style-cast\"")
               "BIO_set_conn_port failed" + _detail::GetOpenSSLError("Load CRL"));
           return nullptr;
         }
-#ifdef __GNUC__
-_Pragma("GCC diagnostic pop")
-#endif
 
         auto requestContext
             = Azure::Core::_internal::MakeUniqueHandle(OCSP_REQ_CTX_new, bio.get(), 1024 * 1024);

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2288,8 +2288,8 @@ CurlConnection::CurlConnection(
 
   if (!options.SslOptions.PemEncodedExpectedRootCertificates.empty())
   {
-    // curl_blob is defined in Curl version 7.77 or newer. Since we prefer to use the OS version of Curl
-    // some may not be up to date enough (e.g. Ubuntu 18.04 uses Curl 7.58)
+    // curl_blob is defined in Curl version 7.77 or newer. Since we prefer to use the OS version of
+    // Curl some may not be up to date enough (e.g. Ubuntu 18.04 uses Curl 7.58)
 #if LIBCURL_VERSION_MAJOR > 7 || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 77)
     curl_blob rootCertBlob
         = {const_cast<void*>(reinterpret_cast<const void*>(
@@ -2305,9 +2305,9 @@ CurlConnection::CurlConnection(
     }
 #else
     throw Azure::Core::Http::TransportException(
-          _detail::DefaultFailedToGetNewConnectionTemplate + hostDisplayName
-          + ". Failed to set CA cert to:" + options.CAInfo + ". "
-          + "Not supported in your version of Curl");
+        _detail::DefaultFailedToGetNewConnectionTemplate + hostDisplayName
+        + ". Failed to set CA cert to:" + options.CAInfo + ". "
+        + "Not supported in your version of Curl");
 #endif
   }
 

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -1500,10 +1500,11 @@ namespace Azure { namespace Core {
           return nullptr;
         }
 
-        // BIO_set_conn_port is a macro that defines a (char*) cast. This causes a warning when building on Debian 9.
-        // Let's temporarily disable this warning here
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
+#ifdef __GNUC__
+        // BIO_set_conn_port is a macro that defines a (char*) cast. This causes a warning when building on Debian 9
+        // so let's suppress that here
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Werror=old-style-cast\"")
 #endif
         if (!BIO_set_conn_port(bio.get(), const_cast<char*>(port.c_str())))
         {
@@ -1513,7 +1514,7 @@ namespace Azure { namespace Core {
           return nullptr;
         }
 #ifdef __GNUC__
-#pragma GCC diagnostic pop
+_Pragma("GCC diagnostic pop")
 #endif
 
         auto requestContext

--- a/sdk/core/azure-core/src/http/websockets/websockets_impl.cpp
+++ b/sdk/core/azure-core/src/http/websockets/websockets_impl.cpp
@@ -652,10 +652,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets { names
   WebSocketImplementation::DecodeFrame(Azure::Core::Context const& context)
   {
     // Ensure single threaded access to receive this frame.
-    // TODO FIXME web sockets should support simulatenous send and receive. Grabbing the mutex
-    // could lead to a deadlock where we are waiting to receive data from the service, and
-    // blocking the sending of data to the service that would trigger a message to be received
-    // std::unique_lock<std::mutex> lock(m_transportMutex);
+    std::unique_lock<std::mutex> lock(m_transportReadMutex);
     if (IsTransportEof())
     {
       throw std::runtime_error("Frame buffer is too small.");
@@ -777,10 +774,7 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets { names
       std::vector<uint8_t> const& sendFrame,
       Azure::Core::Context const& context)
   {
-    // TODO FIXME web sockets should support simulatenous send and receive. Grabbing the mutex
-    // could lead to a deadlock where we are waiting to receive data from the service, and
-    // blocking the sending of data to the service that would trigger a message to be received
-    // std::unique_lock<std::mutex> transportLock(m_transportMutex);
+    std::unique_lock<std::mutex> transportLock(m_transportWriteMutex);
     m_receiveStatistics.BytesSent += static_cast<uint32_t>(sendFrame.size());
     m_receiveStatistics.FramesSent += 1;
     m_transport->SendBuffer(sendFrame.data(), sendFrame.size(), context);

--- a/sdk/core/azure-core/src/http/websockets/websockets_impl.hpp
+++ b/sdk/core/azure-core/src/http/websockets/websockets_impl.hpp
@@ -360,11 +360,11 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets { names
     PingThread m_pingThread;
     SocketMessageType m_currentMessageType{SocketMessageType::Unknown};
     std::mutex m_stateMutex;
+    std::mutex m_transportReadMutex;
+    std::mutex m_transportWriteMutex;
     std::thread::id m_stateOwner;
 
     ReceiveStatistics m_receiveStatistics{};
-
-    //std::mutex m_transportMutex;
 
     std::unique_ptr<Azure::Core::IO::BodyStream> m_initialBodyStream;
     constexpr static size_t m_bufferSize = 1024;

--- a/sdk/core/azure-core/src/http/websockets/websockets_impl.hpp
+++ b/sdk/core/azure-core/src/http/websockets/websockets_impl.hpp
@@ -5,12 +5,12 @@
 #include "azure/core/internal/diagnostics/log.hpp"
 #include "azure/core/internal/http/pipeline.hpp"
 #include <array>
+#include <atomic>
+#include <condition_variable>
 #include <queue>
 #include <random>
 #include <shared_mutex>
 #include <thread>
-#include <condition_variable>
-#include <atomic>
 
 // Implementation of WebSocket protocol.
 namespace Azure { namespace Core { namespace Http { namespace WebSockets { namespace _detail {
@@ -371,6 +371,6 @@ namespace Azure { namespace Core { namespace Http { namespace WebSockets { names
     uint8_t m_buffer[m_bufferSize]{};
     size_t m_bufferPos = 0;
     size_t m_bufferLen = 0;
-    std::atomic<bool> m_eof{ false };
+    std::atomic<bool> m_eof{false};
   };
 }}}}} // namespace Azure::Core::Http::WebSockets::_detail


### PR DESCRIPTION
- Added an ```#ifdef``` around some code that required Curl version 7.77 and newer)to support the single trusted cert. On older version of Curl, an exception will be thrown indicating that feature is not supported. This allows compilation on older versions of Linux (e.g. Ubuntu 20.04) where the built-in Curl version is not new enough without requiring the static/dynamic linking to an external version of Curl
- Added a missing header so the Azure Core networking code can now compile and run on Ubuntu 22.04
- Commented out the use of ```m_transportMutex``` lock since this was causing deadlock like situations since the blocking read from web socket call (with a long timeout of ~30 seconds) would block our ability to write to the web socket since it did not release the lock until after the read had completed or timed out. This would lead to long stalls.