### PR TITLE
Remove OPENSSL_VERSION_NUMBER version check for the CAPath option in libcurl

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -14,10 +14,6 @@
 #include "azure/core/http/transport.hpp"
 #include "azure/core/platform.hpp"
 
-#if defined(AZ_PLATFORM_LINUX)
-#include <openssl/opensslv.h>
-#endif // defined(AZ_PLATFORM_LINUX)
-
 namespace Azure { namespace Core { namespace Http {
   class CurlNetworkConnection;
 

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -16,9 +16,6 @@
 
 #if defined(AZ_PLATFORM_LINUX)
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER >= 0x00905100L
-#define _azure_SUPPORT_SETTING_CAPATH
-#endif // OPENSSL_VERSION_NUMBER >= 0x00905100L
 #endif // defined(AZ_PLATFORM_LINUX)
 
 namespace Azure { namespace Core { namespace Http {
@@ -130,7 +127,7 @@ namespace Azure { namespace Core { namespace Http {
      */
     std::string CAInfo;
 
-#if defined(_azure_SUPPORT_SETTING_CAPATH)
+#if defined(AZ_PLATFORM_LINUX)
     /**
      * @brief Path to a directory which holds PEM encoded file, containing the certificate
      * authorities sent to libcurl handle directly.

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -1283,7 +1283,7 @@ inline std::string GetConnectionKey(std::string const& host, CurlTransportOption
   key.append(",");
   key.append(!options.CAInfo.empty() ? options.CAInfo : "0");
   key.append(",");
-#if defined(_azure_SUPPORT_SETTING_CAPATH)
+#if defined(AZ_PLATFORM_LINUX)
   key.append(!options.CAPath.empty() ? options.CAPath : "0");
 #else
   key.append("0"); // CAPath is always empty on Windows;
@@ -2320,7 +2320,7 @@ CurlConnection::CurlConnection(
     }
   }
 
-#if defined(_azure_SUPPORT_SETTING_CAPATH)
+#if defined(AZ_PLATFORM_LINUX)
   if (!options.CAPath.empty())
   {
     if (!SetLibcurlOption(m_handle, CURLOPT_CAPATH, options.CAPath.c_str(), &result))

--- a/sdk/core/azure-core/test/ut/curl_options_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_options_test.cpp
@@ -235,7 +235,7 @@ namespace Azure { namespace Core { namespace Test {
                         .ConnectionPoolIndex.clear());
   }
 
-#if defined(_azure_SUPPORT_SETTING_CAPATH)
+#if defined(AZ_PLATFORM_LINUX)
   TEST(CurlTransportOptions, setCADirectory)
   {
     Azure::Core::Http::CurlTransportOptions curlOptions;
@@ -267,7 +267,7 @@ namespace Azure { namespace Core { namespace Test {
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
     EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
-    EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
+    EXPECT_NE(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
 
     // Clean the connection from the pool *Windows fails to clean if we leave to be clean upon
     // app-destruction

--- a/sdk/core/azure-core/test/ut/curl_options_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_options_test.cpp
@@ -267,7 +267,7 @@ namespace Azure { namespace Core { namespace Test {
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
     EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
-    EXPECT_NE(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
+    EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
 
     // Clean the connection from the pool *Windows fails to clean if we leave to be clean upon
     // app-destruction


### PR DESCRIPTION
Following-up from https://github.com/Azure/azure-sdk-for-cpp/pull/4982#discussion_r1344779446

https://www.openssl.org/docs/manmaster/man3/OPENSSL_VERSION_NUMBER.html
https://en.wikipedia.org/wiki/OpenSSL#Major_version_releases

> 0x00905100L seems to correspond to 0.9.5 which is 20+ years old. We can assume the version of openssl is 1.1.1 or higher, since we don't support older versions anyway.

cc @phoebusm