### PR TITLE
Temporarily disable UWP CI

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -109,37 +109,6 @@
     },
     {
       "StaticConfigs": {
-        "Win2022": {
-          "VcpkgInstall": "openssl",
-          "OSVmImage": "windows-2022",
-          "Pool": "azsdk-pool-mms-win-2022-general",
-          "CMAKE_GENERATOR": "Visual Studio 17 2022",
-          "PublishMapFiles": "true"
-        }
-      },
-      "TargetPlatform": {
-        "UWP_debug": {
-          "CMAKE_SYSTEM_NAME": "WindowsStore",
-          "CMAKE_SYSTEM_VERSION": "10.0",
-          "CmakeArgs": " -DBUILD_TRANSPORT_WINHTTP=ON -DDISABLE_AZURE_CORE_OPENTELEMETRY=ON ",
-          "BuildArgs": "--parallel 8 --config Debug"
-        },
-        "UWP_release": {
-          "CMAKE_SYSTEM_NAME": "WindowsStore",
-          "CMAKE_SYSTEM_VERSION": "10.0",
-          "CmakeArgs": " -DBUILD_TRANSPORT_WINHTTP=ON -DDISABLE_AZURE_CORE_OPENTELEMETRY=ON ",
-          "BuildArgs": "--parallel 8 --config Release"
-        }
-      },
-      "TargetArchitecture": {
-        "x64": {
-          "CMAKE_GENERATOR_PLATFORM": "x64",
-          "VCPKG_DEFAULT_TRIPLET": "x64-uwp"
-        }
-      }
-    },
-    {
-      "StaticConfigs": {
         "Ubuntu22": {
           "OSVmImage": "MMSUbuntu22.04",
           "Pool": "azsdk-pool-mms-ubuntu-2204-general",


### PR DESCRIPTION
Our UWP CI legs are currently blocked until https://github.com/microsoft/vcpkg/issues/35279 is fixed / https://github.com/microsoft/vcpkg/pull/35116 is merged, so if your PR is blocked, you can merge this PR to unblock. We will revert it once it is fixed in vcpkg.