### PR TITLE
Better cmake UWP detection condition (use the same definition as vcpkg)

### DIFF
--- a/sdk/identity/azure-identity/CMakeLists.txt
+++ b/sdk/identity/azure-identity/CMakeLists.txt
@@ -101,7 +101,7 @@ target_include_directories(
 
 target_link_libraries(azure-identity PUBLIC Azure::azure-core)
 
-if(WIN32 AND NOT CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(WIN32 AND NOT(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND CMAKE_SYSTEM_VERSION STREQUAL "10.0"))
   find_package(wil CONFIG REQUIRED)
   target_link_libraries(azure-identity PRIVATE WIL::WIL bcrypt crypt32)
 else()

--- a/sdk/identity/azure-identity/vcpkg/Config.cmake.in
+++ b/sdk/identity/azure-identity/vcpkg/Config.cmake.in
@@ -6,7 +6,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(azure-core-cpp)
 
-if(WIN32 AND NOT CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(WIN32 AND NOT (CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND  CMAKE_SYSTEM_VERSION STREQUAL "10.0"))
   find_dependency(wil)
 else()
   find_dependency(OpenSSL)

--- a/sdk/identity/azure-identity/vcpkg/Config.cmake.in
+++ b/sdk/identity/azure-identity/vcpkg/Config.cmake.in
@@ -6,7 +6,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(azure-core-cpp)
 
-if(WIN32 AND NOT (CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND  CMAKE_SYSTEM_VERSION STREQUAL "10.0"))
+if(WIN32 AND NOT (CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND CMAKE_SYSTEM_VERSION STREQUAL "10.0"))
   find_dependency(wil)
 else()
   find_dependency(OpenSSL)

--- a/sdk/identity/azure-identity/vcpkg/vcpkg.json
+++ b/sdk/identity/azure-identity/vcpkg/vcpkg.json
@@ -21,16 +21,16 @@
       "platform": "!windows & !uwp"
     },
     {
-      "name": "wil",
-      "platform": "windows & !uwp"
-    },
-    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    },
+    {
+      "name": "wil",
+      "platform": "windows & !uwp"
     }
   ]
 }


### PR DESCRIPTION
This is to better align with the values that vcpkg sets when building any "uwp" triplet: https://github.com/microsoft/vcpkg/blob/f3a4d1aeb7aa1e3bd9f91da479bf8b97b44dfa66/triplets/x64-uwp.cmake#L6