### PR TITLE
Proof of concept for implementing 'failfast' requests via additional HttpRequest options

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -19,6 +19,7 @@
 #include "azure/core/url.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <map>
@@ -164,7 +165,7 @@ namespace Azure { namespace Core { namespace Http {
   }; // extensible enum HttpMethod
 
   namespace Policies { namespace _internal {
-    class RetryPolicy;
+      class RetryPolicy;
   }} // namespace Policies::_internal
 
   /**
@@ -210,6 +211,9 @@ namespace Azure { namespace Core { namespace Http {
     void StartTry();
 
   public:
+    bool DoNotRetry = false;
+    std::chrono::milliseconds ConnectionTimeout = std::chrono::milliseconds(0); // 0 means default
+
     /**
      * @brief Construct an #Azure::Core::Http::Request.
      *

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -140,7 +140,8 @@ namespace Azure { namespace Core {
       Azure::Core::_internal::UniqueHandle<HINTERNET> CreateSessionHandle();
       Azure::Core::_internal::UniqueHandle<HINTERNET> CreateConnectionHandle(
           Azure::Core::Url const& url,
-          Azure::Core::Context const& context);
+          Azure::Core::Context const& context,
+          Azure::Core::_internal::UniqueHandle<HINTERNET> const& sessionHandle);
       std::unique_ptr<_detail::WinHttpRequest> CreateRequestHandle(
           Azure::Core::_internal::UniqueHandle<HINTERNET> const& connectionHandle,
           Azure::Core::Url const& url,

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -345,9 +345,15 @@ std::unique_ptr<RawResponse> CurlTransport::Send(Request& request, Context const
   // Create CurlSession to perform request
   Log::Write(Logger::Level::Verbose, LogMsgPrefix + "Creating a new session.");
 
+  auto options = m_options;
+  if (request.ConnectionTimeout > std::chrono::milliseconds(0))
+  {
+    options.ConnectionTimeout = request.ConnectionTimeout;
+  }
+
   auto session = std::make_unique<CurlSession>(
       request,
-      CurlConnectionPool::g_curlConnectionPool.ExtractOrCreateCurlConnection(request, m_options),
+      CurlConnectionPool::g_curlConnectionPool.ExtractOrCreateCurlConnection(request, options),
       m_options);
 
   CURLcode performing;

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -142,7 +142,8 @@ std::unique_ptr<RawResponse> RetryPolicy::Send(
 
       // If we are out of retry attempts, if a response is non-retriable (or simply 200 OK, i.e
       // doesn't need to be retried), then ShouldRetry returns false.
-      if (!ShouldRetryOnResponse(*response.get(), m_retryOptions, attempt, retryAfter))
+      if (request.DoNotRetry
+          || !ShouldRetryOnResponse(*response.get(), m_retryOptions, attempt, retryAfter))
       {
         // If this is the second attempt and StartTry was called, we need to stop it. Otherwise
         // trying to perform same request would use last retry query/headers
@@ -156,7 +157,7 @@ std::unique_ptr<RawResponse> RetryPolicy::Send(
         Log::Write(Logger::Level::Warning, std::string("HTTP Transport error: ") + e.what());
       }
 
-      if (!ShouldRetryOnTransportFailure(m_retryOptions, attempt, retryAfter))
+      if (request.DoNotRetry || !ShouldRetryOnTransportFailure(m_retryOptions, attempt, retryAfter))
       {
         throw;
       }

--- a/sdk/identity/azure-identity/samples/default_azure_credential.cpp
+++ b/sdk/identity/azure-identity/samples/default_azure_credential.cpp
@@ -1,37 +1,57 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
+#include <azure/core/diagnostics/logger.hpp>
+#include <azure/core/internal/environment.hpp>
 #include <azure/identity/default_azure_credential.hpp>
-#include <azure/service/client.hpp>
 
+// Uncomment as necessary
+// #include <azure/core/http/curl_transport.hpp>
+// #include <azure/core/http/win_http_transport.hpp>
+
+#include <chrono>
 #include <iostream>
+#include <memory>
 
 int main()
 {
+  // Uncomment the code line below if you want no logging.
+  // Otherwise, make sure that you have AZURE_LOG_LEVEL=verbose set in the environment.
+  // Azure::Core::Diagnostics::Logger::SetListener(nullptr);
+
+  // Unset all the variables that other credentials read from, to make sure DefaultAzureCredential
+  // falls into AzureCliCredential.
+  Azure::Core::_internal::Environment::SetVariable("AZURE_AUTHORITY_HOST", "");
+  Azure::Core::_internal::Environment::SetVariable("AZURE_CLIENT_CERTIFICATE_PATH", "");
+  Azure::Core::_internal::Environment::SetVariable("AZURE_CLIENT_ID", "");
+  Azure::Core::_internal::Environment::SetVariable("AZURE_CLIENT_SECRET", "");
+  Azure::Core::_internal::Environment::SetVariable("AZURE_FEDERATED_TOKEN_FILE", "");
+  Azure::Core::_internal::Environment::SetVariable("AZURE_TENANT_ID", "");
+  Azure::Core::_internal::Environment::SetVariable("IDENTITY_ENDPOINT", "");
+  Azure::Core::_internal::Environment::SetVariable("IDENTITY_HEADER", "");
+  Azure::Core::_internal::Environment::SetVariable("IDENTITY_SERVER_THUMBPRINT", "");
+  Azure::Core::_internal::Environment::SetVariable("IMDS_ENDPOINT", "");
+  Azure::Core::_internal::Environment::SetVariable("MSI_ENDPOINT", "");
+  Azure::Core::_internal::Environment::SetVariable("MSI_SECRET", "");
+
+  Azure::Core::Credentials::TokenCredentialOptions credOptions;
+
+  // Uncomment as necessary. I tested with both - it works.
+  //credOptions.Transport.Transport = std::make_shared<Azure::Core::Http::CurlTransport>();
+  //credOptions.Transport.Transport = std::make_shared<Azure::Core::Http::WinHttpTransport>();
+
+  const auto cred = std::make_shared<Azure::Identity::DefaultAzureCredential>(credOptions);
   try
   {
-    // Step 1: Initialize Default Azure Credential.
-    // Default Azure Credential is good for samples and initial development stages only.
-    // It is not recommended used it in a production environment.
-    // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
-
-    auto defaultAzureCredential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
-
-    // Step 2: Pass the credential to an Azure Service Client.
-    Azure::Service::Client azureServiceClient("serviceUrl", defaultAzureCredential);
-
-    // Step 3: Start using the Azure Service Client.
-    azureServiceClient.DoSomething(Azure::Core::Context::ApplicationContext);
-
-    std::cout << "Success!" << std::endl;
+    Azure::Core::Credentials::TokenRequestContext trc;
+    trc.Scopes.push_back("https://vault.azure.net/.default");
+    auto const before = std::chrono::steady_clock::now();
+    static_cast<void>(cred->GetToken(trc, Azure::Core::Context::ApplicationContext));
+    auto const after = std::chrono::steady_clock::now();
+    std::cout << "\n\n-=-=-= Time: "
+              << std::chrono::duration_cast<std::chrono::seconds>(after - before).count()
+              << " seconds. =-=-=-\n";
   }
-  catch (const Azure::Core::Credentials::AuthenticationException& exception)
+  catch (std::exception const& ex)
   {
-    // Step 4: Handle authentication errors, if needed
-    // (invalid credential parameters, insufficient permissions).
-    std::cout << "Authentication error: " << exception.what() << std::endl;
-    return 1;
+    std::cout << "\n\n-=-=-= Exception thrown: =-=-=-\n"
+              << ex.what() << "\n-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n";
   }
-
-  return 0;
 }

--- a/sdk/identity/azure-identity/src/default_azure_credential.cpp
+++ b/sdk/identity/azure-identity/src/default_azure_credential.cpp
@@ -47,7 +47,7 @@ DefaultAzureCredential::DefaultAzureCredential(
   // calls.
   m_impl = std::make_unique<_detail::ChainedTokenCredentialImpl>(
       GetCredentialName(),
-      ChainedTokenCredential::Sources{envCred, wiCred, azCliCred, managedIdentityCred},
+      ChainedTokenCredential::Sources{envCred, wiCred, managedIdentityCred, azCliCred},
       true);
 }
 

--- a/sdk/identity/azure-identity/src/private/managed_identity_source.hpp
+++ b/sdk/identity/azure-identity/src/private/managed_identity_source.hpp
@@ -10,7 +10,9 @@
 #include <azure/core/credentials/token_credential_options.hpp>
 #include <azure/core/url.hpp>
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -173,6 +175,8 @@ namespace Azure { namespace Identity { namespace _detail {
   class ImdsManagedIdentitySource final : public ManagedIdentitySource {
   private:
     Core::Http::Request m_request;
+    mutable std::mutex m_isFirstRequestMutex;
+    mutable std::atomic<bool> m_isFirstRequest = true;
 
     explicit ImdsManagedIdentitySource(
         std::string const& clientId,


### PR DESCRIPTION
Now it takes 2-4 seconds to get token via AzureCliCredential, which sits after the ManagedIdentityCredential.