### PR TITLE
Fix EventHubs samples warnings

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp
@@ -26,6 +26,7 @@ int main()
   if (eventhubName == nullptr)
   {
     std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    return 1;
   }
 
   Azure::Messaging::EventHubs::ConsumerClient consumerClient(

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp
@@ -27,6 +27,7 @@ int main()
   if (eventhubName == nullptr)
   {
     std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    return 1;
   }
 
   Azure::Messaging::EventHubs::ProducerClient producerClient(

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
@@ -27,6 +27,7 @@ int main()
   if (eventhubName == nullptr)
   {
     std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    return 1;
   }
 
   /* Create a sample EventHubs application using a PartitionClient to read all the messages from an

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp
@@ -27,6 +27,7 @@ int main()
   if (eventhubName == nullptr)
   {
     std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    return 1;
   }
 
   Azure::Messaging::EventHubs::ProducerClient producerClient(


### PR DESCRIPTION
These warnings fail live pipelines, even for other packages (I saw it failing Core).

The error is
```
Build FAILED.

       "D:\a\_work\1\s\build\ALL_BUILD.vcxproj" (default target) (1) ->
       "D:\a\_work\1\s\build\sdk\eventhubs\azure-messaging-eventhubs\samples\produce-events\eventhubs-produce_events.vcxproj" (default target) (89) ->
       (ClCompile target) -> 
         D:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\samples\produce-events\produce_events.cpp(32): warning C6387: 'eventhubName' could be '0':  this does not adhere to the specification for the function 'std::basic_string<char,std::char_traits<char>,std::allocator<char> >::{ctor}'. : Lines: 20, 21, 22, 27, 29, d:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\inc\azure\messaging\eventhubs\producer_client.hpp:89, d:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\samples\produce-events\produce_events.cpp:33, 32 [D:\a\_work\1\s\build\sdk\eventhubs\azure-messaging-eventhubs\samples\produce-events\eventhubs-produce_events.vcxproj]


       "D:\a\_work\1\s\build\ALL_BUILD.vcxproj" (default target) (1) ->
       "D:\a\_work\1\s\build\sdk\eventhubs\azure-messaging-eventhubs\samples\basic-operations\eventhubs-create_producer.vcxproj" (default target) (87) ->
         D:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\samples\basic-operations\create_producer.cpp(32): warning C6387: 'eventhubName' could be '0':  this does not adhere to the specification for the function 'std::basic_string<char,std::char_traits<char>,std::allocator<char> >::{ctor}'. : Lines: 20, 21, 22, 27, 29, d:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\inc\azure\messaging\eventhubs\producer_client.hpp:89, d:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\samples\basic-operations\create_producer.cpp:33, 32 [D:\a\_work\1\s\build\sdk\eventhubs\azure-messaging-eventhubs\samples\basic-operations\eventhubs-create_producer.vcxproj]


       "D:\a\_work\1\s\build\ALL_BUILD.vcxproj" (default target) (1) ->
       "D:\a\_work\1\s\build\sdk\eventhubs\azure-messaging-eventhubs\samples\basic-operations\eventhubs-create_consumer.vcxproj" (default target) (85) ->
         D:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\samples\basic-operations\create_consumer.cpp(31): warning C6387: 'eventhubName' could be '0':  this does not adhere to the specification for the function 'std::basic_string<char,std::char_traits<char>,std::allocator<char> >::{ctor}'. : Lines: 19, 20, 21, 26, 28, d:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\inc\azure\messaging\eventhubs\consumer_client.hpp:109, d:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\samples\basic-operations\create_consumer.cpp:32, 31 [D:\a\_work\1\s\build\sdk\eventhubs\azure-messaging-eventhubs\samples\basic-operations\eventhubs-create_consumer.vcxproj]


       "D:\a\_work\1\s\build\ALL_BUILD.vcxproj" (default target) (1) ->
       "D:\a\_work\1\s\build\sdk\eventhubs\azure-messaging-eventhubs\samples\consume-events\eventhubs-consume_events.vcxproj" (default target) (83) ->
         D:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\samples\consume-events\consume_events.cpp(34): warning C6387: 'eventhubName' could be '0':  this does not adhere to the specification for the function 'std::basic_string<char,std::char_traits<char>,std::allocator<char> >::{ctor}'. : Lines: 20, 21, 22, 27, 29, d:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\inc\azure\messaging\eventhubs\consumer_client.hpp:109, d:\a\_work\1\s\sdk\eventhubs\azure-messaging-eventhubs\samples\consume-events\consume_events.cpp:35, 34 [D:\a\_work\1\s\build\sdk\eventhubs\azure-messaging-eventhubs\samples\consume-events\eventhubs-consume_events.vcxproj]
```