### PR TITLE
Make vcpkg.json comment multiline

### DIFF
--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -18,7 +18,7 @@ macro(az_vcpkg_integrate)
       message("AZURE_SDK_DISABLE_AUTO_VCPKG is not defined. Fetch a local copy of vcpkg.")
       # GET VCPKG FROM SOURCE
       #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
-      set(VCPKG_COMMIT_STRING 7d5ed6bd1bc4faf32f1ebcdee30b5842d30032c6) # default SDK tested commit
+      set(VCPKG_COMMIT_STRING 43cf47eccfbe27006cf9534a5db809798f8c37fe) # default SDK tested commit
       if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
         message("AZURE_SDK_VCPKG_COMMIT is defined. Using that instead of the default.")
         set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit

--- a/sdk/attestation/azure-security-attestation/vcpkg/vcpkg.json
+++ b/sdk/attestation/azure-security-attestation/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-security-attestation-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-core-amqp-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/core/azure-core-tracing-opentelemetry/test/ut/test_exporter.hpp
+++ b/sdk/core/azure-core-tracing-opentelemetry/test/ut/test_exporter.hpp
@@ -11,6 +11,7 @@
 #endif
 
 #include <opentelemetry/sdk/trace/exporter.h>
+#include <opentelemetry/sdk/trace/recordable.h>
 
 #if defined(_MSC_VER)
 #pragma warning(pop)

--- a/sdk/core/azure-core-tracing-opentelemetry/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core-tracing-opentelemetry/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-core-tracing-opentelemetry-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/core/azure-core/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-core-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/vcpkg/vcpkg.json
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-messaging-eventhubs-checkpointstore-blob-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/vcpkg.json
+++ b/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-messaging-eventhubs-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/identity/azure-identity/vcpkg/vcpkg.json
+++ b/sdk/identity/azure-identity/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-identity-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/keyvault/azure-security-keyvault-administration/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-administration/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-security-keyvault-administration-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-security-keyvault-certificates-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-security-keyvault-keys-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-security-keyvault-secrets-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-blobs/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-blobs-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-common-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-files-datalake-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-files-shares-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/storage/azure-storage-queues/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-queues/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-storage-queues-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/sdk/template/azure-template/vcpkg/vcpkg.json
+++ b/sdk/template/azure-template/vcpkg/vcpkg.json
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 {
-  "$comment": "NOTE: All changes made to this file will get overwritten by the next port release. Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp.",
+  "$comment": [
+    "NOTE: All changes made to this file will get overwritten by the next port release.",
+    "Please contribute your changes to https://github.com/Azure/azure-sdk-for-cpp."
+  ],
   "name": "azure-template-cpp",
   "version-semver": "@AZ_LIBRARY_VERSION@",
   "description": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-sdk-for-cpp",
   "version": "1.5.0",
-  "builtin-baseline": "7d5ed6bd1bc4faf32f1ebcdee30b5842d30032c6",
+  "builtin-baseline": "43cf47eccfbe27006cf9534a5db809798f8c37fe",
   "dependencies": [
     {
       "name": "curl"


### PR DESCRIPTION
Now that https://github.com/microsoft/vcpkg/issues/34877 is fixed, we can format `vcpkg.json` comment as multi-line.
This way, it is better visible, and it aligns with the existing `portfile.cmake` comment, which is also multi-line:

https://github.com/Azure/azure-sdk-for-cpp/blob/37e1952f71a3bf0b989873d136f4a671484f5c25/sdk/core/azure-core/vcpkg/portfile.cmake#L4-L5

I am updating the vcpkg commit SHA to https://github.com/microsoft/vcpkg/commit/43cf47eccfbe27006cf9534a5db809798f8c37fe, because that is the commit which updates vcpkg to the `2023-11-16` release - `vcpkg-tool` release which contains bugfix for https://github.com/microsoft/vcpkg/issues/34877: https://github.com/microsoft/vcpkg-tool/releases/tag/2023-11-16

--

@LarryOsterman, I am adding `#include <opentelemetry/sdk/trace/recordable.h>` for the `sdk/core/azure-core-tracing-opentelemetry/test/ut/test_exporter.hpp`. It only updates the unit test code and does not require a package release (unit tests are not compiled when our SDK is being installed as vcpkg package). It is not a breaking change either. Everything should compile with both the previous version of `opentelemetry-cpp`, and the new one.

The reason is - vcpkg now has an updated version of `opentelemetry-cpp` - `1.12.0` - https://github.com/microsoft/vcpkg/pull/33983.

And one of the commits which went into that version, was "`[SDK] Header files cleanup, use forward declarations`", which has specifically dropped `#include <opentelemetry/sdk/trace/recordable.h>` line from the `opentelemetry/sdk/trace/exporter.h`, which is the only header file that we were including before at that place. But it is no longer sufficient:
https://github.com/open-telemetry/opentelemetry-cpp/commit/cfcda5728e75e51215d118eccd639e21cf4fd74d#diff-c44d1944597823ab10bd389630f778367fb19eaac5ae68cdefa5e8d5f71a5783L9