### PR TITLE
Added code annotations around proxy information scheme for winhttp to work around clang parsing issue

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -100,7 +100,10 @@ namespace Azure { namespace Core {
        *
        * @remark The Proxy Information string is composed of a set of elements
        * formatted as follows:
+       *
+       * @code
        * (\[\<scheme\>=\]\[\<scheme\>"://"\]\<server\>\[":"\<port\>\])
+       * @endcode
        *
        * Each element should be separated with semicolons or whitespace.
        */


### PR DESCRIPTION
When clang parses doxygen comments, it tokenizes special characters as individual TextComment elements. Because the ApiView parser treats all TextComment lines in a ParagraphComment as separate lines, this results in an awkward display. Basically the line:
```cpp
       * (\[\<scheme\>=\]\[\<scheme\>"://"\]\<server\>\[":"\<port\>\])
```

becomes
```
(
[
<
scheme
>
=
:
```

Putting a \code wrapper around the line forces doxygen to use a fixed face font when rendering it and causes the ApiView documentation node to treat this as a literal comment.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
