### PR TITLE
Shorten build-time paths when building in vcpkg

### DIFF
--- a/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
+++ b/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/attestation/azure-security-attestation ${SOURCE_PATH}/sdk/attestation/_)
-file(RENAME ${SOURCE_PATH}/sdk/attestation ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/attestation/azure-security-attestation")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/attestation/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/attestation/azure-security-attestation" "${SOURCE_PATH}/sdk/attestation/_")
+  file(RENAME "${SOURCE_PATH}/sdk/attestation" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
+++ b/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/attestation/azure-security-attestation ${SOURCE_PATH}/sdk/attestation/_)
+file(RENAME ${SOURCE_PATH}/sdk/attestation ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/attestation/azure-security-attestation/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/core/azure-core-amqp ${SOURCE_PATH}/sdk/core/_)
-file(RENAME ${SOURCE_PATH}/sdk/core ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/core/azure-core-amqp")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/core/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/core/azure-core-amqp" "${SOURCE_PATH}/sdk/core/_")
+  file(RENAME "${SOURCE_PATH}/sdk/core" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/core/azure-core-amqp ${SOURCE_PATH}/sdk/core/_)
+file(RENAME ${SOURCE_PATH}/sdk/core ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/core/azure-core-amqp/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/core/azure-core-tracing-opentelemetry ${SOURCE_PATH}/sdk/core/_)
-file(RENAME ${SOURCE_PATH}/sdk/core ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/core/azure-core-tracing-opentelemetry")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/core/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/core/azure-core-tracing-opentelemetry" "${SOURCE_PATH}/sdk/core/_")
+  file(RENAME "${SOURCE_PATH}/sdk/core" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/core/azure-core-tracing-opentelemetry ${SOURCE_PATH}/sdk/core/_)
+file(RENAME ${SOURCE_PATH}/sdk/core ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/core/azure-core-tracing-opentelemetry/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/core/azure-core/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core/vcpkg/portfile.cmake
@@ -15,8 +15,12 @@ vcpkg_check_features(
         winhttp BUILD_TRANSPORT_WINHTTP
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/core/azure-core ${SOURCE_PATH}/sdk/core/_)
+file(RENAME ${SOURCE_PATH}/sdk/core ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/core/azure-core/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         ${FEATURE_OPTIONS}
         -DWARNINGS_AS_ERRORS=OFF

--- a/sdk/core/azure-core/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core/vcpkg/portfile.cmake
@@ -15,12 +15,18 @@ vcpkg_check_features(
         winhttp BUILD_TRANSPORT_WINHTTP
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/core/azure-core ${SOURCE_PATH}/sdk/core/_)
-file(RENAME ${SOURCE_PATH}/sdk/core ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/core/azure-core")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/core/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/core/azure-core" "${SOURCE_PATH}/sdk/core/_")
+  file(RENAME "${SOURCE_PATH}/sdk/core" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         ${FEATURE_OPTIONS}
         -DWARNINGS_AS_ERRORS=OFF

--- a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
+++ b/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs ${SOURCE_PATH}/sdk/eventhubs/_)
+file(RENAME ${SOURCE_PATH}/sdk/eventhubs ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
+++ b/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs ${SOURCE_PATH}/sdk/eventhubs/_)
-file(RENAME ${SOURCE_PATH}/sdk/eventhubs ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/eventhubs/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs" "${SOURCE_PATH}/sdk/eventhubs/_")
+  file(RENAME "${SOURCE_PATH}/sdk/eventhubs" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/identity/azure-identity/vcpkg/portfile.cmake
+++ b/sdk/identity/azure-identity/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/identity/azure-identity ${SOURCE_PATH}/sdk/identity/_)
+file(RENAME ${SOURCE_PATH}/sdk/identity ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/identity/azure-identity/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/identity/azure-identity/vcpkg/portfile.cmake
+++ b/sdk/identity/azure-identity/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/identity/azure-identity ${SOURCE_PATH}/sdk/identity/_)
-file(RENAME ${SOURCE_PATH}/sdk/identity ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/identity/azure-identity")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/identity/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/identity/azure-identity" "${SOURCE_PATH}/sdk/identity/_")
+  file(RENAME "${SOURCE_PATH}/sdk/identity" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-administration ${SOURCE_PATH}/sdk/keyvault/_)
-file(RENAME ${SOURCE_PATH}/sdk/keyvault ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-administration")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/keyvault/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-administration" "${SOURCE_PATH}/sdk/keyvault/_")
+  file(RENAME "${SOURCE_PATH}/sdk/keyvault" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-administration ${SOURCE_PATH}/sdk/keyvault/_)
+file(RENAME ${SOURCE_PATH}/sdk/keyvault ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-administration/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-certificates ${SOURCE_PATH}/sdk/keyvault/_)
+file(RENAME ${SOURCE_PATH}/sdk/keyvault ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-certificates/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-certificates ${SOURCE_PATH}/sdk/keyvault/_)
-file(RENAME ${SOURCE_PATH}/sdk/keyvault ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-certificates")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/keyvault/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-certificates" "${SOURCE_PATH}/sdk/keyvault/_")
+  file(RENAME "${SOURCE_PATH}/sdk/keyvault" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys ${SOURCE_PATH}/sdk/keyvault/_)
+file(RENAME ${SOURCE_PATH}/sdk/keyvault ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys ${SOURCE_PATH}/sdk/keyvault/_)
-file(RENAME ${SOURCE_PATH}/sdk/keyvault ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/keyvault/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys" "${SOURCE_PATH}/sdk/keyvault/_")
+  file(RENAME "${SOURCE_PATH}/sdk/keyvault" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-secrets ${SOURCE_PATH}/sdk/keyvault/_)
-file(RENAME ${SOURCE_PATH}/sdk/keyvault ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-secrets")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/keyvault/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-secrets" "${SOURCE_PATH}/sdk/keyvault/_")
+  file(RENAME "${SOURCE_PATH}/sdk/keyvault" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-secrets ${SOURCE_PATH}/sdk/keyvault/_)
+file(RENAME ${SOURCE_PATH}/sdk/keyvault ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-secrets/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-blobs ${SOURCE_PATH}/sdk/storage/_)
-file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-blobs")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/storage/azure-storage-blobs" "${SOURCE_PATH}/sdk/storage/_")
+  file(RENAME "${SOURCE_PATH}/sdk/storage" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-blobs ${SOURCE_PATH}/sdk/storage/_)
+file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/storage/azure-storage-blobs/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-common ${SOURCE_PATH}/sdk/storage/_)
+file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/storage/azure-storage-common/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-common ${SOURCE_PATH}/sdk/storage/_)
-file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-common")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/storage/azure-storage-common" "${SOURCE_PATH}/sdk/storage/_")
+  file(RENAME "${SOURCE_PATH}/sdk/storage" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-files-datalake ${SOURCE_PATH}/sdk/storage/_)
+file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/storage/azure-storage-files-datalake/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-files-datalake ${SOURCE_PATH}/sdk/storage/_)
-file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-files-datalake")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/storage/azure-storage-files-datalake" "${SOURCE_PATH}/sdk/storage/_")
+  file(RENAME "${SOURCE_PATH}/sdk/storage" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-files-shares ${SOURCE_PATH}/sdk/storage/_)
+file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/storage/azure-storage-files-shares/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )

--- a/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-files-shares ${SOURCE_PATH}/sdk/storage/_)
-file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-files-shares")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/storage/azure-storage-files-shares" "${SOURCE_PATH}/sdk/storage/_")
+  file(RENAME "${SOURCE_PATH}/sdk/storage" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
 )

--- a/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-queues ${SOURCE_PATH}/sdk/storage/_)
+file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/storage/azure-storage-queues/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/storage/azure-storage-queues ${SOURCE_PATH}/sdk/storage/_)
-file(RENAME ${SOURCE_PATH}/sdk/storage ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-queues")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/storage/azure-storage-queues" "${SOURCE_PATH}/sdk/storage/_")
+  file(RENAME "${SOURCE_PATH}/sdk/storage" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/template/azure-template/vcpkg/portfile.cmake
+++ b/sdk/template/azure-template/vcpkg/portfile.cmake
@@ -8,12 +8,18 @@ vcpkg_from_github(
     SHA512 0
 )
 
-file(RENAME ${SOURCE_PATH}/sdk/template/azure-template ${SOURCE_PATH}/sdk/template/_)
-file(RENAME ${SOURCE_PATH}/sdk/template ${SOURCE_PATH}/sdk/_)
-file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+if(EXISTS "${SOURCE_PATH}/sdk/template/azure-template")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/template/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")
+  file(REMOVE_RECURSE "${SOURCE_PATH}/_")
+
+  file(RENAME "${SOURCE_PATH}/sdk/template/azure-template" "${SOURCE_PATH}/sdk/template/_")
+  file(RENAME "${SOURCE_PATH}/sdk/template" "${SOURCE_PATH}/sdk/_")
+  file(RENAME "${SOURCE_PATH}/sdk" "${SOURCE_PATH}/_")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF

--- a/sdk/template/azure-template/vcpkg/portfile.cmake
+++ b/sdk/template/azure-template/vcpkg/portfile.cmake
@@ -8,8 +8,12 @@ vcpkg_from_github(
     SHA512 0
 )
 
+file(RENAME ${SOURCE_PATH}/sdk/template/azure-template ${SOURCE_PATH}/sdk/template/_)
+file(RENAME ${SOURCE_PATH}/sdk/template ${SOURCE_PATH}/sdk/_)
+file(RENAME ${SOURCE_PATH}/sdk ${SOURCE_PATH}/_)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/sdk/template/azure-template/"
+    SOURCE_PATH "${SOURCE_PATH}/_/_/_/"
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF


### PR DESCRIPTION
Why we do this? In short, Windows path has limit of 260 characters, so when the library is consumed via vcpkg, which lives in something like "C:\users\...", it is easy to go past that limit.

The fix is already in vcpkg: https://github.com/microsoft/vcpkg/pull/33880