### PR TITLE
Updated changelog for azure core amqp and eventhubs around mentions of ostream operators

### DIFF
--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Other Changes
 
-- Added several `ostream` insertion operators for AMQP types.
 - Removed public dependency on azure-uamqp-c to enable local bug fixes.
 
 ## 1.0.0-beta.4 (2023-10-05)

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -18,7 +18,7 @@ parameter to the constructor must match the value provided in the connection str
 
 ### Other Changes
 
-- Several `ostream` insertion operators were added for eventhubs types.
+- Added `ostream` insertion operators to eventhubs model types `Ownership` and `Checkpoint`.
 
 ## 1.0.0-beta.3 (2023-10-10)
 


### PR DESCRIPTION
Following-up from https://github.com/Azure/azure-sdk-for-cpp/pull/5060#discussion_r1372399248

For reference, this diff shows the comparison of what was previously shipped vs what's in main now:
https://github.com/Azure/azure-sdk-for-cpp/compare/azure-messaging-eventhubs_1.0.0-beta.3...main

The additions to AMQP were in `_detail` namespace