### PR TITLE
Add retry for the restore operation in sample

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
@@ -69,7 +69,7 @@ int main()
     DeleteKeyOperation operation = keyClient.StartDeleteKey(rsaKeyName);
     // You only need to wait for completion if you want to purge or recover the key.
     operation.PollUntilDone(std::chrono::milliseconds(2000));
-    keyClient.PurgeDeletedKey(rsaKeyName);
+    // keyClient.PurgeDeletedKey(rsaKeyName);
 
     // Let's wait for a bit (maximum ~5 minutes) so we know the key was purged.
     try
@@ -88,11 +88,12 @@ int main()
     }
     catch (Azure::Core::RequestFailedException const& e)
     {
-      std::cout << "\t" <<e.what() << std::endl << e.Message << std::endl;
+      std::cout << "\t" << e.what() << std::endl;
+      std::cout << e.Message << std::endl;
       std::cout << "\t-Key purged" << std::endl;
     }
     // let's wait for one minute so we know the key was purged.
-    std::this_thread::sleep_for(std::chrono::seconds(60));
+    // std::this_thread::sleep_for(std::chrono::seconds(60));
     // Restore the key from the file backup
     std::cout << "\t-Read from file." << std::endl;
     std::ifstream inFile;

--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
@@ -72,9 +72,10 @@ int main()
     // keyClient.PurgeDeletedKey(rsaKeyName);
 
     // Let's wait for a bit (maximum ~5 minutes) so we know the key was purged.
+    uint16_t loop = 0;
     try
     {
-      uint16_t loop = 0;
+      
       // To check if the key was purged we attempt to get the key from the Key Vault.
       // If we get an exception, the key was purged.
       // If not, we wait a bit more,since the key is in the purge process.
@@ -90,6 +91,7 @@ int main()
     {
       std::cout << "\t" << e.what() << std::endl;
       std::cout << e.Message << std::endl;
+      std::cout << loop << std::endl;
       std::cout << "\t-Key purged" << std::endl;
     }
     // let's wait for one minute so we know the key was purged.

--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
@@ -127,9 +127,9 @@ int main()
     }
 
     if (!restored)
-	{
-	  throw std::runtime_error("Key was not restored.");
-	}
+    {
+      throw std::runtime_error("Key was not restored.");
+    }
     AssertKeysEqual(storedKey.Properties, restoredKey.Properties);
 
     operation = keyClient.StartDeleteKey(rsaKeyName);

--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
@@ -86,11 +86,13 @@ int main()
       }
       throw std::runtime_error("Key was not purged.");
     }
-    catch (Azure::Core::RequestFailedException const&)
+    catch (Azure::Core::RequestFailedException const& e)
     {
+      std::cout << "\t" <<e.what() << std::endl << e.Message << std::endl;
       std::cout << "\t-Key purged" << std::endl;
     }
-
+    // let's wait for one minute so we know the key was purged.
+    std::this_thread::sleep_for(std::chrono::seconds(60));
     // Restore the key from the file backup
     std::cout << "\t-Read from file." << std::endl;
     std::ifstream inFile;

--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
@@ -76,9 +76,8 @@ int main()
     try
     {
 
-      // To check if the key was purged we attempt to get the key from the Key Vault.
-      // If we get an exception, the key was purged.
-      // If not, we wait a bit more,since the key is in the purge process.
+      // To check if the key purged has started we attempt to get the key from the Key Vault.
+      // If we get an exception, the key purge has started.
       // If we get more than 300 loops (~5minutes), we assume something went wrong.
       while (!keyClient.GetDeletedKey(rsaKeyName).Value.Name().empty() && loop < 300)
       {
@@ -92,10 +91,8 @@ int main()
       std::cout << "\t" << e.what() << std::endl;
       std::cout << e.Message << std::endl;
       std::cout << loop << std::endl;
-      std::cout << "\t-Key purged" << std::endl;
+      std::cout << "\t-Key purge started" << std::endl;
     }
-    // let's wait for one minute so we know the key was purged.
-    // std::this_thread::sleep_for(std::chrono::seconds(60));
     // Restore the key from the file backup
     std::cout << "\t-Read from file." << std::endl;
     std::ifstream inFile;
@@ -105,8 +102,34 @@ int main()
     inFile.close();
 
     std::cout << "\t-Restore Key" << std::endl;
-    auto restoredKey = keyClient.RestoreKeyBackup(inMemoryBackup).Value;
 
+    KeyVaultKey restoredKey;
+    bool restored = false;
+    loop = 0;
+    // the purge process is not instantaneous, so when we try to restore the key, it might fail.
+    // we will attempt to restore the key for 5 times, waiting 20 seconds between each try.
+    // If the key is not restored after 5 tries, we assume something went wrong.
+    while (!restored && loop < 5)
+    {
+      try
+      {
+        restoredKey = keyClient.RestoreKeyBackup(inMemoryBackup).Value;
+        restored = true;
+        break;
+      }
+      catch (Azure::Core::RequestFailedException const& e)
+      {
+        std::cout << "\t" << e.what() << std::endl;
+        std::cout << e.Message << std::endl;
+        std::this_thread::sleep_for(std::chrono::seconds(20));
+        loop++;
+      }
+    }
+
+    if (!restored)
+	{
+	  throw std::runtime_error("Key was not restored.");
+	}
     AssertKeysEqual(storedKey.Properties, restoredKey.Properties);
 
     operation = keyClient.StartDeleteKey(rsaKeyName);

--- a/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/samples/sample2-backup-and-restore/sample2_backup_and_restore.cpp
@@ -69,13 +69,13 @@ int main()
     DeleteKeyOperation operation = keyClient.StartDeleteKey(rsaKeyName);
     // You only need to wait for completion if you want to purge or recover the key.
     operation.PollUntilDone(std::chrono::milliseconds(2000));
-    // keyClient.PurgeDeletedKey(rsaKeyName);
+    keyClient.PurgeDeletedKey(rsaKeyName);
 
     // Let's wait for a bit (maximum ~5 minutes) so we know the key was purged.
     uint16_t loop = 0;
     try
     {
-      
+
       // To check if the key was purged we attempt to get the key from the Key Vault.
       // If we get an exception, the key was purged.
       // If not, we wait a bit more,since the key is in the purge process.


### PR DESCRIPTION
The problem is that purge is an opaque async process , thus we need to retry the restore operation, with a limit of 5

 # Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
