### PR TITLE
Re-use the selected credential that works for each subsequent request in `DefaultAzureCredential` by caching the chosen credential per instance.

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- When one of the credential within `DefaultAzureCredential` is successful, it gets re-used during all subsequent attempts to get the token.
+- When one of the credentials within `DefaultAzureCredential` is successful, it gets re-used during all subsequent attempts to get the token.
 
 ### Breaking Changes
 

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Re-use the selected credential that works for each subsequent request in `DefaultAzureCredential`.
+- When one of the credential within `DefaultAzureCredential` is successful, it gets re-used during all subsequent attempts to get the token.
 
 ### Breaking Changes
 

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Re-use the selected credential that works for each subsequent request in `DefaultAzureCredential`.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
@@ -14,7 +14,7 @@
 #include <memory>
 
 #if defined(TESTING_BUILD)
-  class DefaultAzureCredential_CachingCredential_Test;
+class DefaultAzureCredential_CachingCredential_Test;
 #endif
 
 namespace Azure { namespace Identity {

--- a/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
@@ -13,9 +13,9 @@
 
 #include <memory>
 
-// #if defined(TESTING_BUILD)
+#if defined(TESTING_BUILD)
 class DefaultAzureCredential_CachingCredential_Test;
-// #endif
+#endif
 
 namespace Azure { namespace Identity {
   namespace _detail {
@@ -42,10 +42,10 @@ namespace Azure { namespace Identity {
    */
   class DefaultAzureCredential final : public Core::Credentials::TokenCredential {
 
-    // #if defined(TESTING_BUILD)
+#if defined(TESTING_BUILD)
     //  make tests classes friends to validate caching
-    friend class DefaultAzureCredential_CachingCredential_Test;
-    // #endif
+    friend class ::DefaultAzureCredential_CachingCredential_Test;
+#endif
 
   public:
     /**

--- a/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
@@ -13,9 +13,9 @@
 
 #include <memory>
 
-#if defined(TESTING_BUILD)
+// #if defined(TESTING_BUILD)
 class DefaultAzureCredential_CachingCredential_Test;
-#endif
+// #endif
 
 namespace Azure { namespace Identity {
   namespace _detail {
@@ -42,10 +42,10 @@ namespace Azure { namespace Identity {
    */
   class DefaultAzureCredential final : public Core::Credentials::TokenCredential {
 
-#if defined(TESTING_BUILD)
-    // make tests classes friends to validate caching
+    // #if defined(TESTING_BUILD)
+    //  make tests classes friends to validate caching
     friend class DefaultAzureCredential_CachingCredential_Test;
-#endif
+    // #endif
 
   public:
     /**

--- a/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
@@ -13,6 +13,10 @@
 
 #include <memory>
 
+#if defined(TESTING_BUILD)
+  class DefaultAzureCredential_CachingCredential_Test;
+#endif
+
 namespace Azure { namespace Identity {
   namespace _detail {
     class ChainedTokenCredentialImpl;
@@ -37,6 +41,12 @@ namespace Azure { namespace Identity {
    *
    */
   class DefaultAzureCredential final : public Core::Credentials::TokenCredential {
+
+#if defined(TESTING_BUILD)
+    // make tests classes friends to validate caching
+    friend class DefaultAzureCredential_CachingCredential_Test;
+#endif
+
   public:
     /**
      * @brief Constructs `%DefaultAzureCredential`.

--- a/sdk/identity/azure-identity/src/default_azure_credential.cpp
+++ b/sdk/identity/azure-identity/src/default_azure_credential.cpp
@@ -43,9 +43,12 @@ DefaultAzureCredential::DefaultAzureCredential(
   auto const managedIdentityCred = std::make_shared<ManagedIdentityCredential>(options);
   auto const azCliCred = std::make_shared<AzureCliCredential>(options);
 
+  // DefaultAzureCredential caches the selected credential, so that it can be reused on subsequent
+  // calls.
   m_impl = std::make_unique<_detail::ChainedTokenCredentialImpl>(
       GetCredentialName(),
-      ChainedTokenCredential::Sources{envCred, wiCred, managedIdentityCred, azCliCred});
+      ChainedTokenCredential::Sources{envCred, wiCred, managedIdentityCred, azCliCred},
+      true);
 }
 
 DefaultAzureCredential::~DefaultAzureCredential() = default;

--- a/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
@@ -9,18 +9,18 @@
 #include <limits>
 #include <mutex>
 
-#if defined(TESTING_BUILD)
+// #if defined(TESTING_BUILD)
 class DefaultAzureCredential_CachingCredential_Test;
-#endif
+// #endif
 
 namespace Azure { namespace Identity { namespace _detail {
 
   class ChainedTokenCredentialImpl final {
 
-#if defined(TESTING_BUILD)
-    // make tests classes friends to validate caching
+    // #if defined(TESTING_BUILD)
+    //  make tests classes friends to validate caching
     friend class DefaultAzureCredential_CachingCredential_Test;
-#endif
+    // #endif
 
   public:
     ChainedTokenCredentialImpl(

--- a/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
@@ -5,21 +5,36 @@
 
 #include "azure/identity/chained_token_credential.hpp"
 
+#if defined(TESTING_BUILD)
+class DefaultAzureCredential_CachingCredential_Test;
+#endif
+
 namespace Azure { namespace Identity { namespace _detail {
 
   class ChainedTokenCredentialImpl final {
+
+#if defined(TESTING_BUILD)
+    // make tests classes friends to validate caching
+    friend class DefaultAzureCredential_CachingCredential_Test;
+#endif
+
   public:
     ChainedTokenCredentialImpl(
         std::string const& credentialName,
-        ChainedTokenCredential::Sources&& sources);
+        ChainedTokenCredential::Sources&& sources,
+        bool cacheSelectedCredential = false);
 
     Core::Credentials::AccessToken GetToken(
         std::string const& credentialName,
         Core::Credentials::TokenRequestContext const& tokenRequestContext,
-        Core::Context const& context) const;
+        Core::Context const& context);
 
   private:
-    ChainedTokenCredential::Sources m_sources;
+    std::vector<std::shared_ptr<Core::Credentials::TokenCredential>> m_sources;
+    bool m_cacheSelectedCredential;
+    // This needs to be atomic so that sentinel comparison is thread safe.
+    std::atomic<std::size_t> m_SelectedCredentialIndex = std::numeric_limits<std::size_t>::max();
+    std::mutex m_cachingMutex;
   };
 
 }}} // namespace Azure::Identity::_detail

--- a/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
@@ -9,18 +9,18 @@
 #include <limits>
 #include <mutex>
 
-// #if defined(TESTING_BUILD)
+#if defined(TESTING_BUILD)
 class DefaultAzureCredential_CachingCredential_Test;
-// #endif
+#endif
 
 namespace Azure { namespace Identity { namespace _detail {
 
   class ChainedTokenCredentialImpl final {
 
-    // #if defined(TESTING_BUILD)
+#if defined(TESTING_BUILD)
     //  make tests classes friends to validate caching
-    friend class DefaultAzureCredential_CachingCredential_Test;
-    // #endif
+    friend class ::DefaultAzureCredential_CachingCredential_Test;
+#endif
 
   public:
     ChainedTokenCredentialImpl(

--- a/sdk/identity/azure-identity/test/ut/chained_token_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/chained_token_credential_test.cpp
@@ -87,6 +87,17 @@ TEST(ChainedTokenCredential, ErrorThenSuccess)
 
   EXPECT_TRUE(c1->WasInvoked);
   EXPECT_TRUE(c2->WasInvoked);
+
+  // We expect chained token credential will NOT cache the selected credential which was successful
+  // and retry each one from the start.
+  c1->WasInvoked = false;
+  c1->WasInvoked = false;
+
+  token = cred.GetToken({}, {});
+  EXPECT_EQ(token.Token, "Token2");
+
+  EXPECT_TRUE(c1->WasInvoked);
+  EXPECT_TRUE(c2->WasInvoked);
 }
 
 TEST(ChainedTokenCredential, AllErrors)

--- a/sdk/identity/azure-identity/test/ut/default_azure_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/default_azure_credential_test.cpp
@@ -248,12 +248,18 @@ TEST(DefaultAzureCredential, LogMessages)
 
   EXPECT_EQ(
       log.size(),
-      LogMsgVec::size_type(4)); // Request and retry policies will get their messages here as well.
+      LogMsgVec::size_type(5)); // Request and retry policies will get their messages here as well.
 
   EXPECT_EQ(log[3].first, Logger::Level::Informational);
   EXPECT_EQ(
       log[3].second,
-      "Identity: DefaultAzureCredential: Successfully got token from EnvironmentCredential.");
+      "Identity: DefaultAzureCredential: Successfully got token from EnvironmentCredential. Reuse "
+      "this credential for subsequent calls.");
+
+  EXPECT_EQ(log[4].first, Logger::Level::Verbose);
+  EXPECT_EQ(
+      log[4].second,
+      "Identity: DefaultAzureCredential: Save this credential at index 0 for subsequent calls.");
 
   Logger::SetListener(nullptr);
 }


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/4952#issuecomment-1728370828

**There is a substantial performance win here (basically 6000x)!**

Let's assume the chain of credentials is as follows, where only `envCred` is going to succeed (via `ClientSecretCredential`) and comes after managed identity credential, and just measuring the `dacCred.GetToken(...)` call:
> ChainedTokenCredential::Sources{wiCred, managedIdentityCred, envCred, azCliCred}

**Before (i.e. DAC without caching):** 130 ops/s
**After (i.e. DAC with caching):** 774,773 op/s


Just running the e2e azure-identity test locally, to see the first call experience, it is actually fairly quick with and without the caching (i.e. well under 1 second)! Note the timestamps. After this caching change it is almost instant now.
https://github.com/Azure/azure-sdk-for-cpp/blob/a6956c76398d90e531829dbd913fbaa0bc1efe31/sdk/identity/azure-identity/test/e2e/azure_identity_e2e_test.cpp#L86
```cpp
    Azure::Identity::DefaultAzureCredential credential(options);

    TokenRequestContext tokenRequestContext;
    tokenRequestContext.Scopes = {resourceUrl};

    std::cout << "=== ATTEMPT 1 ===" << std::endl;
    auto token = credential.GetToken(tokenRequestContext, Context());

    std::cout << "=== ATTEMPT 2 ===" << std::endl;
    token = credential.GetToken(tokenRequestContext, Context());

    std::cout << "=== ATTEMPT3 ===" << std::endl;
    token = credential.GetToken(tokenRequestContext, Context());
```

**Before:**
```text
[2023-11-10T03:22:43.3706160Z T: 31312] INFO  : Identity: DefaultAzureCredential: Created with the following credentials: WorkloadIdentityCredential, ManagedIdentityCredential, EnvironmentCredential, AzureCliCredential.
=== ATTEMPT 1 ===
[2023-11-10T03:22:43.8745744Z T: 31312] INFO  : Identity: DefaultAzureCredential: Successfully got token from EnvironmentCredential.
=== ATTEMPT 2 ===
[2023-11-10T03:22:43.8936397Z T: 31312] INFO  : Identity: DefaultAzureCredential: Successfully got token from EnvironmentCredential.
=== ATTEMPT3 ===
[2023-11-10T03:22:43.9112237Z T: 31312] INFO  : Identity: DefaultAzureCredential: Successfully got token from EnvironmentCredential.
OK
```

**After:**
```text
[2023-11-10T03:28:18.1340414Z T: 34272] INFO  : Identity: DefaultAzureCredential: Created with the following credentials: WorkloadIdentityCredential, ManagedIdentityCredential, EnvironmentCredential, AzureCliCredential.
=== ATTEMPT 1 ===
[2023-11-10T03:28:18.4760682Z T: 34272] INFO  : Identity: DefaultAzureCredential: Successfully got token from EnvironmentCredential. Reuse this credential for subsequent calls.
[2023-11-10T03:28:18.4766425Z T: 34272] DEBUG : Identity: DefaultAzureCredential: Save this credential at index 2 for subsequent calls.
=== ATTEMPT 2 ===
[2023-11-10T03:28:18.4772765Z T: 34272] INFO  : Identity: DefaultAzureCredential: Successfully got token from EnvironmentCredential. Reuse this credential for subsequent calls.
=== ATTEMPT3 ===
[2023-11-10T03:28:18.4779544Z T: 34272] INFO  : Identity: DefaultAzureCredential: Successfully got token from EnvironmentCredential. Reuse this credential for subsequent calls.
OK
```