### PR TITLE
Nullable::Emplace() to set HasValue()

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- [[#5172]](https://github.com/Azure/azure-sdk-for-cpp/issues/5172) `Azure::Nullable::Emplace()` does not set `HasValue()` to `true`.
+
 ### Other Changes
 
 ## 1.11.0-beta.2 (2023-11-02)

--- a/sdk/core/azure-core/inc/azure/core/nullable.hpp
+++ b/sdk/core/azure-core/inc/azure/core/nullable.hpp
@@ -218,6 +218,7 @@ public:
   {
     Reset();
     ::new (static_cast<void*>(&m_value)) T(std::forward<U>(Args)...);
+    m_hasValue = true;
     return m_value;
   }
 

--- a/sdk/core/azure-core/test/ut/nullable_test.cpp
+++ b/sdk/core/azure-core/test/ut/nullable_test.cpp
@@ -99,6 +99,34 @@ TEST(Nullable, ValueAssignment)
   EXPECT_FALSE(strVal.HasValue());
 }
 
+TEST(Nullable, Emplace)
+{
+  {
+    Azure::Nullable<int> x;
+    EXPECT_FALSE(x.HasValue());
+    EXPECT_EQ(x.Emplace(42), 42);
+    EXPECT_TRUE(x.HasValue());
+    EXPECT_EQ(x.Value(), 42);
+  }
+
+  {
+    Azure::Nullable<int> y;
+    EXPECT_FALSE(y.HasValue());
+    EXPECT_EQ(y.Emplace(), 0);
+    EXPECT_TRUE(y.HasValue());
+    EXPECT_EQ(y.Value(), 0);
+  }
+
+  {
+    Azure::Nullable<int> z = 42;
+    EXPECT_TRUE(z.HasValue());
+    EXPECT_EQ(z.Value(), 42);
+    EXPECT_EQ(z.Emplace(), 0);
+    EXPECT_TRUE(z.HasValue());
+    EXPECT_EQ(z.Value(), 0);
+  }
+}
+
 TEST(Nullable, Swap)
 {
   Nullable<int> val1;


### PR DESCRIPTION
Closes #5172.
This is consistent with `std::optional`: https://godbolt.org/z/8T41ceeG4