### PR TITLE
Update the workload identity credential sample to work with required environment variables that need to be set.

### DIFF
--- a/sdk/identity/azure-identity/samples/workload_identity_credential.cpp
+++ b/sdk/identity/azure-identity/samples/workload_identity_credential.cpp
@@ -9,10 +9,18 @@
 // The following environment variables must be set before running the sample.
 // * AZURE_TENANT_ID: Tenant ID for the Azure account.
 // * AZURE_CLIENT_ID: The Client ID to authenticate the request.
-// * AZURE_CLIENT_CERTIFICATE_PATH: The path to a client certificate.
+// * AZURE_FEDERATED_TOKEN_FILE: The path of a file containing a Kubernetes service account token.
 std::string GetTenantId() { return std::getenv("AZURE_TENANT_ID"); }
 std::string GetClientId() { return std::getenv("AZURE_CLIENT_ID"); }
-std::string GetTokenFilePath() { return std::getenv("AZURE_FEDERATED_TOKEN_FILE"); }
+std::string GetTokenFilePath() {
+  char const* const tokenFilePath{std::getenv("AZURE_FEDERATED_TOKEN_FILE")};
+  if (tokenFilePath == nullptr)
+  {
+    std::cerr << "Missing environment variable AZURE_FEDERATED_TOKEN_FILE" << std::endl;
+    return std::string();
+  }
+  return tokenFilePath;
+}
 
 int main()
 {

--- a/sdk/identity/azure-identity/samples/workload_identity_credential.cpp
+++ b/sdk/identity/azure-identity/samples/workload_identity_credential.cpp
@@ -12,7 +12,8 @@
 // * AZURE_FEDERATED_TOKEN_FILE: The path of a file containing a Kubernetes service account token.
 std::string GetTenantId() { return std::getenv("AZURE_TENANT_ID"); }
 std::string GetClientId() { return std::getenv("AZURE_CLIENT_ID"); }
-std::string GetTokenFilePath() {
+std::string GetTokenFilePath()
+{
   char const* const tokenFilePath{std::getenv("AZURE_FEDERATED_TOKEN_FILE")};
   if (tokenFilePath == nullptr)
   {


### PR DESCRIPTION
Resolving runtime errors with the sample since some required environment variables aren't set as expected:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3057334&view=logs&j=4126397f-f476-5716-6a20-18b5ea93fc4f&t=776d5a94-36e2-587a-9cf7-582038e57d2d&l=39

```text
2023-09-05T19:06:35.8931991Z **********Running sample: /mnt/vss/_work/1/s/build/sdk/identity/azure-identity/samples/workload_identity_credential_sample
2023-09-05T19:06:35.9206301Z terminate called after throwing an instance of 'std::logic_error'
2023-09-05T19:06:35.9207329Z   what():  basic_string::_M_construct null not valid
2023-09-05T19:06:36.1226703Z /mnt/vss/_work/_temp/37641cd3-6877-4053-8118-90743108cb41.sh: line 3: 10973 Aborted                 (core dumped) bash -c "$sample"
2023-09-05T19:06:36.1234073Z *Sample returned a failed code: 134
2023-09-05T19:06:36.1274762Z ##[error]Bash exited with code '1'.
2023-09-05T19:06:36.1284271Z ##[section]Finishing: Run Samples for : identity
```

The samples only run successfully in an environment where the required variables are set. Will need to update the CI machine setup accordingly.