### PR TITLE
Ignore compiler and STL version mismatch on published packages to unblock ApiView

### DIFF
--- a/sdk/attestation/azure-security-attestation/inc/ApiViewSettings.json
+++ b/sdk/attestation/azure-security-attestation/inc/ApiViewSettings.json
@@ -5,7 +5,9 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/ApiViewSettings.json
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/ApiViewSettings.json
@@ -9,6 +9,7 @@
     "../../../storage/azure-storage-blobs/inc"
   ],
   "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
   ],
   "allowInternal": false,
   "includeDetail": false,

--- a/sdk/identity/azure-identity/inc/ApiViewSettings.json
+++ b/sdk/identity/azure-identity/inc/ApiViewSettings.json
@@ -3,7 +3,9 @@
   "additionalIncludeDirectories": [
     "../../../core/azure-core/inc"
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/keyvault/azure-security-keyvault-administration/inc/ApiViewSettings.json
+++ b/sdk/keyvault/azure-security-keyvault-administration/inc/ApiViewSettings.json
@@ -6,7 +6,9 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/ApiViewSettings.json
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/ApiViewSettings.json
@@ -6,7 +6,9 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/ApiViewSettings.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/ApiViewSettings.json
@@ -6,7 +6,9 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/keyvault/azure-security-keyvault-secrets/inc/ApiViewSettings.json
+++ b/sdk/keyvault/azure-security-keyvault-secrets/inc/ApiViewSettings.json
@@ -6,7 +6,9 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/storage/azure-storage-blobs/inc/ApiViewSettings.json
+++ b/sdk/storage/azure-storage-blobs/inc/ApiViewSettings.json
@@ -6,7 +6,9 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/storage/azure-storage-common/inc/ApiViewSettings.json
+++ b/sdk/storage/azure-storage-common/inc/ApiViewSettings.json
@@ -5,7 +5,9 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": true,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/storage/azure-storage-files-datalake/inc/ApiViewSettings.json
+++ b/sdk/storage/azure-storage-files-datalake/inc/ApiViewSettings.json
@@ -7,11 +7,13 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,
-  "filterNamespace": ["Azure::Storage::Files::DataLake", "Azure::Storage::Sas"],
+  "filterNamespace": [ "Azure::Storage::Files::DataLake", "Azure::Storage::Sas" ],
   "reviewName": "Azure Storage Files DataLake",
   "serviceName": "Azure Storage Files DataLake",
   "packageName": "azure-storage-files-datalake-cpp"

--- a/sdk/storage/azure-storage-files-shares/inc/ApiViewSettings.json
+++ b/sdk/storage/azure-storage-files-shares/inc/ApiViewSettings.json
@@ -7,7 +7,9 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/storage/azure-storage-queues/inc/ApiViewSettings.json
+++ b/sdk/storage/azure-storage-queues/inc/ApiViewSettings.json
@@ -7,7 +7,9 @@
   ],
   "sourceFilesToSkip": [
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,

--- a/sdk/template/azure-template/inc/ApiViewSettings.json
+++ b/sdk/template/azure-template/inc/ApiViewSettings.json
@@ -5,7 +5,9 @@
   "additionalIncludeDirectories": [
     "../../../core/azure-core/inc"
   ],
-  "additionalCompilerSwitches": [],
+  "additionalCompilerSwitches": [
+    "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"
+  ],
   "allowInternal": false,
   "includeDetail": false,
   "includePrivate": false,


### PR DESCRIPTION
The current MSVC STL version requires clang 16, but the newest version of clang in VCPKG is clang 15. This change disables the compiler STL version checks to allow the ApiView tool to continue to work with the newest Microsoft STL version.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
