### PR TITLE
Fixed bug in Eventhubs live tests

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor_partition_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor_partition_client.hpp
@@ -58,8 +58,11 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     /// Returns the partition ID associated with this ProcessorPartitionClient.
     std::string PartitionId() const { return m_partitionId; }
 
-    /** Closes the partition client.     */
-    void Close(Core::Context const& context)
+    /** @brief Closes the partition client.
+     *
+     * @param context The context to pass to the close operation.
+     */
+    void Close(Core::Context const& context = {})
     {
       if (m_cleanupFunc)
       {

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/eventhubs_admin_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/eventhubs_admin_client.cpp
@@ -406,8 +406,8 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
       std::string const& resourceGroup,
       std::string const& subscriptionId,
       Azure::Core::Context const& context)
-      : m_name(name), m_resourceGroup(resourceGroup), m_subscriptionId(subscriptionId),
-        m_pipeline{pipeline}
+      : m_name(name), m_resourceGroup(resourceGroup),
+        m_subscriptionId(subscriptionId), m_pipeline{pipeline}
   {
     Azure::Core::Url requestUrl(
         "https://management.azure.com/subscriptions/" + Azure::Core::Url::Encode(m_subscriptionId)

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/eventhubs_admin_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/eventhubs_admin_client.cpp
@@ -9,7 +9,7 @@
 #include <azure/core/internal/json/json.hpp>
 #include <azure/core/platform.hpp>
 #include <azure/core/response.hpp>
-#include <azure/identity/azure_cli_credential.hpp>
+#include <azure/identity/default_azure_credential.hpp>
 
 #include <memory>
 #include <sstream>
@@ -35,7 +35,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
       tokenContext.Scopes = {"https://management.azure.com/.default"};
       perRetrypolicies.emplace_back(
           std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
-              std::make_unique<Azure::Identity::AzureCliCredential>(), tokenContext));
+              std::make_unique<Azure::Identity::DefaultAzureCredential>(), tokenContext));
     }
     std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perCallpolicies;
     options.Telemetry.ApplicationId = "eventhubs.test";

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/processor_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/processor_test.cpp
@@ -581,12 +581,17 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
     while (!partitionClients.empty())
     {
       auto partitionClientIterator = partitionClients.begin();
-      auto partitionClient = partitionClientIterator->second;
+      std::shared_ptr<ProcessorPartitionClient> partitionClient;
       if (partitionClientIterator != partitionClients.end())
       {
+        partitionClient = partitionClientIterator->second;
         partitionClients.erase(partitionClientIterator);
       }
-      partitionClient->Close(context);
+      // Don't re-use the context variable here, because it's been canceled.
+      if (partitionClient)
+      {
+        partitionClient->Close();
+      }
     }
 
     processor.Stop();


### PR DESCRIPTION
Fixes a bug introduced during the blocking close checks. The "Context" variable was inadvertently added to a `ProcessorPartitionClient::Close` call.

Also made the `Context` parameter for `ProcessorPartitionClient::Close` optional.

Also use `AzureCliCredential` rather than `DefaultAzureCredential` for the management API tests, because `DefaultAzureCredential` generates too much noise to enable diagnosis of authentication failures.

## Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
