### PR TITLE
Add CODEOWNERS linter baseline error file

### DIFF
--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -1,0 +1,4 @@
+ahsonkhan is not a public member of Azure.
+schaabs is not a public member of Azure.
+anilba06 is not a public member of Azure.
+EmmaZhu is not a public member of Azure.


### PR DESCRIPTION
CODEOWNERS is now going to be linted. _This PR contains the existing linter errors, deduped, which are used to filter results, otherwise this pipeline couldn't be run on PRs that contain CODEOWNERS changes without the several hundred issues being fixed, which is not ideal._ The linter will run daily and on every change to CODEOWNERS or the baseline file. Specific details of the linting can be found [here](https://github.com/Azure/azure-sdk-tools/tree/main/tools/codeowners-utils#linting) but here is what's being verified in a nutshell.

- Metadata tags - PRLabels, ServiceLabels, ServiceOwners (previously /&lt;NotInRepo&gt;/, both are still valid for the moment) and AzureSdkOwners (new, used for issue triage). 
- Source paths - Does the path exist? If the path is a glob, is it valid and does it have matches in the repository? 
- Owners - There are several verifications for owners:
    - Does the owner, individual or team, have write access (every team/individual in a CODEOWNERS file needs to have write access, this is a GitHub thing).
    - Is the owner public? Individuals need to set their Azure membership to public. This is explicitly mentioned in the [onboarding documents](https://eng.ms/docs/products/azure-developer-experience/onboard/access) for azure-sdk repositories.