### PR TITLE
[CODEOWNERS] Remove automation section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,13 +34,6 @@
 # PRLabel: %EngSys
 /sdk/template/           @danieljurek @weshaggard @LarryOsterman @RickWinter 
 
-################
-# Automation
-################
-
-# Git Hub integration and bot rules
-/.github/                @jsquire @rickwinter @ronniegeraghty
-
 ###########
 # Eng Sys
 ###########


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the automation section, as CODEOWNERS changes no longer require manual syncing.?
