### PR TITLE
Update key_client_create_test_live.cpp to remove dependency on attestation headers

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut-hsm/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut-hsm/CMakeLists.txt
@@ -33,8 +33,7 @@ target_link_libraries(
     azure-security-keyvault-keys-hsm-test 
       PRIVATE 
         azure-security-keyvault-keys 
-        azure-identity azure-core-test-fw  
-        azure-security-attestation
+        azure-identity azure-core-test-fw
         gtest 
         gtest_main 
         gmock)

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/CMakeLists.txt
@@ -45,8 +45,7 @@ target_link_libraries(
     azure-security-keyvault-keys-test 
       PRIVATE 
         azure-security-keyvault-keys 
-        azure-identity azure-core-test-fw  
-        azure-security-attestation
+        azure-identity azure-core-test-fw
         gtest 
         gtest_main 
         gmock)

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_create_test_live.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_create_test_live.cpp
@@ -7,8 +7,6 @@
 #include "private/key_serializers.hpp"
 #include "test_consts.hpp"
 
-#include <azure/attestation.hpp>
-#include <azure/attestation/attestation_client_options.hpp>
 #include <azure/core/base64.hpp>
 #include <azure/core/internal/json/json.hpp>
 #include <azure/keyvault/keys.hpp>
@@ -20,7 +18,6 @@
 using namespace Azure::Core::_internal;
 using namespace Azure::Security::KeyVault::Keys;
 using namespace Azure::Security::KeyVault::Keys::Test;
-using namespace Azure::Security::Attestation;
 using namespace Azure::Core::Http;
 using namespace Azure::Core::Json::_internal;
 using namespace Azure::Security::KeyVault::Keys::Cryptography;


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/4726

Likely introduced accidentally in https://github.com/Azure/azure-sdk-for-cpp/pull/3783