### PR TITLE
Remove code coverage exclusions from Azure SDK for C++

### DIFF
--- a/sdk/attestation/azure-security-attestation/samples/policy-certificates/cryptohelpers.hpp
+++ b/sdk/attestation/azure-security-attestation/samples/policy-certificates/cryptohelpers.hpp
@@ -211,7 +211,7 @@ public:
       raw_x509 = PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr);
       if (raw_x509 == nullptr)
       {
-        throw ::_detail::OpenSSLException("PEM_read_bio_X509"); // LCOV_EXCL_LINE
+        throw ::_detail::OpenSSLException("PEM_read_bio_X509");
       }
       ::_detail::openssl_unique_ptr<X509> x509(raw_x509);
       raw_x509 = nullptr;

--- a/sdk/attestation/azure-security-attestation/src/private/crypto/openssl/opensslcert.cpp
+++ b/sdk/attestation/azure-security-attestation/src/private/crypto/openssl/opensslcert.cpp
@@ -46,7 +46,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
     raw_x509 = PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr);
     if (raw_x509 == nullptr)
     {
-      throw OpenSSLException("PEM_read_bio_X509"); // LCOV_EXCL_LINE
+      throw OpenSSLException("PEM_read_bio_X509");
     }
     openssl_x509 x509(raw_x509);
     raw_x509 = nullptr;
@@ -58,7 +58,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
     auto bio(make_openssl_unique(BIO_new, BIO_s_mem()));
     if (PEM_write_bio_X509(bio.get(), m_certificate.get()) != 1)
     {
-      throw OpenSSLException("PEM_write_bio_X509"); // LCOV_EXCL_LINE
+      throw OpenSSLException("PEM_write_bio_X509");
     }
 
     // Now extract the data from the BIO and return it as a string.
@@ -85,11 +85,11 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
     // Serialize the certificate as a Base64 encoded DER encoded blob into the bio.
     if (i2d_X509_bio(base64bio.get(), m_certificate.get()) != 1)
     {
-      throw OpenSSLException("i2d_X509_bio"); // LCOV_EXCL_LINE
+      throw OpenSSLException("i2d_X509_bio");
     }
     if (BIO_flush(base64bio.get()) != 1)
     {
-      throw OpenSSLException("BIO_flush"); // LCOV_EXCL_LINE
+      throw OpenSSLException("BIO_flush");
     }
 
     // Now that we've written to the underlying bio, pop it back
@@ -204,7 +204,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
               0)
           != 1)
       {
-        throw OpenSSLException("X509_NAME_add_entry_by_NID"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_NAME_add_entry_by_NID");
       }
     }
     return returnValue;
@@ -253,21 +253,21 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
 
     if (X509_set_subject_name(certificate.get(), subjectName.get()) != 1)
     {
-      throw OpenSSLException("X509_set_subject_name"); // LCOV_EXCL_LINE
+      throw OpenSSLException("X509_set_subject_name");
     }
 
     if (issuer)
     {
       if (X509_set_issuer_name(certificate.get(), X509_get_subject_name(issuer.get())) != 1)
       {
-        throw OpenSSLException("X509_set_issuer_name"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_set_issuer_name");
       }
     }
     else
     {
       if (X509_set_issuer_name(certificate.get(), subjectName.get()) != 1)
       {
-        throw OpenSSLException("X509_set_issuer_name"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_set_issuer_name");
       }
     }
 
@@ -280,13 +280,13 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
       OpenSSLAsymmetricKey* key = static_cast<OpenSSLAsymmetricKey*>(publicKey.get());
       if (X509_set_pubkey(certificate.get(), key->GetKey().get()) != 1)
       {
-        throw OpenSSLException("X509_set_pubkey"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_set_pubkey");
       }
     }
 
     if (X509_set_version(certificate.get(), 2) != 1) // Version 3 certificate
     {
-      throw OpenSSLException("X509_set_version"); // LCOV_EXCL_LINE
+      throw OpenSSLException("X509_set_version");
     }
 
     // Transfer the serial number from the current certificate to the child if this is a
@@ -295,7 +295,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
     {
       if (X509_set_serialNumber(certificate.get(), X509_get_serialNumber(issuer.get())) != 1)
       {
-        throw OpenSSLException("X509_set_serialNumber"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_set_serialNumber");
       }
     }
     else
@@ -303,11 +303,11 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
       auto serialNumber(make_openssl_unique(ASN1_INTEGER_new));
       if (ASN1_INTEGER_set(serialNumber.get(), 1) != 1)
       {
-        throw OpenSSLException("ASN1_INTEGER_set"); // LCOV_EXCL_LINE
+        throw OpenSSLException("ASN1_INTEGER_set");
       }
       if (X509_set_serialNumber(certificate.get(), serialNumber.get()) != 1)
       {
-        throw OpenSSLException("X509_set_serialNumber"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_set_serialNumber");
       }
     }
 
@@ -319,7 +319,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
           (isLeafCertificate ? "CA:FALSE" : "CA:TRUE, pathlen:0"));
       if (X509_add_ext(certificate.get(), extension.get(), -1) != 1)
       {
-        throw OpenSSLException("X509_add_ext"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_add_ext");
       }
     }
 
@@ -329,7 +329,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
 
       if (X509_set1_notBefore(certificate.get(), notBeforeTime.get()) != 1)
       {
-        throw OpenSSLException("X509_set1_notBefore"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_set1_notBefore");
       }
     }
 
@@ -340,7 +340,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
 
       if (X509_set1_notAfter(certificate.get(), notAfterTime.get()) != 1)
       {
-        throw OpenSSLException("X509_set1_notAfter"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_set1_notAfter");
       }
     }
 
@@ -350,7 +350,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
           certificate, certificate, NID_subject_key_identifier, "hash");
       if (X509_add_ext(certificate.get(), extension.get(), -1) != 1)
       {
-        throw OpenSSLException("X509_add_ext"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_add_ext");
       }
     } // namespace _internal
 
@@ -370,7 +370,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
       }
       if (X509_add_ext(certificate.get(), extension.get(), -1) != 1)
       {
-        throw OpenSSLException("X509_add_ext"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_add_ext");
       }
     }
 
@@ -398,7 +398,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
       OpenSSLAsymmetricKey* key = static_cast<OpenSSLAsymmetricKey*>(privateKey.get());
       if (X509_sign(certificate.get(), key->GetKey().get(), EVP_sha256()) == 1)
       {
-        throw OpenSSLException("X509_sign"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_sign");
       }
     }
 
@@ -449,7 +449,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
     openssl_evp_pkey pkey(X509_get0_pubkey(m_certificate.get()));
     if (EVP_PKEY_up_ref(pkey.get()) != 1)
     {
-      throw OpenSSLException("EVP_PKEY_up_ref"); // LCOV_EXCL_LINE
+      throw OpenSSLException("EVP_PKEY_up_ref");
     }
     return std::unique_ptr<OpenSSLAsymmetricKey>(new OpenSSLAsymmetricKey(std::move(pkey)));
   }

--- a/sdk/attestation/azure-security-attestation/src/private/crypto/openssl/opensslcert.hpp
+++ b/sdk/attestation/azure-security-attestation/src/private/crypto/openssl/opensslcert.hpp
@@ -170,7 +170,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
       if (X509_PUBKEY_get0_param(&asn1Algorithm, &publicKey, &publicKeyLen, &algorithm, pubkey)
           != 1)
       {
-        throw OpenSSLException("X509_PUBKEY_get0_param"); // LCOV_EXCL_LINE
+        throw OpenSSLException("X509_PUBKEY_get0_param");
       }
 
       int nid = OBJ_obj2nid(asn1Algorithm);
@@ -182,12 +182,10 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
       {
         return "EC";
       }
-      // LCOV_EXCL_START
       std::stringstream ss;
       ss << "Unknown Certificate Key Algorithm: " << std::to_string(nid) << " for certificate "
          << GetSubjectName() << " " << GetIssuerName() << GetThumbprint();
       throw std::invalid_argument(ss.str());
-      // LCOV_EXCL_STOP
     }
 
     std::string GetKeyType() const override
@@ -212,12 +210,10 @@ namespace Azure { namespace Security { namespace Attestation { namespace _detail
       {
         return "EC";
       }
-      // LCOV_EXCL_START
       std::stringstream ss;
       ss << "Unknown Certificate Key Type: " << std::to_string(nid) << " for certificate "
          << GetSubjectName() << " " << GetIssuerName() << GetThumbprint();
       throw std::invalid_argument(ss.str());
-      // LCOV_EXCL_STOP
     }
 
     static std::unique_ptr<X509Certificate> Import(std::string const& pemEncodedKey);

--- a/sdk/attestation/ci.yml
+++ b/sdk/attestation/ci.yml
@@ -30,7 +30,7 @@ stages:
       Location: WestUS
       CtestRegex: azure-security-attestation.*
       LiveTestCtestRegex: azure-security-attestation.*
-      LineCoverageTarget: 90
+      LineCoverageTarget: 89
       BranchCoverageTarget: 42
       Artifacts:
         - Name: azure-security-attestation

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/connection.hpp
@@ -190,14 +190,13 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * @remarks Note that this function should only be overriden if the application is listening
      * on the connection.
      */
-    
+
     virtual bool OnNewEndpoint(Connection const& connection, Endpoint& endpoint)
     {
       (void)connection;
       (void)endpoint;
       return false;
     }
-    
 
     /** @brief called when an I/O error has occurred on the connection.
      *

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/connection.hpp
@@ -190,14 +190,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * @remarks Note that this function should only be overriden if the application is listening
      * on the connection.
      */
-    // LCOV_EXCL_START
+    
     virtual bool OnNewEndpoint(Connection const& connection, Endpoint& endpoint)
     {
       (void)connection;
       (void)endpoint;
       return false;
     }
-    // LCOV_EXCL_STOP
+    
 
     /** @brief called when an I/O error has occurred on the connection.
      *

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/connection.hpp
@@ -190,7 +190,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * @remarks Note that this function should only be overriden if the application is listening
      * on the connection.
      */
-
     virtual bool OnNewEndpoint(Connection const& connection, Endpoint& endpoint)
     {
       (void)connection;

--- a/sdk/core/azure-core-amqp/src/amqp/claim_based_security.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/claim_based_security.cpp
@@ -64,21 +64,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       auto rv{m_management->Open(context)};
       switch (rv)
       {
-        case ManagementOpenStatus::Invalid: 
-          return CbsOpenResult::Invalid; 
+        case ManagementOpenStatus::Invalid:
+          return CbsOpenResult::Invalid;
         case ManagementOpenStatus::Ok:
           return CbsOpenResult::Ok;
         case ManagementOpenStatus::Error:
           return CbsOpenResult::Error;
-        case ManagementOpenStatus::Cancelled: 
-          return CbsOpenResult::Cancelled; 
+        case ManagementOpenStatus::Cancelled:
+          return CbsOpenResult::Cancelled;
         default:
           throw std::runtime_error("Unknown return value from Management::Open()");
       }
     }
     else
     {
-      return CbsOpenResult::Error; 
+      return CbsOpenResult::Error;
     }
   }
 
@@ -113,23 +113,23 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       CbsOperationResult cbsResult;
       switch (result.Status)
       {
-        case ManagementOperationStatus::Invalid: 
-          cbsResult = CbsOperationResult::Invalid; 
+        case ManagementOperationStatus::Invalid:
+          cbsResult = CbsOperationResult::Invalid;
           break;
         case ManagementOperationStatus::Ok:
           cbsResult = CbsOperationResult::Ok;
           break;
-        case ManagementOperationStatus::Error: 
-          cbsResult = CbsOperationResult::Error; 
+        case ManagementOperationStatus::Error:
+          cbsResult = CbsOperationResult::Error;
           break;
-        case ManagementOperationStatus::FailedBadStatus: 
-          cbsResult = CbsOperationResult::Failed; 
+        case ManagementOperationStatus::FailedBadStatus:
+          cbsResult = CbsOperationResult::Failed;
           break;
-        case ManagementOperationStatus::InstanceClosed: 
-          cbsResult = CbsOperationResult::InstanceClosed; 
+        case ManagementOperationStatus::InstanceClosed:
+          cbsResult = CbsOperationResult::InstanceClosed;
           break;
         default:
-          throw std::runtime_error("Unknown management operation status."); 
+          throw std::runtime_error("Unknown management operation status.");
       }
       Log::Stream(Logger::Level::Error)
           << "CBS PutToken result: " << cbsResult << " status code: " << result.StatusCode

--- a/sdk/core/azure-core-amqp/src/amqp/claim_based_security.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/claim_based_security.cpp
@@ -64,21 +64,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       auto rv{m_management->Open(context)};
       switch (rv)
       {
-        case ManagementOpenStatus::Invalid: // LCOV_EXCL_LINE
-          return CbsOpenResult::Invalid; // LCOV_EXCL_LINE
+        case ManagementOpenStatus::Invalid: 
+          return CbsOpenResult::Invalid; 
         case ManagementOpenStatus::Ok:
           return CbsOpenResult::Ok;
         case ManagementOpenStatus::Error:
           return CbsOpenResult::Error;
-        case ManagementOpenStatus::Cancelled: // LCOV_EXCL_LINE
-          return CbsOpenResult::Cancelled; // LCOV_EXCL_LINE
+        case ManagementOpenStatus::Cancelled: 
+          return CbsOpenResult::Cancelled; 
         default:
           throw std::runtime_error("Unknown return value from Management::Open()");
       }
     }
     else
     {
-      return CbsOpenResult::Error; // LCOV_EXCL_LINE
+      return CbsOpenResult::Error; 
     }
   }
 
@@ -113,23 +113,23 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       CbsOperationResult cbsResult;
       switch (result.Status)
       {
-        case ManagementOperationStatus::Invalid: // LCOV_EXCL_LINE
-          cbsResult = CbsOperationResult::Invalid; // LCOV_EXCL_LINE
+        case ManagementOperationStatus::Invalid: 
+          cbsResult = CbsOperationResult::Invalid; 
           break;
         case ManagementOperationStatus::Ok:
           cbsResult = CbsOperationResult::Ok;
           break;
-        case ManagementOperationStatus::Error: // LCOV_EXCL_LINE
-          cbsResult = CbsOperationResult::Error; // LCOV_EXCL_LINE
+        case ManagementOperationStatus::Error: 
+          cbsResult = CbsOperationResult::Error; 
           break;
-        case ManagementOperationStatus::FailedBadStatus: // LCOV_EXCL_LINE
-          cbsResult = CbsOperationResult::Failed; // LCOV_EXCL_LINE
+        case ManagementOperationStatus::FailedBadStatus: 
+          cbsResult = CbsOperationResult::Failed; 
           break;
-        case ManagementOperationStatus::InstanceClosed: // LCOV_EXCL_LINE
-          cbsResult = CbsOperationResult::InstanceClosed; // LCOV_EXCL_LINE
+        case ManagementOperationStatus::InstanceClosed: 
+          cbsResult = CbsOperationResult::InstanceClosed; 
           break;
         default:
-          throw std::runtime_error("Unknown management operation status."); // LCOV_EXCL_LINE
+          throw std::runtime_error("Unknown management operation status."); 
       }
       Log::Stream(Logger::Level::Error)
           << "CBS PutToken result: " << cbsResult << " status code: " << result.StatusCode

--- a/sdk/core/azure-core-amqp/src/amqp/connection.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/connection.cpp
@@ -401,10 +401,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       return cn->m_eventHandler->OnNewEndpoint(
           ConnectionFactory::CreateFromInternal(cn->shared_from_this()), endpoint);
     }
-    return false; 
+    return false;
   }
 
-  
   void ConnectionImpl::OnIOErrorFn(void* context)
   {
     ConnectionImpl* cn = static_cast<ConnectionImpl*>(context);
@@ -417,7 +416,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       }
     }
   }
-  
 
   void ConnectionImpl::EnableAsyncOperation(bool enable)
   {
@@ -471,7 +469,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     if (connection_open(m_connection.get()))
     {
-      throw std::runtime_error("Could not open connection."); 
+      throw std::runtime_error("Could not open connection.");
     }
     m_connectionOpened = true;
     EnableAsyncOperation(true);
@@ -483,7 +481,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         << "ConnectionImpl::Listen: " << this << " ID: " << m_containerId;
     if (connection_listen(m_connection.get()))
     {
-      throw std::runtime_error("Could not listen on connection."); 
+      throw std::runtime_error("Could not listen on connection.");
     }
     m_connectionOpened = true;
 
@@ -499,7 +497,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         << "ConnectionImpl::Close: " << this << " ID: " << m_containerId;
     if (!m_connection)
     {
-      throw std::logic_error("Connection already closed."); 
+      throw std::logic_error("Connection already closed.");
     }
 
     std::unique_lock<LockType> lock(m_amqpMutex);
@@ -526,7 +524,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t maxSize;
     if (connection_get_max_frame_size(m_connection.get(), &maxSize))
     {
-      throw std::runtime_error("COuld not get max frame size."); 
+      throw std::runtime_error("COuld not get max frame size.");
     }
     return maxSize;
   }
@@ -536,7 +534,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint16_t maxChannel;
     if (connection_get_channel_max(m_connection.get(), &maxChannel))
     {
-      throw std::runtime_error("COuld not get channel max."); 
+      throw std::runtime_error("COuld not get channel max.");
     }
     return maxChannel;
   }
@@ -546,7 +544,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     milliseconds ms;
     if (connection_get_idle_timeout(m_connection.get(), &ms))
     {
-      throw std::runtime_error("Could not set max frame size."); 
+      throw std::runtime_error("Could not set max frame size.");
     }
     return std::chrono::milliseconds(ms);
   }
@@ -556,7 +554,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     AMQP_VALUE value;
     if (connection_get_properties(m_connection.get(), &value))
     {
-      throw std::runtime_error("COuld not get properties."); 
+      throw std::runtime_error("COuld not get properties.");
     }
     return Models::AmqpValue{value}.AsMap();
   }
@@ -566,7 +564,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t maxFrameSize;
     if (connection_get_remote_max_frame_size(m_connection.get(), &maxFrameSize))
     {
-      throw std::runtime_error("Could not get remote max frame size."); 
+      throw std::runtime_error("Could not get remote max frame size.");
     }
     return maxFrameSize;
   }
@@ -576,8 +574,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     std::unique_lock<LockType> lock(m_amqpMutex);
     if (connection_set_remote_idle_timeout_empty_frame_send_ratio(m_connection.get(), ratio))
     {
-      throw std::runtime_error(
-          "Could not set remote idle timeout send frame ratio."); 
+      throw std::runtime_error("Could not set remote idle timeout send frame ratio.");
     }
   }
 
@@ -654,7 +651,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       auto cbsOpenStatus = claimsBasedSecurity->Open(context);
       if (cbsOpenStatus != CbsOpenResult::Ok)
       {
-        throw std::runtime_error("Could not open Claims Based Security object."); 
+        throw std::runtime_error("Could not open Claims Based Security object.");
       }
 
       try
@@ -675,7 +672,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             context);
         if (std::get<0>(result) != CbsOperationResult::Ok)
         {
-          throw std::runtime_error("Could not put Claims Based Security token."); 
+          throw std::runtime_error("Could not put Claims Based Security token.");
         }
         claimsBasedSecurity->Close();
         if (m_options.EnableTrace)

--- a/sdk/core/azure-core-amqp/src/amqp/connection.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/connection.cpp
@@ -401,10 +401,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       return cn->m_eventHandler->OnNewEndpoint(
           ConnectionFactory::CreateFromInternal(cn->shared_from_this()), endpoint);
     }
-    return false; // LCOV_EXCL_LINE
+    return false; 
   }
 
-  // LCOV_EXCL_START
+  
   void ConnectionImpl::OnIOErrorFn(void* context)
   {
     ConnectionImpl* cn = static_cast<ConnectionImpl*>(context);
@@ -417,7 +417,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       }
     }
   }
-  // LCOV_EXCL_STOP
+  
 
   void ConnectionImpl::EnableAsyncOperation(bool enable)
   {
@@ -471,7 +471,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     if (connection_open(m_connection.get()))
     {
-      throw std::runtime_error("Could not open connection."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not open connection."); 
     }
     m_connectionOpened = true;
     EnableAsyncOperation(true);
@@ -483,7 +483,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         << "ConnectionImpl::Listen: " << this << " ID: " << m_containerId;
     if (connection_listen(m_connection.get()))
     {
-      throw std::runtime_error("Could not listen on connection."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not listen on connection."); 
     }
     m_connectionOpened = true;
 
@@ -499,7 +499,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         << "ConnectionImpl::Close: " << this << " ID: " << m_containerId;
     if (!m_connection)
     {
-      throw std::logic_error("Connection already closed."); // LCOV_EXCL_LINE
+      throw std::logic_error("Connection already closed."); 
     }
 
     std::unique_lock<LockType> lock(m_amqpMutex);
@@ -526,7 +526,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t maxSize;
     if (connection_get_max_frame_size(m_connection.get(), &maxSize))
     {
-      throw std::runtime_error("COuld not get max frame size."); // LCOV_EXCL_LINE
+      throw std::runtime_error("COuld not get max frame size."); 
     }
     return maxSize;
   }
@@ -536,7 +536,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint16_t maxChannel;
     if (connection_get_channel_max(m_connection.get(), &maxChannel))
     {
-      throw std::runtime_error("COuld not get channel max."); // LCOV_EXCL_LINE
+      throw std::runtime_error("COuld not get channel max."); 
     }
     return maxChannel;
   }
@@ -546,7 +546,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     milliseconds ms;
     if (connection_get_idle_timeout(m_connection.get(), &ms))
     {
-      throw std::runtime_error("Could not set max frame size."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set max frame size."); 
     }
     return std::chrono::milliseconds(ms);
   }
@@ -556,7 +556,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     AMQP_VALUE value;
     if (connection_get_properties(m_connection.get(), &value))
     {
-      throw std::runtime_error("COuld not get properties."); // LCOV_EXCL_LINE
+      throw std::runtime_error("COuld not get properties."); 
     }
     return Models::AmqpValue{value}.AsMap();
   }
@@ -566,7 +566,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t maxFrameSize;
     if (connection_get_remote_max_frame_size(m_connection.get(), &maxFrameSize))
     {
-      throw std::runtime_error("Could not get remote max frame size."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get remote max frame size."); 
     }
     return maxFrameSize;
   }
@@ -577,7 +577,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     if (connection_set_remote_idle_timeout_empty_frame_send_ratio(m_connection.get(), ratio))
     {
       throw std::runtime_error(
-          "Could not set remote idle timeout send frame ratio."); // LCOV_EXCL_LINE
+          "Could not set remote idle timeout send frame ratio."); 
     }
   }
 
@@ -654,7 +654,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       auto cbsOpenStatus = claimsBasedSecurity->Open(context);
       if (cbsOpenStatus != CbsOpenResult::Ok)
       {
-        throw std::runtime_error("Could not open Claims Based Security object."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not open Claims Based Security object."); 
       }
 
       try
@@ -675,7 +675,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             context);
         if (std::get<0>(result) != CbsOperationResult::Ok)
         {
-          throw std::runtime_error("Could not put Claims Based Security token."); // LCOV_EXCL_LINE
+          throw std::runtime_error("Could not put Claims Based Security token."); 
         }
         claimsBasedSecurity->Close();
         if (m_options.EnableTrace)

--- a/sdk/core/azure-core-amqp/src/amqp/link.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/link.cpp
@@ -159,7 +159,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (link_set_max_message_size(m_link, size))
     {
-      throw std::runtime_error("Could not set max message size"); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set max message size"); 
     }
   }
   uint64_t LinkImpl::GetMaxMessageSize() const
@@ -167,7 +167,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint64_t maxMessageSize;
     if (link_get_max_message_size(m_link, &maxMessageSize))
     {
-      throw std::runtime_error("Could not set max message size"); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set max message size"); 
     }
     return maxMessageSize;
   }
@@ -177,7 +177,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     const char* name;
     if (link_get_name(m_link, &name))
     {
-      throw std::runtime_error("Could not get link name"); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get link name"); 
     }
     return name;
   }
@@ -186,7 +186,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     sender_settle_mode settleMode;
     if (link_get_snd_settle_mode(m_link, &settleMode))
     {
-      throw std::runtime_error("Could not get link sender settle mode."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get link sender settle mode."); 
     }
     switch (settleMode)
     {
@@ -197,7 +197,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       case sender_settle_mode_unsettled:
         return Azure::Core::Amqp::_internal::SenderSettleMode::Unsettled;
       default:
-        throw std::logic_error("Unknown settle mode."); // LCOV_EXCL_LINE
+        throw std::logic_error("Unknown settle mode."); 
     }
   }
   void LinkImpl::SetSenderSettleMode(_internal::SenderSettleMode mode)
@@ -214,12 +214,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       case Azure::Core::Amqp::_internal::SenderSettleMode::Mixed:
         settleMode = sender_settle_mode_mixed;
         break;
-      default: // LCOV_EXCL_LINE
-        throw std::logic_error("Unknown settle mode."); // LCOV_EXCL_LINE
+      default: 
+        throw std::logic_error("Unknown settle mode."); 
     }
     if (link_set_snd_settle_mode(m_link, settleMode))
     {
-      throw std::runtime_error("Could not get link sender settle mode."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get link sender settle mode."); 
     }
   }
 
@@ -228,7 +228,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     receiver_settle_mode settleMode;
     if (link_get_rcv_settle_mode(m_link, &settleMode))
     {
-      throw std::runtime_error("Could not get link sender settle mode."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get link sender settle mode."); 
     }
     switch (settleMode)
     {
@@ -236,8 +236,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         return _internal::ReceiverSettleMode::First;
       case receiver_settle_mode_second:
         return _internal::ReceiverSettleMode::Second;
-      default: // LCOV_EXCL_LINE
-        throw std::logic_error("Unknown settle mode."); // LCOV_EXCL_LINE
+      default: 
+        throw std::logic_error("Unknown settle mode."); 
     }
   }
   void LinkImpl::SetReceiverSettleMode(_internal::ReceiverSettleMode mode)
@@ -251,12 +251,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       case _internal::ReceiverSettleMode::Second:
         settleMode = receiver_settle_mode_second;
         break;
-      default: // LCOV_EXCL_LINE
-        throw std::logic_error("Unknown settle mode."); // LCOV_EXCL_LINE
+      default: 
+        throw std::logic_error("Unknown settle mode."); 
     }
     if (link_set_rcv_settle_mode(m_link, settleMode))
     {
-      throw std::runtime_error("Could not get link sender settle mode."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get link sender settle mode."); 
     }
   }
 
@@ -265,7 +265,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t deliveryCount;
     if (link_get_initial_delivery_count(m_link, &deliveryCount))
     {
-      throw std::runtime_error("Could not get link initial delivery count."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get link initial delivery count."); 
     }
     return deliveryCount;
   }
@@ -277,7 +277,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       throw std::runtime_error("Could not get link initial delivery count.");
     }
-    return peerMax; // LCOV_EXCL_LINE
+    return peerMax; 
   }
 
   uint32_t LinkImpl::GetReceivedMessageId() const
@@ -285,7 +285,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t messageId;
     if (link_get_received_message_id(m_link, &messageId))
     {
-      throw std::runtime_error("Could not get link received message ID."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get link received message ID."); 
     }
     return messageId;
   }
@@ -294,21 +294,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (link_set_initial_delivery_count(m_link, count))
     {
-      throw std::runtime_error("Could not set initial delivery count."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set initial delivery count."); 
     }
   }
   void LinkImpl::SetAttachProperties(Models::AmqpValue properties)
   {
     if (link_set_attach_properties(m_link, properties))
     {
-      throw std::runtime_error("Could not set attach properties."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set attach properties."); 
     }
   }
   void LinkImpl::SetMaxLinkCredit(uint32_t credit)
   {
     if (link_set_max_link_credit(m_link, credit))
     {
-      throw std::runtime_error("Could not set attach properties."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set attach properties."); 
     }
   }
 
@@ -340,7 +340,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (link_attach(m_link, nullptr, nullptr, nullptr, this))
     {
-      throw std::runtime_error("Could not set attach properties."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set attach properties."); 
     }
   }
   void LinkImpl::Detach(
@@ -356,7 +356,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             (description.empty() ? nullptr : description.c_str()),
             info))
     {
-      throw std::runtime_error("Could not set attach properties."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set attach properties."); 
     }
   }
 

--- a/sdk/core/azure-core-amqp/src/amqp/link.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/link.cpp
@@ -159,7 +159,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (link_set_max_message_size(m_link, size))
     {
-      throw std::runtime_error("Could not set max message size"); 
+      throw std::runtime_error("Could not set max message size");
     }
   }
   uint64_t LinkImpl::GetMaxMessageSize() const
@@ -167,7 +167,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint64_t maxMessageSize;
     if (link_get_max_message_size(m_link, &maxMessageSize))
     {
-      throw std::runtime_error("Could not set max message size"); 
+      throw std::runtime_error("Could not set max message size");
     }
     return maxMessageSize;
   }
@@ -177,7 +177,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     const char* name;
     if (link_get_name(m_link, &name))
     {
-      throw std::runtime_error("Could not get link name"); 
+      throw std::runtime_error("Could not get link name");
     }
     return name;
   }
@@ -186,7 +186,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     sender_settle_mode settleMode;
     if (link_get_snd_settle_mode(m_link, &settleMode))
     {
-      throw std::runtime_error("Could not get link sender settle mode."); 
+      throw std::runtime_error("Could not get link sender settle mode.");
     }
     switch (settleMode)
     {
@@ -197,7 +197,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       case sender_settle_mode_unsettled:
         return Azure::Core::Amqp::_internal::SenderSettleMode::Unsettled;
       default:
-        throw std::logic_error("Unknown settle mode."); 
+        throw std::logic_error("Unknown settle mode.");
     }
   }
   void LinkImpl::SetSenderSettleMode(_internal::SenderSettleMode mode)
@@ -214,12 +214,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       case Azure::Core::Amqp::_internal::SenderSettleMode::Mixed:
         settleMode = sender_settle_mode_mixed;
         break;
-      default: 
-        throw std::logic_error("Unknown settle mode."); 
+      default:
+        throw std::logic_error("Unknown settle mode.");
     }
     if (link_set_snd_settle_mode(m_link, settleMode))
     {
-      throw std::runtime_error("Could not get link sender settle mode."); 
+      throw std::runtime_error("Could not get link sender settle mode.");
     }
   }
 
@@ -228,7 +228,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     receiver_settle_mode settleMode;
     if (link_get_rcv_settle_mode(m_link, &settleMode))
     {
-      throw std::runtime_error("Could not get link sender settle mode."); 
+      throw std::runtime_error("Could not get link sender settle mode.");
     }
     switch (settleMode)
     {
@@ -236,8 +236,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         return _internal::ReceiverSettleMode::First;
       case receiver_settle_mode_second:
         return _internal::ReceiverSettleMode::Second;
-      default: 
-        throw std::logic_error("Unknown settle mode."); 
+      default:
+        throw std::logic_error("Unknown settle mode.");
     }
   }
   void LinkImpl::SetReceiverSettleMode(_internal::ReceiverSettleMode mode)
@@ -251,12 +251,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       case _internal::ReceiverSettleMode::Second:
         settleMode = receiver_settle_mode_second;
         break;
-      default: 
-        throw std::logic_error("Unknown settle mode."); 
+      default:
+        throw std::logic_error("Unknown settle mode.");
     }
     if (link_set_rcv_settle_mode(m_link, settleMode))
     {
-      throw std::runtime_error("Could not get link sender settle mode."); 
+      throw std::runtime_error("Could not get link sender settle mode.");
     }
   }
 
@@ -265,7 +265,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t deliveryCount;
     if (link_get_initial_delivery_count(m_link, &deliveryCount))
     {
-      throw std::runtime_error("Could not get link initial delivery count."); 
+      throw std::runtime_error("Could not get link initial delivery count.");
     }
     return deliveryCount;
   }
@@ -277,7 +277,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       throw std::runtime_error("Could not get link initial delivery count.");
     }
-    return peerMax; 
+    return peerMax;
   }
 
   uint32_t LinkImpl::GetReceivedMessageId() const
@@ -285,7 +285,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t messageId;
     if (link_get_received_message_id(m_link, &messageId))
     {
-      throw std::runtime_error("Could not get link received message ID."); 
+      throw std::runtime_error("Could not get link received message ID.");
     }
     return messageId;
   }
@@ -294,21 +294,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (link_set_initial_delivery_count(m_link, count))
     {
-      throw std::runtime_error("Could not set initial delivery count."); 
+      throw std::runtime_error("Could not set initial delivery count.");
     }
   }
   void LinkImpl::SetAttachProperties(Models::AmqpValue properties)
   {
     if (link_set_attach_properties(m_link, properties))
     {
-      throw std::runtime_error("Could not set attach properties."); 
+      throw std::runtime_error("Could not set attach properties.");
     }
   }
   void LinkImpl::SetMaxLinkCredit(uint32_t credit)
   {
     if (link_set_max_link_credit(m_link, credit))
     {
-      throw std::runtime_error("Could not set attach properties."); 
+      throw std::runtime_error("Could not set attach properties.");
     }
   }
 
@@ -340,7 +340,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (link_attach(m_link, nullptr, nullptr, nullptr, this))
     {
-      throw std::runtime_error("Could not set attach properties."); 
+      throw std::runtime_error("Could not set attach properties.");
     }
   }
   void LinkImpl::Detach(
@@ -356,7 +356,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             (description.empty() ? nullptr : description.c_str()),
             info))
     {
-      throw std::runtime_error("Could not set attach properties."); 
+      throw std::runtime_error("Could not set attach properties.");
     }
   }
 

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -362,7 +362,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             // If the message receiver is transitioning to an error or state other than open,
             // it's an error.
           default:
-
           case _internal::MessageReceiverState::Idle:
           case _internal::MessageReceiverState::Closing:
           case _internal::MessageReceiverState::Error:

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -69,9 +69,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     m_eventHandler = nullptr;
     if (m_isOpen)
     {
-      AZURE_ASSERT_MSG(!m_isOpen, "Management being destroyed while open."); 
-      Azure::Core::_internal::AzureNoReturnPath(
-          "Management is being destroyed while open."); 
+      AZURE_ASSERT_MSG(!m_isOpen, "Management being destroyed while open.");
+      Azure::Core::_internal::AzureNoReturnPath("Management is being destroyed while open.");
     }
   }
 
@@ -220,9 +219,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (newState == oldState)
     {
-      Log::Stream(Logger::Level::Verbose) 
-          << "OnMessageSenderStateChanged: newState == oldState" << std::endl; 
-      return; 
+      Log::Stream(Logger::Level::Verbose)
+          << "OnMessageSenderStateChanged: newState == oldState" << std::endl;
+      return;
     }
 
     if (m_options.EnableTrace)
@@ -262,7 +261,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-        
+
       case ManagementState::Open:
         switch (newState)
         {
@@ -284,7 +283,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-        
+
       case ManagementState::Closing:
         switch (newState)
         {
@@ -293,7 +292,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
           case _internal::MessageSenderState::Open:
           case _internal::MessageSenderState::Opening:
           case _internal::MessageSenderState::Error:
-            
+
             Log::Stream(Logger::Level::Error) << "Message Sender Changed State to " << newState
                                               << " while management client is closing";
             SetState(ManagementState::Closing);
@@ -302,25 +301,23 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
               m_eventHandler->OnError(Models::_internal::AmqpError{});
             }
             break;
-          
+
           // Ignore message sender closing or idle state changes if we're closing.
           case _internal::MessageSenderState::Idle:
           case _internal::MessageSenderState::Closing:
             break;
         }
         break;
-        
+
       case ManagementState::Idle:
       case ManagementState::Error:
         Log::Stream(Logger::Level::Error)
             << "Message sender state changed to " << newState
             << " when management client is in the error state, ignoring.";
         break;
-        
     }
   }
 
-  
   void ManagementClientImpl::OnMessageSenderDisconnected(Models::_internal::AmqpError const& error)
   {
     Log::Stream(Logger::Level::Error) << "Message sender disconnected: " << error << std::endl;
@@ -330,7 +327,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       m_eventHandler->OnError(error);
     }
   }
-  
 
   void ManagementClientImpl::OnMessageReceiverStateChanged(
       _internal::MessageReceiver const&,
@@ -339,11 +335,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (newState == oldState)
     {
-      
+
       Log::Stream(Logger::Level::Error)
           << "OnMessageReceiverStateChanged: newState == oldState" << std::endl;
       return;
-      
     }
 
     if (m_options.EnableTrace)
@@ -373,7 +368,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             // If the message receiver is transitioning to an error or state other than open,
             // it's an error.
           default:
-            
+
           case _internal::MessageReceiverState::Idle:
           case _internal::MessageReceiverState::Closing:
           case _internal::MessageReceiverState::Error:
@@ -384,7 +379,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             SetState(ManagementState::Closing);
             m_openCompleteQueue.CompleteOperation(_internal::ManagementOpenStatus::Error);
             break;
-            
         }
         break;
       case ManagementState::Open:
@@ -392,7 +386,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         {
             // If the message sender goes to a non-open state, it's an error.
           default:
-            
+
           case _internal::MessageReceiverState::Idle:
           case _internal::MessageReceiverState::Closing:
           case _internal::MessageReceiverState::Error:
@@ -409,7 +403,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             // Ignore message sender open changes.
           case _internal::MessageReceiverState::Open:
             break;
-            
         }
         break;
       case ManagementState::Closing:
@@ -436,7 +429,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-        
+
       case ManagementState::Idle:
       case ManagementState::Error:
         Log::Stream(Logger::Level::Error)
@@ -444,7 +437,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             << static_cast<std::underlying_type<decltype(newState)>::type>(newState)
             << " when management client is in the error state, ignoring.";
         break;
-        
     }
   }
 

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -304,7 +304,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-
       case ManagementState::Idle:
       case ManagementState::Error:
         Log::Stream(Logger::Level::Error)

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -330,7 +330,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (newState == oldState)
     {
-
       Log::Stream(Logger::Level::Error)
           << "OnMessageReceiverStateChanged: newState == oldState" << std::endl;
       return;

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -69,9 +69,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     m_eventHandler = nullptr;
     if (m_isOpen)
     {
-      AZURE_ASSERT_MSG(!m_isOpen, "Management being destroyed while open."); // LCOV_EXCL_LINE
+      AZURE_ASSERT_MSG(!m_isOpen, "Management being destroyed while open."); 
       Azure::Core::_internal::AzureNoReturnPath(
-          "Management is being destroyed while open."); // LCOV_EXCL_LINE
+          "Management is being destroyed while open."); 
     }
   }
 
@@ -220,9 +220,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (newState == oldState)
     {
-      Log::Stream(Logger::Level::Verbose) // LCOV_EXCL_LINE
-          << "OnMessageSenderStateChanged: newState == oldState" << std::endl; // LCOV_EXCL_LINE
-      return; // LCOV_EXCL_LINE
+      Log::Stream(Logger::Level::Verbose) 
+          << "OnMessageSenderStateChanged: newState == oldState" << std::endl; 
+      return; 
     }
 
     if (m_options.EnableTrace)
@@ -262,7 +262,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-        // LCOV_EXCL_START
+        
       case ManagementState::Open:
         switch (newState)
         {
@@ -284,7 +284,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-        // LCOV_EXCL_STOP
+        
       case ManagementState::Closing:
         switch (newState)
         {
@@ -293,7 +293,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
           case _internal::MessageSenderState::Open:
           case _internal::MessageSenderState::Opening:
           case _internal::MessageSenderState::Error:
-            // LCOV_EXCL_START
+            
             Log::Stream(Logger::Level::Error) << "Message Sender Changed State to " << newState
                                               << " while management client is closing";
             SetState(ManagementState::Closing);
@@ -302,25 +302,25 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
               m_eventHandler->OnError(Models::_internal::AmqpError{});
             }
             break;
-          // LCOV_EXCL_STOP
+          
           // Ignore message sender closing or idle state changes if we're closing.
           case _internal::MessageSenderState::Idle:
           case _internal::MessageSenderState::Closing:
             break;
         }
         break;
-        // LCOV_EXCL_START
+        
       case ManagementState::Idle:
       case ManagementState::Error:
         Log::Stream(Logger::Level::Error)
             << "Message sender state changed to " << newState
             << " when management client is in the error state, ignoring.";
         break;
-        // LCOV_EXCL_STOP
+        
     }
   }
 
-  // LCOV_EXCL_START
+  
   void ManagementClientImpl::OnMessageSenderDisconnected(Models::_internal::AmqpError const& error)
   {
     Log::Stream(Logger::Level::Error) << "Message sender disconnected: " << error << std::endl;
@@ -330,7 +330,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       m_eventHandler->OnError(error);
     }
   }
-  // LCOV_EXCL_STOP
+  
 
   void ManagementClientImpl::OnMessageReceiverStateChanged(
       _internal::MessageReceiver const&,
@@ -339,11 +339,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (newState == oldState)
     {
-      // LCOV_EXCL_START
+      
       Log::Stream(Logger::Level::Error)
           << "OnMessageReceiverStateChanged: newState == oldState" << std::endl;
       return;
-      // LCOV_EXCL_STOP
+      
     }
 
     if (m_options.EnableTrace)
@@ -373,7 +373,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             // If the message receiver is transitioning to an error or state other than open,
             // it's an error.
           default:
-            // LCOV_EXCL_START
+            
           case _internal::MessageReceiverState::Idle:
           case _internal::MessageReceiverState::Closing:
           case _internal::MessageReceiverState::Error:
@@ -384,7 +384,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             SetState(ManagementState::Closing);
             m_openCompleteQueue.CompleteOperation(_internal::ManagementOpenStatus::Error);
             break;
-            // LCOV_EXCL_STOP
+            
         }
         break;
       case ManagementState::Open:
@@ -392,7 +392,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         {
             // If the message sender goes to a non-open state, it's an error.
           default:
-            // LCOV_EXCL_START
+            
           case _internal::MessageReceiverState::Idle:
           case _internal::MessageReceiverState::Closing:
           case _internal::MessageReceiverState::Error:
@@ -409,7 +409,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             // Ignore message sender open changes.
           case _internal::MessageReceiverState::Open:
             break;
-            // LCOV_EXCL_STOP
+            
         }
         break;
       case ManagementState::Closing:
@@ -436,7 +436,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-        // LCOV_EXCL_START
+        
       case ManagementState::Idle:
       case ManagementState::Error:
         Log::Stream(Logger::Level::Error)
@@ -444,7 +444,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             << static_cast<std::underlying_type<decltype(newState)>::type>(newState)
             << " when management client is in the error state, ignoring.";
         break;
-        // LCOV_EXCL_STOP
+        
     }
   }
 

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -299,7 +299,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
               m_eventHandler->OnError(Models::_internal::AmqpError{});
             }
             break;
-
           // Ignore message sender closing or idle state changes if we're closing.
           case _internal::MessageSenderState::Idle:
           case _internal::MessageSenderState::Closing:

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -421,7 +421,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-
       case ManagementState::Idle:
       case ManagementState::Error:
         Log::Stream(Logger::Level::Error)

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -290,7 +290,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
           case _internal::MessageSenderState::Open:
           case _internal::MessageSenderState::Opening:
           case _internal::MessageSenderState::Error:
-
             Log::Stream(Logger::Level::Error) << "Message Sender Changed State to " << newState
                                               << " while management client is closing";
             SetState(ManagementState::Closing);

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -379,7 +379,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         {
             // If the message sender goes to a non-open state, it's an error.
           default:
-
           case _internal::MessageReceiverState::Idle:
           case _internal::MessageReceiverState::Closing:
           case _internal::MessageReceiverState::Error:

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -282,7 +282,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-
       case ManagementState::Closing:
         switch (newState)
         {

--- a/sdk/core/azure-core-amqp/src/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/management.cpp
@@ -261,7 +261,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             break;
         }
         break;
-
       case ManagementState::Open:
         switch (newState)
         {

--- a/sdk/core/azure-core-amqp/src/amqp/message_receiver.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/message_receiver.cpp
@@ -334,18 +334,18 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       case MESSAGE_RECEIVER_STATE_CLOSING:
         return MessageReceiverState::Closing;
-      case MESSAGE_RECEIVER_STATE_ERROR: // LCOV_EXCL_LINE
-        return MessageReceiverState::Error; // LCOV_EXCL_LINE
+      case MESSAGE_RECEIVER_STATE_ERROR: 
+        return MessageReceiverState::Error; 
       case MESSAGE_RECEIVER_STATE_IDLE:
         return MessageReceiverState::Idle;
-      case MESSAGE_RECEIVER_STATE_INVALID: // LCOV_EXCL_LINE
-        return MessageReceiverState::Invalid; // LCOV_EXCL_LINE
+      case MESSAGE_RECEIVER_STATE_INVALID: 
+        return MessageReceiverState::Invalid; 
       case MESSAGE_RECEIVER_STATE_OPEN:
         return MessageReceiverState::Open;
       case MESSAGE_RECEIVER_STATE_OPENING:
         return MessageReceiverState::Opening;
-      default: // LCOV_EXCL_LINE
-        throw std::logic_error("Unknown message receiver state."); // LCOV_EXCL_LINE
+      default: 
+        throw std::logic_error("Unknown message receiver state."); 
     }
   }
 
@@ -454,7 +454,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     if (messagereceiver_open(
             m_messageReceiver.get(), MessageReceiverImpl::OnMessageReceivedFn, this))
     {
-      // LCOV_EXCL_START
+      
       auto err = errno;
 #if defined(AZ_PLATFORM_WINDOWS)
       char buf[256];
@@ -464,7 +464,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #endif
       throw std::runtime_error(
           "Could not open message receiver. errno=" + std::to_string(err) + ", \"" + buf + "\".");
-      // LCOV_EXCL_STOP
+      
     }
     m_receiverOpen = true;
 
@@ -503,7 +503,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       m_messageQueue.Clear();
       if (messagereceiver_close(m_messageReceiver.get()))
       {
-        throw std::runtime_error("Could not close message receiver"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not close message receiver"); 
       }
 
 // Release the lock so that the polling thread can make forward progress delivering the

--- a/sdk/core/azure-core-amqp/src/amqp/message_receiver.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/message_receiver.cpp
@@ -334,18 +334,18 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       case MESSAGE_RECEIVER_STATE_CLOSING:
         return MessageReceiverState::Closing;
-      case MESSAGE_RECEIVER_STATE_ERROR: 
-        return MessageReceiverState::Error; 
+      case MESSAGE_RECEIVER_STATE_ERROR:
+        return MessageReceiverState::Error;
       case MESSAGE_RECEIVER_STATE_IDLE:
         return MessageReceiverState::Idle;
-      case MESSAGE_RECEIVER_STATE_INVALID: 
-        return MessageReceiverState::Invalid; 
+      case MESSAGE_RECEIVER_STATE_INVALID:
+        return MessageReceiverState::Invalid;
       case MESSAGE_RECEIVER_STATE_OPEN:
         return MessageReceiverState::Open;
       case MESSAGE_RECEIVER_STATE_OPENING:
         return MessageReceiverState::Opening;
-      default: 
-        throw std::logic_error("Unknown message receiver state."); 
+      default:
+        throw std::logic_error("Unknown message receiver state.");
     }
   }
 
@@ -454,7 +454,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     if (messagereceiver_open(
             m_messageReceiver.get(), MessageReceiverImpl::OnMessageReceivedFn, this))
     {
-      
+
       auto err = errno;
 #if defined(AZ_PLATFORM_WINDOWS)
       char buf[256];
@@ -464,7 +464,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #endif
       throw std::runtime_error(
           "Could not open message receiver. errno=" + std::to_string(err) + ", \"" + buf + "\".");
-      
     }
     m_receiverOpen = true;
 
@@ -503,7 +502,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       m_messageQueue.Clear();
       if (messagereceiver_close(m_messageReceiver.get()))
       {
-        throw std::runtime_error("Could not close message receiver"); 
+        throw std::runtime_error("Could not close message receiver");
       }
 
 // Release the lock so that the polling thread can make forward progress delivering the

--- a/sdk/core/azure-core-amqp/src/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/message_sender.cpp
@@ -205,18 +205,18 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       case MESSAGE_SENDER_STATE_CLOSING:
         return _internal::MessageSenderState::Closing;
-      case MESSAGE_SENDER_STATE_ERROR: // LCOV_EXCL_LINE
-        return _internal::MessageSenderState::Error; // LCOV_EXCL_LINE
+      case MESSAGE_SENDER_STATE_ERROR: 
+        return _internal::MessageSenderState::Error; 
       case MESSAGE_SENDER_STATE_IDLE:
         return _internal::MessageSenderState::Idle;
-      case MESSAGE_SENDER_STATE_INVALID: // LCOV_EXCL_LINE
-        return _internal::MessageSenderState::Invalid; // LCOV_EXCL_LINE
+      case MESSAGE_SENDER_STATE_INVALID: 
+        return _internal::MessageSenderState::Invalid; 
       case MESSAGE_SENDER_STATE_OPEN:
         return _internal::MessageSenderState::Open;
       case MESSAGE_SENDER_STATE_OPENING:
         return _internal::MessageSenderState::Opening;
-      default: // LCOV_EXCL_LINE
-        throw std::logic_error("Unknown message receiver state."); // LCOV_EXCL_LINE
+      default: 
+        throw std::logic_error("Unknown message receiver state."); 
     }
   }
 
@@ -296,7 +296,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     if (messagesender_open(m_messageSender.get()))
     {
-      // LCOV_EXCL_START
+      
       auto err = errno;
 #if defined(AZ_PLATFORM_WINDOWS)
       char buf[256];
@@ -306,7 +306,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #endif
       throw std::runtime_error(
           "Could not open message sender. errno=" + std::to_string(err) + ", \"" + buf + "\".");
-      // LCOV_EXCL_STOP
+      
     }
 
     // Mark the connection as async so that we can use the async APIs.
@@ -343,7 +343,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
       if (messagesender_close(m_messageSender.get()))
       {
-        throw std::runtime_error("Could not close message sender"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not close message sender"); 
       }
 
 #if SENDER_SYNCHRONOUS_CLOSE
@@ -367,7 +367,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         }
         if (std::get<0>(*result))
         {
-          throw std::runtime_error("Error closing message sender"); // LCOV_EXCL_LINE
+          throw std::runtime_error("Error closing message sender"); 
         }
       }
 #endif
@@ -386,21 +386,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       _internal::MessageSendStatus result{_internal::MessageSendStatus::Ok};
       switch (sendResult)
       {
-        case MESSAGE_SEND_RESULT_INVALID: // LCOV_EXCL_LINE
-          result = _internal::MessageSendStatus::Invalid; // LCOV_EXCL_LINE
-          break; // LCOV_EXCL_LINE
+        case MESSAGE_SEND_RESULT_INVALID: 
+          result = _internal::MessageSendStatus::Invalid; 
+          break; 
         case MESSAGE_SEND_OK:
           result = _internal::MessageSendStatus::Ok;
           break;
-        case MESSAGE_SEND_CANCELLED: // LCOV_EXCL_LINE
-          result = _internal::MessageSendStatus::Cancelled; // LCOV_EXCL_LINE
-          break; // LCOV_EXCL_LINE
-        case MESSAGE_SEND_ERROR: // LCOV_EXCL_LINE
-          result = _internal::MessageSendStatus::Error; // LCOV_EXCL_LINE
-          break; // LCOV_EXCL_LINE
-        case MESSAGE_SEND_TIMEOUT: // LCOV_EXCL_LINE
-          result = _internal::MessageSendStatus::Timeout; // LCOV_EXCL_LINE
-          break; // LCOV_EXCL_LINE
+        case MESSAGE_SEND_CANCELLED: 
+          result = _internal::MessageSendStatus::Cancelled; 
+          break; 
+        case MESSAGE_SEND_ERROR: 
+          result = _internal::MessageSendStatus::Error; 
+          break; 
+        case MESSAGE_SEND_TIMEOUT: 
+          result = _internal::MessageSendStatus::Timeout; 
+          break; 
       }
       onComplete(result, disposition);
     }
@@ -422,7 +422,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         0 /*timeout*/);
     if (result == nullptr)
     {
-      throw std::runtime_error("Could not send message"); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not send message"); 
     }
     (void)context;
   }
@@ -487,6 +487,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       return std::move(*result);
     }
-    throw std::runtime_error("Error sending message"); // LCOV_EXCL_LINE
+    throw std::runtime_error("Error sending message"); 
   }
 }}}} // namespace Azure::Core::Amqp::_detail

--- a/sdk/core/azure-core-amqp/src/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/message_sender.cpp
@@ -205,18 +205,18 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       case MESSAGE_SENDER_STATE_CLOSING:
         return _internal::MessageSenderState::Closing;
-      case MESSAGE_SENDER_STATE_ERROR: 
-        return _internal::MessageSenderState::Error; 
+      case MESSAGE_SENDER_STATE_ERROR:
+        return _internal::MessageSenderState::Error;
       case MESSAGE_SENDER_STATE_IDLE:
         return _internal::MessageSenderState::Idle;
-      case MESSAGE_SENDER_STATE_INVALID: 
-        return _internal::MessageSenderState::Invalid; 
+      case MESSAGE_SENDER_STATE_INVALID:
+        return _internal::MessageSenderState::Invalid;
       case MESSAGE_SENDER_STATE_OPEN:
         return _internal::MessageSenderState::Open;
       case MESSAGE_SENDER_STATE_OPENING:
         return _internal::MessageSenderState::Opening;
-      default: 
-        throw std::logic_error("Unknown message receiver state."); 
+      default:
+        throw std::logic_error("Unknown message receiver state.");
     }
   }
 
@@ -296,7 +296,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     if (messagesender_open(m_messageSender.get()))
     {
-      
+
       auto err = errno;
 #if defined(AZ_PLATFORM_WINDOWS)
       char buf[256];
@@ -306,7 +306,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #endif
       throw std::runtime_error(
           "Could not open message sender. errno=" + std::to_string(err) + ", \"" + buf + "\".");
-      
     }
 
     // Mark the connection as async so that we can use the async APIs.
@@ -343,7 +342,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
       if (messagesender_close(m_messageSender.get()))
       {
-        throw std::runtime_error("Could not close message sender"); 
+        throw std::runtime_error("Could not close message sender");
       }
 
 #if SENDER_SYNCHRONOUS_CLOSE
@@ -367,7 +366,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         }
         if (std::get<0>(*result))
         {
-          throw std::runtime_error("Error closing message sender"); 
+          throw std::runtime_error("Error closing message sender");
         }
       }
 #endif
@@ -386,21 +385,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       _internal::MessageSendStatus result{_internal::MessageSendStatus::Ok};
       switch (sendResult)
       {
-        case MESSAGE_SEND_RESULT_INVALID: 
-          result = _internal::MessageSendStatus::Invalid; 
-          break; 
+        case MESSAGE_SEND_RESULT_INVALID:
+          result = _internal::MessageSendStatus::Invalid;
+          break;
         case MESSAGE_SEND_OK:
           result = _internal::MessageSendStatus::Ok;
           break;
-        case MESSAGE_SEND_CANCELLED: 
-          result = _internal::MessageSendStatus::Cancelled; 
-          break; 
-        case MESSAGE_SEND_ERROR: 
-          result = _internal::MessageSendStatus::Error; 
-          break; 
-        case MESSAGE_SEND_TIMEOUT: 
-          result = _internal::MessageSendStatus::Timeout; 
-          break; 
+        case MESSAGE_SEND_CANCELLED:
+          result = _internal::MessageSendStatus::Cancelled;
+          break;
+        case MESSAGE_SEND_ERROR:
+          result = _internal::MessageSendStatus::Error;
+          break;
+        case MESSAGE_SEND_TIMEOUT:
+          result = _internal::MessageSendStatus::Timeout;
+          break;
       }
       onComplete(result, disposition);
     }
@@ -422,7 +421,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         0 /*timeout*/);
     if (result == nullptr)
     {
-      throw std::runtime_error("Could not send message"); 
+      throw std::runtime_error("Could not send message");
     }
     (void)context;
   }
@@ -487,6 +486,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       return std::move(*result);
     }
-    throw std::runtime_error("Error sending message"); 
+    throw std::runtime_error("Error sending message");
   }
 }}}} // namespace Azure::Core::Amqp::_detail

--- a/sdk/core/azure-core-amqp/src/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/session.cpp
@@ -121,21 +121,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       if (session_set_handle_max(m_session.get(), options.MaximumLinkCount.Value()))
       {
-        throw std::runtime_error("Could not set handle max."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set handle max."); 
       }
     }
     if (options.InitialIncomingWindowSize.HasValue())
     {
       if (session_set_incoming_window(m_session.get(), options.InitialIncomingWindowSize.Value()))
       {
-        throw std::runtime_error("Could not set incoming window"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set incoming window"); 
       }
     }
     if (options.InitialOutgoingWindowSize.HasValue())
     {
       if (session_set_outgoing_window(m_session.get(), options.InitialOutgoingWindowSize.Value()))
       {
-        throw std::runtime_error("Could not set outgoing window"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set outgoing window"); 
       }
     }
   }
@@ -153,21 +153,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       if (session_set_handle_max(m_session.get(), options.MaximumLinkCount.Value()))
       {
-        throw std::runtime_error("Could not set handle max."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set handle max."); 
       }
     }
     if (options.InitialIncomingWindowSize.HasValue())
     {
       if (session_set_incoming_window(m_session.get(), options.InitialIncomingWindowSize.Value()))
       {
-        throw std::runtime_error("Could not set incoming window"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set incoming window"); 
       }
     }
     if (options.InitialOutgoingWindowSize.HasValue())
     {
       if (session_set_outgoing_window(m_session.get(), options.InitialOutgoingWindowSize.Value()))
       {
-        throw std::runtime_error("Could not set outgoing window"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set outgoing window"); 
       }
     }
   }
@@ -177,7 +177,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t window;
     if (session_get_incoming_window(m_session.get(), &window))
     {
-      throw std::runtime_error("Could not get incoming window"); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get incoming window"); 
     }
     return window;
   }
@@ -187,7 +187,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t window;
     if (session_get_outgoing_window(m_session.get(), &window))
     {
-      throw std::runtime_error("Could not get outgoing window"); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get outgoing window"); 
     }
     return window;
   }
@@ -197,7 +197,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t max;
     if (session_get_handle_max(m_session.get(), &max))
     {
-      throw std::runtime_error("Could not get handle max."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get handle max."); 
     }
     return max;
   }
@@ -206,7 +206,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (session_begin(m_session.get()))
     {
-      throw std::runtime_error("Could not begin session"); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not begin session"); 
     }
   }
   void SessionImpl::End(const std::string& condition, const std::string& description)
@@ -218,7 +218,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             condition.empty() ? nullptr : condition.c_str(),
             description.empty() ? nullptr : description.c_str()))
     {
-      throw std::runtime_error("Could not begin session"); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not begin session"); 
     }
   }
 

--- a/sdk/core/azure-core-amqp/src/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/session.cpp
@@ -121,21 +121,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       if (session_set_handle_max(m_session.get(), options.MaximumLinkCount.Value()))
       {
-        throw std::runtime_error("Could not set handle max."); 
+        throw std::runtime_error("Could not set handle max.");
       }
     }
     if (options.InitialIncomingWindowSize.HasValue())
     {
       if (session_set_incoming_window(m_session.get(), options.InitialIncomingWindowSize.Value()))
       {
-        throw std::runtime_error("Could not set incoming window"); 
+        throw std::runtime_error("Could not set incoming window");
       }
     }
     if (options.InitialOutgoingWindowSize.HasValue())
     {
       if (session_set_outgoing_window(m_session.get(), options.InitialOutgoingWindowSize.Value()))
       {
-        throw std::runtime_error("Could not set outgoing window"); 
+        throw std::runtime_error("Could not set outgoing window");
       }
     }
   }
@@ -153,21 +153,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
       if (session_set_handle_max(m_session.get(), options.MaximumLinkCount.Value()))
       {
-        throw std::runtime_error("Could not set handle max."); 
+        throw std::runtime_error("Could not set handle max.");
       }
     }
     if (options.InitialIncomingWindowSize.HasValue())
     {
       if (session_set_incoming_window(m_session.get(), options.InitialIncomingWindowSize.Value()))
       {
-        throw std::runtime_error("Could not set incoming window"); 
+        throw std::runtime_error("Could not set incoming window");
       }
     }
     if (options.InitialOutgoingWindowSize.HasValue())
     {
       if (session_set_outgoing_window(m_session.get(), options.InitialOutgoingWindowSize.Value()))
       {
-        throw std::runtime_error("Could not set outgoing window"); 
+        throw std::runtime_error("Could not set outgoing window");
       }
     }
   }
@@ -177,7 +177,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t window;
     if (session_get_incoming_window(m_session.get(), &window))
     {
-      throw std::runtime_error("Could not get incoming window"); 
+      throw std::runtime_error("Could not get incoming window");
     }
     return window;
   }
@@ -187,7 +187,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t window;
     if (session_get_outgoing_window(m_session.get(), &window))
     {
-      throw std::runtime_error("Could not get outgoing window"); 
+      throw std::runtime_error("Could not get outgoing window");
     }
     return window;
   }
@@ -197,7 +197,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t max;
     if (session_get_handle_max(m_session.get(), &max))
     {
-      throw std::runtime_error("Could not get handle max."); 
+      throw std::runtime_error("Could not get handle max.");
     }
     return max;
   }
@@ -206,7 +206,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (session_begin(m_session.get()))
     {
-      throw std::runtime_error("Could not begin session"); 
+      throw std::runtime_error("Could not begin session");
     }
   }
   void SessionImpl::End(const std::string& condition, const std::string& description)
@@ -218,7 +218,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             condition.empty() ? nullptr : condition.c_str(),
             description.empty() ? nullptr : description.c_str()))
     {
-      throw std::runtime_error("Could not begin session"); 
+      throw std::runtime_error("Could not begin session");
     }
   }
 

--- a/sdk/core/azure-core-amqp/src/common/global_state.cpp
+++ b/sdk/core/azure-core-amqp/src/common/global_state.cpp
@@ -45,14 +45,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
       case AZ_LOG_ERROR:
         logLevel = Logger::Level::Error;
         break;
-      case AZ_LOG_INFO: // LCOV_EXCL_LINE
-        logLevel = Logger::Level::Informational; // LCOV_EXCL_LINE
-        break; // LCOV_EXCL_LINE
+      case AZ_LOG_INFO: 
+        logLevel = Logger::Level::Informational; 
+        break; 
       case AZ_LOG_TRACE:
         logLevel = Logger::Level::Verbose;
         break;
-      default: // LCOV_EXCL_LINE
-        logLevel = Logger::Level::Verbose; // LCOV_EXCL_LINE
+      default: 
+        logLevel = Logger::Level::Verbose; 
     }
     std::stringstream ss;
     // We don't want to log header information for outgoing and incoming frames, the header
@@ -89,7 +89,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
   {
     if (platform_init())
     {
-      throw std::runtime_error("Could not initialize platform."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not initialize platform."); 
     }
 
     // Integrate AMQP logging with Azure Core logging.

--- a/sdk/core/azure-core-amqp/src/common/global_state.cpp
+++ b/sdk/core/azure-core-amqp/src/common/global_state.cpp
@@ -45,14 +45,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
       case AZ_LOG_ERROR:
         logLevel = Logger::Level::Error;
         break;
-      case AZ_LOG_INFO: 
-        logLevel = Logger::Level::Informational; 
-        break; 
+      case AZ_LOG_INFO:
+        logLevel = Logger::Level::Informational;
+        break;
       case AZ_LOG_TRACE:
         logLevel = Logger::Level::Verbose;
         break;
-      default: 
-        logLevel = Logger::Level::Verbose; 
+      default:
+        logLevel = Logger::Level::Verbose;
     }
     std::stringstream ss;
     // We don't want to log header information for outgoing and incoming frames, the header
@@ -89,7 +89,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
   {
     if (platform_init())
     {
-      throw std::runtime_error("Could not initialize platform."); 
+      throw std::runtime_error("Could not initialize platform.");
     }
 
     // Integrate AMQP logging with Azure Core logging.

--- a/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
@@ -84,7 +84,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (header_set_ttl(rv.get(), static_cast<milliseconds>(header.TimeToLive.Value().count())))
       {
-        throw std::runtime_error("Could not set header TTL."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set header TTL."); 
       }
     }
 

--- a/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
@@ -84,7 +84,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (header_set_ttl(rv.get(), static_cast<milliseconds>(header.TimeToLive.Value().count())))
       {
-        throw std::runtime_error("Could not set header TTL."); 
+        throw std::runtime_error("Could not set header TTL.");
       }
     }
 

--- a/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
@@ -217,10 +217,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
             rv.BodyType = MessageBodyType::Value;
           }
           break;
-          case MESSAGE_BODY_TYPE_INVALID: 
-            throw std::runtime_error("Invalid message body type."); 
-          default: 
-            throw std::runtime_error("Unknown body type."); 
+          case MESSAGE_BODY_TYPE_INVALID:
+            throw std::runtime_error("Invalid message body type.");
+          default:
+            throw std::runtime_error("Unknown body type.");
         }
       }
     }
@@ -323,9 +323,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
           throw std::runtime_error("Could not set message body AMQP value.");
         }
         break;
-      case MessageBodyType::Invalid: 
-      default: 
-        throw std::runtime_error("Unknown message body type."); 
+      case MessageBodyType::Invalid:
+      default:
+        throw std::runtime_error("Unknown message body type.");
     }
     return rv;
   }
@@ -701,8 +701,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
           case AmqpDescriptors::Footer:
             m_decodedValue.Footer = describedType.GetValue().AsMap();
             break;
-          default: 
-            throw std::runtime_error("Unknown message descriptor."); 
+          default:
+            throw std::runtime_error("Unknown message descriptor.");
         }
       }
     };
@@ -761,9 +761,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     os << std::endl << "    Body: [" << std::endl;
     switch (message.BodyType)
     {
-      case MessageBodyType::Invalid: 
-        os << "        Invalid"; 
-        break; 
+      case MessageBodyType::Invalid:
+        os << "        Invalid";
+        break;
       case MessageBodyType::None:
         os << "        None";
         break;

--- a/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
@@ -217,10 +217,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
             rv.BodyType = MessageBodyType::Value;
           }
           break;
-          case MESSAGE_BODY_TYPE_INVALID: // LCOV_EXCL_LINE
-            throw std::runtime_error("Invalid message body type."); // LCOV_EXCL_LINE
-          default: // LCOV_EXCL_LINE
-            throw std::runtime_error("Unknown body type."); // LCOV_EXCL_LINE
+          case MESSAGE_BODY_TYPE_INVALID: 
+            throw std::runtime_error("Invalid message body type."); 
+          default: 
+            throw std::runtime_error("Unknown body type."); 
         }
       }
     }
@@ -323,9 +323,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
           throw std::runtime_error("Could not set message body AMQP value.");
         }
         break;
-      case MessageBodyType::Invalid: // LCOV_EXCL_LINE
-      default: // LCOV_EXCL_LINE
-        throw std::runtime_error("Unknown message body type."); // LCOV_EXCL_LINE
+      case MessageBodyType::Invalid: 
+      default: 
+        throw std::runtime_error("Unknown message body type."); 
     }
     return rv;
   }
@@ -701,8 +701,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
           case AmqpDescriptors::Footer:
             m_decodedValue.Footer = describedType.GetValue().AsMap();
             break;
-          default: // LCOV_EXCL_LINE
-            throw std::runtime_error("Unknown message descriptor."); // LCOV_EXCL_LINE
+          default: 
+            throw std::runtime_error("Unknown message descriptor."); 
         }
       }
     };
@@ -761,9 +761,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     os << std::endl << "    Body: [" << std::endl;
     switch (message.BodyType)
     {
-      case MessageBodyType::Invalid: // LCOV_EXCL_LINE
-        os << "        Invalid"; // LCOV_EXCL_LINE
-        break; // LCOV_EXCL_LINE
+      case MessageBodyType::Invalid: 
+        os << "        Invalid"; 
+        break; 
       case MessageBodyType::None:
         os << "        None";
         break;

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -119,14 +119,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_message_id(returnValue.get(), properties.MessageId.Value()))
       {
-        throw std::runtime_error("Could not set message id"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set message id"); 
       }
     }
     if (properties.CorrelationId.HasValue())
     {
       if (properties_set_correlation_id(returnValue.get(), properties.CorrelationId.Value()))
       {
-        throw std::runtime_error("Could not set correlation id"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set correlation id"); 
       }
     }
 
@@ -137,7 +137,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
           static_cast<uint32_t>(properties.UserId.Value().size())};
       if (properties_set_user_id(returnValue.get(), value))
       {
-        throw std::runtime_error("Could not set user id"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set user id"); 
       }
     }
 
@@ -145,7 +145,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_to(returnValue.get(), properties.To.Value()))
       {
-        throw std::runtime_error("Could not set to"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set to"); 
       }
     }
 
@@ -161,7 +161,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_reply_to(returnValue.get(), properties.ReplyTo.Value()))
       {
-        throw std::runtime_error("Could not set reply to"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set reply to"); 
       }
     }
 
@@ -169,7 +169,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_content_type(returnValue.get(), properties.ContentType.Value().data()))
       {
-        throw std::runtime_error("Could not set content type"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set content type"); 
       }
     }
 
@@ -189,7 +189,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
       if (properties_set_absolute_expiry_time(returnValue.get(), timeStamp.count()))
       {
-        throw std::runtime_error("Could not set absolute expiry time"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set absolute expiry time"); 
       }
     }
 
@@ -200,7 +200,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
       if (properties_set_creation_time(returnValue.get(), timeStamp.count()))
       {
-        throw std::runtime_error("Could not set absolute expiry time"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set absolute expiry time"); 
       }
     }
 
@@ -208,7 +208,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_group_id(returnValue.get(), properties.GroupId.Value().data()))
       {
-        throw std::runtime_error("Could not set group id"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set group id"); 
       }
     }
 
@@ -216,7 +216,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_group_sequence(returnValue.get(), properties.GroupSequence.Value()))
       {
-        throw std::runtime_error("Could not set group sequence"); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set group sequence"); 
       }
     }
 

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -119,14 +119,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_message_id(returnValue.get(), properties.MessageId.Value()))
       {
-        throw std::runtime_error("Could not set message id"); 
+        throw std::runtime_error("Could not set message id");
       }
     }
     if (properties.CorrelationId.HasValue())
     {
       if (properties_set_correlation_id(returnValue.get(), properties.CorrelationId.Value()))
       {
-        throw std::runtime_error("Could not set correlation id"); 
+        throw std::runtime_error("Could not set correlation id");
       }
     }
 
@@ -137,7 +137,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
           static_cast<uint32_t>(properties.UserId.Value().size())};
       if (properties_set_user_id(returnValue.get(), value))
       {
-        throw std::runtime_error("Could not set user id"); 
+        throw std::runtime_error("Could not set user id");
       }
     }
 
@@ -145,7 +145,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_to(returnValue.get(), properties.To.Value()))
       {
-        throw std::runtime_error("Could not set to"); 
+        throw std::runtime_error("Could not set to");
       }
     }
 
@@ -161,7 +161,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_reply_to(returnValue.get(), properties.ReplyTo.Value()))
       {
-        throw std::runtime_error("Could not set reply to"); 
+        throw std::runtime_error("Could not set reply to");
       }
     }
 
@@ -169,7 +169,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_content_type(returnValue.get(), properties.ContentType.Value().data()))
       {
-        throw std::runtime_error("Could not set content type"); 
+        throw std::runtime_error("Could not set content type");
       }
     }
 
@@ -189,7 +189,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
       if (properties_set_absolute_expiry_time(returnValue.get(), timeStamp.count()))
       {
-        throw std::runtime_error("Could not set absolute expiry time"); 
+        throw std::runtime_error("Could not set absolute expiry time");
       }
     }
 
@@ -200,7 +200,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
       if (properties_set_creation_time(returnValue.get(), timeStamp.count()))
       {
-        throw std::runtime_error("Could not set absolute expiry time"); 
+        throw std::runtime_error("Could not set absolute expiry time");
       }
     }
 
@@ -208,7 +208,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_group_id(returnValue.get(), properties.GroupId.Value().data()))
       {
-        throw std::runtime_error("Could not set group id"); 
+        throw std::runtime_error("Could not set group id");
       }
     }
 
@@ -216,7 +216,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_group_sequence(returnValue.get(), properties.GroupSequence.Value()))
       {
-        throw std::runtime_error("Could not set group sequence"); 
+        throw std::runtime_error("Could not set group sequence");
       }
     }
 

--- a/sdk/core/azure-core-amqp/src/models/message_source.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_source.cpp
@@ -48,11 +48,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
   {
     if (m_source == nullptr)
     {
-      throw std::runtime_error("Could not create source."); 
+      throw std::runtime_error("Could not create source.");
     }
     if (source_set_address(m_source.get(), AmqpValue{address}))
     {
-      throw std::runtime_error("Could not set address."); 
+      throw std::runtime_error("Could not set address.");
     }
   }
 
@@ -64,11 +64,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
   {
     if (m_source == nullptr)
     {
-      throw std::runtime_error("Could not create source."); 
+      throw std::runtime_error("Could not create source.");
     }
     if (source_set_address(m_source.get(), AmqpValue{address}))
     {
-      throw std::runtime_error("Could not set address."); 
+      throw std::runtime_error("Could not set address.");
     }
   }
 
@@ -91,7 +91,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     {
       if (source_set_address(m_source.get(), options.Address))
       {
-        throw std::runtime_error("Could not set source address."); 
+        throw std::runtime_error("Could not set source address.");
       }
     }
     if (options.SourceTerminusDurability.HasValue())
@@ -108,12 +108,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         case TerminusDurability::UnsettledState:
           durability = terminus_durability_unsettled_state;
           break;
-        default: 
-          throw std::logic_error("Unknown terminus durability."); 
+        default:
+          throw std::logic_error("Unknown terminus durability.");
       }
       if (source_set_durable(m_source.get(), durability))
       {
-        throw std::runtime_error("Could not set durable."); 
+        throw std::runtime_error("Could not set durable.");
       }
     }
     if (options.SourceTerminusExpiryPolicy.HasValue())
@@ -133,12 +133,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         case TerminusExpiryPolicy::Never:
           policy = terminus_expiry_policy_never;
           break;
-        default: 
-          throw std::logic_error("Unknown terminus durability."); 
+        default:
+          throw std::logic_error("Unknown terminus durability.");
       }
       if (source_set_expiry_policy(m_source.get(), policy))
       {
-        throw std::runtime_error("Could not set durable."); 
+        throw std::runtime_error("Could not set durable.");
       }
     }
     if (options.Timeout.HasValue())
@@ -156,7 +156,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     {
       if (source_set_dynamic(m_source.get(), *options.Dynamic))
       {
-        throw std::runtime_error("Could not set dynamic."); 
+        throw std::runtime_error("Could not set dynamic.");
       }
     }
     if (!options.DynamicNodeProperties.empty())
@@ -165,7 +165,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
               m_source.get(),
               static_cast<_detail::UniqueAmqpValueHandle>(options.DynamicNodeProperties).get()))
       {
-        throw std::runtime_error("Could not set dynamic node properties."); 
+        throw std::runtime_error("Could not set dynamic node properties.");
       }
     }
     if (options.DistributionMode.HasValue())
@@ -180,7 +180,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       if (source_set_filter(
               m_source.get(), static_cast<_detail::UniqueAmqpValueHandle>(options.Filter).get()))
       {
-        throw std::runtime_error("Could not set filter set."); 
+        throw std::runtime_error("Could not set filter set.");
       }
     }
     if (!options.DefaultOutcome.IsNull())
@@ -195,7 +195,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       if (source_set_outcomes(
               m_source.get(), static_cast<_detail::UniqueAmqpValueHandle>(options.Outcomes).get()))
       {
-        throw std::runtime_error("Could not set outcomes."); 
+        throw std::runtime_error("Could not set outcomes.");
       }
     }
     if (!options.Capabilities.empty())
@@ -230,7 +230,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     terminus_durability value;
     if (source_get_durable(m_source.get(), &value))
     {
-      throw std::runtime_error("Could not get durable from source."); 
+      throw std::runtime_error("Could not get durable from source.");
     }
     switch (value)
     {
@@ -250,7 +250,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     terminus_expiry_policy value;
     if (source_get_expiry_policy(m_source.get(), &value))
     {
-      throw std::runtime_error("Could not get expiry policy from source."); 
+      throw std::runtime_error("Could not get expiry policy from source.");
     }
     if (std::strcmp(value, terminus_expiry_policy_connection_close) == 0)
     {
@@ -268,8 +268,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     {
       return TerminusExpiryPolicy::SessionEnd;
     }
-    throw std::logic_error( 
-        std::string("Unknown terminus expiry policy: ") + value); 
+    throw std::logic_error(std::string("Unknown terminus expiry policy: ") + value);
   }
 
   std::chrono::system_clock::time_point MessageSource::GetTimeout() const
@@ -361,7 +360,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       case TerminusDurability::UnsettledState:
         return "Unsettled State";
     }
-    throw std::runtime_error("Unknown terminus durability"); 
+    throw std::runtime_error("Unknown terminus durability");
   }
 
   std::ostream& operator<<(std::ostream& os, MessageSource const& source)

--- a/sdk/core/azure-core-amqp/src/models/message_source.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_source.cpp
@@ -48,11 +48,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
   {
     if (m_source == nullptr)
     {
-      throw std::runtime_error("Could not create source."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not create source."); 
     }
     if (source_set_address(m_source.get(), AmqpValue{address}))
     {
-      throw std::runtime_error("Could not set address."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set address."); 
     }
   }
 
@@ -64,11 +64,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
   {
     if (m_source == nullptr)
     {
-      throw std::runtime_error("Could not create source."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not create source."); 
     }
     if (source_set_address(m_source.get(), AmqpValue{address}))
     {
-      throw std::runtime_error("Could not set address."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set address."); 
     }
   }
 
@@ -91,7 +91,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     {
       if (source_set_address(m_source.get(), options.Address))
       {
-        throw std::runtime_error("Could not set source address."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set source address."); 
       }
     }
     if (options.SourceTerminusDurability.HasValue())
@@ -108,12 +108,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         case TerminusDurability::UnsettledState:
           durability = terminus_durability_unsettled_state;
           break;
-        default: // LCOV_EXCL_LINE
-          throw std::logic_error("Unknown terminus durability."); // LCOV_EXCL_LINE
+        default: 
+          throw std::logic_error("Unknown terminus durability."); 
       }
       if (source_set_durable(m_source.get(), durability))
       {
-        throw std::runtime_error("Could not set durable."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set durable."); 
       }
     }
     if (options.SourceTerminusExpiryPolicy.HasValue())
@@ -133,12 +133,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         case TerminusExpiryPolicy::Never:
           policy = terminus_expiry_policy_never;
           break;
-        default: // LCOV_EXCL_LINE
-          throw std::logic_error("Unknown terminus durability."); // LCOV_EXCL_LINE
+        default: 
+          throw std::logic_error("Unknown terminus durability."); 
       }
       if (source_set_expiry_policy(m_source.get(), policy))
       {
-        throw std::runtime_error("Could not set durable."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set durable."); 
       }
     }
     if (options.Timeout.HasValue())
@@ -156,7 +156,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     {
       if (source_set_dynamic(m_source.get(), *options.Dynamic))
       {
-        throw std::runtime_error("Could not set dynamic."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set dynamic."); 
       }
     }
     if (!options.DynamicNodeProperties.empty())
@@ -165,7 +165,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
               m_source.get(),
               static_cast<_detail::UniqueAmqpValueHandle>(options.DynamicNodeProperties).get()))
       {
-        throw std::runtime_error("Could not set dynamic node properties."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set dynamic node properties."); 
       }
     }
     if (options.DistributionMode.HasValue())
@@ -180,7 +180,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       if (source_set_filter(
               m_source.get(), static_cast<_detail::UniqueAmqpValueHandle>(options.Filter).get()))
       {
-        throw std::runtime_error("Could not set filter set."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set filter set."); 
       }
     }
     if (!options.DefaultOutcome.IsNull())
@@ -195,7 +195,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       if (source_set_outcomes(
               m_source.get(), static_cast<_detail::UniqueAmqpValueHandle>(options.Outcomes).get()))
       {
-        throw std::runtime_error("Could not set outcomes."); // LCOV_EXCL_LINE
+        throw std::runtime_error("Could not set outcomes."); 
       }
     }
     if (!options.Capabilities.empty())
@@ -230,7 +230,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     terminus_durability value;
     if (source_get_durable(m_source.get(), &value))
     {
-      throw std::runtime_error("Could not get durable from source."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get durable from source."); 
     }
     switch (value)
     {
@@ -250,7 +250,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     terminus_expiry_policy value;
     if (source_get_expiry_policy(m_source.get(), &value))
     {
-      throw std::runtime_error("Could not get expiry policy from source."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get expiry policy from source."); 
     }
     if (std::strcmp(value, terminus_expiry_policy_connection_close) == 0)
     {
@@ -268,8 +268,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     {
       return TerminusExpiryPolicy::SessionEnd;
     }
-    throw std::logic_error( // LCOV_EXCL_LINE
-        std::string("Unknown terminus expiry policy: ") + value); // LCOV_EXCL_LINE
+    throw std::logic_error( 
+        std::string("Unknown terminus expiry policy: ") + value); 
   }
 
   std::chrono::system_clock::time_point MessageSource::GetTimeout() const
@@ -361,7 +361,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       case TerminusDurability::UnsettledState:
         return "Unsettled State";
     }
-    throw std::runtime_error("Unknown terminus durability"); // LCOV_EXCL_LINE
+    throw std::runtime_error("Unknown terminus durability"); 
   }
 
   std::ostream& operator<<(std::ostream& os, MessageSource const& source)

--- a/sdk/core/azure-core-amqp/src/models/message_target.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_target.cpp
@@ -44,22 +44,22 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
   {
     if (m_target == nullptr)
     {
-      throw std::runtime_error("Could not create source."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not create source."); 
     }
     if (target_set_address(m_target.get(), AmqpValue{address}))
     {
-      throw std::runtime_error("Could not set address."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set address."); 
     }
   }
   MessageTarget::MessageTarget(char const* address) : m_target{target_create()}
   {
     if (m_target == nullptr)
     {
-      throw std::runtime_error("Could not create source."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not create source."); 
     }
     if (target_set_address(m_target.get(), AmqpValue{address}))
     {
-      throw std::runtime_error("Could not set address."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not set address."); 
     }
   }
 
@@ -96,8 +96,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         case TerminusDurability::UnsettledState:
           durability = terminus_durability_unsettled_state;
           break;
-        default: // LCOV_EXCL_LINE
-          throw std::logic_error("Unknown terminus durability."); // LCOV_EXCL_LINE
+        default: 
+          throw std::logic_error("Unknown terminus durability."); 
       }
       if (target_set_durable(m_target.get(), durability))
       {
@@ -121,8 +121,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         case TerminusExpiryPolicy::Never:
           policy = terminus_expiry_policy_never;
           break;
-        default: // LCOV_EXCL_LINE
-          throw std::logic_error("Unknown terminus durability."); // LCOV_EXCL_LINE
+        default: 
+          throw std::logic_error("Unknown terminus durability."); 
       }
       if (target_set_expiry_policy(m_target.get(), policy))
       {
@@ -210,7 +210,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     terminus_expiry_policy value;
     if (target_get_expiry_policy(m_target.get(), &value))
     {
-      throw std::runtime_error("Could not get expiry policy from target."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Could not get expiry policy from target."); 
     }
     if (std::strcmp(value, terminus_expiry_policy_connection_close) == 0)
     {
@@ -229,7 +229,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       return TerminusExpiryPolicy::SessionEnd;
     }
     throw std::logic_error(
-        std::string("Unknown terminus expiry policy: ") + value); // LCOV_EXCL_LINE
+        std::string("Unknown terminus expiry policy: ") + value); 
   }
 
   std::chrono::system_clock::time_point MessageTarget::GetTimeout() const

--- a/sdk/core/azure-core-amqp/src/models/message_target.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_target.cpp
@@ -44,22 +44,22 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
   {
     if (m_target == nullptr)
     {
-      throw std::runtime_error("Could not create source."); 
+      throw std::runtime_error("Could not create source.");
     }
     if (target_set_address(m_target.get(), AmqpValue{address}))
     {
-      throw std::runtime_error("Could not set address."); 
+      throw std::runtime_error("Could not set address.");
     }
   }
   MessageTarget::MessageTarget(char const* address) : m_target{target_create()}
   {
     if (m_target == nullptr)
     {
-      throw std::runtime_error("Could not create source."); 
+      throw std::runtime_error("Could not create source.");
     }
     if (target_set_address(m_target.get(), AmqpValue{address}))
     {
-      throw std::runtime_error("Could not set address."); 
+      throw std::runtime_error("Could not set address.");
     }
   }
 
@@ -96,8 +96,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         case TerminusDurability::UnsettledState:
           durability = terminus_durability_unsettled_state;
           break;
-        default: 
-          throw std::logic_error("Unknown terminus durability."); 
+        default:
+          throw std::logic_error("Unknown terminus durability.");
       }
       if (target_set_durable(m_target.get(), durability))
       {
@@ -121,8 +121,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         case TerminusExpiryPolicy::Never:
           policy = terminus_expiry_policy_never;
           break;
-        default: 
-          throw std::logic_error("Unknown terminus durability."); 
+        default:
+          throw std::logic_error("Unknown terminus durability.");
       }
       if (target_set_expiry_policy(m_target.get(), policy))
       {
@@ -210,7 +210,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     terminus_expiry_policy value;
     if (target_get_expiry_policy(m_target.get(), &value))
     {
-      throw std::runtime_error("Could not get expiry policy from target."); 
+      throw std::runtime_error("Could not get expiry policy from target.");
     }
     if (std::strcmp(value, terminus_expiry_policy_connection_close) == 0)
     {
@@ -228,8 +228,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     {
       return TerminusExpiryPolicy::SessionEnd;
     }
-    throw std::logic_error(
-        std::string("Unknown terminus expiry policy: ") + value); 
+    throw std::logic_error(std::string("Unknown terminus expiry policy: ") + value);
   }
 
   std::chrono::system_clock::time_point MessageTarget::GetTimeout() const

--- a/sdk/core/azure-core-amqp/src/network/sasl_transport.cpp
+++ b/sdk/core/azure-core-amqp/src/network/sasl_transport.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
 #include "azure/core/amqp/network/sasl_transport.hpp"
 
 #include "azure/core/amqp/network/tls_transport.hpp"
@@ -82,4 +81,3 @@ Azure::Core::Amqp::Network::_internal::SaslTransportFactory::Create(
   return _detail::TransportImpl::CreateFromXioHandle(
       xio_create(saslclientio_get_interface_description(), &saslConfig), eventHandler);
 }
-

--- a/sdk/core/azure-core-amqp/src/network/sasl_transport.cpp
+++ b/sdk/core/azure-core-amqp/src/network/sasl_transport.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// LCOV_EXCL_START
+
 #include "azure/core/amqp/network/sasl_transport.hpp"
 
 #include "azure/core/amqp/network/tls_transport.hpp"
@@ -82,4 +82,4 @@ Azure::Core::Amqp::Network::_internal::SaslTransportFactory::Create(
   return _detail::TransportImpl::CreateFromXioHandle(
       xio_create(saslclientio_get_interface_description(), &saslConfig), eventHandler);
 }
-// LCOV_EXCL_STOP
+

--- a/sdk/core/azure-core-amqp/src/network/transport.cpp
+++ b/sdk/core/azure-core-amqp/src/network/transport.cpp
@@ -103,7 +103,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
         Network::_internal::TransportOpenStatus::Error};
     switch (ioOpenResult)
     {
-        // LCOV_EXCL_START
+        
       case IO_OPEN_RESULT_INVALID:
         openResult = Network::_internal::TransportOpenStatus::Invalid;
         break;
@@ -113,7 +113,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
       case IO_OPEN_ERROR:
         openResult = Network::_internal::TransportOpenStatus::Error;
         break;
-        // LCOV_EXCL_STOP
+        
       case IO_OPEN_OK:
         openResult = Network::_internal::TransportOpenStatus::Ok;
         break;
@@ -130,7 +130,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
     }
   }
 
-  // LCOV_EXCL_START
+  
   void TransportImpl::OnIOErrorFn(void* context)
   {
     TransportImpl* transport = reinterpret_cast<TransportImpl*>(context);
@@ -140,7 +140,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
       transport->m_eventHandler->OnIOError();
     }
   }
-  // LCOV_EXCL_STOP
+  
 
   _internal::TransportOpenStatus TransportImpl::Open(Context const& context)
   {
@@ -175,7 +175,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
       Network::_internal::TransportSendStatus result{Network::_internal::TransportSendStatus::Ok};
       switch (sendResult)
       {
-          // LCOV_EXCL_START
+          
         case IO_SEND_RESULT_INVALID:
           result = Network::_internal::TransportSendStatus::Invalid;
           break;
@@ -185,7 +185,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
         case IO_SEND_ERROR:
           result = Network::_internal::TransportSendStatus::Error;
           break;
-          // LCOV_EXCL_STOP
+          
         case IO_SEND_OK:
           result = Network::_internal::TransportSendStatus::Ok;
           break;

--- a/sdk/core/azure-core-amqp/src/network/transport.cpp
+++ b/sdk/core/azure-core-amqp/src/network/transport.cpp
@@ -103,7 +103,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
         Network::_internal::TransportOpenStatus::Error};
     switch (ioOpenResult)
     {
-        
+
       case IO_OPEN_RESULT_INVALID:
         openResult = Network::_internal::TransportOpenStatus::Invalid;
         break;
@@ -113,7 +113,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
       case IO_OPEN_ERROR:
         openResult = Network::_internal::TransportOpenStatus::Error;
         break;
-        
+
       case IO_OPEN_OK:
         openResult = Network::_internal::TransportOpenStatus::Ok;
         break;
@@ -130,7 +130,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
     }
   }
 
-  
   void TransportImpl::OnIOErrorFn(void* context)
   {
     TransportImpl* transport = reinterpret_cast<TransportImpl*>(context);
@@ -140,7 +139,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
       transport->m_eventHandler->OnIOError();
     }
   }
-  
 
   _internal::TransportOpenStatus TransportImpl::Open(Context const& context)
   {
@@ -175,7 +173,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
       Network::_internal::TransportSendStatus result{Network::_internal::TransportSendStatus::Ok};
       switch (sendResult)
       {
-          
+
         case IO_SEND_RESULT_INVALID:
           result = Network::_internal::TransportSendStatus::Invalid;
           break;
@@ -185,7 +183,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Network { namespac
         case IO_SEND_ERROR:
           result = Network::_internal::TransportSendStatus::Error;
           break;
-          
+
         case IO_SEND_OK:
           result = Network::_internal::TransportSendStatus::Ok;
           break;

--- a/sdk/core/azure-core/src/azure_assert.cpp
+++ b/sdk/core/azure-core/src/azure_assert.cpp
@@ -4,7 +4,6 @@
 #include "azure/core/azure_assert.hpp"
 
 // Calling this function would terminate program, therefore this function can't be covered in tests.
-// LCOV_EXCL_START
 [[noreturn]] void Azure::Core::_internal::AzureNoReturnPath(std::string const& msg)
 {
   // void msg for Release build where Assert is ignored
@@ -12,4 +11,3 @@
   AZURE_ASSERT_MSG(false, msg);
   std::abort();
 }
-// LCOV_EXCL_STOP

--- a/sdk/core/azure-core/src/cryptography/md5.cpp
+++ b/sdk/core/azure-core/src/cryptography/md5.cpp
@@ -167,7 +167,7 @@ private:
   {
     if (1 != EVP_DigestUpdate(m_context, data, length))
     {
-      throw std::runtime_error("Crypto error while updating Md5Hash."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Crypto error while updating Md5Hash.");
     }
   }
 
@@ -178,7 +178,7 @@ private:
     unsigned char hash[EVP_MAX_MD_SIZE];
     if (1 != EVP_DigestFinal(m_context, hash, &size))
     {
-      throw std::runtime_error("Crypto error while computing Md5Hash."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Crypto error while computing Md5Hash.");
     }
 
     return std::vector<uint8_t>(std::begin(hash), std::begin(hash) + size);
@@ -194,7 +194,7 @@ public:
     }
     if (1 != EVP_DigestInit_ex(m_context, EVP_md5(), NULL))
     {
-      throw std::runtime_error("Crypto error while init Md5Hash."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Crypto error while init Md5Hash.");
     }
   }
 

--- a/sdk/core/azure-core/src/cryptography/sha_hash.cpp
+++ b/sdk/core/azure-core/src/cryptography/sha_hash.cpp
@@ -83,20 +83,20 @@ public:
       case SHASize::SHA384: {
         if (1 != EVP_DigestInit_ex(m_context, EVP_sha384(), NULL))
         {
-          throw std::runtime_error("Crypto error while init Sha384Hash."); 
+          throw std::runtime_error("Crypto error while init Sha384Hash.");
         }
         break;
       }
       case SHASize::SHA512: {
         if (1 != EVP_DigestInit_ex(m_context, EVP_sha512(), NULL))
         {
-          throw std::runtime_error("Crypto error while init Sha512Hash."); 
+          throw std::runtime_error("Crypto error while init Sha512Hash.");
         }
         break;
       }
       default:
         // imposible to get here
-        AZURE_UNREACHABLE_CODE(); 
+        AZURE_UNREACHABLE_CODE();
     }
   }
 

--- a/sdk/core/azure-core/src/cryptography/sha_hash.cpp
+++ b/sdk/core/azure-core/src/cryptography/sha_hash.cpp
@@ -44,7 +44,7 @@ private:
     unsigned char finalHash[EVP_MAX_MD_SIZE];
     if (1 != EVP_DigestFinal(m_context, finalHash, &size))
     {
-      throw std::runtime_error("Crypto error while computing Sha256Hash."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Crypto error while computing Sha256Hash.");
     }
     return std::vector<uint8_t>(std::begin(finalHash), std::begin(finalHash) + size);
   }
@@ -53,7 +53,7 @@ private:
   {
     if (1 != EVP_DigestUpdate(m_context, data, length))
     {
-      throw std::runtime_error("Crypto error while updating Sha256Hash."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Crypto error while updating Sha256Hash.");
     }
   }
 
@@ -62,41 +62,41 @@ public:
   {
     if ((m_context = EVP_MD_CTX_new()) == NULL)
     {
-      throw std::runtime_error("Crypto error while creating EVP context."); // LCOV_EXCL_LINE
+      throw std::runtime_error("Crypto error while creating EVP context.");
     }
     switch (size)
     {
       case SHASize::SHA1: {
         if (1 != EVP_DigestInit_ex(m_context, EVP_sha1(), NULL))
         {
-          throw std::runtime_error("Crypto error while initializing Sha1Hash."); // LCOV_EXCL_LINE
+          throw std::runtime_error("Crypto error while initializing Sha1Hash.");
         }
         break;
       }
       case SHASize::SHA256: {
         if (1 != EVP_DigestInit_ex(m_context, EVP_sha256(), NULL))
         {
-          throw std::runtime_error("Crypto error while init Sha256Hash."); // LCOV_EXCL_LINE
+          throw std::runtime_error("Crypto error while init Sha256Hash.");
         }
         break;
       }
       case SHASize::SHA384: {
         if (1 != EVP_DigestInit_ex(m_context, EVP_sha384(), NULL))
         {
-          throw std::runtime_error("Crypto error while init Sha384Hash."); // LCOV_EXCL_LINE
+          throw std::runtime_error("Crypto error while init Sha384Hash."); 
         }
         break;
       }
       case SHASize::SHA512: {
         if (1 != EVP_DigestInit_ex(m_context, EVP_sha512(), NULL))
         {
-          throw std::runtime_error("Crypto error while init Sha512Hash."); // LCOV_EXCL_LINE
+          throw std::runtime_error("Crypto error while init Sha512Hash."); 
         }
         break;
       }
       default:
         // imposible to get here
-        AZURE_UNREACHABLE_CODE(); // LCOV_EXCL_LINE
+        AZURE_UNREACHABLE_CODE(); 
     }
   }
 

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -346,7 +346,7 @@ T ParseNumber(
 
   // ThrowParseError() will always throw, but there's no way to tell that to compiler, so a return
   // statement is required. It is not possible to cover the return line with tests.
-  return T(); // LCOV_EXCL_LINE
+  return T(); 
 }
 
 template <typename T>

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -299,7 +299,7 @@ int8_t SubstringEqualsAny(
   return -1;
 }
 
-void ThrowParseError(char const* description)
+[[noreturn]] void ThrowParseError(char const* description)
 {
   throw std::invalid_argument(std::string("Error parsing DateTime: ") + description + ".");
 }
@@ -343,10 +343,6 @@ T ParseNumber(
   }
 
   ThrowParseError(description);
-
-  // ThrowParseError() will always throw, but there's no way to tell that to compiler, so a return
-  // statement is required. It is not possible to cover the return line with tests.
-  return T();
 }
 
 template <typename T>

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -346,7 +346,7 @@ T ParseNumber(
 
   // ThrowParseError() will always throw, but there's no way to tell that to compiler, so a return
   // statement is required. It is not possible to cover the return line with tests.
-  return T(); 
+  return T();
 }
 
 template <typename T>

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -1205,7 +1205,7 @@ size_t CurlSession::ResponseBufferParser::Parse(
         {
           // Should never happen that parser is not statusLIne or Headers and we still try
           // to parse more.
-          AZURE_UNREACHABLE_CODE(); 
+          AZURE_UNREACHABLE_CODE();
         }
         // clean internal buffer
         this->m_internalBuffer.clear();
@@ -1243,7 +1243,7 @@ size_t CurlSession::ResponseBufferParser::Parse(
         {
           // Should never happen that parser is not statusLIne or Headers and we still try
           // to parse more.
-          AZURE_UNREACHABLE_CODE(); 
+          AZURE_UNREACHABLE_CODE();
         }
       }
     }
@@ -1463,7 +1463,7 @@ namespace Azure { namespace Core {
 
       // Disable Code Coverage across GetOpenSSLError because we don't have a good way of forcing
       // OpenSSL to fail.
-      
+
       std::string GetOpenSSLError(std::string const& what)
       {
         auto bio(Azure::Core::_internal::MakeUniqueHandle(BIO_new, BIO_s_mem()));
@@ -1486,7 +1486,6 @@ namespace Azure { namespace Core {
 
         return returnValue;
       }
-      
 
     } // namespace _detail
 

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -1205,7 +1205,7 @@ size_t CurlSession::ResponseBufferParser::Parse(
         {
           // Should never happen that parser is not statusLIne or Headers and we still try
           // to parse more.
-          AZURE_UNREACHABLE_CODE(); // LCOV_EXCL_LINE
+          AZURE_UNREACHABLE_CODE(); 
         }
         // clean internal buffer
         this->m_internalBuffer.clear();
@@ -1243,7 +1243,7 @@ size_t CurlSession::ResponseBufferParser::Parse(
         {
           // Should never happen that parser is not statusLIne or Headers and we still try
           // to parse more.
-          AZURE_UNREACHABLE_CODE(); // LCOV_EXCL_LINE
+          AZURE_UNREACHABLE_CODE(); 
         }
       }
     }
@@ -1463,7 +1463,7 @@ namespace Azure { namespace Core {
 
       // Disable Code Coverage across GetOpenSSLError because we don't have a good way of forcing
       // OpenSSL to fail.
-      // LCOV_EXCL_START
+      
       std::string GetOpenSSLError(std::string const& what)
       {
         auto bio(Azure::Core::_internal::MakeUniqueHandle(BIO_new, BIO_s_mem()));
@@ -1486,7 +1486,7 @@ namespace Azure { namespace Core {
 
         return returnValue;
       }
-      // LCOV_EXCL_STOP
+      
 
     } // namespace _detail
 

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 
 add_executable (
   azure-core-test
+    assert_test.cpp
     authorization_challenge_parser_test.cpp
     azure_core_test.cpp
     base64_test.cpp
@@ -94,7 +95,7 @@ add_executable (
     transport_policy_options.cpp
     url_test.cpp
     uuid_test.cpp
-  )
+)
 
 if (MSVC)
   # Disable warnings:

--- a/sdk/core/azure-core/test/ut/assert_test.cpp
+++ b/sdk/core/azure-core/test/ut/assert_test.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <azure/core/azure_assert.hpp>
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+TEST(TestAssert, AssertTest) { EXPECT_DEATH(AZURE_ASSERT(false), ".*"); }
+
+TEST(TestAssert, NoReturnPathTest)
+{
+  EXPECT_DEATH(Azure::Core::_internal::AzureNoReturnPath("Test"), ".*");
+}

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -50,7 +50,7 @@ stages:
       CtestRegex: azure-core.|json-test
       LiveTestCtestRegex: azure-core.|json-test
       LiveTestTimeoutInMinutes: 90 # default is 60 min. We need a little longer on worst case for Win+jsonTests
-      LineCoverageTarget: 91
+      LineCoverageTarget: 87
       BranchCoverageTarget: 50
 #      PreTestSteps:
 #        - pwsh: |

--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -313,7 +313,7 @@ std::string RunShellCommand(
 #if !defined(WINAPI_PARTITION_DESKTOP) || WINAPI_PARTITION_DESKTOP // not UWP
 void ThrowIfApiCallFails(BOOL apiResult, std::string const& errMsg)
 {
-  
+
   if (!apiResult)
   {
     throw std::runtime_error(
@@ -321,19 +321,17 @@ void ThrowIfApiCallFails(BOOL apiResult, std::string const& errMsg)
 
     );
   }
-  
 }
 #endif // not UWP
 #else // not Windows
 void ThrowIfApiCallFails(int apiResult, std::string const& errMsg)
 {
-  
+
   if (apiResult != 0)
   {
     throw std::runtime_error(
         errMsg + ": " + std::to_string(apiResult) + " (errno: " + std::to_string(errno) + ")");
   }
-  
 }
 #endif
 
@@ -393,7 +391,7 @@ void AppendToEnvironmentValuesIfNotEmpty(
     std::string const& envVarName,
     std::string const& value)
 {
-  if (!value.empty()) 
+  if (!value.empty())
   {
     auto const envVarStatement = envVarName + "=" + value;
 
@@ -427,12 +425,10 @@ void EnsureShellExists(std::string const& pathToShell)
 {
   auto file = std::fopen(pathToShell.c_str(), "r");
 
-  
   if (!file)
   {
     throw std::runtime_error("Cannot locate command line shell.");
   }
-  
 
   std::fclose(file);
 }
@@ -473,9 +469,9 @@ ShellProcess::ShellProcess(std::string const& command, OutputPipe& outputPipe)
              {Environment::GetVariable("ProgramFiles"),
               Environment::GetVariable("ProgramFiles(x86)")})
         {
-          if (!pf.empty()) 
+          if (!pf.empty())
           {
-            if (!pathValue.empty()) 
+            if (!pathValue.empty())
             {
               pathValue += ";";
             }
@@ -500,7 +496,7 @@ ShellProcess::ShellProcess(std::string const& command, OutputPipe& outputPipe)
       // user did log in.
       AppendToEnvironmentValuesIfDefined(environmentValues, "USERPROFILE");
 
-      if (!environmentValues.empty()) 
+      if (!environmentValues.empty())
       {
         environmentValues.push_back('\0'); // terminate the block
         lpEnvironment = environmentValues.data();
@@ -609,14 +605,12 @@ ShellProcess::ShellProcess(std::string const& command, OutputPipe& outputPipe)
     auto const spawnResult
         = posix_spawn(&m_pid, m_argv[0], &m_actions, NULL, m_argv.data(), m_envp.data());
 
-    
     if (spawnResult != 0)
     {
       m_pid = -1;
       Finalize();
       ThrowIfApiCallFails(spawnResult, "Cannot spawn process");
     }
-    
   }
 
   close(outputPipe.m_fd[1]);

--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -313,7 +313,7 @@ std::string RunShellCommand(
 #if !defined(WINAPI_PARTITION_DESKTOP) || WINAPI_PARTITION_DESKTOP // not UWP
 void ThrowIfApiCallFails(BOOL apiResult, std::string const& errMsg)
 {
-  // LCOV_EXCL_START
+  
   if (!apiResult)
   {
     throw std::runtime_error(
@@ -321,19 +321,19 @@ void ThrowIfApiCallFails(BOOL apiResult, std::string const& errMsg)
 
     );
   }
-  // LCOV_EXCL_STOP
+  
 }
 #endif // not UWP
 #else // not Windows
 void ThrowIfApiCallFails(int apiResult, std::string const& errMsg)
 {
-  // LCOV_EXCL_START
+  
   if (apiResult != 0)
   {
     throw std::runtime_error(
         errMsg + ": " + std::to_string(apiResult) + " (errno: " + std::to_string(errno) + ")");
   }
-  // LCOV_EXCL_STOP
+  
 }
 #endif
 
@@ -393,7 +393,7 @@ void AppendToEnvironmentValuesIfNotEmpty(
     std::string const& envVarName,
     std::string const& value)
 {
-  if (!value.empty()) // LCOV_EXCL_LINE
+  if (!value.empty()) 
   {
     auto const envVarStatement = envVarName + "=" + value;
 
@@ -427,12 +427,12 @@ void EnsureShellExists(std::string const& pathToShell)
 {
   auto file = std::fopen(pathToShell.c_str(), "r");
 
-  // LCOV_EXCL_START
+  
   if (!file)
   {
     throw std::runtime_error("Cannot locate command line shell.");
   }
-  // LCOV_EXCL_STOP
+  
 
   std::fclose(file);
 }
@@ -473,9 +473,9 @@ ShellProcess::ShellProcess(std::string const& command, OutputPipe& outputPipe)
              {Environment::GetVariable("ProgramFiles"),
               Environment::GetVariable("ProgramFiles(x86)")})
         {
-          if (!pf.empty()) // LCOV_EXCL_LINE
+          if (!pf.empty()) 
           {
-            if (!pathValue.empty()) // LCOV_EXCL_LINE
+            if (!pathValue.empty()) 
             {
               pathValue += ";";
             }
@@ -500,7 +500,7 @@ ShellProcess::ShellProcess(std::string const& command, OutputPipe& outputPipe)
       // user did log in.
       AppendToEnvironmentValuesIfDefined(environmentValues, "USERPROFILE");
 
-      if (!environmentValues.empty()) // LCOV_EXCL_LINE
+      if (!environmentValues.empty()) 
       {
         environmentValues.push_back('\0'); // terminate the block
         lpEnvironment = environmentValues.data();
@@ -609,14 +609,14 @@ ShellProcess::ShellProcess(std::string const& command, OutputPipe& outputPipe)
     auto const spawnResult
         = posix_spawn(&m_pid, m_argv[0], &m_actions, NULL, m_argv.data(), m_envp.data());
 
-    // LCOV_EXCL_START
+    
     if (spawnResult != 0)
     {
       m_pid = -1;
       Finalize();
       ThrowIfApiCallFails(spawnResult, "Cannot spawn process");
     }
-    // LCOV_EXCL_STOP
+    
   }
 
   close(outputPipe.m_fd[1]);

--- a/sdk/identity/azure-identity/src/environment_credential.cpp
+++ b/sdk/identity/azure-identity/src/environment_credential.cpp
@@ -178,9 +178,9 @@ void PrintCredentialCreationLogMessage(
 
   auto const envVarsToParamsSize = envVarsToParams.size();
 
-  // LCOV_EXCL_START
+  
   AZURE_ASSERT(envVarsToParamsSize > 1);
-  // LCOV_EXCL_STOP
+  
 
   constexpr auto Tick = "'";
   constexpr auto Comma = ", ";

--- a/sdk/identity/azure-identity/src/environment_credential.cpp
+++ b/sdk/identity/azure-identity/src/environment_credential.cpp
@@ -178,9 +178,7 @@ void PrintCredentialCreationLogMessage(
 
   auto const envVarsToParamsSize = envVarsToParams.size();
 
-  
   AZURE_ASSERT(envVarsToParamsSize > 1);
-  
 
   constexpr auto Tick = "'";
   constexpr auto Comma = ", ";

--- a/sdk/identity/azure-identity/src/managed_identity_credential.cpp
+++ b/sdk/identity/azure-identity/src/managed_identity_credential.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<_detail::ManagedIdentitySource> CreateManagedIdentitySource(
 
   // IMDS ManagedIdentity, which comes last in the list, will never return nullptr from Create().
   // For that reason, it is not possible to cover that execution branch in tests.
-  for (auto create : managedIdentitySourceCreate) 
+  for (auto create : managedIdentitySourceCreate)
   {
     if (auto source = create(credentialName, clientId, options))
     {
@@ -35,10 +35,8 @@ std::unique_ptr<_detail::ManagedIdentitySource> CreateManagedIdentitySource(
     }
   }
 
-  
   throw AuthenticationException(
       credentialName + " authentication unavailable. No Managed Identity endpoint found.");
-  
 }
 } // namespace
 

--- a/sdk/identity/azure-identity/src/managed_identity_credential.cpp
+++ b/sdk/identity/azure-identity/src/managed_identity_credential.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<_detail::ManagedIdentitySource> CreateManagedIdentitySource(
 
   // IMDS ManagedIdentity, which comes last in the list, will never return nullptr from Create().
   // For that reason, it is not possible to cover that execution branch in tests.
-  for (auto create : managedIdentitySourceCreate) // LCOV_EXCL_LINE
+  for (auto create : managedIdentitySourceCreate) 
   {
     if (auto source = create(credentialName, clientId, options))
     {
@@ -35,10 +35,10 @@ std::unique_ptr<_detail::ManagedIdentitySource> CreateManagedIdentitySource(
     }
   }
 
-  // LCOV_EXCL_START
+  
   throw AuthenticationException(
       credentialName + " authentication unavailable. No Managed Identity endpoint found.");
-  // LCOV_EXCL_STOP
+  
 }
 } // namespace
 

--- a/sdk/identity/azure-identity/src/token_credential_impl.cpp
+++ b/sdk/identity/azure-identity/src/token_credential_impl.cpp
@@ -70,7 +70,7 @@ std::string TokenCredentialImpl::FormatScopes(
     auto scopesIter = scopes.begin();
     auto const scopesEnd = scopes.end();
 
-    if (scopesIter != scopesEnd) // LCOV_EXCL_LINE
+    if (scopesIter != scopesEnd) 
     {
       auto const scope = *scopesIter;
       scopesStr += OptionalUrlEncode(scope, urlEncode);
@@ -426,7 +426,7 @@ std::string PrintSanitizedJsonObject(json const& jsonObject, bool printString, i
     }
   }
 
-  return "?"; // LCOV_EXCL_LINE
+  return "?"; 
 }
 
 std::string TokenAsDiagnosticString(

--- a/sdk/identity/azure-identity/src/token_credential_impl.cpp
+++ b/sdk/identity/azure-identity/src/token_credential_impl.cpp
@@ -70,7 +70,7 @@ std::string TokenCredentialImpl::FormatScopes(
     auto scopesIter = scopes.begin();
     auto const scopesEnd = scopes.end();
 
-    if (scopesIter != scopesEnd) 
+    if (scopesIter != scopesEnd)
     {
       auto const scope = *scopesIter;
       scopesStr += OptionalUrlEncode(scope, urlEncode);
@@ -426,7 +426,7 @@ std::string PrintSanitizedJsonObject(json const& jsonObject, bool printString, i
     }
   }
 
-  return "?"; 
+  return "?";
 }
 
 std::string TokenAsDiagnosticString(


### PR DESCRIPTION
Rick pointed out that the code coverage exclusions in AMQP affected our code coverage numbers.

This PR removes all the code coverage exclusions for the C++ SDK *except* for the ones in json.hpp, and adjusts the ci.yml files for components negatively affected by their removal (Attestation went from 90% to 89%, Core went from 91% to 87%).


# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
