### PR TITLE
Update azure-core dependency on curl to 7.48 from 7.44 since that's the minimum available on vcpkg.

### DIFF
--- a/sdk/core/azure-core/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg.json
@@ -36,7 +36,7 @@
           "features": [
             "ssl"
           ],
-          "version>=": "7.44"
+          "version>=": "7.48"
         }
       ]
     },

--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -41,7 +41,7 @@
           "features": [
             "ssl"
           ],
-          "version>=": "7.44"
+          "version>=": "7.48"
         }
       ]
     },


### PR DESCRIPTION
See https://github.com/microsoft/vcpkg/blob/4e2b371cb52a661ae0d48f256b1aa9934be75b73/versions/c-/curl.json#L425

For context, see these:
https://github.com/Azure/azure-sdk-for-cpp/pull/4814#discussion_r1293902295
https://github.com/microsoft/vcpkg/pull/33109