### PR TITLE
Remove some usages of internal APIs in samples

### DIFF
--- a/samples/integration/vcpkg-all-smoke/src/main.cpp
+++ b/samples/integration/vcpkg-all-smoke/src/main.cpp
@@ -8,7 +8,6 @@
 
 #include <azure/attestation.hpp>
 #include <azure/core.hpp>
-#include <azure/core/internal/json/json.hpp>
 #include <azure/identity.hpp>
 #include <azure/keyvault/certificates.hpp>
 #include <azure/keyvault/keys.hpp>

--- a/sdk/attestation/azure-security-attestation/samples/policy/reset_policy.cpp
+++ b/sdk/attestation/azure-security-attestation/samples/policy/reset_policy.cpp
@@ -17,9 +17,6 @@
  */
 
 #include <azure/attestation.hpp>
-#include <azure/core/base64.hpp>
-#include <azure/core/cryptography/hash.hpp>
-#include <azure/core/internal/cryptography/sha_hash.hpp>
 #include <azure/identity.hpp>
 
 #include <chrono>
@@ -34,7 +31,6 @@ using namespace Azure::Security::Attestation;
 using namespace Azure::Security::Attestation::Models;
 using namespace std::chrono_literals;
 using namespace Azure::Core;
-using namespace Azure::Core::Cryptography::_internal;
 
 int main()
 {

--- a/sdk/attestation/azure-security-attestation/samples/policy/reset_sealed_policy.cpp
+++ b/sdk/attestation/azure-security-attestation/samples/policy/reset_sealed_policy.cpp
@@ -20,9 +20,6 @@
 #include "cryptohelpers.hpp"
 
 #include <azure/attestation.hpp>
-#include <azure/core/base64.hpp>
-#include <azure/core/cryptography/hash.hpp>
-#include <azure/core/internal/cryptography/sha_hash.hpp>
 #include <azure/identity.hpp>
 
 #include <chrono>
@@ -37,7 +34,6 @@ using namespace Azure::Security::Attestation;
 using namespace Azure::Security::Attestation::Models;
 using namespace std::chrono_literals;
 using namespace Azure::Core;
-using namespace Azure::Core::Cryptography::_internal;
 
 int main()
 {

--- a/sdk/attestation/azure-security-attestation/samples/policy/set_policy.cpp
+++ b/sdk/attestation/azure-security-attestation/samples/policy/set_policy.cpp
@@ -29,7 +29,7 @@
 #include <thread>
 #include <vector>
 
-// cspell:: words mrsigner mrenclave mitm
+// cspell: words mrsigner mitm
 using namespace Azure::Security::Attestation;
 using namespace Azure::Security::Attestation::Models;
 using namespace std::chrono_literals;

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
@@ -21,12 +21,12 @@ int main()
   char* const eventhubName{std::getenv("EVENTHUB_NAME")};
   if (eventhubConnectionString == nullptr)
   {
-    std::cout << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
     return 1;
   }
   if (eventhubName == nullptr)
   {
-    std::cout << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
     return 1;
   }
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
@@ -11,12 +11,7 @@
 // Both of these should be available from the Azure portal.
 //
 
-#include <azure/core/diagnostics/logger.hpp>
-#include <azure/core/internal/diagnostics/log.hpp>
 #include <azure/messaging/eventhubs.hpp>
-
-using namespace Azure::Core::Diagnostics;
-using namespace Azure::Core::Diagnostics::_internal;
 
 #include <iostream>
 
@@ -43,7 +38,6 @@ int main()
   // Retrieve properties about the EventHubs instance just created.
   auto eventhubProperties{consumerClient.GetEventHubProperties()};
   std::cout << "Created event hub, properties: " << eventhubProperties << std::endl;
-  Log::Stream(Logger::Level::Verbose) << "Created event hub, properties: " << eventhubProperties;
 
   // Retrieve properties about the EventHubs instance just created.
   auto partitionProperties{
@@ -57,13 +51,11 @@ int main()
   partitionClientOptions.StartPosition.Earliest = true;
   partitionClientOptions.StartPosition.Inclusive = true;
 
-  Log::Stream(Logger::Level::Verbose)
-      << "Creating partition client. Start position: " << partitionClientOptions.StartPosition;
-  Log::Stream(Logger::Level::Verbose)
-      << "Creating partition client. Start position: " << partitionClientOptions.StartPosition;
+  std::cerr << "Creating partition client. Start position: "
+            << partitionClientOptions.StartPosition;
 
-  Log::Stream(Logger::Level::Verbose) << "earliest: HasValue: " << std::boolalpha
-                                      << partitionClientOptions.StartPosition.Earliest.HasValue();
+  std::cerr << "earliest: HasValue: " << std::boolalpha
+            << partitionClientOptions.StartPosition.Earliest.HasValue();
   if (partitionClientOptions.StartPosition.Earliest.HasValue())
   {
     std::cerr << "earliest: Value: " << std::boolalpha

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
@@ -21,12 +21,12 @@ int main()
   char* const eventhubName{std::getenv("EVENTHUB_NAME")};
   if (eventhubConnectionString == nullptr)
   {
-    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    std::cout << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
     return 1;
   }
   if (eventhubName == nullptr)
   {
-    std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    std::cout << "Missing environment variable EVENTHUB_NAME" << std::endl;
     return 1;
   }
 
@@ -51,14 +51,14 @@ int main()
   partitionClientOptions.StartPosition.Earliest = true;
   partitionClientOptions.StartPosition.Inclusive = true;
 
-  std::cerr << "Creating partition client. Start position: "
+  std::cout << "Creating partition client. Start position: "
             << partitionClientOptions.StartPosition;
 
-  std::cerr << "earliest: HasValue: " << std::boolalpha
+  std::cout << "earliest: HasValue: " << std::boolalpha
             << partitionClientOptions.StartPosition.Earliest.HasValue();
   if (partitionClientOptions.StartPosition.Earliest.HasValue())
   {
-    std::cerr << "earliest: Value: " << std::boolalpha
+    std::cout << "earliest: Value: " << std::boolalpha
               << partitionClientOptions.StartPosition.Earliest.Value() << std::endl;
   }
 


### PR DESCRIPTION
These are the easy to remove.
We have about 4 more instances of using `_internal` in samples that are not as straightforward to remove:
* `Azure::Storage::_internal::ParseConnectionString()` (`blob_sas.cpp`) - #5192
* `Azure::Core::Cryptography::_internal::Sha256Hash` (`set_policy.cpp`, `set_sealed_policy.cpp`) - #5193
* `Azure::Core::_internal::StringExtensions::ToUpper()` (`cryptohelpers.hpp`) - #5194
* `Azure::Core::_internal::Base64Url::Base64UrlDecode()` (`attestation_collateral.cpp`) - #5195

In either case I would address them in separate PRs, but maybe I'll just create the issues for them and let the service owners to fix them.

--
UWP CI is currently blocked until https://github.com/microsoft/vcpkg/issues/35279 is fixed / https://github.com/microsoft/vcpkg/pull/35116 is merged (#5181 would unblock)