### PR TITLE
Disable libcurl globalCleanUp test until it has been investigated

### DIFF
--- a/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
@@ -29,7 +29,7 @@ namespace Azure { namespace Core { namespace Test {
   class CurlConnectionPool_connectionPoolTest_Test;
   class CurlConnectionPool_uniquePort_Test;
   class CurlConnectionPool_connectionClose_Test;
-  class SdkWithLibcurl_globalCleanUp_Test;
+  class SdkWithLibcurl_DISABLED_globalCleanUp_Test;
 }}} // namespace Azure::Core::Test
 #endif
 
@@ -48,7 +48,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
     friend class Azure::Core::Test::CurlConnectionPool_uniquePort_Test;
     friend class Azure::Core::Test::CurlConnectionPool_connectionClose_Test;
-    friend class Azure::Core::Test::SdkWithLibcurl_globalCleanUp_Test;
+    friend class Azure::Core::Test::SdkWithLibcurl_DISABLED_globalCleanUp_Test;
 #endif
 
   public:

--- a/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
@@ -22,7 +22,7 @@
 // Define the class name that reads from ConnectionPool private members
 namespace Azure { namespace Core { namespace Test {
   class CurlConnectionPool_connectionPoolTest_Test;
-  class SdkWithLibcurl_globalCleanUp_Test;
+  class SdkWithLibcurl_DISABLED_globalCleanUp_Test;
 }}} // namespace Azure::Core::Test
 #endif
 
@@ -43,7 +43,7 @@ namespace Azure { namespace Core { namespace Http {
 #ifdef TESTING_BUILD
     // Give access to private to this tests class
     friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
-    friend class Azure::Core::Test::SdkWithLibcurl_globalCleanUp_Test;
+    friend class Azure::Core::Test::SdkWithLibcurl_DISABLED_globalCleanUp_Test;
 #endif
   private:
     /**

--- a/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
+++ b/sdk/core/azure-core/test/ut/azure_libcurl_core_main_test.cpp
@@ -31,7 +31,8 @@
 #include <gtest/gtest.h>
 
 namespace Azure { namespace Core { namespace Test {
-  TEST(SdkWithLibcurl, globalCleanUp)
+  // This test fails intermittently: https://github.com/Azure/azure-sdk-for-cpp/issues/4332
+  TEST(SdkWithLibcurl, DISABLED_globalCleanUp)
   {
     Azure::Core::Http::Request req(
         Azure::Core::Http::HttpMethod::Get, Azure::Core::Url("https://httpbin.org/get"));


### PR DESCRIPTION
We still see this test failing, either the test needs to be re-written to be more reliable, or investigate further the root cause:
https://github.com/Azure/azure-sdk-for-cpp/issues/4332