### PR TITLE
Move the connection back to the connection pool when HTTP error 404 was received

### DIFF
--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2132,8 +2132,7 @@ void CurlConnectionPool::MoveConnectionBackToPool(
     HttpStatusCode lastStatusCode)
 {
   auto code = static_cast<std::underlying_type<Http::HttpStatusCode>::type>(lastStatusCode);
-  // laststatusCode = 0
-  if ((code < 200 || code >= 300) && code != 404)
+  if ((code < 200 || code >= 300) && lastStatusCode != HttpStatusCode::NotFound)
   {
     // A handler with previous response with Error can't be re-use.
     return;

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2133,7 +2133,7 @@ void CurlConnectionPool::MoveConnectionBackToPool(
 {
   auto code = static_cast<std::underlying_type<Http::HttpStatusCode>::type>(lastStatusCode);
   // laststatusCode = 0
-  if (code < 200 || code >= 300)
+  if ((code < 200 || code >= 300) && code != 404)
   {
     // A handler with previous response with Error can't be re-use.
     return;


### PR DESCRIPTION
The HTTP error 404 should not be a reason to drop the connection. This specific error does not indicate circumstances where establishing a new connection is preferable. This principle applies to almost all 4xx errors, but 404 should definitely be considered a regular part of the workflow. By dropping the connection after a 404 error, the performance of a multithreaded application is significantly decreased without a serious reason.