### PR TITLE
Format vcpkg manifest

### DIFF
--- a/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
@@ -15,11 +15,9 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.9.0-beta.1"
+      "version>=": "1.10.1"
     },
-    {
-      "name": "azure-uamqp-c"
-    },
+    "azure-uamqp-c",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
@@ -15,7 +15,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.10.1"
+      "version>=": "1.9.0-beta.1"
     },
     "azure-uamqp-c",
     {


### PR DESCRIPTION
When you commit to vcpkg, or even when you run `vcpkg x-add-version`, it requires the manifest to be formatted exactly as running it with `vcpkg format-manifest` would produce it. So, it is better to have the file already formatted - `vcpkg x-add-version` won't complain, and it is easier to do manual commits to vckpkg repo, should it come to that.