### PR TITLE
Fix the x64 release with perf tests CMakePresets.json by adding the missing `enable-tests` inheritance

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -418,6 +418,7 @@
       "inherits": [
         "x64-static",
         "release-build",
+        "enable-tests",
         "enable-perf"
       ]
     },


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/5148