### PR TITLE
Accurate vcpkg feature availability for winhttp

### DIFF
--- a/sdk/core/azure-core/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg.json
@@ -13,10 +13,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "wil",
-      "platform": "windows"
     }
   ],
   "default-features": [
@@ -62,11 +58,13 @@
     },
     "winhttp": {
       "description": "WinHTTP HTTP transport implementation",
+      "supports": "windows & !uwp",
       "dependencies": [
         {
           "name": "azure-core-cpp",
           "default-features": false
-        }
+        },
+        "wil"
       ]
     }
   }

--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE:  All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
   "name": "azure-core-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": "NOTE:  All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
   "name": "azure-core-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -68,7 +68,7 @@
     },
     "winhttp": {
       "description": "WinHTTP HTTP transport implementation",
-      "supports": "windows",
+      "supports": "windows & !uwp",
       "dependencies": [
         {
           "name": "azure-core-cpp",


### PR DESCRIPTION
Aligns with https://github.com/microsoft/vcpkg/pull/34704, and also aligns manifest-mode dev-time manifest with the release template manifest.

The change is right - yes, if you only install default features, or as `azure-core-cpp[http]` on UWP, winhttp won't be selected. But, you can still initiate installing it on UWP it as `azure-core-cpp[core,winhttp]`, but then the build will fail.

This PR fixes that:
```
PS C:\src\vcpkg> .\vcpkg install azure-core-cpp[core,winhttp]:x64-uwp
Computing installation plan...
azure-core-cpp[winhttp] is only supported on 'windows & !uwp', which does not match x64-uwp.
This usually means that there are known build failures, or runtime problems, when building other platforms.
To ignore this and attempt to build azure-core-cpp anyway, rerun vcpkg with `--allow-unsupported`.
```