### PR TITLE
Change the default value for the authority host option to be read from the environment variable first.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bld*/
 [Oo]bj/
 [Ll]og/
 [Oo]ut/
+[Tt]emp
 #these are for build from source temp directories 
 [Ss]dk/**/[Ss]dk/
 **/[Oo]ut/**

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Change the default value for the authority host option to be read from the environment variable first.
+
 ### Other Changes
 
 ## 1.6.0-beta.2 (2023-09-13)

--- a/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
@@ -45,8 +45,8 @@ namespace Azure { namespace Identity {
   {
     /**
      * @brief Authentication authority URL.
-     * @note Default value is read from the 'AZURE_AUTHORITY_HOST' environment variable with Azure
-     * AD global authority as the fallback (https://login.microsoftonline.com/).
+     * @note Defaults to the value of the environment variable 'AZURE_AUTHORITY_HOST'. If that's not
+     * set, the default value is Azure AD global authority (https://login.microsoftonline.com/).
      *
      * @note Example of an authority host string: "https://login.microsoftonline.us/". See national
      * clouds' Azure AD authentication endpoints:

--- a/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
@@ -13,6 +13,7 @@
 
 #include <azure/core/credentials/credentials.hpp>
 #include <azure/core/credentials/token_credential_options.hpp>
+#include <azure/core/internal/environment.hpp>
 #include <azure/core/internal/unique_handle.hpp>
 #include <azure/core/url.hpp>
 
@@ -50,7 +51,8 @@ namespace Azure { namespace Identity {
      * clouds' Azure AD authentication endpoints:
      * https://docs.microsoft.com/azure/active-directory/develop/authentication-national-cloud.
      */
-    std::string AuthorityHost = _detail::ClientCredentialCore::AadGlobalAuthority;
+    std::string AuthorityHost
+        = Azure::Core::_internal::Environment::GetVariable(_detail::AzureAuthorityHostEnvVarName);
 
     /**
      * @brief For multi-tenant applications, specifies additional tenants for which the credential

--- a/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
@@ -45,7 +45,8 @@ namespace Azure { namespace Identity {
   {
     /**
      * @brief Authentication authority URL.
-     * @note Default value is Azure AD global authority (https://login.microsoftonline.com/).
+     * @note Default value is read from the 'AZURE_AUTHORITY_HOST' environment variable with Azure
+     * AD global authority as the fallback (https://login.microsoftonline.com/).
      *
      * @note Example of an authority host string: "https://login.microsoftonline.us/". See national
      * clouds' Azure AD authentication endpoints:

--- a/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
@@ -13,6 +13,7 @@
 
 #include <azure/core/credentials/credentials.hpp>
 #include <azure/core/credentials/token_credential_options.hpp>
+#include <azure/core/internal/environment.hpp>
 #include <azure/core/url.hpp>
 
 #include <memory>
@@ -38,7 +39,8 @@ namespace Azure { namespace Identity {
      * clouds' Azure AD authentication endpoints:
      * https://docs.microsoft.com/azure/active-directory/develop/authentication-national-cloud.
      */
-    std::string AuthorityHost = _detail::ClientCredentialCore::AadGlobalAuthority;
+    std::string AuthorityHost
+        = Azure::Core::_internal::Environment::GetVariable(_detail::AzureAuthorityHostEnvVarName);
 
     /**
      * @brief For multi-tenant applications, specifies additional tenants for which the credential

--- a/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
@@ -33,8 +33,8 @@ namespace Azure { namespace Identity {
   {
     /**
      * @brief Authentication authority URL.
-     * @note Default value is read from the 'AZURE_AUTHORITY_HOST' environment variable with Azure
-     * AD global authority as the fallback (https://login.microsoftonline.com/).
+     * @note Defaults to the value of the environment variable 'AZURE_AUTHORITY_HOST'. If that's not
+     * set, the default value is Azure AD global authority (https://login.microsoftonline.com/).
      *
      * @note Example of an authority host string: "https://login.microsoftonline.us/". See national
      * clouds' Azure AD authentication endpoints:

--- a/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
@@ -33,7 +33,8 @@ namespace Azure { namespace Identity {
   {
     /**
      * @brief Authentication authority URL.
-     * @note Default value is Azure AD global authority (https://login.microsoftonline.com/).
+     * @note Default value is read from the 'AZURE_AUTHORITY_HOST' environment variable with Azure
+     * AD global authority as the fallback (https://login.microsoftonline.com/).
      *
      * @note Example of an authority host string: "https://login.microsoftonline.us/". See national
      * clouds' Azure AD authentication endpoints:

--- a/sdk/identity/azure-identity/inc/azure/identity/detail/client_credential_core.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/detail/client_credential_core.hpp
@@ -12,14 +12,14 @@
 #include <vector>
 
 namespace Azure { namespace Identity { namespace _detail {
+  constexpr auto AzureAuthorityHostEnvVarName = "AZURE_AUTHORITY_HOST";
+
   class ClientCredentialCore final {
     std::vector<std::string> m_additionallyAllowedTenants;
     Core::Url m_authorityHost;
     std::string m_tenantId;
 
   public:
-    AZ_IDENTITY_DLLEXPORT static std::string const AadGlobalAuthority;
-
     explicit ClientCredentialCore(
         std::string tenantId,
         std::string const& authorityHost,

--- a/sdk/identity/azure-identity/inc/azure/identity/workload_identity_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/workload_identity_credential.hpp
@@ -41,7 +41,7 @@ namespace Azure { namespace Identity {
 
     /**
      * @brief Authentication authority URL.
-     * @note Defaults to the value of the environment variable AZURE_AUTHORITY_HOST. If that's not
+     * @note Defaults to the value of the environment variable 'AZURE_AUTHORITY_HOST'. If that's not
      * set, the default value is Azure AD global authority (https://login.microsoftonline.com/).
      *
      * @note Example of an authority host string: "https://login.microsoftonline.us/". See national

--- a/sdk/identity/azure-identity/src/client_credential_core.cpp
+++ b/sdk/identity/azure-identity/src/client_credential_core.cpp
@@ -6,8 +6,6 @@
 #include "private/tenant_id_resolver.hpp"
 #include "private/token_credential_impl.hpp"
 
-#include <utility>
-
 using Azure::Identity::_detail::ClientCredentialCore;
 
 using Azure::Core::Url;
@@ -15,15 +13,22 @@ using Azure::Core::Credentials::TokenRequestContext;
 using Azure::Identity::_detail::TenantIdResolver;
 using Azure::Identity::_detail::TokenCredentialImpl;
 
-decltype(ClientCredentialCore::AadGlobalAuthority) ClientCredentialCore::AadGlobalAuthority
-    = "https://login.microsoftonline.com/";
+namespace {
+const std::string AadGlobalAuthority = "https://login.microsoftonline.com/";
+}
 
+// The authority host used be the credentials is in the following order of precedence:
+// 1. AuthorityHost option set/overriden by the user.
+// 2. The value of AZURE_AUTHORITY_HOST environment variable, which is the default value of the
+// option.
+// 3. If the option is empty, use Azure Public Cloud.
 ClientCredentialCore::ClientCredentialCore(
     std::string tenantId,
     std::string const& authorityHost,
     std::vector<std::string> additionallyAllowedTenants)
     : m_additionallyAllowedTenants(std::move(additionallyAllowedTenants)),
-      m_authorityHost(Url(authorityHost)), m_tenantId(std::move(tenantId))
+      m_authorityHost(Url(authorityHost.empty() ? AadGlobalAuthority : authorityHost)),
+      m_tenantId(std::move(tenantId))
 {
 }
 

--- a/sdk/identity/azure-identity/src/client_credential_core.cpp
+++ b/sdk/identity/azure-identity/src/client_credential_core.cpp
@@ -17,7 +17,7 @@ namespace {
 const std::string AadGlobalAuthority = "https://login.microsoftonline.com/";
 }
 
-// The authority host used be the credentials is in the following order of precedence:
+// The authority host used by the credentials is in the following order of precedence:
 // 1. AuthorityHost option set/overriden by the user.
 // 2. The value of AZURE_AUTHORITY_HOST environment variable, which is the default value of the
 // option.

--- a/sdk/identity/azure-identity/src/environment_credential.cpp
+++ b/sdk/identity/azure-identity/src/environment_credential.cpp
@@ -5,6 +5,7 @@
 
 #include "azure/identity/client_certificate_credential.hpp"
 #include "azure/identity/client_secret_credential.hpp"
+#include "azure/identity/detail/client_credential_core.hpp"
 #include "private/identity_log.hpp"
 
 #include <azure/core/azure_assert.hpp>
@@ -64,7 +65,7 @@ EnvironmentCredential::EnvironmentCredential(
 
       if (!authority.empty())
       {
-        envVarsToParams.push_back({AzureAuthorityHostEnvVarName, "authorityHost"});
+        envVarsToParams.push_back({_detail::AzureAuthorityHostEnvVarName, "authorityHost"});
         clientSecretCredentialOptions.AuthorityHost = authority;
       }
 
@@ -84,7 +85,7 @@ EnvironmentCredential::EnvironmentCredential(
 
       if (!authority.empty())
       {
-        envVarsToParams.push_back({AzureAuthorityHostEnvVarName, "authorityHost"});
+        envVarsToParams.push_back({_detail::AzureAuthorityHostEnvVarName, "authorityHost"});
         clientCertificateCredentialOptions.AuthorityHost = authority;
       }
 
@@ -108,7 +109,7 @@ EnvironmentCredential::EnvironmentCredential(
       auto logMsg = GetCredentialName() + ": Both '" + AzureTenantIdEnvVarName + "' and '"
           + AzureClientIdEnvVarName + "', and at least one of '" + AzureClientSecretEnvVarName
           + "', '" + AzureClientCertificatePathEnvVarName + "' needs to be set. Additionally, '"
-          + AzureAuthorityHostEnvVarName
+          + _detail::AzureAuthorityHostEnvVarName
           + "' could be set to override the default authority host. Currently:\n";
 
       std::pair<char const*, bool> envVarStatus[] = {
@@ -116,7 +117,7 @@ EnvironmentCredential::EnvironmentCredential(
           {AzureClientIdEnvVarName, !clientId.empty()},
           {AzureClientSecretEnvVarName, !clientSecret.empty()},
           {AzureClientCertificatePathEnvVarName, !clientCertificatePath.empty()},
-          {AzureAuthorityHostEnvVarName, !authority.empty()},
+          {_detail::AzureAuthorityHostEnvVarName, !authority.empty()},
       };
       for (auto const& status : envVarStatus)
       {

--- a/sdk/identity/azure-identity/src/environment_credential.cpp
+++ b/sdk/identity/azure-identity/src/environment_credential.cpp
@@ -28,7 +28,6 @@ namespace {
 constexpr auto AzureTenantIdEnvVarName = "AZURE_TENANT_ID";
 constexpr auto AzureClientIdEnvVarName = "AZURE_CLIENT_ID";
 constexpr auto AzureClientSecretEnvVarName = "AZURE_CLIENT_SECRET";
-constexpr auto AzureAuthorityHostEnvVarName = "AZURE_AUTHORITY_HOST";
 constexpr auto AzureClientCertificatePathEnvVarName = "AZURE_CLIENT_CERTIFICATE_PATH";
 
 void PrintCredentialCreationLogMessage(
@@ -46,7 +45,7 @@ EnvironmentCredential::EnvironmentCredential(
   auto clientId = Environment::GetVariable(AzureClientIdEnvVarName);
 
   auto clientSecret = Environment::GetVariable(AzureClientSecretEnvVarName);
-  auto authority = Environment::GetVariable(AzureAuthorityHostEnvVarName);
+  auto authority = Environment::GetVariable(_detail::AzureAuthorityHostEnvVarName);
 
   auto clientCertificatePath = Environment::GetVariable(AzureClientCertificatePathEnvVarName);
 

--- a/sdk/identity/azure-identity/src/workload_identity_credential.cpp
+++ b/sdk/identity/azure-identity/src/workload_identity_credential.cpp
@@ -26,7 +26,6 @@ using Azure::Identity::_detail::TokenCredentialImpl;
 namespace {
 constexpr auto AzureTenantIdEnvVarName = "AZURE_TENANT_ID";
 constexpr auto AzureClientIdEnvVarName = "AZURE_CLIENT_ID";
-constexpr auto AzureAuthorityHostEnvVarName = "AZURE_AUTHORITY_HOST";
 constexpr auto AzureFederatedTokenFileEnvVarName = "AZURE_FEDERATED_TOKEN_FILE";
 } // namespace
 
@@ -52,11 +51,7 @@ WorkloadIdentityCredential::WorkloadIdentityCredential(
   }
   if (authorityHost.empty())
   {
-    authorityHost = Environment::GetVariable(AzureAuthorityHostEnvVarName);
-    if (authorityHost.empty())
-    {
-      authorityHost = _detail::ClientCredentialCore::AadGlobalAuthority;
-    }
+    authorityHost = Environment::GetVariable(_detail::AzureAuthorityHostEnvVarName);
   }
   if (m_tokenFilePath.empty())
   {
@@ -89,11 +84,7 @@ WorkloadIdentityCredential::WorkloadIdentityCredential(
 
   if (!tenantId.empty() && !clientId.empty() && !m_tokenFilePath.empty())
   {
-    std::string authorityHost = Environment::GetVariable(AzureAuthorityHostEnvVarName);
-    if (authorityHost.empty())
-    {
-      authorityHost = _detail::ClientCredentialCore::AadGlobalAuthority;
-    }
+    std::string authorityHost = Environment::GetVariable(_detail::AzureAuthorityHostEnvVarName);
 
     m_clientCredentialCore = Azure::Identity::_detail::ClientCredentialCore(
         tenantId, authorityHost, std::vector<std::string>());

--- a/sdk/identity/azure-identity/test/ut/client_certificate_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/client_certificate_credential_test.cpp
@@ -148,6 +148,26 @@ TEST_P(GetCredentialName, )
   EXPECT_EQ(cred.GetCredentialName(), "ClientCertificateCredential");
 }
 
+TEST(ClientCertificateCredential, GetOptionsFromEnvironment)
+{
+  {
+    std::map<std::string, std::string> envVars = {{"AZURE_AUTHORITY_HOST", ""}};
+    CredentialTestHelper::EnvironmentOverride const env(envVars);
+
+    ClientCertificateCredentialOptions options;
+    EXPECT_EQ(options.AuthorityHost, "");
+  }
+
+  {
+    std::map<std::string, std::string> envVars
+        = {{"AZURE_AUTHORITY_HOST", "https://microsoft.com/"}};
+    CredentialTestHelper::EnvironmentOverride const env(envVars);
+
+    ClientCertificateCredentialOptions options;
+    EXPECT_EQ(options.AuthorityHost, "https://microsoft.com/");
+  }
+}
+
 TEST_P(GetToken, )
 {
   auto const actual = CredentialTestHelper::SimulateTokenRequest(

--- a/sdk/identity/azure-identity/test/ut/client_secret_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/client_secret_credential_test.cpp
@@ -21,6 +21,26 @@ TEST(ClientSecretCredential, GetCredentialName)
   EXPECT_EQ(cred.GetCredentialName(), "ClientSecretCredential");
 }
 
+TEST(ClientSecretCredential, GetOptionsFromEnvironment)
+{
+  {
+    std::map<std::string, std::string> envVars = {{"AZURE_AUTHORITY_HOST", ""}};
+    CredentialTestHelper::EnvironmentOverride const env(envVars);
+
+    ClientSecretCredentialOptions options;
+    EXPECT_EQ(options.AuthorityHost, "");
+  }
+
+  {
+    std::map<std::string, std::string> envVars
+        = {{"AZURE_AUTHORITY_HOST", "https://microsoft.com/"}};
+    CredentialTestHelper::EnvironmentOverride const env(envVars);
+
+    ClientSecretCredentialOptions options;
+    EXPECT_EQ(options.AuthorityHost, "https://microsoft.com/");
+  }
+}
+
 TEST(ClientSecretCredential, Regular)
 {
   auto const actual = CredentialTestHelper::SimulateTokenRequest(


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/4875

Ultimately, this isn't a breaking change, but rather a bug fix to match user intention:

1) If the user set the option before to a particular value, it continues to get honored (since that is the highest precedence)
2) If the user doesn't set the option, and was running in an environment where the environment variable **wasn't** set, we previously fell back to the default authority (which is the public cloud), and we continue to do so, since the env var value will be empty.
3) If the user doesn't set the option, and was running in an environment where the environment variable **was** set, we now correctly use that value over the fallback default authority. That's the bug fix here.

If, for some reason, the user really wanted the previous behavior, and ignore the environment variable set on the environment, they can explicitly set the `AuthorityHost` option to the desired value. This way the intent is explicit and clear, rather than implicit/accidental.