### PR TITLE
Include cstdint explicitly for g++ 13 or later

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/base64.hpp
+++ b/sdk/core/azure-core/inc/azure/core/base64.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -11,6 +11,7 @@
 #include "azure/core/platform.hpp"
 
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <string>
 

--- a/sdk/keyvault/azure-security-keyvault-keys/src/private/key_sign_parameters.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/private/key_sign_parameters.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/sdk/keyvault/azure-security-keyvault-keys/src/private/key_verify_parameters.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/private/key_verify_parameters.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [x] No typos
- [ ] Update changelog
- [x] Not work-in-progress
- [ ] External references or docs updated
- [x] Self review of PR done
- [ ] Any breaking changes?

# Description

We can use uint8_t without `#include <cstdint>` with g++ 12 or earlier but it causes the following error with g++ 13:

    sdk/core/azure-core/inc/azure/core/base64.hpp:42:55: error: 'uint8_t' was not declared in this scope
       42 |     static std::string Base64Encode(const std::vector<uint8_t>& data);
          |                                                       ^~~~~~~
    sdk/core/azure-core/inc/azure/core/base64.hpp:16:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       15 | #include <vector>
      +++ |+#include <cstdint>
       16 |
