### PR TITLE
For existing surface area, classes marked as final should not have virtual methods.

### DIFF
--- a/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
@@ -110,8 +110,9 @@ namespace Azure { namespace Identity {
   private:
 #else
   protected:
+    virtual
 #endif
-    virtual std::string GetAzCommand(std::string const& scopes, std::string const& tenantId) const;
+    std::string GetAzCommand(std::string const& scopes, std::string const& tenantId) const;
     virtual int GetLocalTimeToUtcDiffSeconds() const;
   };
 

--- a/sdk/identity/azure-identity/inc/azure/identity/detail/token_cache.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/detail/token_cache.hpp
@@ -34,11 +34,20 @@ namespace Azure { namespace Identity { namespace _detail {
 #else
   protected:
 #endif
-    // A test hook that gets invoked before cache write lock gets acquired.
-    virtual void OnBeforeCacheWriteLock() const {};
 
-    // A test hook that gets invoked before item write lock gets acquired.
-    virtual void OnBeforeItemWriteLock() const {};
+#if defined(TESTING_BUILD)
+    virtual
+#endif
+        // A test hook that gets invoked before cache write lock gets acquired.
+        void
+        OnBeforeCacheWriteLock() const {};
+
+#if defined(TESTING_BUILD)
+    virtual
+#endif
+        // A test hook that gets invoked before item write lock gets acquired.
+        void
+        OnBeforeItemWriteLock() const {};
 
     struct CacheKey
     {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/5253 for existing identity surface.

For other parts of the repo (like in core/etc.), will follow-up separately and might consider a macro approach to make these ifdefs a little cleaner (an exception to the guideline to avoid using macros)