### PR TITLE
Codifying the behavior of json.contains with nested properties, in the unit test.

### DIFF
--- a/sdk/core/azure-core/test/ut/json_test.cpp
+++ b/sdk/core/azure-core/test/ut/json_test.cpp
@@ -16,3 +16,31 @@ TEST(Json, create)
 
   EXPECT_EQ(expected, j.dump());
 }
+
+TEST(Json, duplicateName)
+{
+  json jsonRoot = json::parse(R"({"KeyName": 1, "AnotherObject": {"KeyName": 2}})");
+  int value = 0;
+  if (jsonRoot.contains("KeyName"))
+  {
+    value = jsonRoot["KeyName"].get<int>();
+  }
+  EXPECT_EQ(value, 1);
+
+  jsonRoot = json::parse(R"({"AnotherObject": {"KeyName": 2}})");
+  value = 0;
+
+  // The nested KeyName property is considered not found, when at the root.
+  if (jsonRoot.contains("KeyName"))
+  {
+    value = jsonRoot["KeyName"].get<int>();
+  }
+  EXPECT_EQ(value, 0);
+
+  // The nested KeyName property is considered found, when navigating to the nested object first.
+  if (jsonRoot["AnotherObject"].contains("KeyName"))
+  {
+    value = jsonRoot["AnotherObject"]["KeyName"].get<int>();
+  }
+  EXPECT_EQ(value, 2);
+}


### PR DESCRIPTION
It is useful to highlight the behavior of APIs like `.contains()` when we have properties with the same name in nested objects within the JSON payload.

Follow-up from https://github.com/Azure/autorest.cpp/pull/246#issuecomment-1605120877