### PR TITLE
Do not throw an exception during `AzureCliCredential` construction, but rather delay it on GetToken() call.

### DIFF
--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -92,8 +92,6 @@ AzureCliCredential::AzureCliCredential(
 {
   static_cast<void>(options);
 
-  ThrowIfNotSafeCmdLineInput(m_tenantId, "TenantID");
-
   IdentityLog::Write(
       IdentityLog::Level::Informational,
       GetCredentialName()
@@ -123,6 +121,7 @@ std::string AzureCliCredential::GetAzCommand(std::string const& scopes, std::str
     const
 {
   ThrowIfNotSafeCmdLineInput(scopes, "Scopes");
+  ThrowIfNotSafeCmdLineInput(m_tenantId, "TenantID");
   std::string command = "az account get-access-token --output json --scope \"" + scopes + "\"";
 
   if (!tenantId.empty())

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -325,9 +325,11 @@ TEST(AzureCliCredential, UnsafeChars)
     AzureCliCredentialOptions options;
     options.TenantId = "01234567-89AB-CDEF-0123-456789ABCDEF";
     options.TenantId += Exploit;
+    AzureCliCredential azCliCred(options);
 
-    EXPECT_THROW(
-        static_cast<void>(std::make_unique<AzureCliCredential>(options)), AuthenticationException);
+    TokenRequestContext trc;
+    trc.Scopes.push_back(std::string("https://storage.azure.com/.default"));
+    EXPECT_THROW(static_cast<void>(azCliCred.GetToken(trc, {})), AuthenticationException);
   }
 
   {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/4978