### PR TITLE
Reworked cmake presets to reduce presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,6 +28,27 @@
       }
     },
     {
+      "name": "msvc-windows-default",
+      "displayName": "MSVC Windows",
+      "description": "Sets MSVC generator, and compilers. Configures vcpkg in manifest mode.",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "hidden": true,
+      "cacheVariables": {
+        "VCPKG_MANIFEST_MODE": true
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [ "Windows" ]
+        }
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
       "name": "x64-static",
       "displayName": "Windows x64 Static",
       "description": "Windows Default, x64 architecture, static CRT.",
@@ -56,6 +77,18 @@
         "value": "x86",
         "strategy": "external"
       }
+    },
+    {
+      "name": "x86-msvc-static",
+      "displayName": "Windows x86 MSVC Static",
+      "description": "Windows Default, MSVC, x86 architecture.",
+      "inherits": "msvc-windows-default",
+      "hidden": true,
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x86-windows-static",
+        "MSVC_USE_STATIC_CRT": true
+      },
+      "architecture": "win32"
     },
     {
       "name": "x64",
@@ -88,140 +121,90 @@
       }
     },
     {
-      "name": "x64-debug",
-      "displayName": "x64 Debug",
-      "description": "Windows x64 Debug",
-      "inherits": "x64",
+      "name": "debug-build",
+      "displayName": "Debug Build",
+      "description": "Debug Build (Hidden)",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
-      "name": "x64-release",
-      "displayName": "x64 Release",
-      "description": "Windows x64 Release",
-      "inherits": "x64",
+      "name": "release-build",
+      "displayName": "Release Build",
+      "description": "Release Build (Hidden)",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
     {
-      "name": "x86-debug",
-      "displayName": "x86 Debug",
-      "description": "Windows x86 Debug",
-      "inherits": "x86",
+      "name": "enable-tests",
+      "displayName": "Enable Tests",
+      "description": "Enable Tests (Hidden)",
       "hidden": true,
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "name": "x86-release",
-      "displayName": "x86 Release",
-      "description": "Windows x86 Release",
-      "inherits": "x86",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
-    },
-    {
-      "name": "x64-static-debug",
-      "displayName": "Windows x64 Debug",
-      "description": "Windows x64 Debug",
-      "inherits": "x64-static",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "name": "x64-static-release",
-      "displayName": "Windows x64 Release, static",
-      "description": "Windows x64 Release, static",
-      "inherits": "x64-static",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
-    },
-    {
-      "name": "x86-static-debug",
-      "displayName": "Windows x86 Debug, static",
-      "description": "Windows x86 Debug, static",
-      "inherits": "x86-static",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "name": "x86-static-release",
-      "displayName": "Windows x86 Release, static",
-      "description": "Windows x86 Release, static",
-      "inherits": "x86-static",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
-    },
-    {
-      "name": "x86-static-debug-tests",
-      "displayName": "x86 Debug With Tests, static",
-      "description": "Windows x86 Debug build with Tests configured",
-      "inherits": "x86-static-debug",
       "cacheVariables": {
         "BUILD_TESTING": true,
         "ENABLE_PROXY_TESTS": false
       }
     },
     {
+      "name": "enable-samples",
+      "displayName": "Enable Samples",
+      "description": "Enable Samples (Hidden)",
+      "hidden": true,
+      "cacheVariables": {
+        "BUILD_SAMPLES": true
+      }
+    },
+    {
+      "name": "enable-perf",
+      "displayName": "Enable Perf",
+      "description": "Enable Perf (Hidden)",
+      "hidden": true,
+      "cacheVariables": {
+        "BUILD_PERFORMANCE_TESTS": true
+      }
+    },
+    {
+      "name": "x86-static-debug-tests",
+      "displayName": "x86 Debug With Tests, static",
+      "description": "Windows x86 Debug build with Tests configured",
+      "inherits": [ "x86-static", "debug-build", "enable-tests" ]
+    },
+    {
       "name": "x86-static-release-tests",
       "displayName": "x86 Release With Tests, static, libcurl",
       "description": "Windows x86 Release build with Tests configured",
-      "inherits": "x86-static-release",
+      "inherits": [ "x86-static", "release-build", "enable-tests" ],
       "cacheVariables": {
-        "BUILD_TESTING": true,
-        "ENABLE_PROXY_TESTS": false,
-        "BUILD_SAMPLES": true,
-        "BUILD_PERFORMANCE_TESTS": true,
-        "RUN_LONG_UNIT_TESTS": true,
-        "BUILD_TRANSPORT_CURL": true
+        "RUN_LONG_UNIT_TESTS": true
       }
     },
     {
       "name": "x64-debug-tests",
-      "displayName": "x64 Debug With Tests, winhttp+curl",
+      "displayName": "x64 Debug With Tests",
       "description": "Windows x64 Debug build with Tests configured",
-      "inherits": "x64-debug",
-      "cacheVariables": {
-        "BUILD_TESTING": true,
-        "ENABLE_PROXY_TESTS": false,
-        "BUILD_SAMPLES": true,
-        "BUILD_PERFORMANCE_TESTS": true,
-        "BUILD_TRANSPORT_WINHTTP": true,
-        "BUILD_TRANSPORT_CURL": true
-      }
+      "inherits": [ "x64", "debug-build", "enable-tests" ]
+    },
+    {
+      "name": "x86-msvc-static-debug-tests",
+      "displayName": "x86 MSVC Debug With Tests, static",
+      "description": "Windows x86 MSVC Debug build with Tests configured",
+      "inherits": [ "x86-msvc-static", "debug-build", "enable-tests" ]
     },
     {
       "name": "x64-static-debug-tests",
       "displayName": "x64 Debug With Tests, static",
       "description": "Windows x64 Debug build with Tests configured",
-      "inherits": "x64-static-debug",
-      "cacheVariables": {
-        "BUILD_TESTING": true,
-        "ENABLE_PROXY_TESTS": false,
-        "BUILD_SAMPLES": true,
-        "BUILD_PERFORMANCE_TESTS": true
-      }
+      "inherits": [ "x64-static", "debug-build", "enable-tests" ]
+
     },
     {
       "name": "x64-static-debug-tests-curl",
       "displayName": "x64 Debug With Tests, static, libcurl",
       "description": "Windows x64 Debug build with Tests configured",
-      "inherits": "x64-static-debug-tests",
+      "inherits": [ "x64-static", "debug-build", "enable-tests" ],
       "cacheVariables": {
         "BUILD_TRANSPORT_CURL": true
       }
@@ -230,7 +213,7 @@
       "name": "x64-static-debug-tests-winhttp",
       "displayName": "x64 Debug With Tests, static, winhttp",
       "description": "Windows x64 Debug build with Tests configured",
-      "inherits": "x64-static-debug-tests",
+      "inherits": [ "x64-static", "debug-build", "enable-tests" ],
       "cacheVariables": {
         "BUILD_TRANSPORT_WINHTTP": true
       }
@@ -239,7 +222,7 @@
       "name": "x64-static-debug-tests-OpenSSL111",
       "displayName": "x64 Debug With Tests, static, OpenSSL 1.1.1, libcurl",
       "description": "Windows x64 Debug build with Tests configured on OpenSSL 1.1.1",
-      "inherits": "x64-static-debug-tests",
+      "inherits": [ "x64-static", "debug-build", "enable-tests" ],
       "cacheVariables": {
         "VCPKG_OVERLAY_PORTS": "${sourceDir}\\vcpkg-custom-ports"
       }
@@ -248,7 +231,11 @@
       "name": "x86-static-release-tests-curl",
       "displayName": "x86 Release With Tests, static, libcurl",
       "description": "Windows x86 Release build with Tests configured",
-      "inherits": "x86-static-release-tests",
+      "inherits": [
+        "x86-static",
+        "release-build",
+        "enable-tests"
+      ],
       "cacheVariables": {
         "BUILD_TRANSPORT_CURL": true
       }
@@ -256,51 +243,51 @@
     {
       "name": "x86-release-tests",
       "displayName": "x86 Release With Tests (Note: Does not link because it sets BUILD_TRANSPORT_CUSTOM)",
-      "inherits": "x86-release",
+      "inherits": [ "x86", "release-build", "enable-tests" ],
       "cacheVariables": {
-        "BUILD_TESTING": true,
         "BUILD_TRANSPORT_CURL": true,
         "BUILD_TRANSPORT_CUSTOM": true,
-        "BUILD_TRANSPORT_WINHTTP": true,
-        "BUILD_PERFORMANCE_TESTS": true
+        "BUILD_TRANSPORT_WINHTTP": true
       }
     },
     {
       "name": "x64-release-tests",
       "displayName": "x64 Release With Tests (Note: Does not link because it sets BUILD_TRANSPORT_CUSTOM)",
-      "inherits": "x64-release",
+      "inherits": [ "x64", "release-build", "enable-tests" ],
       "cacheVariables": {
-        "BUILD_TESTING": true,
         "BUILD_TRANSPORT_CURL": true,
         "BUILD_TRANSPORT_CUSTOM": true,
-        "BUILD_TRANSPORT_WINHTTP": true,
-        "BUILD_PERFORMANCE_TESTS": true,
-        "BUILD_SAMPLES": true
+        "BUILD_TRANSPORT_WINHTTP": true
       }
     },
     {
       "name": "x64-static-debug-perftests",
-      "displayName": "x64 Debug static With Perf Tests and samples",
-      "inherits": "x64-static-debug-tests",
+      "displayName": "x64 Debug static With Perf Tests and samples, libcurl+winhttp",
+      "inherits": [
+        "x64-static",
+        "debug-build",
+        "enable-tests",
+        "enable-samples",
+        "enable-perf"
+      ],
       "cacheVariables": {
         "BUILD_TRANSPORT_CURL": true,
+        "BUILD_TRANSPORT_WINHTTP": true
+      }
+    },
+    {
+      "name": "x86-msvc-static-debug-perftests",
+      "displayName": "x86 MSVC Debug static With Perf Tests and samples",
+      "inherits": [ "x86-msvc-static", "debug-build", "enable-tests", "enable-perf", "enable-samples" ],
+      "cacheVariables": {
         "BUILD_TRANSPORT_WINHTTP": true,
-        "BUILD_PERFORMANCE_TESTS": true,
-        "BUILD_SAMPLES": true
+        "BUILD_TRANSPORT_CURL": true
       }
     },
     {
       "name": "x64-static-release-perftests",
       "displayName": "x64 Release With Perf Tests, static",
-      "inherits": "x64-static-release",
-      "cacheVariables": {
-        "INSTALL_GTEST": false,
-        "BUILD_TESTING": true,
-        "BUILD_TRANSPORT_CURL": true,
-        "BUILD_TRANSPORT_WINHTTP": true,
-        "BUILD_PERFORMANCE_TESTS": true,
-        "BUILD_SAMPLES": true
-      }
+      "inherits": [ "x64-static", "release-build", "enable-perf" ]
     },
     {
       "name": "linux-basic-gcc9",
@@ -317,22 +304,6 @@
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
-      }
-    },
-    {
-      "name": "linux-gcc9-debug",
-      "displayName": "Linux GCC 9 Debug",
-      "inherits": "linux-basic-gcc9",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "name": "linux-gcc9-debug-tests",
-      "inherits": "linux-gcc9-debug",
-      "displayName": "Linux GCC 9 Debug+Tests",
-      "cacheVariables": {
-        "BUILD_TESTING": "true"
       }
     },
     {
@@ -353,22 +324,6 @@
       }
     },
     {
-      "name": "linux-clang-11-debug",
-      "displayName": "Linux clang 11 Debug",
-      "inherits": "linux-basic-clang-11",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "name": "linux-clang-11-debug-tests",
-      "inherits": "linux-clang-11-debug",
-      "displayName": "Linux clang 11 Debug+Tests",
-      "cacheVariables": {
-        "BUILD_TESTING": "true"
-      }
-    },
-    {
       "name": "linux-basic-g++",
       "displayName": "Linux G++",
       "description": "Using compilers: C = /usr/bin/cc, CXX = /usr/bin/c++",
@@ -386,20 +341,34 @@
       }
     },
     {
+      "name": "linux-gcc9-debug",
+      "displayName": "Linux GCC 9 Debug",
+      "inherits": [ "linux-basic-gcc9", "debug-build" ]
+    },
+    {
+      "name": "linux-gcc9-debug-tests",
+      "inherits": [ "linux-basic-gcc9", "debug-build", "enable-tests" ],
+      "displayName": "Linux GCC 9 Debug+Tests"
+    },
+    {
+      "name": "linux-clang-11-debug",
+      "displayName": "Linux clang 11 Debug",
+      "inherits": [ "linux-basic-clang-11", "debug-build" ]
+    },
+    {
+      "name": "linux-clang-11-debug-tests",
+      "inherits": [ "linux-basic-clang-11", "debug-build", "enable-tests" ],
+      "displayName": "Linux clang 11 Debug+Tests"
+    },
+    {
       "name": "linux-g++-debug",
       "displayName": "Linux c++ Debug",
-      "inherits": "linux-basic-g++",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
+      "inherits": [ "linux-basic-g++", "debug-build" ]
     },
     {
       "name": "linux-g++-debug-tests",
-      "inherits": "linux-g++-debug",
-      "displayName": "Linux c++ Debug+Tests",
-      "cacheVariables": {
-        "BUILD_TESTING": "true"
-      }
+      "inherits": [ "linux-basic-g++", "debug-build", "enable-tests" ],
+      "displayName": "Linux c++ Debug+Tests"
     },
     {
       "name": "generate-doxygen",


### PR DESCRIPTION
Reworked CMake Presets to reduce the complexity of presets.

With this change, when you create a public preset, you specify a flavor (x86, x64, x86-static, x64-static), a build type (debug-build, release-build) and if you enable tests (enable-tests), samples (enable-samples) and perf tests (enable-perf).

For example, consider: 
```json
    {
      "name": "x86-static-release-tests-curl",
      "displayName": "x86 Release With Tests, static, libcurl",
      "description": "Windows x86 Release build with Tests configured",
      "inherits": [
        "x86-static",
        "release-build",
        "enable-tests"
      ],
      "cacheVariables": {
        "BUILD_TRANSPORT_CURL": true
      }
    },
```

This defines the x86-static-release-tests-curl preset which is an x86 build, using static runtime libraries. The build is a release build, and it includes tests.

In addition, this particular build type enables the CURL transport.

This change also enables presets which use the MSVC generator as well as the Ninja generator on Windows.


## Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
