### PR TITLE
Fix SAS token generation

### DIFF
--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -1,4 +1,5 @@
 param(
+    [string] $StorageAccountName = 'cppvcpkgcache',
     [string] $StorageAccountKey
 )
 
@@ -27,7 +28,7 @@ $env:PSModulePath = $modulePaths -join $moduleSeperator
 Install-ModuleIfNotInstalled "Az.Storage" "4.3.0" | Import-Module
 
 $ctx = New-AzStorageContext `
-    -StorageAccountName 'cppvcpkgcache' `
+    -StorageAccountName $StorageAccountName `
     -StorageAccountKey $StorageAccountKey
 $token = New-AzStorageAccountSASToken `
     -Service Blob `
@@ -35,8 +36,15 @@ $token = New-AzStorageAccountSASToken `
     -Permission "rwc" `
     -Context $ctx `
     -ExpiryTime (Get-Date).AddDays(1)
-$vcpkgBinarySourceSas = $token.Substring(1)
+
+$vcpkgBinarySourceSas = $token
+if ($token.StartsWith('?')) {
+    $vcpkgBinarySourceSas = $token.Substring(1)
+}
 
 Write-Host "Setting vcpkg binary cache to read and write"
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
 Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"
+
+Write-Host "Enusre redaction of SAS tokens in logs" 
+Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -37,10 +37,10 @@ $token = New-AzStorageAccountSASToken `
     -Context $ctx `
     -ExpiryTime (Get-Date).AddDays(1)
 
-# $vcpkgBinarySourceSas = $token
-# if ($token.StartsWith('?')) {
+$vcpkgBinarySourceSas = $token
+if ($token.StartsWith('?')) {
     $vcpkgBinarySourceSas = $token.Substring(1)
-# }
+}
 
 Write-Host "Enusre redaction of SAS tokens in logs" 
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -42,9 +42,9 @@ if ($token.StartsWith('?')) {
     $vcpkgBinarySourceSas = $token.Substring(1)
 }
 
+Write-Host "Enusre redaction of SAS tokens in logs" 
+Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"
+
 Write-Host "Setting vcpkg binary cache to read and write"
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
 Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"
-
-Write-Host "Enusre redaction of SAS tokens in logs" 
-Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -37,10 +37,10 @@ $token = New-AzStorageAccountSASToken `
     -Context $ctx `
     -ExpiryTime (Get-Date).AddDays(1)
 
-$vcpkgBinarySourceSas = $token
-if ($token.StartsWith('?')) {
+# $vcpkgBinarySourceSas = $token
+# if ($token.StartsWith('?')) {
     $vcpkgBinarySourceSas = $token.Substring(1)
-}
+# }
 
 Write-Host "Enusre redaction of SAS tokens in logs" 
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -42,7 +42,7 @@ if ($token.StartsWith('?')) {
     $vcpkgBinarySourceSas = $token.Substring(1)
 }
 
-Write-Host "Enusre redaction of SAS tokens in logs" 
+Write-Host "Ensure redaction of SAS tokens in logs" 
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"
 
 Write-Host "Setting vcpkg binary cache to read and write"


### PR DESCRIPTION
Fixes #5214
Fixes #5191

* Improve log redaction for internal logs -- [Example logs showing improved redaction](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3306501&view=logs&j=5b40fe45-3be6-55b8-8b6c-da8150e7e0d7&t=11993ae9-0d33-503c-0a4e-62d7d35853c8&l=142)
* Ensure proper token is passed to vcpkg -- The recent 6.0.0 release of the Az.Storage PowerShell module [removes the preceding `?` in the token](https://github.com/Azure/azure-powershell/issues/15309). The previous implementation assumed that the `?` was always present and removed the first character, producing an invalid token. 