### PR TITLE
[feature branch] Update eventhubs unit test CMakeLists.txt to remove dependency on attestation

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/CMakeLists.txt
@@ -31,8 +31,7 @@ target_link_libraries(
     azure-messaging-eventhubs-test
       PRIVATE 
         azure-messaging-eventhubs 
-        azure-identity azure-core-test-fw  
-        azure-security-attestation
+        azure-identity azure-core-test-fw
         gtest 
         gtest_main 
         gmock


### PR DESCRIPTION
Similar to https://github.com/Azure/azure-sdk-for-cpp/pull/4727

Service SDKs should not be depending on each other. Likely just a copy/paste error from KeyVault tests which also had this issue.