### PR TITLE
Fix vcpkg install for the vendored uamqp

### DIFF
--- a/sdk/core/azure-core-amqp/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/CMakeLists.txt
@@ -41,6 +41,7 @@ if (VENDOR_UAMQP)
 
   # uAMQP specific compiler settings. Primarily used to disable warnings in the uAMQP codebase.
   if (MSVC)
+    target_compile_definitions(uamqp PRIVATE _CRT_SECURE_NO_WARNINGS)
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(uamqp PUBLIC -Wno-extra-semi -Wno-gnu-zero-variadic-macro-arguments -Wno-cast-qual -Wno-format-pedantic)
   else()
@@ -130,7 +131,6 @@ set(AZURE_CORE_AMQP_SOURCE
 add_library(azure-core-amqp ${AZURE_CORE_AMQP_SOURCE} ${AZURE_CORE_AMQP_HEADER} $<TARGET_OBJECTS:uamqp>)
 
 if (VENDOR_UAMQP)
-target_compile_definitions(uamqp PRIVATE _CRT_SECURE_NO_WARNINGS)
 target_include_directories(azure-core-amqp SYSTEM PRIVATE ${UAMQP_INC_FOLDER})
 endif()
 

--- a/sdk/core/azure-core-amqp/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/CMakeLists.txt
@@ -126,10 +126,10 @@ set(AZURE_CORE_AMQP_SOURCE
     src/private/package_version.hpp
 )
 
-add_library(azure-core-amqp ${AZURE_CORE_AMQP_SOURCE} ${AZURE_CORE_AMQP_HEADER})
+add_library(azure-core-amqp ${AZURE_CORE_AMQP_SOURCE} ${AZURE_CORE_AMQP_HEADER} $<TARGET_OBJECTS:uamqp>)
 
 if (VENDOR_UAMQP)
-target_compile_definitions(azure-core-amqp PRIVATE _CRT_SECURE_NO_WARNINGS)
+target_compile_definitions(uamqp PRIVATE _CRT_SECURE_NO_WARNINGS)
 target_include_directories(azure-core-amqp SYSTEM PRIVATE ${UAMQP_INC_FOLDER})
 endif()
 
@@ -151,7 +151,6 @@ create_code_coverage(core azure-core-amqp-uamqp azure-core-amqp-uamqp-tests "tes
 # cspell:words aziotsharedutil
 # uAMQP's headers require the manual addition of umock_c, azure_macro_utils_c, and aziotsharedutil to the target link libraries. 
 target_link_libraries(azure-core-amqp PRIVATE
-    uamqp
     umock_c
     azure_macro_utils_c
     aziotsharedutil

--- a/sdk/core/azure-core-amqp/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/CMakeLists.txt
@@ -35,6 +35,7 @@ if (VENDOR_UAMQP)
   message(STATUS "Using vendored uamqp")
   set(use_installed_dependencies ON CACHE BOOL "Use vcpkg dependencies." FORCE)
   set(skip_samples ON CACHE BOOL "Skip building samples" FORCE)
+  set(build_as_object_library ON CACHE BOOL "Produce object library" FORCE)
 
   add_subdirectory(vendor/azure-uamqp-c SYSTEM)
 

--- a/sdk/core/azure-core-amqp/samples/README.md
+++ b/sdk/core/azure-core-amqp/samples/README.md
@@ -14,7 +14,7 @@ urlFragment: azure-core-amqp
 These code samples show common scenario operations for the Azure SDK for C++ AMQP support.
 
 The AMQP client library is a C++ library for communicating with entities that use the AMQP 
-protocol. It is a wrapper around the [Azure uAMQP Library](https://github.com/Azure/azure-uamqp-c/).
+protocol.
 
 These samples are intended to demonstrate common AMQP use scenarios for Azure Service authors and are 
 not intended to be a comprehensive collection of all possible uses for the library. The samples are

--- a/sdk/core/azure-core-amqp/vendor/azure-uamqp-c/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/vendor/azure-uamqp-c/CMakeLists.txt
@@ -269,10 +269,10 @@ endif()
 set(UAMQP_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "This is the include folder for UAMQP" FORCE)
 set(UAMQP_SRC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/src CACHE INTERNAL "This is the lib folder for UAMQP" FORCE)
 
-# Set CMAKE_INSTALL_LIBDIR if not defined
-include(GNUInstallDirs)
-
 if (NOT build_as_object_library)
+    # Set CMAKE_INSTALL_LIBDIR if not defined
+    include(GNUInstallDirs)
+
     # Install uamqp
     set(package_location "cmake")
 

--- a/sdk/core/azure-core-amqp/vendor/azure-uamqp-c/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/vendor/azure-uamqp-c/CMakeLists.txt
@@ -238,7 +238,7 @@ else()
     )
 endif()
 
-add_library(uamqp
+add_library(uamqp OBJECT
     ${uamqp_c_files}
     ${uamqp_h_files}
     ${socketlistener_c_files}
@@ -259,51 +259,5 @@ endif()
 # The following "set" statetement exports across the project a global variable
 set(UAMQP_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "This is the include folder for UAMQP" FORCE)
 set(UAMQP_SRC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/src CACHE INTERNAL "This is the lib folder for UAMQP" FORCE)
-
-# Set CMAKE_INSTALL_LIBDIR if not defined
-include(GNUInstallDirs)
-
-# Install uamqp
-set(package_location "cmake")
-
-if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-    set(CMAKE_INSTALL_LIBDIR "lib")
-endif()
-
-install(TARGETS uamqp EXPORT uamqpTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
-)
-install(FILES ${uamqp_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot/azure_uamqp_c)
-
-include(CMakePackageConfigHelpers)
-
-write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
-    VERSION ${UAMQP_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
-
-configure_file("configs/${PROJECT_NAME}Config.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
-    COPYONLY
-)
-
-install(EXPORT uamqpTargets
-    FILE
-        "${PROJECT_NAME}Targets.cmake"
-    DESTINATION
-        ${package_location}
-)
-
-install(
-    FILES
-        "configs/${PROJECT_NAME}Config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
-    DESTINATION
-        ${package_location}
-)
 
 compileTargetAsC99(uamqp)

--- a/sdk/core/azure-core-amqp/vendor/azure-uamqp-c/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/vendor/azure-uamqp-c/CMakeLists.txt
@@ -12,6 +12,7 @@ option(skip_samples "set skip_samples to ON to skip building samples (default is
 option(use_installed_dependencies "set use_installed_dependencies to ON to use installed packages instead of building dependencies from submodules" OFF)
 option(memory_trace "set memory_trace to ON if memory usage is to be used, set to OFF to not use it" OFF)
 option(use_custom_heap "use externally defined heap functions instead of the malloc family" OFF)
+option(build_as_object_library "produce cmake object library and skip install steps" OFF)
 
 if(${use_custom_heap})
     add_definitions(-DGB_USE_CUSTOM_HEAP)
@@ -238,11 +239,19 @@ else()
     )
 endif()
 
-add_library(uamqp OBJECT
-    ${uamqp_c_files}
-    ${uamqp_h_files}
-    ${socketlistener_c_files}
-    )
+if (build_as_object_library)
+    add_library(uamqp OBJECT
+        ${uamqp_c_files}
+        ${uamqp_h_files}
+        ${socketlistener_c_files}
+        )
+else()
+    add_library(uamqp
+        ${uamqp_c_files}
+        ${uamqp_h_files}
+        ${socketlistener_c_files}
+        )
+endif()
 setTargetBuildProperties(uamqp)
 
 target_link_libraries(uamqp aziotsharedutil)
@@ -259,5 +268,53 @@ endif()
 # The following "set" statetement exports across the project a global variable
 set(UAMQP_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "This is the include folder for UAMQP" FORCE)
 set(UAMQP_SRC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/src CACHE INTERNAL "This is the lib folder for UAMQP" FORCE)
+
+# Set CMAKE_INSTALL_LIBDIR if not defined
+include(GNUInstallDirs)
+
+if (NOT build_as_object_library)
+    # Install uamqp
+    set(package_location "cmake")
+
+    if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+        set(CMAKE_INSTALL_LIBDIR "lib")
+    endif()
+
+    install(TARGETS uamqp EXPORT uamqpTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
+    )
+    install(FILES ${uamqp_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot/azure_uamqp_c)
+
+    include(CMakePackageConfigHelpers)
+
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+        VERSION ${UAMQP_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
+
+    configure_file("configs/${PROJECT_NAME}Config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
+        COPYONLY
+    )
+
+    install(EXPORT uamqpTargets
+        FILE
+            "${PROJECT_NAME}Targets.cmake"
+        DESTINATION
+            ${package_location}
+    )
+
+    install(
+        FILES
+            "configs/${PROJECT_NAME}Config.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+        DESTINATION
+            ${package_location}
+    )
+endif()
 
 compileTargetAsC99(uamqp)


### PR DESCRIPTION
This time, I think, it is the final fix. I was able to vcpkg install azure-messaging-eventhubs-cpp, which build the updated amqp, and both as static and shared library.

I turned uamqp into an "object library", i.e. the .lib file never exists on disk but rather vendored uamqp's .obj files are getting into the azure-core-amqp-cpp's .lib file instead.

Should customers be using uamqp library themselves, the private uamqp version that we build won't interfere with it.

Vcpkg listall library looks very clean, uamqp is nowhere to be seen, as it should - as if its code is a part of the azure-core-amqp-cpp, which it is.

Built as DLLs:
```
x64-windows\bin\azure-core-amqp.dll
x64-windows\bin\azure-core-amqp.pdb
x64-windows\bin\azure-core.dll
x64-windows\bin\azure-core.pdb
x64-windows\bin\azure-messaging-eventhubs.dll
x64-windows\bin\azure-messaging-eventhubs.pdb
x64-windows\bin\libcurl.dll
x64-windows\bin\libcurl.pdb
x64-windows\bin\zlib.pdb
x64-windows\bin\zlib1.dll

x64-windows\debug\bin\azure-core-amqp.dll
x64-windows\debug\bin\azure-core-amqp.pdb
x64-windows\debug\bin\azure-core.dll
x64-windows\debug\bin\azure-core.pdb
x64-windows\debug\bin\azure-messaging-eventhubs.dll
x64-windows\debug\bin\azure-messaging-eventhubs.pdb
x64-windows\debug\bin\libcurl-d.dll
x64-windows\debug\bin\libcurl-d.pdb
x64-windows\debug\bin\zlibd.pdb
x64-windows\debug\bin\zlibd1.dll

x64-windows\debug\lib\aziotsharedutil.lib
x64-windows\debug\lib\azure-core-amqp.lib
x64-windows\debug\lib\azure-core.lib
x64-windows\debug\lib\azure-messaging-eventhubs.lib
x64-windows\debug\lib\libcurl-d.lib
x64-windows\debug\lib\umock_c.lib
x64-windows\debug\lib\zlibd.lib
x64-windows\debug\lib\pkgconfig\libcurl.pc
x64-windows\debug\lib\pkgconfig\zlib.pc

x64-windows\include\zconf.h
x64-windows\include\zlib.h

x64-windows\include\azure\core.hpp
x64-windows\include\azure\core\amqp.hpp
x64-windows\include\azure\core\azure_assert.hpp
x64-windows\include\azure\core\base64.hpp
...
x64-windows\include\azure\core\uuid.hpp
x64-windows\include\azure\core\amqp\cancellable.hpp
...
x64-windows\include\azure\core\amqp\network\transport.hpp
x64-windows\include\azure\core\credentials\credentials.hpp
...
x64-windows\include\azure\core\internal\client_options.hpp
...
x64-windows\include\azure\core\tracing\tracing.hpp
x64-windows\include\azure\messaging\eventhubs.hpp
...
x64-windows\include\azure\messaging\eventhubs\models\processor_models.hpp

x64-windows\include\azure_macro_utils\macro_utils_generated.h
x64-windows\include\azure_macro_utils\macro_utils.h

x64-windows\include\azureiot\azure_c_shared_utility\agenttime.h
...
x64-windows\include\azureiot\azure_c_shared_utility\xlogging.h
x64-windows\include\curl\curl.h
...
x64-windows\include\curl\websockets.h
x64-windows\include\umock_c\umock_c_internal.h
...
x64-windows\include\umock_c\umocktypes.h
x64-windows\include\wil\com_apartment_variable.h
...
x64-windows\include\wil\wrl.h

x64-windows\lib\aziotsharedutil.lib
x64-windows\lib\azure-core-amqp.lib
x64-windows\lib\azure-core.lib
x64-windows\lib\azure-messaging-eventhubs.lib
x64-windows\lib\libcurl.lib
x64-windows\lib\umock_c.lib
x64-windows\lib\zlib.lib
x64-windows\lib\pkgconfig\libcurl.pc
x64-windows\lib\pkgconfig\zlib.pc
```

Built as static libs:
```
x64-windows-static\debug\lib\aziotsharedutil.lib
x64-windows-static\debug\lib\azure-core-amqp.lib
x64-windows-static\debug\lib\azure-core.lib
x64-windows-static\debug\lib\azure-messaging-eventhubs.lib
x64-windows-static\debug\lib\libcurl-d.lib
x64-windows-static\debug\lib\umock_c.lib
x64-windows-static\debug\lib\zlibd.lib
x64-windows-static\debug\lib\pkgconfig\libcurl.pc
x64-windows-static\debug\lib\pkgconfig\zlib.pc

x64-windows-static\include\zconf.h
x64-windows-static\include\zlib.h
...
x64-windows-static\include\azure\core.hpp
x64-windows-static\include\azure\core\amqp.hpp
x64-windows-static\include\azure\core\azure_assert.hpp
x64-windows-static\include\azure\core\base64.hpp
...
x64-windows-static\include\azure\core\amqp\cancellable.hpp
...
x64-windows-static\include\azure\messaging\eventhubs\checkpoint_store.hpp
...
x64-windows-static\include\azure_macro_utils\macro_utils_generated.h
x64-windows-static\include\azure_macro_utils\macro_utils.h

x64-windows-static\include\azureiot\azure_c_shared_utility\agenttime.h
...
x64-windows-static\include\azureiot\azure_c_shared_utility\xlogging.h
x64-windows-static\include\curl\curl.h
...
x64-windows-static\include\umock_c\umock_c_internal.h
...
x64-windows-static\include\wil\com_apartment_variable.h
...
x64-windows-static\lib\aziotsharedutil.lib
x64-windows-static\lib\azure-core-amqp.lib
x64-windows-static\lib\azure-core.lib
x64-windows-static\lib\azure-messaging-eventhubs.lib
x64-windows-static\lib\libcurl.lib
x64-windows-static\lib\umock_c.lib
x64-windows-static\lib\zlib.lib

x64-windows-static\lib\pkgconfig\libcurl.pc
x64-windows-static\lib\pkgconfig\zlib.pc

x64-windows-static\share\azure_c_shared_utility\azure_c_shared_utilityConfig.cmake
x64-windows-static\share\azure_c_shared_utility\azure_c_shared_utilityConfigVersion.cmake
x64-windows-static\share\azure_c_shared_utility\azure_c_shared_utilityFunctions.cmake
x64-windows-static\share\azure_c_shared_utility\azure_c_shared_utilityTargets-debug.cmake
x64-windows-static\share\azure_c_shared_utility\azure_c_shared_utilityTargets-release.cmake
x64-windows-static\share\azure_c_shared_utility\azure_c_shared_utilityTargets.cmake
x64-windows-static\share\azure_c_shared_utility\azure_iot_build_rules.cmake

x64-windows-static\share\azure_macro_utils_c\azure_macro_utils_cConfig.cmake
x64-windows-static\share\azure_macro_utils_c\azure_macro_utils_cConfigVersion.cmake
x64-windows-static\share\azure_macro_utils_c\azure_macro_utils_cTargets.cmake
x64-windows-static\share\azure_macro_utils_c\include\azure_macro_utils\macro_utils.h

x64-windows-static\share\azure-c-shared-utility\azure_iot_build_rules.cmake
x64-windows-static\share\azure-c-shared-utility\copyright
x64-windows-static\share\azure-c-shared-utility\vcpkg_abi_info.txt
x64-windows-static\share\azure-c-shared-utility\vcpkg.spdx.json

x64-windows-static\share\azure-core-amqp-cpp\azure-core-amqp-cppConfig.cmake
x64-windows-static\share\azure-core-amqp-cpp\azure-core-amqp-cppConfigVersion.cmake
x64-windows-static\share\azure-core-amqp-cpp\azure-core-amqp-cppTargets-debug.cmake
x64-windows-static\share\azure-core-amqp-cpp\azure-core-amqp-cppTargets-release.cmake
x64-windows-static\share\azure-core-amqp-cpp\azure-core-amqp-cppTargets.cmake
x64-windows-static\share\azure-core-amqp-cpp\copyright
x64-windows-static\share\azure-core-amqp-cpp\vcpkg_abi_info.txt
x64-windows-static\share\azure-core-amqp-cpp\vcpkg.spdx.json

x64-windows-static\share\azure-core-cpp\azure-core-cppConfig.cmake
x64-windows-static\share\azure-core-cpp\azure-core-cppConfigVersion.cmake
x64-windows-static\share\azure-core-cpp\azure-core-cppTargets-debug.cmake
x64-windows-static\share\azure-core-cpp\azure-core-cppTargets-release.cmake
x64-windows-static\share\azure-core-cpp\azure-core-cppTargets.cmake
x64-windows-static\share\azure-core-cpp\copyright
x64-windows-static\share\azure-core-cpp\vcpkg_abi_info.txt
x64-windows-static\share\azure-core-cpp\vcpkg.spdx.json

x64-windows-static\share\azure-macro-utils-c\copyright
x64-windows-static\share\azure-macro-utils-c\vcpkg_abi_info.txt
x64-windows-static\share\azure-macro-utils-c\vcpkg.spdx.json

x64-windows-static\share\azure-messaging-eventhubs-cpp\azure-messaging-eventhubs-cppConfig.cmake
x64-windows-static\share\azure-messaging-eventhubs-cpp\azure-messaging-eventhubs-cppConfigVersion.cmake
x64-windows-static\share\azure-messaging-eventhubs-cpp\azure-messaging-eventhubs-cppTargets-debug.cmake
x64-windows-static\share\azure-messaging-eventhubs-cpp\azure-messaging-eventhubs-cppTargets-release.cmake
x64-windows-static\share\azure-messaging-eventhubs-cpp\azure-messaging-eventhubs-cppTargets.cmake
x64-windows-static\share\azure-messaging-eventhubs-cpp\copyright
x64-windows-static\share\azure-messaging-eventhubs-cpp\vcpkg_abi_info.txt
x64-windows-static\share\azure-messaging-eventhubs-cpp\vcpkg.spdx.json

x64-windows-static\share\curl\copyright
x64-windows-static\share\curl\CURLConfig.cmake
x64-windows-static\share\curl\CURLConfigComponents.cmake
x64-windows-static\share\curl\CURLConfigVersion.cmake
x64-windows-static\share\curl\CURLTargets-debug.cmake
x64-windows-static\share\curl\CURLTargets-release.cmake
x64-windows-static\share\curl\CURLTargets.cmake
x64-windows-static\share\curl\usage
x64-windows-static\share\curl\vcpkg_abi_info.txt
x64-windows-static\share\curl\vcpkg-cmake-wrapper.cmake
x64-windows-static\share\curl\vcpkg.spdx.json

x64-windows-static\share\umock_c\umock_cConfig.cmake
x64-windows-static\share\umock_c\umock_cConfigVersion.cmake
x64-windows-static\share\umock_c\umock_cFunctions.cmake
x64-windows-static\share\umock_c\umock_cTargets-debug.cmake
x64-windows-static\share\umock_c\umock_cTargets-release.cmake
x64-windows-static\share\umock_c\umock_cTargets.cmake
x64-windows-static\share\umock-c\copyright
x64-windows-static\share\umock-c\vcpkg_abi_info.txt
x64-windows-static\share\umock-c\vcpkg.spdx.json

x64-windows-static\share\wil\copyright
x64-windows-static\share\wil\vcpkg_abi_info.txt
x64-windows-static\share\wil\vcpkg.spdx.json
x64-windows-static\share\wil\wilConfig.cmake
x64-windows-static\share\wil\natvis\wil.natvis

x64-windows-static\share\zlib\copyright
x64-windows-static\share\zlib\usage
x64-windows-static\share\zlib\vcpkg_abi_info.txt
x64-windows-static\share\zlib\vcpkg-cmake-wrapper.cmake
x64-windows-static\share\zlib\vcpkg.spdx.json

x64-windows-static\tools\curl\bin\curl-config
x64-windows-static\tools\curl\debug\bin\curl-config
```