### PR TITLE
Removed version>= dependency for curl

### DIFF
--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -40,8 +40,7 @@
           "default-features": false,
           "features": [
             "ssl"
-          ],
-          "version>=": "7.48"
+          ]
         }
       ]
     },


### PR DESCRIPTION
# Removed version>= dependency for curl.

All versions of curl in vcpkg are greater than the azure core minimum version of 7.44. As a result, there is no benefit to setting a `version>=` value for curl. And due to the way curl has been versioned over time, the minimum version of curl which could satisfy a `version>=` dependency is unrelated to any azure core dependencies.

After discussion with the vcpkg team, the version in the vcpkg.json file is intended ONLY for vcpkg's use to ensure the minimum package version. It is not intended as a statement about the actual minimum supported version of a package.

Since all versions of curl in vcpkg meet the minimum versioning requirements of Azure Core, it doesn't make sense to include this version.

If in the future we take a dependency on a new feature of curl, we should update the version to the version of curl with that new feature, but only at that time.



## Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
