### PR TITLE
Identity: Improve diagnosability

### DIFF
--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -8,6 +8,7 @@
 #include "private/token_credential_impl.hpp"
 
 #include <azure/core/internal/environment.hpp>
+#include <azure/core/internal/json/json.hpp>
 #include <azure/core/internal/strings.hpp>
 #include <azure/core/internal/unique_handle.hpp>
 #include <azure/core/platform.hpp>
@@ -47,6 +48,7 @@ using Azure::Core::Credentials::AccessToken;
 using Azure::Core::Credentials::AuthenticationException;
 using Azure::Core::Credentials::TokenCredentialOptions;
 using Azure::Core::Credentials::TokenRequestContext;
+using Azure::Core::Json::_internal::json;
 using Azure::Identity::AzureCliCredentialOptions;
 using Azure::Identity::_detail::IdentityLog;
 using Azure::Identity::_detail::TenantIdResolver;
@@ -160,10 +162,18 @@ AccessToken AzureCliCredential::GetToken(
         return TokenCredentialImpl::ParseToken(
             azCliResult, "accessToken", "expiresIn", "expiresOn");
       }
-      catch (std::exception const&)
+      catch (json::exception const&)
       {
-        // Throw the az command output (error message)
-        // limited to 250 characters (250 has no special meaning).
+        // json::exception gets thrown when a string we provided for parsing is not a json object.
+        // It should not get thrown if the string is a valid JSON, but there are specific problems
+        // with the token JSON object - missing property, failure to parse a specific property etc.
+        // I.e. this means that the az commnd has rather printed some error message
+        // (such as "ERROR: Please run az login to setup account.") instead of producing a JSON
+        // object output. In this case, we want the exception to be thrown with the output from the
+        // command (which is likely the error message) and not with the details of the exception
+        // that was thrown from ParseToken() (which mist likely will be "Unexpected token ...").
+        // So, we limit the az command output (error message) limited to 250 characters so it is not
+        // too long, and throw that.
         throw std::runtime_error(azCliResult.substr(0, 250));
       }
     }

--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -171,7 +171,7 @@ AccessToken AzureCliCredential::GetToken(
         // (such as "ERROR: Please run az login to setup account.") instead of producing a JSON
         // object output. In this case, we want the exception to be thrown with the output from the
         // command (which is likely the error message) and not with the details of the exception
-        // that was thrown from ParseToken() (which mist likely will be "Unexpected token ...").
+        // that was thrown from ParseToken() (which most likely will be "Unexpected token ...").
         // So, we limit the az command output (error message) limited to 250 characters so it is not
         // too long, and throw that.
         throw std::runtime_error(azCliResult.substr(0, 250));

--- a/sdk/identity/azure-identity/src/token_credential_impl.cpp
+++ b/sdk/identity/azure-identity/src/token_credential_impl.cpp
@@ -11,7 +11,6 @@
 #include <azure/core/url.hpp>
 
 #include <chrono>
-#include <limits>
 #include <map>
 
 using Azure::Identity::_detail::TokenCredentialImpl;

--- a/sdk/identity/azure-identity/src/token_credential_impl.cpp
+++ b/sdk/identity/azure-identity/src/token_credential_impl.cpp
@@ -198,7 +198,7 @@ std::string TokenAsDiagnosticString(
     }
 
     std::map<std::string, json> otherProperties;
-    for (auto const property : jsonObject.items())
+    for (auto const& property : jsonObject.items())
     {
       if (property.key() != accessTokenPropertyName && property.key() != expiresInPropertyName
           && property.key() != expiresOnPropertyName)

--- a/sdk/identity/azure-identity/src/token_credential_impl.cpp
+++ b/sdk/identity/azure-identity/src/token_credential_impl.cpp
@@ -9,7 +9,6 @@
 #include <azure/core/internal/json/json.hpp>
 #include <azure/core/internal/strings.hpp>
 #include <azure/core/url.hpp>
-#include <azure/core/uuid.hpp>
 
 #include <chrono>
 #include <limits>
@@ -23,7 +22,6 @@ using Azure::Identity::_detail::PackageVersion;
 using Azure::DateTime;
 using Azure::Core::Context;
 using Azure::Core::Url;
-using Azure::Core::Uuid;
 using Azure::Core::_internal::PosixTimeConverter;
 using Azure::Core::_internal::StringExtensions;
 using Azure::Core::Credentials::AccessToken;
@@ -151,8 +149,8 @@ AccessToken TokenCredentialImpl::GetToken(
 namespace {
 std::string const ParseTokenLogPrefix = "TokenCredentialImpl::ParseToken(): ";
 
-constexpr std::int64_t MaxPosixTimestamp = 253402300799; // 9999-12-31T23:59:59
 constexpr std::int64_t MaxExpirationInSeconds = 2147483647; // int32 max (68+ years)
+constexpr std::int64_t MaxPosixTimestamp = 253402300799; // 9999-12-31T23:59:59
 
 std::int64_t ParseNumericExpiration(
     std::string const& numericString,

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -364,7 +364,7 @@ TEST(AzureCliCredential, Diagnosability)
 {
   {
     AzureCliTestCredential const azCliCred(
-        EchoCommand("'az' is not recognized as an internal or external command, "
+        EchoCommand("az is not recognized as an internal or external command, "
                     "operable program or batch file."));
 
     TokenRequestContext trc;
@@ -377,7 +377,7 @@ TEST(AzureCliCredential, Diagnosability)
     {
       std::string const expectedMsgStart
           = "AzureCliCredential didn't get the token: "
-            "\"'az' is not recognized as an internal or external command, "
+            "\"az is not recognized as an internal or external command, "
             "operable program or batch file.";
 
       std::string actualMsgStart = e.what();

--- a/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
@@ -667,6 +667,49 @@ TEST(TokenCredentialImpl, ExpirationFormats)
   EXPECT_EQ(response43.AccessToken.ExpiresOn, DateTime(3333, 11, 22, 4, 5, 6));
 }
 
+TEST(TokenCredentialImpl, MaxValues)
+{
+  // 'exp_in' negative
+  EXPECT_THROW(
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"token\": \"x\",\"exp_in\":-1}", "token", "exp_in", "exp_at")),
+      std::exception);
+
+  // 'exp_in' zero
+  EXPECT_NO_THROW(static_cast<void>(TokenCredentialImpl::ParseToken(
+      "{\"token\": \"x\",\"exp_in\":0}", "token", "exp_in", "exp_at")));
+
+  // 'exp_in' == int32 max
+  EXPECT_NO_THROW(static_cast<void>(TokenCredentialImpl::ParseToken(
+      "{\"token\": \"x\",\"exp_in\":2147483647}", "token", "exp_in", "exp_at")));
+
+  // 'exp_in' > int32 max
+  EXPECT_THROW(
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"token\": \"x\",\"exp_in\":2147483648}", "token", "exp_in", "exp_at")),
+      std::exception);
+
+  // 'exp_at' negative
+  EXPECT_THROW(
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"token\": \"x\",\"exp_at\":-1}", "token", "exp_in", "exp_at")),
+      std::exception);
+
+  // 'exp_at' zero
+  EXPECT_NO_THROW(static_cast<void>(TokenCredentialImpl::ParseToken(
+      "{\"token\": \"x\",\"exp_at\":0}", "token", "exp_in", "exp_at")));
+
+  // 'exp_at' == '9999-12-31 23:59:59'
+  EXPECT_NO_THROW(static_cast<void>(TokenCredentialImpl::ParseToken(
+      "{\"token\": \"x\",\"exp_at\":253402300799}", "token", "exp_in", "exp_at")));
+
+  // 'exp_at' > '9999-12-31 23:59:59'
+  EXPECT_THROW(
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"token\": \"x\",\"exp_at\":253402300800}", "token", "exp_in", "exp_at")),
+      std::exception);
+}
+
 TEST(TokenCredentialImpl, Diagnosability)
 {
   using Azure::Core::Diagnostics::Logger;
@@ -2357,7 +2400,10 @@ TEST(TokenCredentialImpl, Diagnosability)
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
-          "\"3333-11-22T04:05:06.000Z\"", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+          "\"3333-11-22T04:05:06.000Z\"",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
     }
     catch (std::exception const& e)
     {

--- a/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
@@ -996,7 +996,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     Logger::SetListener(nullptr);
   }
 
-  // No log message is emitted when parse is succesfull.
+  // No log message is emitted when parse is successful.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -1273,7 +1273,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     Logger::SetListener(nullptr);
   }
 
-  // Not sanitining double (scientific notation).
+  // Not sanitizing double (scientific notation).
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -1855,8 +1855,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
           "{\"TokenForAccessing\":\"1337LEAK\","
-          "\"TokenExpiresInSeconds\":\"3XP3CT3D\","
-          "\"TokenExpiresAtTime\":\"3XP3CT3D\","
+          "\"TokenExpiresInSeconds\":\"EXPECTED\","
+          "\"TokenExpiresAtTime\":\"EXPECTED\","
           "\"OtherProperty\":\"1337LEAK\""
           "}",
           "TokenForAccessing",
@@ -1881,8 +1881,8 @@ TEST(TokenCredentialImpl, Diagnosability)
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
         "Token JSON: Access token property ('TokenForAccessing'): string.length=8, "
-        "relative expiration property ('TokenExpiresInSeconds'): \"3XP3CT3D\", "
-        "absolute expiration property ('TokenExpiresAtTime'): \"3XP3CT3D\", "
+        "relative expiration property ('TokenExpiresInSeconds'): \"EXPECTED\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"EXPECTED\", "
         "other properties: 'OtherProperty': ~\"1337\".");
 
     Logger::SetListener(nullptr);

--- a/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
@@ -996,7 +996,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     Logger::SetListener(nullptr);
   }
 
-  // No log message is emitted when parse is succesful.
+  // No log message is emitted when parse is succesfull.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -1230,7 +1230,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     Logger::SetListener(nullptr);
   }
 
-  // Not sanitining double.
+  // Not sanitizing double.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -1845,7 +1845,7 @@ TEST(TokenCredentialImpl, Diagnosability)
   // as possible to form a valid base-n (where n=base) integer number representation and converts
   // them to an integer value". This means that if we verify that the string can be parsed as long
   // long and then simply print jsonObject.dump() thinking it is safe, we may print any string that
-  // starts with a number. Instead, we only want to print the integet that was parsed as a string.
+  // starts with a number. Instead, we only want to print the integer that was parsed as a string.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -1855,8 +1855,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
           "{\"TokenForAccessing\":\"1337LEAK\","
-          "\"TokenExpiresInSeconds\":\"BYDESIGN\","
-          "\"TokenExpiresAtTime\":\"BYDESIGN\","
+          "\"TokenExpiresInSeconds\":\"3XP3CT3D\","
+          "\"TokenExpiresAtTime\":\"3XP3CT3D\","
           "\"OtherProperty\":\"1337LEAK\""
           "}",
           "TokenForAccessing",
@@ -1881,8 +1881,8 @@ TEST(TokenCredentialImpl, Diagnosability)
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
         "Token JSON: Access token property ('TokenForAccessing'): string.length=8, "
-        "relative expiration property ('TokenExpiresInSeconds'): \"BYDESIGN\", "
-        "absolute expiration property ('TokenExpiresAtTime'): \"BYDESIGN\", "
+        "relative expiration property ('TokenExpiresInSeconds'): \"3XP3CT3D\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"3XP3CT3D\", "
         "other properties: 'OtherProperty': ~\"1337\".");
 
     Logger::SetListener(nullptr);

--- a/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
@@ -726,6 +726,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): undefined, "
         "relative expiration property ('TokenExpiresInSeconds'): undefined, "
         "absolute expiration property ('TokenExpiresAtTime'): undefined, "
@@ -765,6 +766,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): {}, "
         "relative expiration property ('TokenExpiresInSeconds'): undefined, "
         "absolute expiration property ('TokenExpiresAtTime'): undefined, "
@@ -804,6 +806,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
         "relative expiration property ('TokenExpiresInSeconds'): undefined, "
         "absolute expiration property ('TokenExpiresAtTime'): undefined, "
@@ -845,6 +848,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
         "relative expiration property ('TokenExpiresInSeconds'): \"one\", "
         "absolute expiration property (''): undefined, "
@@ -889,6 +893,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
         "relative expiration property ('TokenExpiresInSeconds'): 1.5, "
         "absolute expiration property ('TokenExpiresAtTime'): null, "
@@ -934,6 +939,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
         "relative expiration property ('TokenExpiresInSeconds'): undefined, "
         "absolute expiration property ('TokenExpiresAtTime'): "
@@ -984,6 +990,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
         "relative expiration property ('TokenExpiresInSeconds'): -1, "
         "absolute expiration property ('TokenExpiresAtTime'): true, "
@@ -1050,6 +1057,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): null, "
         "relative expiration property ('TokenExpiresInSeconds'): null, "
         "absolute expiration property ('TokenExpiresAtTime'): null, "
@@ -1093,6 +1101,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): true, "
         "relative expiration property ('TokenExpiresInSeconds'): true, "
         "absolute expiration property ('TokenExpiresAtTime'): true, "
@@ -1136,6 +1145,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): false, "
         "relative expiration property ('TokenExpiresInSeconds'): false, "
         "absolute expiration property ('TokenExpiresAtTime'): false, "
@@ -1144,7 +1154,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     Logger::SetListener(nullptr);
   }
 
-  // Not sanitizing uint64.
+  // Not sanitizing int64 max.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -1153,10 +1163,10 @@ TEST(TokenCredentialImpl, Diagnosability)
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
-          "{\"TokenForAccessing\":9007199254740991,"
-          "\"TokenExpiresInSeconds\":9007199254740991," // would fail to parse as int32
-          "\"TokenExpiresAtTime\":null," // needs to fail for the log message to get printed
-          "\"OtherProperty\":9007199254740991"
+          "{\"TokenForAccessing\":9223372036854775807,"
+          "\"TokenExpiresInSeconds\":9223372036854775807," // > int32 max (68+ years)
+          "\"TokenExpiresAtTime\":9223372036854775807," // > year 9999
+          "\"OtherProperty\":9223372036854775807"
           "}",
           "TokenForAccessing",
           "TokenExpiresInSeconds",
@@ -1179,15 +1189,16 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing'): 9007199254740991, "
-        "relative expiration property ('TokenExpiresInSeconds'): 9007199254740991, "
-        "absolute expiration property ('TokenExpiresAtTime'): null, "
-        "other properties: 'OtherProperty': 9007199254740991.");
+        "Please report an issue with the following details:\n"
+        "Token JSON: Access token property ('TokenForAccessing'): 9223372036854775807, "
+        "relative expiration property ('TokenExpiresInSeconds'): 9223372036854775807, "
+        "absolute expiration property ('TokenExpiresAtTime'): 9223372036854775807, "
+        "other properties: 'OtherProperty': 9223372036854775807.");
 
     Logger::SetListener(nullptr);
   }
 
-  // Not sanitizing int64.
+  // Not sanitizing int64 min.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -1196,10 +1207,10 @@ TEST(TokenCredentialImpl, Diagnosability)
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
-          "{\"TokenForAccessing\":-9007199254740991,"
-          "\"TokenExpiresInSeconds\":-9007199254740991," // would fail to parse as unsigned
-          "\"TokenExpiresAtTime\":null," // Needs to fail so that the log message gets printed
-          "\"OtherProperty\":-9007199254740991"
+          "{\"TokenForAccessing\":-9223372036854775808,"
+          "\"TokenExpiresInSeconds\":-9223372036854775808," // would fail to parse as unsigned
+          "\"TokenExpiresAtTime\":-9223372036854775808," // would fail to parse as unsigned
+          "\"OtherProperty\":-9223372036854775808"
           "}",
           "TokenForAccessing",
           "TokenExpiresInSeconds",
@@ -1222,10 +1233,11 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing'): -9007199254740991, "
-        "relative expiration property ('TokenExpiresInSeconds'): -9007199254740991, "
-        "absolute expiration property ('TokenExpiresAtTime'): null, "
-        "other properties: 'OtherProperty': -9007199254740991.");
+        "Please report an issue with the following details:\n"
+        "Token JSON: Access token property ('TokenForAccessing'): -9223372036854775808, "
+        "relative expiration property ('TokenExpiresInSeconds'): -9223372036854775808, "
+        "absolute expiration property ('TokenExpiresAtTime'): -9223372036854775808, "
+        "other properties: 'OtherProperty': -9223372036854775808.");
 
     Logger::SetListener(nullptr);
   }
@@ -1265,6 +1277,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): -1.25, "
         "relative expiration property ('TokenExpiresInSeconds'): -1.25, "
         "absolute expiration property ('TokenExpiresAtTime'): -1.25, "
@@ -1284,7 +1297,7 @@ TEST(TokenCredentialImpl, Diagnosability)
       static_cast<void>(TokenCredentialImpl::ParseToken(
           "{\"TokenForAccessing\":-9.00719925e+15,"
           "\"TokenExpiresInSeconds\":-9.00719925e+15,"
-          "\"TokenExpiresAtTime\":-9.00719925e+15,"
+          "\"TokenExpiresAtTime\":-9.00719925E+15,"
           "\"OtherProperty\":-9.00719925E+15"
           "}",
           "TokenForAccessing",
@@ -1308,6 +1321,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): -9.00719925e+15, "
         "relative expiration property ('TokenExpiresInSeconds'): -9.00719925e+15, "
         "absolute expiration property ('TokenExpiresAtTime'): -9.00719925e+15, "
@@ -1351,6 +1365,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): [...], "
         "relative expiration property ('TokenExpiresInSeconds'): [...], "
         "absolute expiration property ('TokenExpiresAtTime'): [...], "
@@ -1394,6 +1409,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=4, "
         "relative expiration property ('TokenExpiresInSeconds'): \"NULL\", "
         "absolute expiration property ('TokenExpiresAtTime'): \"Null\", "
@@ -1437,6 +1453,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=4, "
         "relative expiration property ('TokenExpiresInSeconds'): \"TRUE\", "
         "absolute expiration property ('TokenExpiresAtTime'): \"True\", "
@@ -1480,6 +1497,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=5, "
         "relative expiration property ('TokenExpiresInSeconds'): \"FALSE\", "
         "absolute expiration property ('TokenExpiresAtTime'): \"False\", "
@@ -1523,6 +1541,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=5, "
         "relative expiration property ('TokenExpiresInSeconds'): \"maybe\", "
         "absolute expiration property ('TokenExpiresAtTime'): \"maybe\", "
@@ -1531,7 +1550,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     Logger::SetListener(nullptr);
   }
 
-  // Not sanitizing strings that represent uint64, except for access token.
+  // Not sanitizing strings that represent int64 max, except for access token.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -1540,10 +1559,10 @@ TEST(TokenCredentialImpl, Diagnosability)
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
-          "{\"TokenForAccessing\":\"9007199254740991\","
-          "\"TokenExpiresInSeconds\":\"9007199254740991\"," // would fail to parse as int32
-          "\"TokenExpiresAtTime\":\"fail9007199254740991\","
-          "\"OtherProperty\":\"9007199254740991\""
+          "{\"TokenForAccessing\":\"9223372036854775807\","
+          "\"TokenExpiresInSeconds\":\"9223372036854775807\"," // > int32 max (68+ years)
+          "\"TokenExpiresAtTime\":\"9223372036854775807\"," // > year 9999
+          "\"OtherProperty\":\"9223372036854775807\""
           "}",
           "TokenForAccessing",
           "TokenExpiresInSeconds",
@@ -1566,10 +1585,11 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing'): string.length=16, "
-        "relative expiration property ('TokenExpiresInSeconds'): \"9007199254740991\", "
-        "absolute expiration property ('TokenExpiresAtTime'): \"fail9007199254740991\", "
-        "other properties: 'OtherProperty': \"9007199254740991\".");
+        "Please report an issue with the following details:\n"
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=19, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"9223372036854775807\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"9223372036854775807\", "
+        "other properties: 'OtherProperty': \"9223372036854775807\".");
 
     Logger::SetListener(nullptr);
   }
@@ -1583,10 +1603,10 @@ TEST(TokenCredentialImpl, Diagnosability)
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
-          "{\"TokenForAccessing\":\"-9007199254740991\","
-          "\"TokenExpiresInSeconds\":\"-9007199254740991\"," // would fail to parse as unsigned
-          "\"TokenExpiresAtTime\":\"fail-9007199254740991\","
-          "\"OtherProperty\":\"-9007199254740991\""
+          "{\"TokenForAccessing\":\"-9223372036854775808\","
+          "\"TokenExpiresInSeconds\":\"-9223372036854775808\"," // would fail to parse as being < 0
+          "\"TokenExpiresAtTime\":\"-9223372036854775808\"," // would fail to parse as being < 0
+          "\"OtherProperty\":\"-9223372036854775808\""
           "}",
           "TokenForAccessing",
           "TokenExpiresInSeconds",
@@ -1609,10 +1629,11 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing'): string.length=17, "
-        "relative expiration property ('TokenExpiresInSeconds'): \"-9007199254740991\", "
-        "absolute expiration property ('TokenExpiresAtTime'): \"fail-9007199254740991\", "
-        "other properties: 'OtherProperty': \"-9007199254740991\".");
+        "Please report an issue with the following details:\n"
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=20, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"-9223372036854775808\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"-9223372036854775808\", "
+        "other properties: 'OtherProperty': \"-9223372036854775808\".");
 
     Logger::SetListener(nullptr);
   }
@@ -1627,8 +1648,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
           "{\"TokenForAccessing\":\"-1.25\","
-          "\"TokenExpiresInSeconds\":\"fail-1.25\","
-          "\"TokenExpiresAtTime\":\"fail-1.25\","
+          "\"TokenExpiresInSeconds\":\"-1.25\","
+          "\"TokenExpiresAtTime\":\"-1.25\","
           "\"OtherProperty\":\"-1.25\""
           "}",
           "TokenForAccessing",
@@ -1652,10 +1673,11 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=5, "
-        "relative expiration property ('TokenExpiresInSeconds'): \"fail-1.25\", "
-        "absolute expiration property ('TokenExpiresAtTime'): \"fail-1.25\", "
-        "other properties: 'OtherProperty': ~\"-1\".");
+        "relative expiration property ('TokenExpiresInSeconds'): \"-1.25\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"-1.25\", "
+        "other properties: 'OtherProperty': string.length=5.");
 
     Logger::SetListener(nullptr);
   }
@@ -1670,9 +1692,9 @@ TEST(TokenCredentialImpl, Diagnosability)
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
           "{\"TokenForAccessing\":\"-9.00719925e+15\","
-          "\"TokenExpiresInSeconds\":\"fail-9.00719925e+15\","
-          "\"TokenExpiresAtTime\":\"fail-9.00719925e+15\","
-          "\"OtherProperty\":\"-9.00719925E+15\""
+          "\"TokenExpiresInSeconds\":\"-9.00719925e+15\","
+          "\"TokenExpiresAtTime\":\"-9.00719925E+15\","
+          "\"OtherProperty\":\"-9.00719925e+15\""
           "}",
           "TokenForAccessing",
           "TokenExpiresInSeconds",
@@ -1695,10 +1717,11 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=15, "
-        "relative expiration property ('TokenExpiresInSeconds'): \"fail-9.00719925e+15\", "
-        "absolute expiration property ('TokenExpiresAtTime'): \"fail-9.00719925e+15\", "
-        "other properties: 'OtherProperty': ~\"-9\".");
+        "relative expiration property ('TokenExpiresInSeconds'): \"-9.00719925e+15\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"-9.00719925E+15\", "
+        "other properties: 'OtherProperty': string.length=15.");
 
     Logger::SetListener(nullptr);
   }
@@ -1713,7 +1736,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
           "{\"TokenForAccessing\":\"3333-11-22T04:05:06.000Z\","
-          "\"TokenExpiresInSeconds\":\"fail3333-11-22T04:05:06.000Z\","
+          "\"TokenExpiresInSeconds\":\"3333-11-22T04:05:06.000Z\","
           "\"TokenExpiresAtTime\":\"fail3333-11-22T04:05:06.000Z\","
           "\"OtherProperty\":\"3333-11-22T04:05:06.000Z\""
           "}",
@@ -1738,10 +1761,11 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=24, "
-        "relative expiration property ('TokenExpiresInSeconds'): \"fail3333-11-22T04:05:06.000Z\", "
+        "relative expiration property ('TokenExpiresInSeconds'): \"3333-11-22T04:05:06.000Z\", "
         "absolute expiration property ('TokenExpiresAtTime'): \"fail3333-11-22T04:05:06.000Z\", "
-        "other properties: 'OtherProperty': ~\"3333-11-22T04:05:06Z\".");
+        "other properties: 'OtherProperty': \"3333-11-22T04:05:06Z\".");
 
     Logger::SetListener(nullptr);
   }
@@ -1781,12 +1805,14 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=29, "
         "relative expiration property ('TokenExpiresInSeconds'): "
         "\"Sun, 22 Nov 3333 04:05:06 GMT\", "
         "absolute expiration property ('TokenExpiresAtTime'): "
         "\"failSun, 22 Nov 3333 04:05:06 GMT\", "
-        "other properties: 'OtherProperty': \"Sun, 22 Nov 3333 04:05:06 GMT\".");
+        "other properties: 'OtherProperty': "
+        "\"Sun, 22 Nov 3333 04:05:06 GMT\".");
 
     Logger::SetListener(nullptr);
   }
@@ -1830,6 +1856,7 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=61, "
         "relative expiration property ('TokenExpiresInSeconds'): "
         "\"Sunday, November 22nd of 3333 A.D. at 6 seconds past 405 Zulu\", "
@@ -1855,8 +1882,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
           "{\"TokenForAccessing\":\"1337LEAK\","
-          "\"TokenExpiresInSeconds\":\"EXPECTED\","
-          "\"TokenExpiresAtTime\":\"EXPECTED\","
+          "\"TokenExpiresInSeconds\":\"1337LEAK\","
+          "\"TokenExpiresAtTime\":\"1337LEAK\","
           "\"OtherProperty\":\"1337LEAK\""
           "}",
           "TokenForAccessing",
@@ -1880,10 +1907,11 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=8, "
-        "relative expiration property ('TokenExpiresInSeconds'): \"EXPECTED\", "
-        "absolute expiration property ('TokenExpiresAtTime'): \"EXPECTED\", "
-        "other properties: 'OtherProperty': ~\"1337\".");
+        "relative expiration property ('TokenExpiresInSeconds'): \"1337LEAK\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"1337LEAK\", "
+        "other properties: 'OtherProperty': string.length=8.");
 
     Logger::SetListener(nullptr);
   }
@@ -1947,32 +1975,33 @@ TEST(TokenCredentialImpl, Diagnosability)
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): "
         "{"
         "'a': null, 'b': true, 'c': false, 'd': 1, 'e': string.length=1, 'f': {...}, "
         "'g': \"null\", 'h': \"true\", 'i': \"false\", 'j': \"1\", 'k': [...], "
-        "'l': ~\"3333-11-22T04:05:06Z\", "
+        "'l': \"3333-11-22T04:05:06Z\", "
         "'m': \"Sun, 22 Nov 3333 04:05:06 GMT\""
         "}, "
         "relative expiration property ('TokenExpiresInSeconds'): "
         "{"
         "'a': null, 'b': true, 'c': false, 'd': 1, 'e': string.length=1, 'f': {...}, "
         "'g': \"null\", 'h': \"true\", 'i': \"false\", 'j': \"1\", 'k': [...], "
-        "'l': ~\"3333-11-22T04:05:06Z\", "
+        "'l': \"3333-11-22T04:05:06Z\", "
         "'m': \"Sun, 22 Nov 3333 04:05:06 GMT\""
         "}, "
         "absolute expiration property ('TokenExpiresAtTime'): "
         "{"
         "'a': null, 'b': true, 'c': false, 'd': 1, 'e': string.length=1, 'f': {...}, "
         "'g': \"null\", 'h': \"true\", 'i': \"false\", 'j': \"1\", 'k': [...], "
-        "'l': ~\"3333-11-22T04:05:06Z\", "
+        "'l': \"3333-11-22T04:05:06Z\", "
         "'m': \"Sun, 22 Nov 3333 04:05:06 GMT\""
         "}, "
         "other properties: 'OtherProperty': "
         "{"
         "'a': null, 'b': true, 'c': false, 'd': 1, 'e': string.length=1, 'f': {...}, "
         "'g': \"null\", 'h': \"true\", 'i': \"false\", 'j': \"1\", 'k': [...], "
-        "'l': ~\"3333-11-22T04:05:06Z\", "
+        "'l': \"3333-11-22T04:05:06Z\", "
         "'m': \"Sun, 22 Nov 3333 04:05:06 GMT\""
         "}.");
 

--- a/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
@@ -2007,4 +2007,415 @@ TEST(TokenCredentialImpl, Diagnosability)
 
     Logger::SetListener(nullptr);
   }
+
+  // Token is not an object, but a string.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "\"Hello, world!\"", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (string.length=13).");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but a null.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "null", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (null).");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but a boolean true.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "true", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (true).");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but a boolean false.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "false", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (false).");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but a number.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "-1234.56", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (-1234.56).");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but an array.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "[1, 2, 3]", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object ([...]).");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but an "null" string.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "\"nUlL\"", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (\"nUlL\").");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but an "true" string.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "\"tRuE\"", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (\"tRuE\").");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but an "false" string.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "\"fAlSe\"", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (\"fAlSe\").");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but an integer string.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "\"31337\"", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (\"31337\").");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but an RFC3339 datetime.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "\"3333-11-22T04:05:06.000Z\"", "TokenForAccessing", "TokenExpiresInSeconds", "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (\"3333-11-22T04:05:06Z\").");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Token is not an object, but an RFC1123 datetime.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "\"Sun, 22 Nov 3333 04:05:06 GMT\"",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Please report an issue with the following details:\n"
+        "Token JSON is not an object (\"Sun, 22 Nov 3333 04:05:06 GMT\").");
+
+    Logger::SetListener(nullptr);
+  }
 }

--- a/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
@@ -675,6 +675,7 @@ TEST(TokenCredentialImpl, Diagnosability)
 
   Logger::SetLevel(Logger::Level::Verbose);
 
+  // When AzureCliCredential passes an output from the command it ran.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -697,10 +698,12 @@ TEST(TokenCredentialImpl, Diagnosability)
     Logger::SetListener(nullptr);
   }
 
+  // Empty JSON object.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
 
+    auto exceptionThrown = false;
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
@@ -708,6 +711,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     }
     catch (std::exception const& e)
     {
+      exceptionThrown = true;
+
       EXPECT_EQ(
           e.what(),
           std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
@@ -715,23 +720,26 @@ TEST(TokenCredentialImpl, Diagnosability)
                       " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
     }
 
+    EXPECT_TRUE(exceptionThrown);
     EXPECT_EQ(log.size(), 1U);
     EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing') is NOT present, "
-        "relative expiration property ('TokenExpiresInSeconds') is NOT present, "
-        "absolute expiration property ('TokenExpiresAtTime') is NOT present, "
+        "Token JSON: Access token property ('TokenForAccessing'): undefined, "
+        "relative expiration property ('TokenExpiresInSeconds'): undefined, "
+        "absolute expiration property ('TokenExpiresAtTime'): undefined, "
         "and there are no other properties.");
 
     Logger::SetListener(nullptr);
   }
 
+  // Access token is not a string.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
 
+    auto exceptionThrown = false;
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
@@ -742,6 +750,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     }
     catch (std::exception const& e)
     {
+      exceptionThrown = true;
+
       EXPECT_EQ(
           e.what(),
           std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
@@ -749,23 +759,26 @@ TEST(TokenCredentialImpl, Diagnosability)
                       " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
     }
 
+    EXPECT_TRUE(exceptionThrown);
     EXPECT_EQ(log.size(), 1U);
     EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing') is NOT a string (value='{}'), "
-        "relative expiration property ('TokenExpiresInSeconds') is NOT present, "
-        "absolute expiration property ('TokenExpiresAtTime') is NOT present, "
+        "Token JSON: Access token property ('TokenForAccessing'): {}, "
+        "relative expiration property ('TokenExpiresInSeconds'): undefined, "
+        "absolute expiration property ('TokenExpiresAtTime'): undefined, "
         "and there are no other properties.");
 
     Logger::SetListener(nullptr);
   }
 
+  // Token is ok, but expiration is missing.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
 
+    auto exceptionThrown = false;
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
@@ -776,6 +789,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     }
     catch (std::exception const& e)
     {
+      exceptionThrown = true;
+
       EXPECT_EQ(
           e.what(),
           std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
@@ -783,23 +798,26 @@ TEST(TokenCredentialImpl, Diagnosability)
                       " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
     }
 
+    EXPECT_TRUE(exceptionThrown);
     EXPECT_EQ(log.size(), 1U);
     EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing') is string (length=11), "
-        "relative expiration property ('TokenExpiresInSeconds') is NOT present, "
-        "absolute expiration property ('TokenExpiresAtTime') is NOT present, "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
+        "relative expiration property ('TokenExpiresInSeconds'): undefined, "
+        "absolute expiration property ('TokenExpiresAtTime'): undefined, "
         "and there are no other properties.");
 
     Logger::SetListener(nullptr);
   }
 
+  // Token is ok, but relative expiration can't be parsed, and absolute expiration is missing.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
 
+    auto exceptionThrown = false;
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
@@ -812,6 +830,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     }
     catch (std::exception const& e)
     {
+      exceptionThrown = true;
+
       EXPECT_EQ(
           e.what(),
           std::string("Token JSON object: can't find or parse 'TokenExpiresInSeconds' property."
@@ -819,23 +839,27 @@ TEST(TokenCredentialImpl, Diagnosability)
                       " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
     }
 
+    EXPECT_TRUE(exceptionThrown);
     EXPECT_EQ(log.size(), 1U);
     EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing') is string (length=11), "
-        "relative expiration property ('TokenExpiresInSeconds') is present (value='\"one\"'), "
-        "absolute expiration property ('') is NOT present, "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"one\", "
+        "absolute expiration property (''): undefined, "
         "and there are no other properties.");
 
     Logger::SetListener(nullptr);
   }
 
+  // Token is ok, relative expiration can't be parsed, absolute expiration is null,
+  // and one other property has RFC3339 timestamp string.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
 
+    auto exceptionThrown = false;
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
@@ -850,6 +874,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     }
     catch (std::exception const& e)
     {
+      exceptionThrown = true;
+
       EXPECT_EQ(
           e.what(),
           std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
@@ -857,23 +883,27 @@ TEST(TokenCredentialImpl, Diagnosability)
                       " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
     }
 
+    EXPECT_TRUE(exceptionThrown);
     EXPECT_EQ(log.size(), 1U);
     EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing') is string (length=11), "
-        "relative expiration property ('TokenExpiresInSeconds') is present (value='1.5'), "
-        "absolute expiration property ('TokenExpiresAtTime') is present (value='null'), "
-        "other properties: 'token_expires_at_time' (value='\"Sun, 22 Nov 3333 04:05:06 GMT\"').");
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
+        "relative expiration property ('TokenExpiresInSeconds'): 1.5, "
+        "absolute expiration property ('TokenExpiresAtTime'): null, "
+        "other properties: 'token_expires_at_time': \"Sun, 22 Nov 3333 04:05:06 GMT\".");
 
     Logger::SetListener(nullptr);
   }
 
+  // Token is ok, relative expiration is missing, absolute expiration can't be parsed,
+  // And one other property has RFC3339 timestamp string, while the other is a number.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
 
+    auto exceptionThrown = false;
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
@@ -889,6 +919,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     }
     catch (std::exception const& e)
     {
+      exceptionThrown = true;
+
       EXPECT_EQ(
           e.what(),
           std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
@@ -896,25 +928,30 @@ TEST(TokenCredentialImpl, Diagnosability)
                       " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
     }
 
+    EXPECT_TRUE(exceptionThrown);
     EXPECT_EQ(log.size(), 1U);
     EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing') is string (length=11), "
-        "relative expiration property ('TokenExpiresInSeconds') is NOT present, "
-        "absolute expiration property ('TokenExpiresAtTime') is present "
-        "(value='\"Sunday, November 22nd of 3333 A.D. at 6 seconds past 405 Zulu\"'), "
-        "other properties: 'token_expires_at_time' (value='\"Sun, 22 Nov 3333 04:05:06 GMT\"'), "
-        "'token_expires_in_seconds' (value='45').");
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
+        "relative expiration property ('TokenExpiresInSeconds'): undefined, "
+        "absolute expiration property ('TokenExpiresAtTime'): "
+        "\"Sunday, November 22nd of 3333 A.D. at 6 seconds past 405 Zulu\", "
+        "other properties: 'token_expires_at_time': \"Sun, 22 Nov 3333 04:05:06 GMT\", "
+        "'token_expires_in_seconds': 45.");
 
     Logger::SetListener(nullptr);
   }
 
+  // Token is ok, relative expiration can't be parsed, absolute expiration can't be parsed,
+  // One other property has RFC3339 timestamp string, another is a number, third is a string,
+  // fourth is array.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
 
+    auto exceptionThrown = false;
     try
     {
       static_cast<void>(TokenCredentialImpl::ParseToken(
@@ -923,10 +960,8 @@ TEST(TokenCredentialImpl, Diagnosability)
           "\"TokenExpiresAtTime\":true,"
           "\"tokenexpiresattime\":\"Sun, 22 Nov 3333 04:05:06 GMT\","
           "\"token_expires_in_seconds\":45,"
-          "\"token_for_accessing\":\"ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN."
-          "ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN\","
-          "\"string_array\":[\"ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN."
-          "ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN.ACCESSTOKEN\"]"
+          "\"token_for_accessing\":\"ACCESSTOKEN\","
+          "\"array\":[1, 2, 3]"
           "}",
           "TokenForAccessing",
           "TokenExpiresInSeconds",
@@ -934,6 +969,8 @@ TEST(TokenCredentialImpl, Diagnosability)
     }
     catch (std::exception const& e)
     {
+      exceptionThrown = true;
+
       EXPECT_EQ(
           e.what(),
           std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
@@ -941,23 +978,25 @@ TEST(TokenCredentialImpl, Diagnosability)
                       " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
     }
 
+    EXPECT_TRUE(exceptionThrown);
     EXPECT_EQ(log.size(), 1U);
     EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
     EXPECT_EQ(
         log.at(0).second,
         "Identity: TokenCredentialImpl::ParseToken(): "
-        "Token JSON: Access token property ('TokenForAccessing') is string (length=11), "
-        "relative expiration property ('TokenExpiresInSeconds') is present (value='-1'), "
-        "absolute expiration property ('TokenExpiresAtTime') is present (value='true'), "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
+        "relative expiration property ('TokenExpiresInSeconds'): -1, "
+        "absolute expiration property ('TokenExpiresAtTime'): true, "
         "other properties: "
-        "'string_array' (value size=147), "
-        "'token_expires_in_seconds' (value='45'), "
-        "'token_for_accessing' (string length=143), "
-        "'tokenexpiresattime' (value='\"Sun, 22 Nov 3333 04:05:06 GMT\"').");
+        "'array': [...], "
+        "'token_expires_in_seconds': 45, "
+        "'token_for_accessing': string.length=11, "
+        "'tokenexpiresattime': \"Sun, 22 Nov 3333 04:05:06 GMT\".");
 
     Logger::SetListener(nullptr);
   }
 
+  // No log message is emitted when parse is succesful.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -972,6 +1011,970 @@ TEST(TokenCredentialImpl, Diagnosability)
         "TokenExpiresAtTime")));
 
     EXPECT_EQ(log.size(), 0U);
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing nulls.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":null,"
+          "\"TokenExpiresInSeconds\":null,"
+          "\"TokenExpiresAtTime\":null,"
+          "\"OtherProperty\":null"
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): null, "
+        "relative expiration property ('TokenExpiresInSeconds'): null, "
+        "absolute expiration property ('TokenExpiresAtTime'): null, "
+        "other properties: 'OtherProperty': null.");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing boolean true.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":true,"
+          "\"TokenExpiresInSeconds\":true,"
+          "\"TokenExpiresAtTime\":true,"
+          "\"OtherProperty\":true"
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): true, "
+        "relative expiration property ('TokenExpiresInSeconds'): true, "
+        "absolute expiration property ('TokenExpiresAtTime'): true, "
+        "other properties: 'OtherProperty': true.");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing boolean false.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":false,"
+          "\"TokenExpiresInSeconds\":false,"
+          "\"TokenExpiresAtTime\":false,"
+          "\"OtherProperty\":false"
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): false, "
+        "relative expiration property ('TokenExpiresInSeconds'): false, "
+        "absolute expiration property ('TokenExpiresAtTime'): false, "
+        "other properties: 'OtherProperty': false.");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing uint64.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":9007199254740991,"
+          "\"TokenExpiresInSeconds\":9007199254740991," // would fail to parse as int32
+          "\"TokenExpiresAtTime\":null," // needs to fail for the log message to get printed
+          "\"OtherProperty\":9007199254740991"
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): 9007199254740991, "
+        "relative expiration property ('TokenExpiresInSeconds'): 9007199254740991, "
+        "absolute expiration property ('TokenExpiresAtTime'): null, "
+        "other properties: 'OtherProperty': 9007199254740991.");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing int64.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":-9007199254740991,"
+          "\"TokenExpiresInSeconds\":-9007199254740991," // would fail to parse as unsigned
+          "\"TokenExpiresAtTime\":null," // Needs to fail so that the log message gets printed
+          "\"OtherProperty\":-9007199254740991"
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): -9007199254740991, "
+        "relative expiration property ('TokenExpiresInSeconds'): -9007199254740991, "
+        "absolute expiration property ('TokenExpiresAtTime'): null, "
+        "other properties: 'OtherProperty': -9007199254740991.");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitining double.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":-1.25,"
+          "\"TokenExpiresInSeconds\":-1.25,"
+          "\"TokenExpiresAtTime\":-1.25,"
+          "\"OtherProperty\":-1.25"
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): -1.25, "
+        "relative expiration property ('TokenExpiresInSeconds'): -1.25, "
+        "absolute expiration property ('TokenExpiresAtTime'): -1.25, "
+        "other properties: 'OtherProperty': -1.25.");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitining double (scientific notation).
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":-9.00719925e+15,"
+          "\"TokenExpiresInSeconds\":-9.00719925e+15,"
+          "\"TokenExpiresAtTime\":-9.00719925e+15,"
+          "\"OtherProperty\":-9.00719925E+15"
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): -9.00719925e+15, "
+        "relative expiration property ('TokenExpiresInSeconds'): -9.00719925e+15, "
+        "absolute expiration property ('TokenExpiresAtTime'): -9.00719925e+15, "
+        "other properties: 'OtherProperty': -9.00719925e+15.");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Sanitizing arrays.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":[1, 2, 3],"
+          "\"TokenExpiresInSeconds\":[1, 2, 3],"
+          "\"TokenExpiresAtTime\":[1, 2, 3],"
+          "\"OtherProperty\":[1, 2, 3]"
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): [...], "
+        "relative expiration property ('TokenExpiresInSeconds'): [...], "
+        "absolute expiration property ('TokenExpiresAtTime'): [...], "
+        "other properties: 'OtherProperty': [...].");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing strings that say "null" (case insensitive), except for access token.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"null\","
+          "\"TokenExpiresInSeconds\":\"NULL\","
+          "\"TokenExpiresAtTime\":\"Null\","
+          "\"OtherProperty\":\"nUlL\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=4, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"NULL\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"Null\", "
+        "other properties: 'OtherProperty': \"nUlL\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing strings that say "true" (case insensitive), except for access token.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"true\","
+          "\"TokenExpiresInSeconds\":\"TRUE\","
+          "\"TokenExpiresAtTime\":\"True\","
+          "\"OtherProperty\":\"tRuE\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=4, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"TRUE\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"True\", "
+        "other properties: 'OtherProperty': \"tRuE\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing strings that say "false" (case insensitive), except for access token.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"false\","
+          "\"TokenExpiresInSeconds\":\"FALSE\","
+          "\"TokenExpiresAtTime\":\"False\","
+          "\"OtherProperty\":\"fAlSe\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=5, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"FALSE\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"False\", "
+        "other properties: 'OtherProperty': \"fAlSe\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Sanitizing other strings, except for the expiration properties.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"maybe\","
+          "\"TokenExpiresInSeconds\":\"maybe\","
+          "\"TokenExpiresAtTime\":\"maybe\","
+          "\"OtherProperty\":\"maybe\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=5, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"maybe\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"maybe\", "
+        "other properties: 'OtherProperty': string.length=5.");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing strings that represent uint64, except for access token.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"9007199254740991\","
+          "\"TokenExpiresInSeconds\":\"9007199254740991\"," // would fail to parse as int32
+          "\"TokenExpiresAtTime\":\"fail9007199254740991\","
+          "\"OtherProperty\":\"9007199254740991\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=16, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"9007199254740991\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"fail9007199254740991\", "
+        "other properties: 'OtherProperty': \"9007199254740991\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing strings that represent int64, except for access token.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"-9007199254740991\","
+          "\"TokenExpiresInSeconds\":\"-9007199254740991\"," // would fail to parse as unsigned
+          "\"TokenExpiresAtTime\":\"fail-9007199254740991\","
+          "\"OtherProperty\":\"-9007199254740991\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=17, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"-9007199254740991\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"fail-9007199254740991\", "
+        "other properties: 'OtherProperty': \"-9007199254740991\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing strings that represent double, except for access token.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"-1.25\","
+          "\"TokenExpiresInSeconds\":\"fail-1.25\","
+          "\"TokenExpiresAtTime\":\"fail-1.25\","
+          "\"OtherProperty\":\"-1.25\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=5, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"fail-1.25\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"fail-1.25\", "
+        "other properties: 'OtherProperty': ~\"-1\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing strings that represent double (scientific notation), except for access token.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"-9.00719925e+15\","
+          "\"TokenExpiresInSeconds\":\"fail-9.00719925e+15\","
+          "\"TokenExpiresAtTime\":\"fail-9.00719925e+15\","
+          "\"OtherProperty\":\"-9.00719925E+15\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=15, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"fail-9.00719925e+15\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"fail-9.00719925e+15\", "
+        "other properties: 'OtherProperty': ~\"-9\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing strings that represent datetime (RFC3339), except for access token.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"3333-11-22T04:05:06.000Z\","
+          "\"TokenExpiresInSeconds\":\"fail3333-11-22T04:05:06.000Z\","
+          "\"TokenExpiresAtTime\":\"fail3333-11-22T04:05:06.000Z\","
+          "\"OtherProperty\":\"3333-11-22T04:05:06.000Z\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=24, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"fail3333-11-22T04:05:06.000Z\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"fail3333-11-22T04:05:06.000Z\", "
+        "other properties: 'OtherProperty': ~\"3333-11-22T04:05:06Z\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Not sanitizing strings that represent datetime (RFC1123), except for access token.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"Sun, 22 Nov 3333 04:05:06 GMT\","
+          "\"TokenExpiresInSeconds\":\"Sun, 22 Nov 3333 04:05:06 GMT\","
+          "\"TokenExpiresAtTime\":\"failSun, 22 Nov 3333 04:05:06 GMT\","
+          "\"OtherProperty\":\"Sun, 22 Nov 3333 04:05:06 GMT\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=29, "
+        "relative expiration property ('TokenExpiresInSeconds'): "
+        "\"Sun, 22 Nov 3333 04:05:06 GMT\", "
+        "absolute expiration property ('TokenExpiresAtTime'): "
+        "\"failSun, 22 Nov 3333 04:05:06 GMT\", "
+        "other properties: 'OtherProperty': \"Sun, 22 Nov 3333 04:05:06 GMT\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // More explicitly, do sanitize unknown datetime format, except for the expiration properties.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":"
+          "\"Sunday, November 22nd of 3333 A.D. at 6 seconds past 405 Zulu\","
+          "\"TokenExpiresInSeconds\":"
+          "\"Sunday, November 22nd of 3333 A.D. at 6 seconds past 405 Zulu\","
+          "\"TokenExpiresAtTime\":"
+          "\"Sunday, November 22nd of 3333 A.D. at 6 seconds past 405 Zulu\","
+          "\"OtherProperty\":"
+          "\"Sunday, November 22nd of 3333 A.D. at 6 seconds past 405 Zulu\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=61, "
+        "relative expiration property ('TokenExpiresInSeconds'): "
+        "\"Sunday, November 22nd of 3333 A.D. at 6 seconds past 405 Zulu\", "
+        "absolute expiration property ('TokenExpiresAtTime'): "
+        "\"Sunday, November 22nd of 3333 A.D. at 6 seconds past 405 Zulu\", "
+        "other properties: 'OtherProperty': string.length=61.");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // std::stoll() et al. have a leak: "Discards any whitespace characters (as identified by calling
+  // std::isspace) until the first non-whitespace character is found, then takes as many characters
+  // as possible to form a valid base-n (where n=base) integer number representation and converts
+  // them to an integer value". This means that if we verify that the string can be parsed as long
+  // long and then simply print jsonObject.dump() thinking it is safe, we may print any string that
+  // starts with a number. Instead, we only want to print the integet that was parsed as a string.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":\"1337LEAK\","
+          "\"TokenExpiresInSeconds\":\"BYDESIGN\","
+          "\"TokenExpiresAtTime\":\"BYDESIGN\","
+          "\"OtherProperty\":\"1337LEAK\""
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenExpiresAtTime' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): string.length=8, "
+        "relative expiration property ('TokenExpiresInSeconds'): \"BYDESIGN\", "
+        "absolute expiration property ('TokenExpiresAtTime'): \"BYDESIGN\", "
+        "other properties: 'OtherProperty': ~\"1337\".");
+
+    Logger::SetListener(nullptr);
+  }
+
+  // Sanitizing JSON objects.
+  {
+    LogMsgVec log;
+    Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
+
+    auto exceptionThrown = false;
+    try
+    {
+      static_cast<void>(TokenCredentialImpl::ParseToken(
+          "{\"TokenForAccessing\":"
+          "{"
+          "\"a\":null,\"b\":true,\"c\":false,\"d\":1,\"e\":\"E\",\"f\":{\"x\":true,\"y\":false},"
+          "\"g\":\"null\",\"h\":\"true\",\"i\":\"false\",\"j\":\"1\",\"k\":[1,2,3],"
+          "\"l\":\"3333-11-22T04:05:06.000Z\","
+          "\"m\":\"Sun, 22 Nov 3333 04:05:06 GMT\""
+          "},"
+          "\"TokenExpiresInSeconds\":"
+          "{"
+          "\"a\":null,\"b\":true,\"c\":false,\"d\":1,\"e\":\"E\",\"f\":{\"x\":true,\"y\":false},"
+          "\"g\":\"null\",\"h\":\"true\",\"i\":\"false\",\"j\":\"1\",\"k\":[1,2,3],"
+          "\"l\":\"3333-11-22T04:05:06.000Z\","
+          "\"m\":\"Sun, 22 Nov 3333 04:05:06 GMT\""
+          "},"
+          "\"TokenExpiresAtTime\":"
+          "{"
+          "\"a\":null,\"b\":true,\"c\":false,\"d\":1,\"e\":\"E\",\"f\":{\"x\":true,\"y\":false},"
+          "\"g\":\"null\",\"h\":\"true\",\"i\":\"false\",\"j\":\"1\",\"k\":[1,2,3],"
+          "\"l\":\"3333-11-22T04:05:06.000Z\","
+          "\"m\":\"Sun, 22 Nov 3333 04:05:06 GMT\""
+          "},"
+          "\"OtherProperty\":"
+          "{"
+          "\"a\":null,\"b\":true,\"c\":false,\"d\":1,\"e\":\"E\",\"f\":{\"x\":true,\"y\":false},"
+          "\"g\":\"null\",\"h\":\"true\",\"i\":\"false\",\"j\":\"1\",\"k\":[1,2,3],"
+          "\"l\":\"3333-11-22T04:05:06.000Z\","
+          "\"m\":\"Sun, 22 Nov 3333 04:05:06 GMT\""
+          "}"
+          "}",
+          "TokenForAccessing",
+          "TokenExpiresInSeconds",
+          "TokenExpiresAtTime"));
+    }
+    catch (std::exception const& e)
+    {
+      exceptionThrown = true;
+
+      EXPECT_EQ(
+          e.what(),
+          std::string("Token JSON object: can't find or parse 'TokenForAccessing' property."
+                      "\nSee Azure::Core::Diagnostics::Logger for details"
+                      " (https://aka.ms/azsdk/cpp/identity/troubleshooting)."));
+    }
+
+    EXPECT_TRUE(exceptionThrown);
+    EXPECT_EQ(log.size(), 1U);
+    EXPECT_EQ(log.at(0).first, Logger::Level::Verbose);
+    EXPECT_EQ(
+        log.at(0).second,
+        "Identity: TokenCredentialImpl::ParseToken(): "
+        "Token JSON: Access token property ('TokenForAccessing'): "
+        "{"
+        "'a': null, 'b': true, 'c': false, 'd': 1, 'e': string.length=1, 'f': {...}, "
+        "'g': \"null\", 'h': \"true\", 'i': \"false\", 'j': \"1\", 'k': [...], "
+        "'l': ~\"3333-11-22T04:05:06Z\", "
+        "'m': \"Sun, 22 Nov 3333 04:05:06 GMT\""
+        "}, "
+        "relative expiration property ('TokenExpiresInSeconds'): "
+        "{"
+        "'a': null, 'b': true, 'c': false, 'd': 1, 'e': string.length=1, 'f': {...}, "
+        "'g': \"null\", 'h': \"true\", 'i': \"false\", 'j': \"1\", 'k': [...], "
+        "'l': ~\"3333-11-22T04:05:06Z\", "
+        "'m': \"Sun, 22 Nov 3333 04:05:06 GMT\""
+        "}, "
+        "absolute expiration property ('TokenExpiresAtTime'): "
+        "{"
+        "'a': null, 'b': true, 'c': false, 'd': 1, 'e': string.length=1, 'f': {...}, "
+        "'g': \"null\", 'h': \"true\", 'i': \"false\", 'j': \"1\", 'k': [...], "
+        "'l': ~\"3333-11-22T04:05:06Z\", "
+        "'m': \"Sun, 22 Nov 3333 04:05:06 GMT\""
+        "}, "
+        "other properties: 'OtherProperty': "
+        "{"
+        "'a': null, 'b': true, 'c': false, 'd': 1, 'e': string.length=1, 'f': {...}, "
+        "'g': \"null\", 'h': \"true\", 'i': \"false\", 'j': \"1\", 'k': [...], "
+        "'l': ~\"3333-11-22T04:05:06Z\", "
+        "'m': \"Sun, 22 Nov 3333 04:05:06 GMT\""
+        "}.");
 
     Logger::SetListener(nullptr);
   }


### PR DESCRIPTION
Look at the bug #4723: the customer did a great job debugging the problem with SDK, finding the actual server response, and including it in the bug.

This change is to make diagnosability simpler: turn on the verbose level of logging and if there is token JSON parse error, see more details. It is easier to log a bug, or if a customer contacts us with just the exception, we can tell them how to easily get more details for the bug.

It is good to have this, because access token JSON is basically the only external input for Identity, and also it could be that we can't reproduce the same response in our environment, but when we have these details, we could much better see what kind of response is there, construct the similar input and make a fix.

If this functionality was in place when the customer has logged that bug, here's what they'd seen:

`Azure::Core::Credentials::AuthenticationException` with the description
```
"GetToken(): Token JSON object: can't find or parse 'expires_in' property.
See Azure::Core::Diagnostics::Logger for details (https://aka.ms/azsdk/cpp/identity/troubleshooting)."
```
would've been thrown.

The log would say:
```
[2023-07-01T08:28:30.5602314Z] DEBUG : Identity: TokenCredentialImpl::ParseToken(): Please report an 
issue with the following details:
Token JSON: Access token property ('access_token'): string.length=2062, relative expiration property 
('expires_in'): "84671", absolute expiration property (''): undefined, other properties: 'client_id': 
string.length=36, 'expires_on': "1687364401", 'ext_expires_in': "86399", 'not_before': "1687277701", 
'resource': string.length=28, 'token_type': string.length=6.
```