### PR TITLE
Update certificate_client.cpp to use a typo word that cspell previously considered valid (respone)

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-certificates/src/certificate_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/src/certificate_client.cpp
@@ -96,7 +96,7 @@ Response<KeyVaultCertificateWithPolicy> CertificateClient::GetCertificate(
 {
   auto request = CreateRequest(HttpMethod::Get, {CertificatesPath, certificateName});
 
-  // Send and parse response
+  // Send and parse respone
   auto rawResponse = SendRequest(request, context);
   auto value = _detail::KeyVaultCertificateSerializer::Deserialize(certificateName, *rawResponse);
   return Azure::Response<KeyVaultCertificateWithPolicy>(std::move(value), std::move(rawResponse));


### PR DESCRIPTION
Testing that the override like this works as expected to catch future typos:
https://github.com/Azure/azure-sdk-for-cpp/pull/4750
