### PR TITLE
Update amqp dependency on core that isn't a beta

### DIFF
--- a/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
@@ -15,7 +15,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.9.0-beta.1"
+      "version>=": "1.10.0"
     },
     "azure-uamqp-c",
     {


### PR DESCRIPTION
As far as I know, this is the minimum version of core that's needed. If we need a newer version that amqp needs, we can bump up this dependency.
https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core/CHANGELOG.md#1100-2023-06-01