### PR TITLE
URL: avoid double slash at the start of the path

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- [[#5130]](https://github.com/Azure/azure-sdk-for-cpp/issues/5130) `Url::AppendPath()` and `Url::SetPath()` may end up with a double slash at the beginning of a path.
+
 ### Other Changes
 
 ## 1.11.0-beta.2 (2023-11-02)

--- a/sdk/core/azure-core/src/http/url.cpp
+++ b/sdk/core/azure-core/src/http/url.cpp
@@ -219,7 +219,10 @@ std::string Url::GetUrlWithoutQuery(bool relative) const
   {
     if (!relative)
     {
-      url += "/";
+      if (m_encodedPath.empty() || m_encodedPath[0] != '/')
+      {
+        url += "/";
+      }
     }
 
     url += m_encodedPath;

--- a/sdk/core/azure-core/test/ut/url_test.cpp
+++ b/sdk/core/azure-core/test/ut/url_test.cpp
@@ -339,6 +339,9 @@ namespace Azure { namespace Core { namespace Test {
     Core::Url const u0("https://www.microsoft.com");
     Core::Url const u1("https://www.microsoft.com/");
 
+    EXPECT_EQ(u0.GetAbsoluteUrl(), "https://www.microsoft.com");
+    EXPECT_EQ(u1.GetAbsoluteUrl(), "https://www.microsoft.com");
+
     {
       auto url0 = u0;
       auto url1 = u1;

--- a/sdk/core/azure-core/test/ut/url_test.cpp
+++ b/sdk/core/azure-core/test/ut/url_test.cpp
@@ -7,8 +7,7 @@
 
 namespace Azure { namespace Core { namespace Test {
 
-  class TestURL : public ::testing::Test {
-  };
+  class TestURL : public ::testing::Test {};
 
 }}} // namespace Azure::Core::Test
 
@@ -332,5 +331,47 @@ namespace Azure { namespace Core { namespace Test {
     EXPECT_EQ(params.size(), 1);
     EXPECT_NE(params.find("param"), params.end());
     EXPECT_EQ(params["param"], "value");
+  }
+
+  TEST(URL, LeadingSlashInPath)
+  {
+    Core::Url const u0("https://www.microsoft.com");
+    Core::Url const u1("https://www.microsoft.com/");
+
+    {
+      auto url0 = u0;
+      auto url1 = u1;
+      url0.AppendPath("path");
+      url1.AppendPath("path");
+      EXPECT_EQ(url0.GetAbsoluteUrl(), "https://www.microsoft.com/path");
+      EXPECT_EQ(url1.GetAbsoluteUrl(), "https://www.microsoft.com/path");
+    }
+
+    {
+      auto url0 = u0;
+      auto url1 = u1;
+      url0.AppendPath("/path");
+      url1.AppendPath("/path");
+      EXPECT_EQ(url0.GetAbsoluteUrl(), "https://www.microsoft.com/path");
+      EXPECT_EQ(url1.GetAbsoluteUrl(), "https://www.microsoft.com/path");
+    }
+
+    {
+      auto url0 = u0;
+      auto url1 = u1;
+      url0.SetPath("path");
+      url1.SetPath("path");
+      EXPECT_EQ(url0.GetAbsoluteUrl(), "https://www.microsoft.com/path");
+      EXPECT_EQ(url1.GetAbsoluteUrl(), "https://www.microsoft.com/path");
+    }
+
+    {
+      auto url0 = u0;
+      auto url1 = u1;
+      url0.SetPath("/path");
+      url1.SetPath("/path");
+      EXPECT_EQ(url0.GetAbsoluteUrl(), "https://www.microsoft.com/path");
+      EXPECT_EQ(url1.GetAbsoluteUrl(), "https://www.microsoft.com/path");
+    }
   }
 }}} // namespace Azure::Core::Test

--- a/sdk/core/azure-core/test/ut/url_test.cpp
+++ b/sdk/core/azure-core/test/ut/url_test.cpp
@@ -7,7 +7,8 @@
 
 namespace Azure { namespace Core { namespace Test {
 
-  class TestURL : public ::testing::Test {};
+  class TestURL : public ::testing::Test {
+  };
 
 }}} // namespace Azure::Core::Test
 


### PR DESCRIPTION
Closes #5130.

Previous behavior:
```cpp
  TEST(URL, LeadingSlashInPath)
  {
    Core::Url const u0("https://www.microsoft.com");
    Core::Url const u1("https://www.microsoft.com/");

    EXPECT_EQ(u0.GetAbsoluteUrl(), "https://www.microsoft.com");
    EXPECT_EQ(u1.GetAbsoluteUrl(), "https://www.microsoft.com");

    {
      auto url0 = u0;
      auto url1 = u1;
      url0.AppendPath("path");
      url1.AppendPath("path");
      EXPECT_EQ(url0.GetAbsoluteUrl(), "https://www.microsoft.com/path");
      EXPECT_EQ(url1.GetAbsoluteUrl(), "https://www.microsoft.com/path");
    }

    {
      auto url0 = u0;
      auto url1 = u1;
      url0.AppendPath("/path");
      url1.AppendPath("/path");
      EXPECT_EQ(url0.GetAbsoluteUrl(), "https://www.microsoft.com//path"); // <-- fixed in this PR
      EXPECT_EQ(url1.GetAbsoluteUrl(), "https://www.microsoft.com//path"); // <-- fixed in this PR
    }

    {
      auto url0 = u0;
      auto url1 = u1;
      url0.SetPath("path");
      url1.SetPath("path");
      EXPECT_EQ(url0.GetAbsoluteUrl(), "https://www.microsoft.com/path");
      EXPECT_EQ(url1.GetAbsoluteUrl(), "https://www.microsoft.com/path");
    }

    {
      auto url0 = u0;
      auto url1 = u1;
      url0.SetPath("/path");
      url1.SetPath("/path");
      EXPECT_EQ(url0.GetAbsoluteUrl(), "https://www.microsoft.com//path"); // <-- fixed in this PR
      EXPECT_EQ(url1.GetAbsoluteUrl(), "https://www.microsoft.com//path"); // <-- fixed in this PR
    }
  }
```

--
UWP CI is currently blocked until https://github.com/microsoft/vcpkg/issues/35279 is fixed / https://github.com/microsoft/vcpkg/pull/35116 is merged (#5181 would unblock)