### PR TITLE
Update cspell to forbid misspelled word

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -31,6 +31,7 @@
   // * Alphabetize the list when making changes so the list is easier for future
   //   users to maintain and reason about.
   "words": [
+    "!respone",
     "ABFS",
     "ABNF",
     "Adls",

--- a/sdk/keyvault/azure-security-keyvault-certificates/src/certificate_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/src/certificate_client.cpp
@@ -96,7 +96,7 @@ Response<KeyVaultCertificateWithPolicy> CertificateClient::GetCertificate(
 {
   auto request = CreateRequest(HttpMethod::Get, {CertificatesPath, certificateName});
 
-  // Send and parse respone
+  // Send and parse response
   auto rawResponse = SendRequest(request, context);
   auto value = _detail::KeyVaultCertificateSerializer::Deserialize(certificateName, *rawResponse);
   return Azure::Response<KeyVaultCertificateWithPolicy>(std::move(value), std::move(rawResponse));

--- a/sdk/keyvault/azure-security-keyvault-certificates/src/certificate_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/src/certificate_client.cpp
@@ -96,7 +96,7 @@ Response<KeyVaultCertificateWithPolicy> CertificateClient::GetCertificate(
 {
   auto request = CreateRequest(HttpMethod::Get, {CertificatesPath, certificateName});
 
-  // Send and parse response
+  // Send and parse respone
   auto rawResponse = SendRequest(request, context);
   auto value = _detail::KeyVaultCertificateSerializer::Deserialize(certificateName, *rawResponse);
   return Azure::Response<KeyVaultCertificateWithPolicy>(std::move(value), std::move(rawResponse));


### PR DESCRIPTION
Preventing the "allowed" typo that was fixed in #4716.