### PR TITLE
Move squid image to registry mirror

### DIFF
--- a/sdk/core/azure-core/test/ut/proxy_tests/localproxy.passwd/Dockerfile
+++ b/sdk/core/azure-core/test/ut/proxy_tests/localproxy.passwd/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # DisableDockerDetector "This was used for testing in the past. If such testing can be supported in the future this container will be used again."
-FROM ubuntu/squid
+FROM azsdkengsys.azurecr.io/mirror/ubuntu/squid
 LABEL maintainer "Larry Osterman<github.com/LarryOsterman>"
 
 ENV NGINX_VERSION 1.23.1

--- a/sdk/core/azure-core/test/ut/proxy_tests/localproxy/Dockerfile
+++ b/sdk/core/azure-core/test/ut/proxy_tests/localproxy/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # DisableDockerDetector "This was used for testing in the past. If such testing can be supported in the future this container will be used again."
-FROM ubuntu/squid
+FROM azsdkengsys.azurecr.io/mirror/ubuntu/squid
 LABEL maintainer "Larry Osterman<github.com/LarryOsterman>"
 
 ENV NGINX_VERSION 1.23.1

--- a/sdk/core/azure-core/test/ut/proxy_tests/readme.md
+++ b/sdk/core/azure-core/test/ut/proxy_tests/readme.md
@@ -4,8 +4,7 @@
 
 Running the proxy tests requires two docker containers, one hosting an anonymous squid proxy, the other hosting an authenticated squid proxy.
 
-This container is derived from the ubuntu/squid container on dockerhub. This container is maintained by the Ubuntu team and has
-a current version of Ubuntu in it, with a version of squid built to match.
+This container is derived from the azsdkengsys.azurecr.io/mirror/ubuntu/squid container. This container is mirrored from ubuntu/squid on dockerhub, maintained by the Ubuntu team and has a current version of Ubuntu in it, with a version of squid built to match. To update the image in the mirror, see [this pipeline](https://dev.azure.com/azure-sdk/internal/_build/index?definitionId=6572).
 
 ## Building the container
 

--- a/sdk/core/azure-core/test/ut/proxy_tests/readme.md
+++ b/sdk/core/azure-core/test/ut/proxy_tests/readme.md
@@ -4,7 +4,7 @@
 
 Running the proxy tests requires two docker containers, one hosting an anonymous squid proxy, the other hosting an authenticated squid proxy.
 
-This container is derived from the azsdkengsys.azurecr.io/mirror/ubuntu/squid container. This container is mirrored from ubuntu/squid on dockerhub, maintained by the Ubuntu team and has a current version of Ubuntu in it, with a version of squid built to match. To update the image in the mirror, see [this pipeline](https://dev.azure.com/azure-sdk/internal/_build/index?definitionId=6572).
+This container is derived from the azsdkengsys.azurecr.io/mirror/ubuntu/squid container, and requires [authentication to the azsdkengsys container registry](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli) to pull. This container is mirrored from ubuntu/squid on dockerhub, maintained by the Ubuntu team and has a current version of Ubuntu in it, with a version of squid built to match. To update the image in the mirror, see [this pipeline](https://dev.azure.com/azure-sdk/internal/_build/index?definitionId=6572).
 
 ## Building the container
 

--- a/sdk/core/azure-core/test/ut/proxy_tests/readme.md
+++ b/sdk/core/azure-core/test/ut/proxy_tests/readme.md
@@ -4,7 +4,7 @@
 
 Running the proxy tests requires two docker containers, one hosting an anonymous squid proxy, the other hosting an authenticated squid proxy.
 
-This container is derived from the azsdkengsys.azurecr.io/mirror/ubuntu/squid container, and requires [authentication to the azsdkengsys container registry](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli) to pull. This container is mirrored from ubuntu/squid on dockerhub, maintained by the Ubuntu team and has a current version of Ubuntu in it, with a version of squid built to match. To update the image in the mirror, see [this pipeline](https://dev.azure.com/azure-sdk/internal/_build/index?definitionId=6572).
+This container is derived from the `azsdkengsys.azurecr.io/mirror/ubuntu/squid` container, and requires [authentication to the azsdkengsys container registry](https://learn.microsoft.com/azure/container-registry/container-registry-authentication?tabs=azure-cli) to pull. This container is mirrored from ubuntu/squid on dockerhub, maintained by the Ubuntu team and has a current version of Ubuntu in it, with a version of squid built to match. To update the image in the mirror, see [this pipeline](https://dev.azure.com/azure-sdk/internal/_build/index?definitionId=6572).
 
 ## Building the container
 

--- a/sdk/core/azure-core/test/ut/proxy_tests/remoteproxy.passwd/Dockerfile
+++ b/sdk/core/azure-core/test/ut/proxy_tests/remoteproxy.passwd/Dockerfile
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 
 # DisableDockerDetector "This was used for testing in the past. If such testing can be supported in the future this container will be used again."
+# NOTE: this registry requires authentication in order to be pulled from.
 FROM azsdkengsys.azurecr.io/mirror/ubuntu/squid
 LABEL maintainer "Larry Osterman<github.com/LarryOsterman>"
 

--- a/sdk/core/azure-core/test/ut/proxy_tests/remoteproxy.passwd/Dockerfile
+++ b/sdk/core/azure-core/test/ut/proxy_tests/remoteproxy.passwd/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # DisableDockerDetector "This was used for testing in the past. If such testing can be supported in the future this container will be used again."
-FROM ubuntu/squid
+FROM azsdkengsys.azurecr.io/mirror/ubuntu/squid
 LABEL maintainer "Larry Osterman<github.com/LarryOsterman>"
 
 ENV NGINX_VERSION 1.23.1

--- a/sdk/core/azure-core/test/ut/proxy_tests/remoteproxy/Dockerfile
+++ b/sdk/core/azure-core/test/ut/proxy_tests/remoteproxy/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # DisableDockerDetector "This was used for testing in the past. If such testing can be supported in the future this container will be used again."
-FROM ubuntu/squid
+FROM azsdkengsys.azurecr.io/mirror/ubuntu/squid
 LABEL maintainer "Larry Osterman<github.com/LarryOsterman>"
 
 ENV NGINX_VERSION 1.23.1

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -76,10 +76,10 @@ stages:
 #          workingDirectory: $(Build.SourcesDirectory)/sdk/core/azure-core/test/ut/proxy_tests
 #          displayName: Verify Proxy Server Working Correctly.
 #          condition: and(succeeded(), variables.RunProxyTests, contains(variables.CmakeArgs, 'BUILD_TESTING=ON'))
-            
+
 #      PostTestSteps:
 #        - pwsh: |
-#            docker ps -q -f ancestor=ubuntu/squid | ForEach-Object { `
+#            docker ps -q -f ancestor=azsdkengsys.azurecr.io/mirror/ubuntu/squid | ForEach-Object { `
 #                docker stop $_ `
 #            }
 #          displayName: Shutdown Squid Proxy.
@@ -102,7 +102,7 @@ stages:
           Value: "https://non-real-account.vault.azure.net"
         - Name: AZURE_KEYVAULT_HSM_URL
           Value: "https://non-real-account.managedhsm.azure.net/"
-# Key Vault & Identity 
+# Key Vault & Identity
         - Name: AZURE_TENANT_ID
           Value: "33333333-3333-3333-3333-333333333333"
         - Name: AZURE_CLIENT_ID


### PR DESCRIPTION
Moving all images we consume from the public registry to a mirrored registry. See https://dev.azure.com/azure-sdk/internal/_build/index?definitionId=6572 to update the mirrored image(s).
