### PR TITLE
Drop non-essential line from Storage FAQ

### DIFF
--- a/sdk/storage/faq.md
+++ b/sdk/storage/faq.md
@@ -299,8 +299,6 @@ If you want to add some time-variant headers like authentication, you should use
 ```C++
 class NewPolicy final : public Azure::Core::Http::Policies::HttpPolicy {
 public:
-  ~NewPolicy() override {}
-
   std::unique_ptr<HttpPolicy> Clone() const override
   {
     return std::make_unique<NewPolicy>(*this);


### PR DESCRIPTION
This is to make the code look cleaner. Declaring the destructor there is not essential, in my opinion. I think that there would realistically be no need in declaring it in 99% of cases. And if a customer needs to declare it - that would be pretty straightforward for them, they'll just write one themselves.
Otherwise, without knowing I might even think that it is somewhat important to have it there, especially if I try the code, something breaks or does not work, one of the first things I might try to do is to undo the customizations I did on top of the official sample.