### PR TITLE
Cleanup vendored uamqp cmake files after vcpkg install

### DIFF
--- a/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
@@ -26,16 +26,8 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake/uamqpConfig.cmake")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake/uamqpConfigVersion.cmake")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake/uamqpTargets-release.cmake")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake/uamqpTargets.cmake")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake/uamqpConfig.cmake")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake/uamqpConfigVersion.cmake")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake/uamqpTargets-debug.cmake")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake/uamqpTargets.cmake")
-
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
@@ -26,6 +26,16 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake/uamqpConfig.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake/uamqpConfigVersion.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake/uamqpTargets-release.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake/uamqpTargets.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake/uamqpConfig.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake/uamqpConfigVersion.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake/uamqpTargets-debug.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake/uamqpTargets.cmake")
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")


### PR DESCRIPTION
Without this fix, vcpkg install fails with error:
```
warning: The following cmake files were found outside /share/azure-core-amqp-cpp.

  C:\src\vcpkg\packages\azure-core-amqp-cpp_x64-windows-static\cmake\uamqpConfig.cmake
  C:\src\vcpkg\packages\azure-core-amqp-cpp_x64-windows-static\cmake\uamqpConfigVersion.cmake
  C:\src\vcpkg\packages\azure-core-amqp-cpp_x64-windows-static\cmake\uamqpTargets-release.cmake
  C:\src\vcpkg\packages\azure-core-amqp-cpp_x64-windows-static\cmake\uamqpTargets.cmake
  C:\src\vcpkg\packages\azure-core-amqp-cpp_x64-windows-static\debug\cmake\uamqpConfig.cmake
  C:\src\vcpkg\packages\azure-core-amqp-cpp_x64-windows-static\debug\cmake\uamqpConfigVersion.cmake
  C:\src\vcpkg\packages\azure-core-amqp-cpp_x64-windows-static\debug\cmake\uamqpTargets-debug.cmake
  C:\src\vcpkg\packages\azure-core-amqp-cpp_x64-windows-static\debug\cmake\uamqpTargets.cmake

error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: C:\src\vcpkg\ports\azure-core-amqp-cpp\portfile.cmake
```
