### PR TITLE
vcpkg asset cache configuration forward slash

### DIFF
--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -1,7 +1,7 @@
 steps:
   - pwsh: |
       Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
-      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container,,read"
+      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,,read"
     displayName: Set Vcpkg Variables
 
   - task: PowerShell@2


### PR DESCRIPTION
The configuration requires a forward slash. 

Example using the forward slash: https://dev.azure.com/azure-sdk/public/_build/results?buildId=3100323&view=logs&j=5f3ffd68-137a-5778-3aee-fd1fc601ce2c&t=f33f4e80-6956-52ca-bb30-74c383c809d2