### PR TITLE
Test what happens when we use type information on different compilers and with RTTI off.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
@@ -37,11 +37,24 @@ namespace Azure { namespace Core { namespace Json { namespace _internal {
     static inline void SetIfExists(
         Azure::Nullable<T>& destination,
         Azure::Core::Json::_internal::json const& jsonKey,
-        std::string const& key) noexcept
+        std::string const& key)
     {
       if (jsonKey.contains(key) && !jsonKey[key].is_null()) // In Json and not-Null
       {
-        destination = jsonKey[key].get<T>();
+        try
+        {
+          destination = jsonKey[key].get<T>();
+        }
+        catch (std::exception const& e)
+        {
+          // Catch the Azure::Core::Json::_internal::detail::type_error thrown by the 3rd party
+          // library which we don't want to expose.
+          throw std::runtime_error(
+              std::string(
+                  "Could not find required field '" + key + "' of type '" + typeid(T).name()
+                  + "'. ")
+              + e.what());
+        }
       }
     }
 

--- a/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
@@ -55,9 +55,8 @@ namespace Azure { namespace Core { namespace Json { namespace _internal {
                   + "'. ")
               + e.what());
         }
-        throw std::runtime_error(
-            std::string(
-                "Could not find required field '" + key + "' of type '" + typeid(T).name() + "'. "));
+        throw std::runtime_error(std::string(
+            "Could not find required field '" + key + "' of type '" + typeid(T).name() + "'. "));
       }
     }
 

--- a/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/json/json_optional.hpp
@@ -55,6 +55,9 @@ namespace Azure { namespace Core { namespace Json { namespace _internal {
                   + "'. ")
               + e.what());
         }
+        throw std::runtime_error(
+            std::string(
+                "Could not find required field '" + key + "' of type '" + typeid(T).name() + "'. "));
       }
     }
 

--- a/sdk/core/azure-core/test/ut/json_test.cpp
+++ b/sdk/core/azure-core/test/ut/json_test.cpp
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 #include <azure/core/internal/json/json.hpp>
+#include <azure/core/internal/json/json_optional.hpp>
 
 #include <gtest/gtest.h>
 
 using json = Azure::Core::Json::_internal::json;
+
+using namespace Azure::Core::Json::_internal;
 
 // Just a simple test to ensure that Azure Core internal is wrapping nlohmann json
 TEST(Json, create)
@@ -15,6 +18,16 @@ TEST(Json, create)
   std::string expected("{\"pi\":3.141}");
 
   EXPECT_EQ(expected, j.dump());
+}
+
+TEST(Json, customExceptionsDontEscape)
+{
+  json jsonRoot = json::parse(R"({"KeyName": 1, "AnotherObject": {"KeyName": 2}})");
+  Azure::Nullable<std::string> dest;
+
+  // Setting a number field to string results in a type mismatch error.
+  EXPECT_THROW(
+      JsonOptional::SetIfExists(dest, jsonRoot["AnotherObject"], "KeyName"), std::runtime_error);
 }
 
 TEST(Json, duplicateName)

--- a/sdk/core/azure-core/test/ut/json_test.cpp
+++ b/sdk/core/azure-core/test/ut/json_test.cpp
@@ -24,7 +24,7 @@ TEST(Json, customExceptionsDontEscape)
 {
   json jsonRoot = json::parse(R"({"KeyName": 1, "AnotherObject": {"KeyName": 2}})");
   Azure::Nullable<std::string> dest;
-
+  JsonOptional::SetIfExists(dest, jsonRoot["AnotherObject"], "KeyName");
   // Setting a number field to string results in a type mismatch error.
   EXPECT_THROW(
       JsonOptional::SetIfExists(dest, jsonRoot["AnotherObject"], "KeyName"), std::runtime_error);

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_test.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_test.cpp
@@ -32,7 +32,6 @@ TEST(KeyVaultKeyClientUnitTest, ServiceVersion)
 {
   auto credential
       = std::make_shared<Azure::Identity::ClientSecretCredential>("tenantID", "AppId", "SecretId");
-  // 7.3
   EXPECT_NO_THROW(auto options = KeyClientOptions();
                   KeyClient keyClient("http://account.vault.azure.net", credential, options);
                   EXPECT_EQ(options.ApiVersion, "7.3"););


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk-for-cpp/pull/4776#discussion_r1258926969