### PR TITLE
Retroactively update AMQP's changelog

### DIFF
--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features Added
 
-The `Close` method on AMQP Message Sender and Message Receiver now blocks until the client receives a `DETACH` response from the remote node.
+- The `Close` method on AMQP Message Sender and Message Receiver now blocks until the client receives a `DETACH` response from the remote node.
 
 ### Breaking Changes
 


### PR DESCRIPTION
We missed a dash.

I already updated the GitHub release page (https://github.com/Azure/azure-sdk-for-cpp/releases/tag/azure-core-amqp_1.0.0-beta.7), as well as the changelog that is going to be published along with the February release blog post.

This is just to keep everything in sync. All the places where it might have went, or is about to go, are looking as if that dash was there from the beginning.