### PR TITLE
Increase CI timeouts from 2 hours to 3 hours

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -24,7 +24,7 @@ stages:
 
   jobs:
   - job: Run
-    timeoutInMinutes: 180
+    timeoutInMinutes: 120
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
       vmImage: ubuntu-22.04

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -24,7 +24,7 @@ stages:
 
   jobs:
   - job: Run
-    timeoutInMinutes: 120
+    timeoutInMinutes: 180
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
       vmImage: ubuntu-22.04

--- a/eng/pipelines/templates/jobs/cmake-generate-jobs.yml
+++ b/eng/pipelines/templates/jobs/cmake-generate-jobs.yml
@@ -16,7 +16,7 @@ parameters:
     default: []
   - name: TimeoutInMinutes
     type: number
-    default: 120
+    default: 180
 
 jobs:
 - template: /eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml

--- a/eng/pipelines/templates/jobs/cmake-generate.tests.yml
+++ b/eng/pipelines/templates/jobs/cmake-generate.tests.yml
@@ -30,7 +30,7 @@ parameters:
     default: CMakeGenerate
   - name: TimeoutInMinutes
     type: number
-    default: 120
+    default: 180
 
 jobs:
 - job: ${{ parameters.JobName }}

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -16,7 +16,7 @@ parameters:
   default: sdk/*/*/*cov_xml.xml
 - name: TimeoutInMinutes
   type: number
-  default: 120
+  default: 180
 - name: DependsOn
   type: string
   default: ''

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -25,7 +25,7 @@ parameters:
   default: 'sdk/*/*/*cov_xml.xml'
 - name: LiveTestTimeoutInMinutes
   type: number
-  default: 120
+  default: 180
 - name: LineCoverageTarget
   type: number
   default: 95
@@ -75,7 +75,7 @@ parameters:
   default: []
 - name: CMakeGenerationTimeoutInMinutes 
   type: number
-  default: 120
+  default: 180
 
 stages:
   - stage: CMakeGeneration

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -13,7 +13,7 @@ parameters:
   default: sdk/*/*/*cov_xml.xml
 - name: TimeoutInMinutes
   type: number
-  default: 120
+  default: 180
 - name: Location
   type: string
   default: ''


### PR DESCRIPTION
Currently, `CMakeGenerate Mac` takes almost 2 hours (#5191). I have notified the EngSys team in the chat.
It is notpossible to check in some PRs, when the job is taking >120 minutes.
Sometimes, it is just 5 minutes under 2 hours. Sometimes, it would be 3 minutes over.
I am restarting failed CI jobs for up to 5 times per PR, wasting resources and my time.
https://dev.azure.com/azure-sdk/public/_build/results?buildId=3298466&view=logs&j=94476f33-b33b-5d10-fc7e-16660285ffcd&s=5af4c603-7527-5b9e-aad4-3d4eca22d489

Until Mac CI performance is not fixed, increasing timeouts to 3 hours is the lesser evil.
We can revert timeoouts back to 2 hours once Mac CI performance issue is fixed.