### PR TITLE
Fix AMQP vcpkg depndencies

### DIFF
--- a/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
@@ -21,6 +21,10 @@
     "azure-macro-utils-c",
     "umock-c",
     {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
       "name": "vcpkg-cmake-config",
       "host": true
     }


### PR DESCRIPTION
The dependency used to be there, but it must have been dropped accidentally.
It is a vcpkg install-time dependency. All our packages have it, and use that vcpkg macro.
Without it `vcpkg_cmake_configure()` is an unnown command, and installing azure-core-amqp-cpp fails with that error.