### PR TITLE
Update perf test secret_credential_test.hpp to be more generic to make local modifications and runs easier

### DIFF
--- a/sdk/identity/azure-identity/test/perf/inc/azure/identity/test/secret_credential_test.hpp
+++ b/sdk/identity/azure-identity/test/perf/inc/azure/identity/test/secret_credential_test.hpp
@@ -28,7 +28,7 @@ namespace Azure { namespace Identity { namespace Test {
     std::string m_clientId;
     std::string m_secret;
     Core::Credentials::TokenRequestContext m_tokenRequestContext;
-    std::unique_ptr<Azure::Identity::ClientSecretCredential> m_credential;
+    std::unique_ptr<Azure::Core::Credentials::TokenCredential> m_credential;
 
   public:
     /**


### PR DESCRIPTION
The perf test remains identical but rather than saving the concrete credential class, we can just save the base `TokenCredential` class instead. This helps us modify the concrete type in the `Setup()` as needed, and the performance test, which just calls `GetToken()` isn't impacted.