### PR TITLE
Add a remark in CAInfo doc comment mentioning it is Linux only.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -120,7 +120,7 @@ namespace Azure { namespace Core { namespace Http {
      * @remark The default is the built-in system specific path. More about this option:
      * https://curl.se/libcurl/c/CURLOPT_CAINFO.html
      *
-     * @remark This option is only supported on Linux and will throw if set on other platforms.
+     * @remark This option is known to only work on Linux and might throw if set on other platforms.
      *
      */
     std::string CAInfo;

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -119,7 +119,7 @@ namespace Azure { namespace Core { namespace Http {
      *
      * @remark The default is the built-in system specific path. More about this option:
      * https://curl.se/libcurl/c/CURLOPT_CAINFO.html
-     * 
+     *
      * @remark This option is only supported on Linux and will throw if set on other platforms.
      *
      */

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -119,6 +119,8 @@ namespace Azure { namespace Core { namespace Http {
      *
      * @remark The default is the built-in system specific path. More about this option:
      * https://curl.se/libcurl/c/CURLOPT_CAINFO.html
+     * 
+     * @remark This option is only supported on Linux and will throw if set on other platforms.
      *
      */
     std::string CAInfo;


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk-for-cpp/pull/5207