### PR TITLE
Add X_VCPKG_ASSET_SOURCES to vcpkg cache configuration

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -45,6 +45,7 @@
     "azsdkengsys",
     "azurecr",
     "azuresdk",
+    "azurl",
     "azuresdkforcpp",
     "centralus",
     "centraluseuap",

--- a/eng/pipelines/templates/steps/cmake-build.yml
+++ b/eng/pipelines/templates/steps/cmake-build.yml
@@ -21,6 +21,7 @@ steps:
     displayName: cmake generate
     env:
       VCPKG_BINARY_SOURCES: $(VCPKG_BINARY_SOURCES_SECRET)
+      X_VCPKG_ASSET_SOURCES: $(X_VCPKG_ASSET_SOURCES)
 
 # Core should build all cmake tagets
   - ${{ if and(eq(parameters.Build, true), eq(parameters.ServiceDirectory, 'core')) }}:

--- a/eng/pipelines/templates/steps/cmake-build.yml
+++ b/eng/pipelines/templates/steps/cmake-build.yml
@@ -21,7 +21,7 @@ steps:
     displayName: cmake generate
     env:
       VCPKG_BINARY_SOURCES: $(VCPKG_BINARY_SOURCES_SECRET)
-      X_VCPKG_ASSET_SOURCES: $(X_VCPKG_ASSET_SOURCES)
+      X_VCPKG_ASSET_SOURCES: $(X_VCPKG_ASSET_SOURCES_SECRET)
 
 # Core should build all cmake tagets
   - ${{ if and(eq(parameters.Build, true), eq(parameters.ServiceDirectory, 'core')) }}:

--- a/eng/pipelines/templates/steps/cmake-build.yml
+++ b/eng/pipelines/templates/steps/cmake-build.yml
@@ -16,7 +16,7 @@ steps:
     displayName: cmake --version
 
   - script: |
-      ${{ parameters.Env }} cmake ${{ parameters.VcpkgArgs }} ${{ parameters.GenerateArgs }} ..
+      ${{ parameters.Env }} cmake --debug ${{ parameters.VcpkgArgs }} ${{ parameters.GenerateArgs }} ..
     workingDirectory: build
     displayName: cmake generate
     env:

--- a/eng/pipelines/templates/steps/cmake-build.yml
+++ b/eng/pipelines/templates/steps/cmake-build.yml
@@ -16,7 +16,7 @@ steps:
     displayName: cmake --version
 
   - script: |
-      ${{ parameters.Env }} cmake --debug ${{ parameters.VcpkgArgs }} ${{ parameters.GenerateArgs }} ..
+      ${{ parameters.Env }} cmake ${{ parameters.VcpkgArgs }} ${{ parameters.GenerateArgs }} ..
     workingDirectory: build
     displayName: cmake generate
     env:

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -1,7 +1,6 @@
 steps:
   - pwsh: |
-      # Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
-      Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear"
+      Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
       Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,,read"
     displayName: Set Vcpkg Variables
 

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -1,6 +1,7 @@
 steps:
   - pwsh: |
       Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
+      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,,read"
     displayName: Set Vcpkg Variables
 
   - task: PowerShell@2

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -13,7 +13,3 @@ steps:
       arguments: -StorageAccountKey '$(cpp-vcpkg-cache-storage-key)'
     displayName: Set Vcpkg Write-mode Cache
     condition: and(succeeded(), eq(variables['System.TeamProject'], 'internal'))
-
-  - pwsh:
-      $env:X_VCPKG_ASSET_SOURCES -like '*readwrite'
-    displayName: Check Vcpkg Asset Sources ends with readwrite

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -1,6 +1,7 @@
 steps:
   - pwsh: |
       # Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
+      Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear"
       Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,,read"
     displayName: Set Vcpkg Variables
 

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -2,7 +2,7 @@ steps:
   - pwsh: |
       # Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
       Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear"
-      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,,read"
+      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,,read"
     displayName: Set Vcpkg Variables
 
   - task: PowerShell@2

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -13,3 +13,7 @@ steps:
       arguments: -StorageAccountKey '$(cpp-vcpkg-cache-storage-key)'
     displayName: Set Vcpkg Write-mode Cache
     condition: and(succeeded(), eq(variables['System.TeamProject'], 'internal'))
+
+  - pwsh:
+      $env:X_VCPKG_ASSET_SOURCES -like '*readwrite'
+    displayName: Check Vcpkg Asset Sources ends with readwrite

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -1,6 +1,6 @@
 steps:
   - pwsh: |
-      Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
+      # Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
       Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,,read"
     displayName: Set Vcpkg Variables
 

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -39,4 +39,4 @@ $vcpkgBinarySourceSas = $token.Substring(1)
 
 Write-Host "Setting vcpkg binary cache to read and write"
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
-Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"
+Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -38,5 +38,5 @@ $token = New-AzStorageAccountSASToken `
 $vcpkgBinarySourceSas = $token.Substring(1)
 
 Write-Host "Setting vcpkg binary cache to read and write"
-# Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
+Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
 Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -39,3 +39,4 @@ $vcpkgBinarySourceSas = $token.Substring(1)
 
 Write-Host "Setting vcpkg binary cache to read and write"
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
+Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,$vcpkgBinarySourceSas,readwrite"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -39,4 +39,4 @@ $vcpkgBinarySourceSas = $token.Substring(1)
 
 Write-Host "Setting vcpkg binary cache to read and write"
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
-Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,$vcpkgBinarySourceSas,readwrite"
+Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -39,4 +39,4 @@ $vcpkgBinarySourceSas = $token.Substring(1)
 
 Write-Host "Setting vcpkg binary cache to read and write"
 # Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
-Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"
+Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -39,4 +39,4 @@ $vcpkgBinarySourceSas = $token.Substring(1)
 
 Write-Host "Setting vcpkg binary cache to read and write"
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
-Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,$vcpkgBinarySourceSas,readwrite"
+Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,?$vcpkgBinarySourceSas,readwrite"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -38,5 +38,5 @@ $token = New-AzStorageAccountSASToken `
 $vcpkgBinarySourceSas = $token.Substring(1)
 
 Write-Host "Setting vcpkg binary cache to read and write"
-Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
+# Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
 Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"


### PR DESCRIPTION
Uses asset cache. Took a while to remember that secrets need to be directly mapped into `env`. 