### PR TITLE
Catch nlohmann json specific exceptions to avoid leaking them.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
@@ -37,11 +37,24 @@ namespace Azure { namespace Core { namespace Json { namespace _internal {
     static inline void SetIfExists(
         Azure::Nullable<T>& destination,
         Azure::Core::Json::_internal::json const& jsonKey,
-        std::string const& key) noexcept
+        std::string const& key)
     {
       if (jsonKey.contains(key) && !jsonKey[key].is_null()) // In Json and not-Null
       {
-        destination = jsonKey[key].get<T>();
+        try
+        {
+          destination = jsonKey[key].get<T>();
+        }
+        catch (std::exception const& e)
+        {
+          // Catch the Azure::Core::Json::_internal::detail::type_error thrown by the 3rd party
+          // library which we don't want to expose.
+          throw std::runtime_error(
+              std::string(
+                  "Could not find required field '" + key + "' of type '" + typeid(T).name()
+                  + "'. ")
+              + e.what());
+        }
       }
     }
 

--- a/sdk/core/azure-core/test/ut/json_test.cpp
+++ b/sdk/core/azure-core/test/ut/json_test.cpp
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 #include <azure/core/internal/json/json.hpp>
+#include <azure/core/internal/json/json_optional.hpp>
 
 #include <gtest/gtest.h>
 
 using json = Azure::Core::Json::_internal::json;
+
+using namespace Azure::Core::Json::_internal;
 
 // Just a simple test to ensure that Azure Core internal is wrapping nlohmann json
 TEST(Json, create)
@@ -15,6 +18,16 @@ TEST(Json, create)
   std::string expected("{\"pi\":3.141}");
 
   EXPECT_EQ(expected, j.dump());
+}
+
+TEST(Json, customExceptionsDontEscape)
+{
+  json jsonRoot = json::parse(R"({"KeyName": 1, "AnotherObject": {"KeyName": 2}})");
+  Azure::Nullable<std::string> dest;
+
+  // Setting a number field to string results in a type mismatch error.
+  EXPECT_THROW(
+      JsonOptional::SetIfExists(dest, jsonRoot["AnotherObject"], "KeyName"), std::runtime_error);
 }
 
 TEST(Json, duplicateName)


### PR DESCRIPTION
We'd have to wrap other API calls too, such as `parse()` and `dump()`, along with some operator calls like `[]`.

Before, we'd fail with nlohmann json's custom exception, `type_error`:
> C++ exception with description "[json.exception.type_error.302] type must be string, but is number" thrown in the test body.

Now, we will with `runtime_error`:
> C++ exception with description "Could not find required field 'KeyName' of type 'class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >'. [json.exception.type_error.302] type must be string, but is number" thrown in the test body.