### PR TITLE
Add sanitizer for test-proxy to scrub client secrets from recording files

### DIFF
--- a/sdk/core/azure-core-test/src/test_proxy_manager.cpp
+++ b/sdk/core/azure-core-test/src/test_proxy_manager.cpp
@@ -228,7 +228,7 @@ void TestProxyManager::SetProxySanitizer()
     {
       "key": "Location",
       "value": "REDACTED",
-      "regex": "client_secret=(?<clientsecret>[a-zA-Z0-9\\%]+).",
+      "regex": "client_secret=(?<clientsecret>[a-zA-Z0-9\\%]+)",
       "groupForReplace": "clientsecret"
     }
     )json";


### PR DESCRIPTION
This PR includes:

1. Use raw string literals for hard-coded json strings, making it more readable and maintainable by avoiding escape characters.
2. Add a new sanitizer to scrub client secrets sending from identity to `login.microsoftonline.com`. [Here](https://github.com/Azure/azure-sdk-for-cpp/issues/4147#issuecomment-1379829565)'s an example what was scrubbed.





REF: https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md#add-sanitizer


# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
