### PR TITLE
AzureCliCredential: add support for `expires_on` field.

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- [[#5116]](https://github.com/Azure/azure-sdk-for-cpp/issues/5116) `AzureCliCredential`: Added support for the new response field which represents token expiration timestamp as time zone agnostic value.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -156,11 +156,11 @@ AccessToken AzureCliCredential::GetToken(
         // The order of elements in the vector below does matter - the code tries to find them
         // consequently, and if finding the first one succeeds, we would not attempt to parse the
         // second one. That is important, because the newer Azure CLI versions do have the new
-        // 'expires_on' field, which is not affected by time zone changes. The 'ExpiresOn' field was
+        // 'expires_on' field, which is not affected by time zone changes. The 'expiresOn' field was
         // the only field that was present in the older versions, and it had problems, because it
         // was a local timestamp without the time zone information.
         // So, if only the 'expires_on' is available, we try to use it, and only if it is not
-        // available, we fall back to trying to get the value via 'ExpiresOn', which we also now are
+        // available, we fall back to trying to get the value via 'expiresOn', which we also now are
         // able to handle correctly, except when the token expiration crosses the time when the
         // local system clock moves to and from DST.
         return TokenCredentialImpl::ParseToken(

--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -154,7 +154,10 @@ AccessToken AzureCliCredential::GetToken(
       try
       {
         return TokenCredentialImpl::ParseToken(
-            azCliResult, "accessToken", "expiresIn", "expiresOn");
+            azCliResult,
+            "accessToken",
+            "expiresIn",
+            std::vector<std::string>{"expires_on", "expiresOn"});
       }
       catch (json::exception const&)
       {

--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -153,6 +153,16 @@ AccessToken AzureCliCredential::GetToken(
 
       try
       {
+        // The order of elements in the vector below does matter - the code tries to find them
+        // consequently, and if finding the first one succeeds, we would not attempt to parse the
+        // second one. That is important, because the newer Azure CLI versions do have the new
+        // 'expires_on' field, which is not affected by time zone changes. The 'ExpiresOn' field was
+        // the only field that was present in the older versions, and it had problems, because it
+        // was a local timestamp without the time zone information.
+        // So, if only the 'expires_on' is available, we try to use it, and only if it is not
+        // available, we fall back to trying to get the value via 'ExpiresOn', which we also now are
+        // able to handle correctly, except when the token expiration crosses the time when the
+        // local system clock moves to and from DST.
         return TokenCredentialImpl::ParseToken(
             azCliResult,
             "accessToken",

--- a/sdk/identity/azure-identity/src/private/token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/token_credential_impl.hpp
@@ -68,11 +68,16 @@ namespace Azure { namespace Identity { namespace _detail {
      * @param expiresInPropertyName Name of a property in the JSON object that represents token
      * expiration in number of seconds from now.
      * @param expiresOnPropertyNames Names of properties in the JSON object that represent token
-     * expiration as absolute date-time stamp.
+     * expiration as absolute date-time stamp. Can be empty, in which case no attempt to parse the
+     * corresponding property will be made. Empty string elements will be ignored.
+     *
      *
      * @return A successfully parsed access token.
      *
      * @throw `std::exception` if there was a problem parsing the token.
+     *
+     * @note The order of elements in \p expiresOnPropertyNames does matter: the code will first try
+     * to find a property with the name of the first element, then of a second one, and so on.
      */
     static Core::Credentials::AccessToken ParseToken(
         std::string const& jsonString,

--- a/sdk/identity/azure-identity/src/private/token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/token_credential_impl.hpp
@@ -67,6 +67,27 @@ namespace Azure { namespace Identity { namespace _detail {
      * token.
      * @param expiresInPropertyName Name of a property in the JSON object that represents token
      * expiration in number of seconds from now.
+     * @param expiresOnPropertyNames Names of properties in the JSON object that represent token
+     * expiration as absolute date-time stamp.
+     *
+     * @return A successfully parsed access token.
+     *
+     * @throw `std::exception` if there was a problem parsing the token.
+     */
+    static Core::Credentials::AccessToken ParseToken(
+        std::string const& jsonString,
+        std::string const& accessTokenPropertyName,
+        std::string const& expiresInPropertyName,
+        std::vector<std::string> const& expiresOnPropertyNames);
+
+    /**
+     * @brief Parses JSON that contains access token and its expiration.
+     *
+     * @param jsonString String with a JSON object to parse.
+     * @param accessTokenPropertyName Name of a property in the JSON object that represents access
+     * token.
+     * @param expiresInPropertyName Name of a property in the JSON object that represents token
+     * expiration in number of seconds from now.
      * @param expiresOnPropertyName Name of a property in the JSON object that represents token
      * expiration as absolute date-time stamp. Can be empty, in which case no attempt to parse it is
      * made.
@@ -79,7 +100,14 @@ namespace Azure { namespace Identity { namespace _detail {
         std::string const& jsonString,
         std::string const& accessTokenPropertyName,
         std::string const& expiresInPropertyName,
-        std::string const& expiresOnPropertyName);
+        std::string const& expiresOnPropertyName)
+    {
+      return ParseToken(
+          jsonString,
+          accessTokenPropertyName,
+          expiresInPropertyName,
+          std::vector<std::string>{expiresOnPropertyName});
+    }
 
     /**
      * @brief Holds `#Azure::Core::Http::Request` and all the associated resources for the HTTP

--- a/sdk/identity/azure-identity/src/private/token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/token_credential_impl.hpp
@@ -71,7 +71,6 @@ namespace Azure { namespace Identity { namespace _detail {
      * expiration as absolute date-time stamp. Can be empty, in which case no attempt to parse the
      * corresponding property will be made. Empty string elements will be ignored.
      *
-     *
      * @return A successfully parsed access token.
      *
      * @throw `std::exception` if there was a problem parsing the token.

--- a/sdk/identity/azure-identity/src/token_credential_impl.cpp
+++ b/sdk/identity/azure-identity/src/token_credential_impl.cpp
@@ -288,7 +288,8 @@ AccessToken TokenCredentialImpl::ParseToken(
 
   if (nonEmptyExpiresOnPropertyNames.empty())
   {
-    // 'expires_in' is undefined, 'expires_on' is not expected.
+    // The code was not able to parse the value of 'expires_in', and the caller did not pass any
+    // 'expires_on' for us to find and try parse.
     ThrowJsonPropertyError(
         expiresInPropertyName,
         parsedJson,

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -252,10 +252,8 @@ TEST(AzureCliCredential, ExpiresOnUnixTimestampString)
   TokenRequestContext trc;
   trc.Scopes.push_back("https://storage.azure.com/.default");
 
-  auto const timestampBefore = std::chrono::system_clock::now();
   auto const token = azCliCred.GetToken(trc, {});
-  auto const timestampAfter = std::chrono::system_clock::now();
-
+  
   EXPECT_EQ(token.Token, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
 
   EXPECT_EQ(

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -248,9 +248,9 @@ TEST(AzureCliCredential, ExpiresOnUnixTimestampInt)
 TEST(AzureCliCredential, ExpiresOnUnixTimestampString)
 {
   // 'expires_on' is 1700692424, which is a Unix timestamp of a date in 2023.
-  // 'ExpiresOn' is a date in 2022.
+  // 'expiresOn' is a date in 2022.
   // The test checks that when both are present, 'expires_on' value (2023) is taken,
-  // and not that of 'ExpiresOn'.
+  // and not that of 'expiresOn'.
   // The test is similar to the one above, but the Unix timestamp is represented as string
   // containing an integer.
   constexpr auto Token = "{\"accessToken\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\","

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -253,7 +253,7 @@ TEST(AzureCliCredential, ExpiresOnUnixTimestampString)
   trc.Scopes.push_back("https://storage.azure.com/.default");
 
   auto const token = azCliCred.GetToken(trc, {});
-  
+
   EXPECT_EQ(token.Token, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
 
   EXPECT_EQ(

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -221,6 +221,50 @@ TEST(AzureCliCredential, ExpiresIn)
   EXPECT_LE(token.ExpiresOn, timestampAfter + std::chrono::seconds(30));
 }
 
+TEST(AzureCliCredential, ExpiresOnUnixTimestampInt)
+{
+  constexpr auto Token = "{\"accessToken\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\","
+                         "\"expiresOn\":\"2022-08-24 00:43:08.000000\","
+                         "\"expires_on\":1700692424}";
+
+  AzureCliTestCredential const azCliCred(EchoCommand(Token));
+
+  TokenRequestContext trc;
+  trc.Scopes.push_back("https://storage.azure.com/.default");
+
+  auto const timestampBefore = std::chrono::system_clock::now();
+  auto const token = azCliCred.GetToken(trc, {});
+  auto const timestampAfter = std::chrono::system_clock::now();
+
+  EXPECT_EQ(token.Token, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+  EXPECT_EQ(
+      token.ExpiresOn,
+      DateTime::Parse("2023-11-22T22:33:44.000000Z", DateTime::DateFormat::Rfc3339));
+}
+
+TEST(AzureCliCredential, ExpiresOnUnixTimestampString)
+{
+  constexpr auto Token = "{\"accessToken\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\","
+                         "\"expiresOn\":\"2022-08-24 00:43:08.000000\","
+                         "\"expires_on\":\"1700692424\"}";
+
+  AzureCliTestCredential const azCliCred(EchoCommand(Token));
+
+  TokenRequestContext trc;
+  trc.Scopes.push_back("https://storage.azure.com/.default");
+
+  auto const timestampBefore = std::chrono::system_clock::now();
+  auto const token = azCliCred.GetToken(trc, {});
+  auto const timestampAfter = std::chrono::system_clock::now();
+
+  EXPECT_EQ(token.Token, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+  EXPECT_EQ(
+      token.ExpiresOn,
+      DateTime::Parse("2023-11-22T22:33:44.000000Z", DateTime::DateFormat::Rfc3339));
+}
+
 TEST(AzureCliCredential, TimedOut)
 {
   AzureCliCredentialOptions options;

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -232,9 +232,7 @@ TEST(AzureCliCredential, ExpiresOnUnixTimestampInt)
   TokenRequestContext trc;
   trc.Scopes.push_back("https://storage.azure.com/.default");
 
-  auto const timestampBefore = std::chrono::system_clock::now();
   auto const token = azCliCred.GetToken(trc, {});
-  auto const timestampAfter = std::chrono::system_clock::now();
 
   EXPECT_EQ(token.Token, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
 

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -223,9 +223,13 @@ TEST(AzureCliCredential, ExpiresIn)
 
 TEST(AzureCliCredential, ExpiresOnUnixTimestampInt)
 {
+  // 'expires_on' is 1700692424, which is a Unix timestamp of a date in 2023.
+  // 'ExpiresOn' is a date in 2022.
+  // The test checks that when both are present, 'expires_on' value (2023) is taken,
+  // and not that of 'ExpiresOn'.
   constexpr auto Token = "{\"accessToken\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\","
-                         "\"expiresOn\":\"2022-08-24 00:43:08.000000\","
-                         "\"expires_on\":1700692424}";
+                         "\"expiresOn\":\"2022-08-24 00:43:08.000000\"," // <-- 2022
+                         "\"expires_on\":1700692424}"; // <-- 2023
 
   AzureCliTestCredential const azCliCred(EchoCommand(Token));
 
@@ -243,9 +247,15 @@ TEST(AzureCliCredential, ExpiresOnUnixTimestampInt)
 
 TEST(AzureCliCredential, ExpiresOnUnixTimestampString)
 {
+  // 'expires_on' is 1700692424, which is a Unix timestamp of a date in 2023.
+  // 'ExpiresOn' is a date in 2022.
+  // The test checks that when both are present, 'expires_on' value (2023) is taken,
+  // and not that of 'ExpiresOn'.
+  // The test is similar to the one above, but the Unix timestamp is represented as string
+  // containing an integer.
   constexpr auto Token = "{\"accessToken\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\","
-                         "\"expiresOn\":\"2022-08-24 00:43:08.000000\","
-                         "\"expires_on\":\"1700692424\"}";
+                         "\"expiresOn\":\"2022-08-24 00:43:08.000000\"," // <-- 2022
+                         "\"expires_on\":\"1700692424\"}"; // <-- 2023
 
   AzureCliTestCredential const azCliCred(EchoCommand(Token));
 

--- a/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
@@ -872,7 +872,7 @@ TEST(TokenCredentialImpl, Diagnosability)
           "}",
           "TokenForAccessing",
           "TokenExpiresInSeconds",
-          ""));
+          std::string{}));
     }
     catch (std::exception const& e)
     {
@@ -947,6 +947,17 @@ TEST(TokenCredentialImpl, Diagnosability)
 
   // Token is ok, relative expiration can't be parsed, two absolute expiration property names were
   // provided, none of them can be parsed.
+  // I.e.
+  // 1. Token is ok.
+  // 2. Relative expiration ('TokenExpiresInSeconds') is not ok (null),
+  // 3. Absolute expiration (two properties - 'TokenExpiresAtTime' and 'token_expires_at_time')
+  //    are not ok (both are null).
+  //
+  // The test verifies that we print the log message that involves the names of BOTH absolute
+  // expiration properties.
+  //
+  // For all other tests, the message would include only one absolute expiration property
+  // ('TokenExpiresAtTime'), now we check that both are printed.
   {
     LogMsgVec log;
     Logger::SetListener([&](auto lvl, auto msg) { log.push_back(std::make_pair(lvl, msg)); });
@@ -984,8 +995,8 @@ TEST(TokenCredentialImpl, Diagnosability)
         "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
         "relative expiration property ('TokenExpiresInSeconds'): null, "
-        "absolute expiration property ('token_expires_at_time'): null, "
-        "absolute expiration property ('TokenExpiresAtTime'): null, "
+        "absolute expiration property ('token_expires_at_time'): null, " // <-- this gets printed
+        "absolute expiration property ('TokenExpiresAtTime'): null, " // <-- as well as this
         "and there are no other properties.");
 
     Logger::SetListener(nullptr);

--- a/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_impl_test.cpp
@@ -894,7 +894,6 @@ TEST(TokenCredentialImpl, Diagnosability)
         "Please report an issue with the following details:\n"
         "Token JSON: Access token property ('TokenForAccessing'): string.length=11, "
         "relative expiration property ('TokenExpiresInSeconds'): \"one\", "
-        "absolute expiration property (''): undefined, "
         "and there are no other properties.");
 
     Logger::SetListener(nullptr);


### PR DESCRIPTION
Closes #5116.

It works the following way - if `expires_on` (the new one) property is present, it gets parsed before `ExpiresOn` (the old one) property.

This PR is not a replacement for #5179, which mitigates the issue if the user has older version of Azure CLI installed. We can't expect users to always have the latest installed. The one without time zone info has been there first, for many years, and only now they are adding the `expires_on` property.

#5179 is good enough, but not ideal - once a year, one day in fall, when it is close to moving from DST, the token will be off for one hour, and then everything should work, but an extra token request will be sent when the auth policy will supply a token which was obtained when the DST was on, but the service will reject it, and then the policy will tell the credential to get a new token, and everything will work once again.
And one day in spring, when the clock moves to DST, the tokens obtained will have 1 hour shorter expiration than what they actually are, and some extra requests to refresh tokens will be made.

--
UWP CI is currently blocked until https://github.com/microsoft/vcpkg/issues/35279 is fixed / https://github.com/microsoft/vcpkg/pull/35116 is merged (#5181 would unblock)