### PR TITLE
Update changelog for the next release of AMQP

### DIFF
--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ### Features Added
 
+- Added `Azure::Core::Amqp::Models::AmqpBinaryData::operator=(std::vector<std::uint8_t> const&)`.
+- Added `Azure::Core::Amqp::Models::AmqpMessage::MessageFormat`.
+- Collection types (`AmqpArray`, `AmqpMap`, `AmqpList`, `AmqpBinaryData`, `AmqpSymbol` and `AmqpComposite`):
+  - Added explicit cast operator to underlying collection type.
+  - Added `find()`.
+
 ### Breaking Changes
+
+- Renamed `Azure::Core::Amqp::Models::AmqpMessageFormatValue` to `AmqpDefaultMessageFormatValue`.
 
 ### Bugs Fixed
 


### PR DESCRIPTION
The commit to add EventHubs (https://github.com/Azure/azure-sdk-for-cpp/commit/a627ab3f22e5f3a71fdcbca4f9426ce11ab2f6e2#diff-fa36f8c42381216cd81570ace5ae8c93137046ceddc1529098fc7b4ed65e0bbd) has updates to core-amqp. I just tried to build eventhubs in vcpkg against `azure-core-amqp-cpp 1.0.0-beta.1`, and the build fails, because it needs these recent changes.

So, in order to release eventhubs, we'll have to release `beta.2` of AMQP.

And to release, we need changelog entries.
This PR adds them.