### PR TITLE
Support root cert validation on CURL

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- [[#4792]](https://github.com/Azure/azure-sdk-for-cpp/issues/4792) Only support CURL's root cert validation when CURL version is >= 7.77.0.
+
 ### Other Changes
 
 ## 1.10.1 (2023-07-06)

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -61,6 +61,8 @@ namespace Azure { namespace Core { namespace Http {
      *
      * @remark More about this option:
      * https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html
+     * 
+     * @warning Requires libcurl >= 7.44.0
      *
      */
     std::string PemEncodedExpectedRootCertificates;

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -61,7 +61,7 @@ namespace Azure { namespace Core { namespace Http {
      *
      * @remark More about this option:
      * https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html
-     * 
+     *
      * @warning Requires libcurl >= 7.44.0
      *
      */

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -53,6 +53,7 @@ namespace Azure { namespace Core { namespace Http {
      */
     bool AllowFailedCrlRetrieval = false;
 
+#if LIBCURL_VERSION_NUM >= 0x074D00 // 7.77.0 
     /**
      * @brief A set of PEM encoded X.509 certificates and CRLs describing the certificates used to
      * validate the server.
@@ -66,6 +67,7 @@ namespace Azure { namespace Core { namespace Http {
      *
      */
     std::string PemEncodedExpectedRootCertificates;
+#endif
   };
 
   /**

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -53,7 +53,6 @@ namespace Azure { namespace Core { namespace Http {
      */
     bool AllowFailedCrlRetrieval = false;
 
-#if LIBCURL_VERSION_NUM >= 0x074D00 // 7.77.0 
     /**
      * @brief A set of PEM encoded X.509 certificates and CRLs describing the certificates used to
      * validate the server.
@@ -67,7 +66,6 @@ namespace Azure { namespace Core { namespace Http {
      *
      */
     std::string PemEncodedExpectedRootCertificates;
-#endif
   };
 
   /**

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -307,11 +307,13 @@ Azure::Core::Http::CurlTransportOptions CurlTransportOptionsFromTransportOptions
   curlOptions.SslOptions.EnableCertificateRevocationListCheck
       = transportOptions.EnableCertificateRevocationListCheck;
 
+#if LIBCURL_VERSION_NUM >= 0x074D00 // 7.77.0
   if (!transportOptions.ExpectedTlsRootCertificate.empty())
   {
     curlOptions.SslOptions.PemEncodedExpectedRootCertificates
         = PemEncodeFromBase64(transportOptions.ExpectedTlsRootCertificate, "CERTIFICATE");
   }
+#endif
   curlOptions.SslVerifyPeer = !transportOptions.DisableTlsCertificateValidation;
   return curlOptions;
 }
@@ -1297,10 +1299,14 @@ inline std::string GetConnectionKey(std::string const& host, CurlTransportOption
   key.append(",");
   key.append(options.SslOptions.AllowFailedCrlRetrieval ? "FC" : "0");
   key.append(",");
+#if LIBCURL_VERSION_NUM >= 0x074D00 // 7.77.0
   key.append(
       !options.SslOptions.PemEncodedExpectedRootCertificates.empty() ? std::to_string(
           std::hash<std::string>{}(options.SslOptions.PemEncodedExpectedRootCertificates))
                                                                      : "0");
+#else
+  key.append("0");
+#endif
   key.append(",");
   // using DefaultConnectionTimeout or 0 result in the same setting
   key.append(

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2308,6 +2308,7 @@ CurlConnection::CurlConnection(
     }
   }
 
+#if LIBCURL_VERSION_NUM >= 0x072C00 // 7.44.0
   if (!options.SslOptions.PemEncodedExpectedRootCertificates.empty())
   {
     curl_blob rootCertBlob
@@ -2323,6 +2324,7 @@ CurlConnection::CurlConnection(
           + std::string(curl_easy_strerror(result)));
     }
   }
+#endif
 
 #if defined(AZ_PLATFORM_WINDOWS)
   long sslOption = 0;

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2308,7 +2308,7 @@ CurlConnection::CurlConnection(
     }
   }
 
-#if LIBCURL_VERSION_NUM >= 0x072C00 // 7.44.0
+#if LIBCURL_VERSION_NUM >= 0x074D00 // 7.77.0
   if (!options.SslOptions.PemEncodedExpectedRootCertificates.empty())
   {
     curl_blob rootCertBlob


### PR DESCRIPTION
Add support for validating root certificates when CURL version is >= 7.77.0 .

Fixes #4792 