### PR TITLE
Remove unnecessary condition

### DIFF
--- a/sdk/core/azure-core/src/http/url.cpp
+++ b/sdk/core/azure-core/src/http/url.cpp
@@ -219,7 +219,7 @@ std::string Url::GetUrlWithoutQuery(bool relative) const
   {
     if (!relative)
     {
-      if (m_encodedPath.empty() || m_encodedPath[0] != '/')
+      if (m_encodedPath[0] != '/')
       {
         url += "/";
       }


### PR DESCRIPTION
We check that `!m_encodedPath.empty()` 5 lines above, so another check is not necessary.

PR feedback from [5211](https://github.com/Azure/azure-sdk-for-cpp/pull/5187#discussion_r1408604226).