### PR TITLE
Remove old warning suppression from Storage

### DIFF
--- a/sdk/storage/azure-storage-common/CMakeLists.txt
+++ b/sdk/storage/azure-storage-common/CMakeLists.txt
@@ -97,8 +97,6 @@ target_link_libraries(azure-storage-common PUBLIC Azure::azure-core)
 
 if(WIN32)
     target_link_libraries(azure-storage-common PRIVATE bcrypt webservices)
-    # C28020 and C28204 are introduced by nlohmann/json
-    target_compile_options(azure-storage-common PUBLIC /wd28204 /wd28020)
 else()
     find_package(LibXml2 REQUIRED)
     target_include_directories(azure-storage-common SYSTEM PRIVATE ${LIBXML2_INCLUDE_DIRS})


### PR DESCRIPTION
That line was introduced back in 2020, when Core did not have Json, and Storage had its own copy.

First of all, the condition is not sufficient - it should have been "`if (MSVC)`" and not "`if (WIN32)`" - because I got a customer who is using Clang on Windows, and this breaks their build.

But second, and most important - that line is no longer needed.