### PR TITLE
Publishing to vcpkg-betas syncs vcpkg baseline to our repo

### DIFF
--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -77,7 +77,7 @@ try {
     $rawVcpkgConfig = Get-Content -Raw -Path $vcpkgConfigPath
     $vcpkgConfig = ConvertFrom-Json $rawVcpkgConfig
 
-    $azSdkRepoBaseline = (Get-Content $RepoRoot/vcpkg.json -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).'builtin-baseline'
+    $azSdkRepoBaseline = (Get-Content $PSScriptRoot/../../vcpkg.json -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).'builtin-baseline'
     if ($azSdkRepoBaseline -and $vcpkgConfig.'default-registry'.baseline) {
         $vcpkgConfig.'default-registry'.baseline = $azSdkRepoBaseline
     }

--- a/eng/scripts/Update-VcpkgBeta.ps1
+++ b/eng/scripts/Update-VcpkgBeta.ps1
@@ -77,9 +77,15 @@ try {
     $rawVcpkgConfig = Get-Content -Raw -Path $vcpkgConfigPath
     $vcpkgConfig = ConvertFrom-Json $rawVcpkgConfig
 
+    $azSdkRepoBaseline = (Get-Content $RepoRoot/vcpkg.json -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).'builtin-baseline'
+    if ($azSdkRepoBaseline -and $vcpkgConfig.'default-registry'.baseline) {
+        $vcpkgConfig.'default-registry'.baseline = $azSdkRepoBaseline
+    }
+
     $vcpkgConfig.registries[0].baseline = $baseHash
     if (!($vcpkgConfig.registries[0].packages -contains $VcpkgPortName)) {
         $vcpkgConfig.registries[0].packages += $VcpkgPortName
+        $vcpkgConfig.registries[0].packages = $vcpkgConfig.registries[0].packages | Sort-Object
     }
 
     $vcpkgConfigJson = ConvertTo-Json $vcpkgConfig -Depth 100


### PR DESCRIPTION
...and also it sorts packages.

I do this by hand, and sometimes I forget. It is time to automate this.

---
More detailed explanation of what this change does:

When publishing to https://github.com/Azure/azure-sdk-vcpkg-betas/commits/main, it takes `builtin-baseline` from https://github.com/Azure/azure-sdk-for-cpp/blob/735da80bf84e291d70fbf8493b557c35a41c37d6/vcpkg.json#L4

, and puts it into vcpkg-beta's `vcpkg-configuration.json` - https://github.com/Azure/azure-sdk-vcpkg-betas/blob/8672d4e9c2a599c7610042981b7b3b1ff7300d31/vcpkg-configuration.json#L4

--
**Result of running this**: https://github.com/Azure/azure-sdk-vcpkg-betas/commit/f88436d9b8a43875062c4484d117e9d141b50517