### PR TITLE
Guard against Windows' min/max macros

### DIFF
--- a/sdk/core/azure-core-amqp/README.md
+++ b/sdk/core/azure-core-amqp/README.md
@@ -49,7 +49,7 @@ An AMQP Message Sender is responsible for sending messages to an AMQP server ove
   senderOptions.Name = "sender-link";
   senderOptions.MessageSource = "source";
   senderOptions.SettleMode = Azure::Core::Amqp::_internal::SenderSettleMode::Unsettled;
-  senderOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  senderOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
 
   Azure::Core::Amqp::_internal::MessageSender sender(
       session, credentials->GetEntityPath(), senderOptions, nullptr);

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
@@ -228,7 +228,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * @remarks The maximum frame size must be at least 512 bytes. The default value is the maximum
      * value for a uint32.
      */
-    uint32_t MaxFrameSize{std::numeric_limits<uint32_t>::max()};
+    uint32_t MaxFrameSize{(std::numeric_limits<uint32_t>::max)()};
 
     /** @brief The maximum number of channels supported.
      *

--- a/sdk/core/azure-core-amqp/samples/README.md
+++ b/sdk/core/azure-core-amqp/samples/README.md
@@ -79,7 +79,7 @@ Demonstrates writing messages to the Azure Event Hubs service using the AMQP pro
   senderOptions.Name = "sender-link";
   senderOptions.MessageSource = "source";
   senderOptions.SettleMode = Azure::Core::Amqp::_internal::SenderSettleMode::Unsettled;
-  senderOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  senderOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
 
   Azure::Core::Amqp::_internal::MessageSender sender(
       session, credentials->GetEntityPath(), senderOptions, nullptr);

--- a/sdk/core/azure-core-amqp/samples/internal/eventhub_async_writer_sample/eventhub_async_writer_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/eventhub_async_writer_sample/eventhub_async_writer_sample.cpp
@@ -29,8 +29,8 @@ int main()
       credentials->GetHostName(), credentials->GetPort(), credentials, connectionOptions);
 
   Azure::Core::Amqp::_internal::SessionOptions sessionOptions;
-  sessionOptions.InitialIncomingWindowSize = std::numeric_limits<int32_t>::max();
-  sessionOptions.InitialOutgoingWindowSize = std::numeric_limits<uint16_t>::max();
+  sessionOptions.InitialIncomingWindowSize = (std::numeric_limits<int32_t>::max)();
+  sessionOptions.InitialOutgoingWindowSize = (std::numeric_limits<uint16_t>::max)();
   Azure::Core::Amqp::_internal::Session session(connection);
 
   // @begin_snippet: CreateSender
@@ -38,7 +38,7 @@ int main()
   senderOptions.Name = "sender-link";
   senderOptions.MessageSource = "source";
   senderOptions.SettleMode = Azure::Core::Amqp::_internal::SenderSettleMode::Unsettled;
-  senderOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  senderOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
 
   Azure::Core::Amqp::_internal::MessageSender sender(
       session, credentials->GetEntityPath(), senderOptions, nullptr);

--- a/sdk/core/azure-core-amqp/samples/internal/eventhub_get_properties_sample/eventhub_get_eventhub_properties_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/eventhub_get_properties_sample/eventhub_get_eventhub_properties_sample.cpp
@@ -187,8 +187,8 @@ int main()
 
   // Establish a session to the eventhub.
   Azure::Core::Amqp::_internal::SessionOptions sessionOptions;
-  sessionOptions.InitialIncomingWindowSize = std::numeric_limits<int32_t>::max();
-  sessionOptions.InitialOutgoingWindowSize = std::numeric_limits<uint16_t>::max();
+  sessionOptions.InitialIncomingWindowSize = (std::numeric_limits<int32_t>::max)();
+  sessionOptions.InitialOutgoingWindowSize = (std::numeric_limits<uint16_t>::max)();
   Azure::Core::Amqp::_internal::Session session(connection.CreateSession(sessionOptions));
 
   auto eventHubProperties = GetEventHubProperties(session, eventhubsEntity);

--- a/sdk/core/azure-core-amqp/samples/internal/eventhub_reader_sample/eventhub_reader_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/eventhub_reader_sample/eventhub_reader_sample.cpp
@@ -33,7 +33,7 @@ int main()
   receiverOptions.Name = "receiver-link";
   receiverOptions.MessageTarget = "ingress-rx";
   receiverOptions.SettleMode = Azure::Core::Amqp::_internal::ReceiverSettleMode::First;
-  receiverOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  receiverOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
 
   Azure::Core::Amqp::_internal::MessageReceiver receiver(session, hostUrl, receiverOptions);
 

--- a/sdk/core/azure-core-amqp/samples/internal/eventhub_sas_reader_sample/eventhub_sas_reader_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/eventhub_sas_reader_sample/eventhub_sas_reader_sample.cpp
@@ -38,7 +38,7 @@ int main()
   receiverOptions.Name = "receiver-link";
   receiverOptions.MessageTarget = "ingress-rx";
   receiverOptions.SettleMode = Azure::Core::Amqp::_internal::ReceiverSettleMode::First;
-  receiverOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  receiverOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
   receiverOptions.EnableTrace = true;
 
   Azure::Core::Amqp::_internal::MessageReceiver receiver(session.CreateMessageReceiver(

--- a/sdk/core/azure-core-amqp/samples/internal/eventhub_sas_writer_sample/eventhub_sas_writer_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/eventhub_sas_writer_sample/eventhub_sas_writer_sample.cpp
@@ -30,8 +30,8 @@ int main()
       credential->GetHostName(), credential, connectionOptions);
 
   Azure::Core::Amqp::_internal::SessionOptions sessionOptions;
-  sessionOptions.InitialIncomingWindowSize = std::numeric_limits<int32_t>::max();
-  sessionOptions.InitialOutgoingWindowSize = std::numeric_limits<uint16_t>::max();
+  sessionOptions.InitialIncomingWindowSize = (std::numeric_limits<int32_t>::max)();
+  sessionOptions.InitialOutgoingWindowSize = (std::numeric_limits<uint16_t>::max)();
 
   Azure::Core::Amqp::_internal::Session session(connection.CreateSession(sessionOptions));
 
@@ -44,7 +44,7 @@ int main()
   senderOptions.Name = "sender-link";
   senderOptions.MessageSource = "ingress";
   senderOptions.SettleMode = Azure::Core::Amqp::_internal::SenderSettleMode::Settled;
-  senderOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  senderOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
   Azure::Core::Amqp::_internal::MessageSender sender(
       session.CreateMessageSender(entityPath, senderOptions, nullptr));
 

--- a/sdk/core/azure-core-amqp/samples/internal/eventhub_token_reader_sample/eventhub_token_reader_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/eventhub_token_reader_sample/eventhub_token_reader_sample.cpp
@@ -40,7 +40,7 @@ int main()
   receiverOptions.Name = "receiver-link";
   receiverOptions.MessageTarget = "ingress-rx";
   receiverOptions.SettleMode = Azure::Core::Amqp::_internal::ReceiverSettleMode::First;
-  receiverOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  receiverOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
   receiverOptions.EnableTrace = true;
 
   Azure::Core::Amqp::_internal::MessageReceiver receiver(session.CreateMessageReceiver(

--- a/sdk/core/azure-core-amqp/samples/internal/eventhub_token_writer_sample/eventhub_token_writer_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/eventhub_token_writer_sample/eventhub_token_writer_sample.cpp
@@ -41,8 +41,8 @@ int main()
   Azure::Core::Amqp::_internal::Connection connection(eventhubsHost, credential, connectionOptions);
 
   Azure::Core::Amqp::_internal::SessionOptions sessionOptions;
-  sessionOptions.InitialIncomingWindowSize = std::numeric_limits<int32_t>::max();
-  sessionOptions.InitialOutgoingWindowSize = std::numeric_limits<uint16_t>::max();
+  sessionOptions.InitialIncomingWindowSize = (std::numeric_limits<int32_t>::max)();
+  sessionOptions.InitialOutgoingWindowSize = (std::numeric_limits<uint16_t>::max)();
 
   Azure::Core::Amqp::_internal::Session session(connection.CreateSession(sessionOptions));
 
@@ -52,7 +52,7 @@ int main()
   message.SetBody(Azure::Core::Amqp::Models::AmqpValue{"Hello"});
 
   Azure::Core::Amqp::_internal::MessageSenderOptions senderOptions;
-  senderOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  senderOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
   senderOptions.MessageSource = "ingress";
   senderOptions.Name = "sender-link";
   senderOptions.SettleMode = Azure::Core::Amqp::_internal::SenderSettleMode::Settled;

--- a/sdk/core/azure-core-amqp/samples/internal/eventhub_writer_sample/eventhub_writer_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/eventhub_writer_sample/eventhub_writer_sample.cpp
@@ -25,8 +25,8 @@ int main()
       credentials->GetHostName(), connectionOptions);
 
   Azure::Core::Amqp::_internal::SessionOptions sessionOptions;
-  sessionOptions.InitialIncomingWindowSize = std::numeric_limits<int32_t>::max();
-  sessionOptions.InitialOutgoingWindowSize = std::numeric_limits<uint16_t>::max();
+  sessionOptions.InitialIncomingWindowSize = (std::numeric_limits<int32_t>::max)();
+  sessionOptions.InitialOutgoingWindowSize = (std::numeric_limits<uint16_t>::max)();
 
   Azure::Core::Amqp::_internal::Session session(connection, credentials, sessionOptions);
 
@@ -36,7 +36,7 @@ int main()
   senderOptions.Name = "sender-link";
   senderOptions.MessageSource = "ingress";
   senderOptions.SettleMode = Azure::Core::Amqp::_internal::SenderSettleMode::Unsettled;
-  senderOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  senderOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
   Azure::Core::Amqp::_internal::MessageSender sender(
       session, credentials->GetEntityPath(), senderOptions, nullptr);
 

--- a/sdk/core/azure-core-amqp/samples/internal/local_client_async_sample/local_client_async_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/local_client_async_sample/local_client_async_sample.cpp
@@ -18,15 +18,15 @@ int main()
   Azure::Core::Amqp::_internal::Connection connection("localhost", nullptr, connectionOptions);
 
   Azure::Core::Amqp::_internal::SessionOptions sessionOptions;
-  sessionOptions.InitialIncomingWindowSize = std::numeric_limits<int32_t>::max();
-  sessionOptions.InitialOutgoingWindowSize = std::numeric_limits<uint16_t>::max();
+  sessionOptions.InitialIncomingWindowSize = (std::numeric_limits<int32_t>::max)();
+  sessionOptions.InitialOutgoingWindowSize = (std::numeric_limits<uint16_t>::max)();
 
   Azure::Core::Amqp::_internal::Session session = connection.CreateSession(sessionOptions);
 
   Azure::Core::Amqp::_internal::MessageSenderOptions senderOptions;
   senderOptions.Name = "sender-link";
   senderOptions.MessageSource = "ingress";
-  senderOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  senderOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
   Azure::Core::Amqp::_internal::MessageSender sender{
       session.CreateMessageSender("localhost/ingress", senderOptions, nullptr)};
 

--- a/sdk/core/azure-core-amqp/samples/internal/local_client_sample/local_client_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/local_client_sample/local_client_sample.cpp
@@ -17,15 +17,15 @@ int main()
   Azure::Core::Amqp::_internal::Connection connection("localhost", nullptr, connectionOptions);
 
   Azure::Core::Amqp::_internal::SessionOptions sessionOptions;
-  sessionOptions.InitialIncomingWindowSize = std::numeric_limits<int32_t>::max();
-  sessionOptions.InitialOutgoingWindowSize = std::numeric_limits<uint16_t>::max();
+  sessionOptions.InitialIncomingWindowSize = (std::numeric_limits<int32_t>::max)();
+  sessionOptions.InitialOutgoingWindowSize = (std::numeric_limits<uint16_t>::max)();
 
   Azure::Core::Amqp::_internal::Session session{connection.CreateSession(sessionOptions)};
 
   Azure::Core::Amqp::_internal::MessageSenderOptions senderOptions;
   senderOptions.Name = "sender-link";
   senderOptions.MessageSource = "ingress";
-  senderOptions.MaxMessageSize = std::numeric_limits<uint16_t>::max();
+  senderOptions.MaxMessageSize = (std::numeric_limits<uint16_t>::max)();
   Azure::Core::Amqp::_internal::MessageSender sender{
       session.CreateMessageSender("localhost/ingress", senderOptions, nullptr)};
 

--- a/sdk/core/azure-core-amqp/src/amqp/message_receiver.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/message_receiver.cpp
@@ -219,7 +219,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     else
     {
-      m_link->SetMaxMessageSize(std::numeric_limits<uint64_t>::max());
+      m_link->SetMaxMessageSize((std::numeric_limits<uint64_t>::max)());
     }
     if (m_options.MaxLinkCredit != 0)
     {

--- a/sdk/core/azure-core-amqp/src/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/message_sender.cpp
@@ -219,7 +219,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     else
     {
-      m_link->SetMaxMessageSize(std::numeric_limits<uint64_t>::max());
+      m_link->SetMaxMessageSize((std::numeric_limits<uint64_t>::max)());
     }
     if (m_options.MaxLinkCredits != 0)
     {

--- a/sdk/core/azure-core-amqp/test/ut/amqp_value_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/amqp_value_tests.cpp
@@ -1237,7 +1237,7 @@ template <typename T> T GenerateRandomValue()
   std::random_device rd;
   std::mt19937 gen(rd());
   std::uniform_int_distribution<T> dis(
-      std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
+      (std::numeric_limits<T>::min)(), (std::numeric_limits<T>::max)());
   return dis(gen);
 }
 

--- a/sdk/core/azure-core-amqp/test/ut/azure_core_amqp_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/azure_core_amqp_tests.cpp
@@ -12,6 +12,7 @@
 #if defined(AZ_PLATFORM_WINDOWS)
 #if defined(_DEBUG) && defined(_MSC_VER)
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 // MSVC CRT error callback.
 // This function is called when a CRT error is detected.

--- a/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
@@ -70,7 +70,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
 
       // Verify defaults are something "reasonable".
       EXPECT_EQ(1, session.GetIncomingWindow());
-      EXPECT_EQ(std::numeric_limits<uint32_t>::max(), session.GetHandleMax());
+      EXPECT_EQ((std::numeric_limits<uint32_t>::max)(), session.GetHandleMax());
       EXPECT_EQ(1, session.GetOutgoingWindow());
     }
 

--- a/sdk/core/azure-core-test/inc/azure/core/test/test_proxy_manager.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_proxy_manager.hpp
@@ -40,11 +40,11 @@ namespace Azure { namespace Core { namespace Test {
     {
       Core::Credentials::AccessToken accessToken;
       accessToken.Token = "magicToken";
-      accessToken.ExpiresOn = DateTime::max();
+      accessToken.ExpiresOn = (DateTime::max)();
 
       if (context.IsCancelled() || tokenRequestContext.Scopes.size() == 0)
       {
-        accessToken.ExpiresOn = DateTime::min();
+        accessToken.ExpiresOn = (DateTime::min)();
       }
 
       return accessToken;

--- a/sdk/core/azure-core/src/context.cpp
+++ b/sdk/core/azure-core/src/context.cpp
@@ -11,7 +11,7 @@ Azure::DateTime Azure::Core::Context::GetDeadline() const
 {
   // Contexts form a tree. Here, we walk from a node all the way back to the root in order to find
   // the earliest deadline value.
-  auto result = DateTime::max();
+  auto result = (DateTime::max)();
   for (auto ptr = m_contextSharedState; ptr; ptr = ptr->Parent)
   {
     auto deadline = ContextSharedState::FromDateTimeRepresentation(ptr->Deadline);

--- a/sdk/core/azure-core/src/cryptography/md5.cpp
+++ b/sdk/core/azure-core/src/cryptography/md5.cpp
@@ -5,6 +5,9 @@
 #include "azure/core/platform.hpp"
 
 #if defined(AZ_PLATFORM_WINDOWS)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+
 // Windows needs to go before bcrypt
 #include <windows.h>
 

--- a/sdk/core/azure-core/src/cryptography/sha_hash.cpp
+++ b/sdk/core/azure-core/src/cryptography/sha_hash.cpp
@@ -4,6 +4,9 @@
 #include <azure/core/platform.hpp>
 
 #if defined(AZ_PLATFORM_WINDOWS)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+
 // Windows needs to go before bcrypt
 #include <windows.h>
 

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -44,15 +44,15 @@ DateTime GetSystemClockEpoch()
 DateTime GetMaxDateTime()
 {
   auto const systemClockMax = std::chrono::duration_cast<DateTime::clock::duration>(
-                                  std::chrono::system_clock::time_point::max().time_since_epoch())
+                                  (std::chrono::system_clock::time_point::max)().time_since_epoch())
                                   .count();
 
   auto const systemClockEpoch = GetSystemClockEpoch().time_since_epoch().count();
 
-  constexpr auto repMax = std::numeric_limits<DateTime::clock::duration::rep>::max();
+  constexpr auto repMax = (std::numeric_limits<DateTime::clock::duration::rep>::max)();
 
   return DateTime(DateTime::time_point(
-      DateTime::duration(systemClockMax + std::min(systemClockEpoch, (repMax - systemClockMax)))));
+      DateTime::duration(systemClockMax + (std::min)(systemClockEpoch, (repMax - systemClockMax)))));
 }
 
 template <typename T>
@@ -315,7 +315,7 @@ T ParseNumber(
 {
   if (*cursor + minLength <= strLen)
   {
-    auto const MaxChars = std::min(static_cast<int>(strLen - *cursor), maxLength);
+    auto const MaxChars = (std::min)(static_cast<int>(strLen - *cursor), maxLength);
     int64_t value = 0;
     auto i = 0;
     for (; i < MaxChars; ++i)
@@ -335,7 +335,7 @@ T ParseNumber(
       break;
     }
 
-    if (value >= 0 && value <= std::numeric_limits<T>::max())
+    if (value >= 0 && value <= (std::numeric_limits<T>::max)())
     {
       *cursor += i;
       return static_cast<T>(value);
@@ -422,7 +422,7 @@ DateTime::DateTime(
 
 DateTime::operator std::chrono::system_clock::time_point() const
 {
-  static DateTime SystemClockMin(std::chrono::system_clock::time_point::min());
+  static DateTime SystemClockMin((std::chrono::system_clock::time_point::min)());
   static DateTime SystemClockMax(GetMaxDateTime());
 
   auto outOfRange = 0;

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -51,8 +51,8 @@ DateTime GetMaxDateTime()
 
   constexpr auto repMax = (std::numeric_limits<DateTime::clock::duration::rep>::max)();
 
-  return DateTime(DateTime::time_point(
-      DateTime::duration(systemClockMax + (std::min)(systemClockEpoch, (repMax - systemClockMax)))));
+  return DateTime(DateTime::time_point(DateTime::duration(
+      systemClockMax + (std::min)(systemClockEpoch, (repMax - systemClockMax)))));
 }
 
 template <typename T>

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -154,7 +154,7 @@ int pollSocketUntilEventOrTimeout(
     // Before doing any work, check to make sure that the context hasn't already been cancelled.
     context.ThrowIfCancelled();
     int pollTimeoutMs = static_cast<int>(
-        std::min(
+        (std::min)(
             pollInterval, std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now))
             .count());
 #if defined(AZ_PLATFORM_POSIX)

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -81,10 +81,10 @@ std::chrono::milliseconds CalculateExponentialDelay(
       = std::numeric_limits<int32_t>::digits - (std::numeric_limits<int32_t>::is_signed ? 1 : 0);
 
   // Scale exponentially: 1 x RetryDelay on 1st attempt, 2x on 2nd, 4x on 3rd, 8x on 4th ... all the
-  // way up to std::numeric_limits<int32_t>::max() * RetryDelay.
+  // way up to (std::numeric_limits<int32_t>::max()) * RetryDelay.
   auto exponentialRetryAfter = retryOptions.RetryDelay
       * (((attempt - 1) <= beforeLastBit) ? (1 << (attempt - 1))
-                                          : std::numeric_limits<int32_t>::max());
+                                          : (std::numeric_limits<int32_t>::max()));
 
   // Multiply exponentialRetryAfter by jitterFactor
   exponentialRetryAfter = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(
@@ -92,7 +92,7 @@ std::chrono::milliseconds CalculateExponentialDelay(
        * jitterFactor)
           .count()));
 
-  return std::min(exponentialRetryAfter, retryOptions.MaxRetryDelay);
+  return (std::min)(exponentialRetryAfter, retryOptions.MaxRetryDelay);
 }
 
 bool WasLastAttempt(RetryOptions const& retryOptions, int32_t attempt)

--- a/sdk/core/azure-core/src/http/url.cpp
+++ b/sdk/core/azure-core/src/http/url.cpp
@@ -51,7 +51,7 @@ Url::Url(std::string const& url)
     // stoi will throw out_of_range when `int` is overflow, but we need to throw if uint16 is
     // overflow
     {
-      constexpr auto const MaxPortNumberSupported = std::numeric_limits<uint16_t>::max();
+      constexpr auto const MaxPortNumberSupported = (std::numeric_limits<uint16_t>::max)();
       if (portNumber > MaxPortNumberSupported)
       {
         throw std::out_of_range(

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -13,6 +13,13 @@
 #include "azure/core/http/win_http_transport.hpp"
 #include "azure/core/url.hpp"
 
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+
 #include <Windows.h>
 
 #include <memory>

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -14,6 +14,13 @@
 #include "win_http_request.hpp"
 #endif
 
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+
 #include <Windows.h>
 
 #include <algorithm>

--- a/sdk/core/azure-core/src/io/body_stream.cpp
+++ b/sdk/core/azure-core/src/io/body_stream.cpp
@@ -82,7 +82,7 @@ std::vector<uint8_t> BodyStream::ReadToEnd(Context const& context)
 size_t MemoryBodyStream::OnRead(uint8_t* buffer, size_t count, Context const& context)
 {
   (void)context;
-  size_t copy_length = std::min(count, this->m_length - this->m_offset);
+  size_t copy_length = (std::min)(count, this->m_length - this->m_offset);
   // Copy what's left or just the count
   std::memcpy(buffer, this->m_data + m_offset, static_cast<size_t>(copy_length));
   // move position

--- a/sdk/core/azure-core/src/io/random_access_file_body_stream.cpp
+++ b/sdk/core/azure-core/src/io/random_access_file_body_stream.cpp
@@ -38,7 +38,7 @@ size_t RandomAccessFileBodyStream::OnRead(
   auto numberOfBytesRead = pread(
       this->m_fileDescriptor,
       buffer,
-      std::min(static_cast<int64_t>(count), this->m_length - this->m_offset),
+      (std::min)(static_cast<int64_t>(count), this->m_length - this->m_offset),
       this->m_baseOffset + this->m_offset);
 
   if (numberOfBytesRead < 0)
@@ -59,10 +59,10 @@ size_t RandomAccessFileBodyStream::OnRead(
       fileHandle,
       buffer,
       // at most 4Gb to be read
-      static_cast<DWORD>(std::min(
+      static_cast<DWORD>((std::min)(
           static_cast<uint64_t>(0xFFFFFFFFUL),
           static_cast<uint64_t>(
-              std::min(static_cast<int64_t>(count), (this->m_length - this->m_offset))))),
+              (std::min)(static_cast<int64_t>(count), (this->m_length - this->m_offset))))),
       &numberOfBytesRead,
       &o);
 

--- a/sdk/core/perf/src/random_stream.cpp
+++ b/sdk/core/perf/src/random_stream.cpp
@@ -36,7 +36,8 @@ void RandomBuffer(uint8_t* buffer, size_t length)
     *(start_addr++) = RandomChar();
   }
 
-  std::uniform_int_distribution<uint64_t> distribution(0ULL, (std::numeric_limits<uint64_t>::max)());
+  std::uniform_int_distribution<uint64_t> distribution(
+      0ULL, (std::numeric_limits<uint64_t>::max)());
   while (start_addr + rand_int_size <= end_addr)
   {
     *reinterpret_cast<uint64_t*>(start_addr) = distribution(random_generator);

--- a/sdk/core/perf/src/random_stream.cpp
+++ b/sdk/core/perf/src/random_stream.cpp
@@ -36,7 +36,7 @@ void RandomBuffer(uint8_t* buffer, size_t length)
     *(start_addr++) = RandomChar();
   }
 
-  std::uniform_int_distribution<uint64_t> distribution(0ULL, std::numeric_limits<uint64_t>::max());
+  std::uniform_int_distribution<uint64_t> distribution(0ULL, (std::numeric_limits<uint64_t>::max)());
   while (start_addr + rand_int_size <= end_addr)
   {
     *reinterpret_cast<uint64_t*>(start_addr) = distribution(random_generator);
@@ -70,7 +70,7 @@ size_t Azure::Perf::RandomStream::CircularStream::OnRead(
     return 0;
   }
 
-  size_t toRead = std::min(count, available);
+  size_t toRead = (std::min)(count, available);
   auto read = m_memoryStream.Read(buffer, toRead, context);
 
   // Circurl implementation. Rewind the stream every time we reach the end

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
@@ -99,7 +99,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
   {
     SessionOptions sessionOptions;
     sessionOptions.InitialIncomingWindowSize
-        = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        = static_cast<uint32_t>((std::numeric_limits<int32_t>::max)());
 
     return m_connections.at(partitionId).CreateSession(sessionOptions);
   }

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/processor_load_balancer.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/processor_load_balancer.cpp
@@ -122,7 +122,7 @@ std::vector<Azure::Messaging::EventHubs::Models::Ownership> ProcessorLoadBalance
   std::vector<Models::Ownership> randomOwnerships;
   std::vector<Models::Ownership> remainingOwnerships = ownerships;
 
-  size_t numOwnerships = std::min(ownerships.size(), count);
+  size_t numOwnerships = (std::min)(ownerships.size(), count);
 
   for (size_t i = 0; i < numOwnerships; i++)
   {

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
@@ -185,8 +185,8 @@ namespace Azure { namespace Messaging { namespace EventHubs {
       std::string const& partitionId)
   {
     Azure::Core::Amqp::_internal::SessionOptions sessionOptions;
-    sessionOptions.InitialIncomingWindowSize = std::numeric_limits<int32_t>::max();
-    sessionOptions.InitialOutgoingWindowSize = std::numeric_limits<uint16_t>::max();
+    sessionOptions.InitialIncomingWindowSize = (std::numeric_limits<int32_t>::max)();
+    sessionOptions.InitialOutgoingWindowSize = (std::numeric_limits<uint16_t>::max)();
     return m_connections.at(partitionId).CreateSession(sessionOptions);
   }
   std::shared_ptr<_detail::EventHubsPropertiesClient> ProducerClient::GetPropertiesClient()

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
@@ -127,10 +127,10 @@ std::chrono::milliseconds Azure::Messaging::EventHubs::_detail::RetryOperation::
       = std::numeric_limits<int32_t>::digits - (std::numeric_limits<int32_t>::is_signed ? 1 : 0);
 
   // Scale exponentially: 1 x RetryDelay on 1st attempt, 2x on 2nd, 4x on 3rd, 8x on 4th ... all
-  // the way up to std::numeric_limits<int32_t>::max() * RetryDelay.
+  // the way up to (std::numeric_limits<int32_t>::max()) * RetryDelay.
   auto exponentialRetryAfter = m_retryOptions.RetryDelay
       * (((attempt - 1) <= beforeLastBit) ? (1 << (attempt - 1))
-                                          : std::numeric_limits<int32_t>::max());
+                                          : (std::numeric_limits<int32_t>::max)());
 
   // Multiply exponentialRetryAfter by jitterFactor
   exponentialRetryAfter = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(
@@ -138,5 +138,5 @@ std::chrono::milliseconds Azure::Messaging::EventHubs::_detail::RetryOperation::
        * jitterFactor)
           .count()));
 
-  return std::min(exponentialRetryAfter, m_retryOptions.MaxRetryDelay);
+  return (std::min)(exponentialRetryAfter, m_retryOptions.MaxRetryDelay);
 }

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
@@ -71,12 +71,12 @@ TEST_F(ProducerClientTest, SendMessage_LIVEONLY_)
   message3.Body = {'H', 'e', 'l', 'l', 'o', '3'};
 
   Azure::Messaging::EventHubs::EventDataBatchOptions edboptions;
-  edboptions.MaxBytes = std::numeric_limits<uint16_t>::max();
+  edboptions.MaxBytes = (std::numeric_limits<uint16_t>::max)();
   edboptions.PartitionId = "1";
   Azure::Messaging::EventHubs::EventDataBatch eventBatch{client.CreateBatch(edboptions)};
 
   Azure::Messaging::EventHubs::EventDataBatchOptions edboptions2;
-  edboptions2.MaxBytes = std::numeric_limits<uint16_t>::max();
+  edboptions2.MaxBytes = (std::numeric_limits<uint16_t>::max)();
   ;
   edboptions2.PartitionId = "2";
   Azure::Messaging::EventHubs::EventDataBatch eventBatch2{client.CreateBatch(edboptions2)};

--- a/sdk/identity/azure-identity/src/client_certificate_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_certificate_credential.cpp
@@ -20,7 +20,10 @@
 #include <vector>
 
 #if defined(AZ_PLATFORM_WINDOWS)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <Windows.h>
+#include <wincrypt.h>
 
 #if !defined(WINAPI_PARTITION_DESKTOP) || WINAPI_PARTITION_DESKTOP // not UWP
 #pragma warning(push)

--- a/sdk/identity/azure-identity/src/client_certificate_credential.cpp
+++ b/sdk/identity/azure-identity/src/client_certificate_credential.cpp
@@ -23,6 +23,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <Windows.h>
+
 #include <wincrypt.h>
 
 #if !defined(WINAPI_PARTITION_DESKTOP) || WINAPI_PARTITION_DESKTOP // not UWP

--- a/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
@@ -38,7 +38,7 @@ namespace Azure { namespace Identity { namespace _detail {
     mutable std::mutex m_sourcesMutex;
     // Used as a sentinel value to indicate that the index of the source being used for future calls
     // hasn't been found yet.
-    constexpr static std::size_t SuccessfulSourceNotSet = std::numeric_limits<std::size_t>::max();
+    constexpr static std::size_t SuccessfulSourceNotSet = (std::numeric_limits<std::size_t>::max)();
     // This needs to be atomic so that sentinel comparison is thread safe.
     mutable std::atomic<std::size_t> m_successfulSourceIndex = {SuccessfulSourceNotSet};
     bool m_reuseSuccessfulSource;

--- a/sdk/identity/azure-identity/src/token_cache.cpp
+++ b/sdk/identity/azure-identity/src/token_cache.cpp
@@ -128,7 +128,7 @@ template <
     T L = 0, // Left hand side
     T R = 1, // Right hand side
     size_t N = 0, // Counter (for array)
-    bool X = ((std::numeric_limits<T>::max() - L) < R)> // Condition to stop (integer overflow of T)
+    bool X = (((std::numeric_limits<T>::max)() - L) < R)> // Condition to stop (integer overflow of T)
 struct SortedFibonacciSequence
 {
   static constexpr auto Get();

--- a/sdk/identity/azure-identity/src/token_cache.cpp
+++ b/sdk/identity/azure-identity/src/token_cache.cpp
@@ -128,7 +128,8 @@ template <
     T L = 0, // Left hand side
     T R = 1, // Right hand side
     size_t N = 0, // Counter (for array)
-    bool X = (((std::numeric_limits<T>::max)() - L) < R)> // Condition to stop (integer overflow of T)
+    bool X
+    = (((std::numeric_limits<T>::max)() - L) < R)> // Condition to stop (integer overflow of T)
 struct SortedFibonacciSequence
 {
   static constexpr auto Get();

--- a/sdk/identity/azure-identity/src/token_credential_impl.cpp
+++ b/sdk/identity/azure-identity/src/token_credential_impl.cpp
@@ -308,7 +308,7 @@ AccessToken TokenCredentialImpl::ParseToken(
         if (value <= MaxExpirationInSeconds)
         {
           static_assert(
-              MaxExpirationInSeconds <= std::numeric_limits<std::int32_t>::max(),
+              MaxExpirationInSeconds <= (std::numeric_limits<std::int32_t>::max)(),
               "Can safely cast to int32");
 
           accessToken.ExpiresOn += std::chrono::seconds(static_cast<std::int32_t>(value));
@@ -335,7 +335,7 @@ AccessToken TokenCredentialImpl::ParseToken(
         if (value <= MaxExpirationInSeconds)
         {
           static_assert(
-              MaxExpirationInSeconds <= std::numeric_limits<std::int32_t>::max(),
+              MaxExpirationInSeconds <= (std::numeric_limits<std::int32_t>::max)(),
               "Can safely cast to int32");
 
           auto expiresInSeconds = std::chrono::seconds(static_cast<std::int32_t>(value));
@@ -356,7 +356,7 @@ AccessToken TokenCredentialImpl::ParseToken(
       {
         // 'expires_in' as numeric string (seconds until expiration)
         static_assert(
-            MaxExpirationInSeconds <= std::numeric_limits<std::int32_t>::max(),
+            MaxExpirationInSeconds <= (std::numeric_limits<std::int32_t>::max)(),
             "Can safely cast to int32");
 
         auto expiresInSeconds = std::chrono::seconds(static_cast<std::int32_t>(
@@ -495,8 +495,8 @@ std::string PrintSanitizedJsonObject(json const& jsonObject, bool printString, i
              std::function<std::string()>([&]() -> std::string {
                return std::to_string(ParseNumericExpiration(
                    stringValue,
-                   std::numeric_limits<std::int64_t>::max(),
-                   std::numeric_limits<std::int64_t>::min()));
+                   (std::numeric_limits<std::int64_t>::max)(),
+                   (std::numeric_limits<std::int64_t>::min)()));
              }),
              std::function<std::string()>([&]() -> std::string {
                return DateTime::Parse(stringValue, DateTime::DateFormat::Rfc1123)

--- a/sdk/storage/azure-storage-blobs/src/blob_batch.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_batch.cpp
@@ -102,7 +102,7 @@ namespace Azure { namespace Storage { namespace Blobs {
 
       const char* AfterNext(const std::string& expect) const
       {
-        return std::min(endPos, FindNext(expect) + expect.length());
+        return (std::min)(endPos, FindNext(expect) + expect.length());
       }
 
       std::string GetBeforeNextAndConsume(const std::string& expect)
@@ -110,7 +110,7 @@ namespace Azure { namespace Storage { namespace Blobs {
         // This moves currPos
         auto ePos = FindNext(expect);
         std::string ret(currPos, ePos);
-        currPos = std::min(endPos, ePos + expect.length());
+        currPos = (std::min)(endPos, ePos + expect.length());
         return ret;
       }
     };
@@ -486,7 +486,7 @@ namespace Azure { namespace Storage { namespace Blobs {
         Azure::Core::Context const& context)
     {
       (void)context;
-      size_t copy_length = std::min(count, m_content.length() - m_offset);
+      size_t copy_length = (std::min)(count, m_content.length() - m_offset);
       std::memcpy(buffer, &m_content[0] + m_offset, static_cast<size_t>(copy_length));
       m_offset += copy_length;
       return copy_length;

--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -314,7 +314,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     int64_t firstChunkLength = options.TransferOptions.InitialChunkSize;
     if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
     {
-      firstChunkLength = std::min(firstChunkLength, options.Range.Value().Length.Value());
+      firstChunkLength = (std::min)(firstChunkLength, options.Range.Value().Length.Value());
     }
 
     DownloadBlobOptions firstChunkOptions;
@@ -334,16 +334,16 @@ namespace Azure { namespace Storage { namespace Blobs {
       blobRangeSize = blobSize - firstChunkOffset;
       if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
       {
-        blobRangeSize = std::min(blobRangeSize, options.Range.Value().Length.Value());
+        blobRangeSize = (std::min)(blobRangeSize, options.Range.Value().Length.Value());
       }
     }
     else
     {
       blobRangeSize = blobSize;
     }
-    firstChunkLength = std::min(firstChunkLength, blobRangeSize);
+    firstChunkLength = (std::min)(firstChunkLength, blobRangeSize);
 
-    if (static_cast<uint64_t>(blobRangeSize) > std::numeric_limits<size_t>::max()
+    if (static_cast<uint64_t>(blobRangeSize) > (std::numeric_limits<size_t>::max)()
         || static_cast<size_t>(blobRangeSize) > bufferSize)
     {
       throw Azure::Core::RequestFailedException(
@@ -421,7 +421,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     int64_t firstChunkLength = options.TransferOptions.InitialChunkSize;
     if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
     {
-      firstChunkLength = std::min(firstChunkLength, options.Range.Value().Length.Value());
+      firstChunkLength = (std::min)(firstChunkLength, options.Range.Value().Length.Value());
     }
 
     DownloadBlobOptions firstChunkOptions;
@@ -441,14 +441,14 @@ namespace Azure { namespace Storage { namespace Blobs {
       blobRangeSize = blobSize - firstChunkOffset;
       if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
       {
-        blobRangeSize = std::min(blobRangeSize, options.Range.Value().Length.Value());
+        blobRangeSize = (std::min)(blobRangeSize, options.Range.Value().Length.Value());
       }
     }
     else
     {
       blobRangeSize = blobSize;
     }
-    firstChunkLength = std::min(firstChunkLength, blobRangeSize);
+    firstChunkLength = (std::min)(firstChunkLength, blobRangeSize);
 
     auto bodyStreamToFile = [](Azure::Core::IO::BodyStream& stream,
                                _internal::FileWriter& fileWriter,

--- a/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
@@ -157,7 +157,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     constexpr int64_t BlockGrainSize = 1 * 1024 * 1024;
 
     if (static_cast<uint64_t>(options.TransferOptions.SingleUploadThreshold)
-        > std::numeric_limits<size_t>::max())
+        > (std::numeric_limits<size_t>::max)())
     {
       throw Azure::Core::RequestFailedException("Single upload threshold is too big");
     }
@@ -183,7 +183,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     {
       int64_t minChunkSize = (bufferSize + MaxBlockNumber - 1) / MaxBlockNumber;
       minChunkSize = (minChunkSize + BlockGrainSize - 1) / BlockGrainSize * BlockGrainSize;
-      chunkSize = std::max(DefaultStageBlockSize, minChunkSize);
+      chunkSize = (std::max)(DefaultStageBlockSize, minChunkSize);
     }
     if (chunkSize > MaxStageBlockSize)
     {
@@ -293,7 +293,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     {
       int64_t minChunkSize = (fileReader.GetFileSize() + MaxBlockNumber - 1) / MaxBlockNumber;
       minChunkSize = (minChunkSize + BlockGrainSize - 1) / BlockGrainSize * BlockGrainSize;
-      chunkSize = std::max(DefaultStageBlockSize, minChunkSize);
+      chunkSize = (std::max)(DefaultStageBlockSize, minChunkSize);
     }
     if (chunkSize > MaxStageBlockSize)
     {

--- a/sdk/storage/azure-storage-blobs/src/private/avro_parser.cpp
+++ b/sdk/storage/azure-storage-blobs/src/private/avro_parser.cpp
@@ -176,7 +176,7 @@ namespace Azure { namespace Storage { namespace Blobs { namespace _detail {
       return availableBytes;
     }
     const size_t MinRead = 4096;
-    size_t tryReadSize = std::max(n, MinRead);
+    size_t tryReadSize = (std::max)(n, MinRead);
     size_t currSize = m_streambuffer.size();
     m_streambuffer.resize(m_streambuffer.size() + tryReadSize);
     size_t actualReadSize = m_stream->Read(m_streambuffer.data() + currSize, tryReadSize, context);
@@ -631,7 +631,7 @@ namespace Azure { namespace Storage { namespace Blobs { namespace _detail {
   {
     if (m_parserBuffer.Length != 0)
     {
-      size_t bytesToCopy = std::min(m_parserBuffer.Length, count);
+      size_t bytesToCopy = (std::min)(m_parserBuffer.Length, count);
       std::memcpy(buffer, m_parserBuffer.Data, bytesToCopy);
       m_parserBuffer.Data += bytesToCopy;
       m_parserBuffer.Length -= bytesToCopy;

--- a/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/block_blob_client_test.cpp
@@ -1724,10 +1724,10 @@ namespace Azure { namespace Storage { namespace Test {
       std::vector<uint8_t> downloadBuffer;
       std::vector<uint8_t> expectedData = blobContent;
       int64_t blobSize = blobContent.size();
-      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
+      int64_t actualDownloadSize = (std::min)(downloadSize, blobSize);
       if (offset.HasValue() && length.HasValue())
       {
-        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
+        actualDownloadSize = (std::min)(length.Value(), blobSize - offset.Value());
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
@@ -1799,10 +1799,10 @@ namespace Azure { namespace Storage { namespace Test {
       }
       std::vector<uint8_t> expectedData = blobContent;
       int64_t blobSize = blobContent.size();
-      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
+      int64_t actualDownloadSize = (std::min)(downloadSize, blobSize);
       if (offset.HasValue() && length.HasValue())
       {
-        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
+        actualDownloadSize = (std::min)(length.Value(), blobSize - offset.Value());
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(

--- a/sdk/storage/azure-storage-blobs/test/ut/storage_retry_policy_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/storage_retry_policy_test.cpp
@@ -48,7 +48,7 @@ namespace Azure { namespace Storage { namespace Test {
 
       const auto requestHeaders = request.GetHeaders();
       int64_t requestOffset = 0;
-      int64_t requestLength = std::numeric_limits<int64_t>::max();
+      int64_t requestLength = (std::numeric_limits<int64_t>::max)();
       {
         std::string rangeStr;
         if (requestHeaders.find("Range") != requestHeaders.end())
@@ -129,7 +129,7 @@ namespace Azure { namespace Storage { namespace Test {
               }
               auto response = std::make_unique<Core::Http::RawResponse>(
                   Core::Http::RawResponse(1, 1, Core::Http::HttpStatusCode::Ok, "OK"));
-              int64_t bodyLength = std::min(
+              int64_t bodyLength = (std::min)(
                   static_cast<int64_t>(m_primaryContent->length()) - requestOffset, requestLength);
               auto bodyStream = std::make_unique<Core::IO::MemoryBodyStream>(
                   reinterpret_cast<const uint8_t*>(m_primaryContent->data() + requestOffset),
@@ -159,7 +159,7 @@ namespace Azure { namespace Storage { namespace Test {
             }
             auto response = std::make_unique<Core::Http::RawResponse>(
                 Core::Http::RawResponse(1, 1, Core::Http::HttpStatusCode::Ok, "OK"));
-            int64_t bodyLength = std::min(
+            int64_t bodyLength = (std::min)(
                 static_cast<int64_t>(m_secondaryContent->length()) - requestOffset, requestLength);
             auto bodyStream = std::make_unique<Core::IO::MemoryBodyStream>(
                 reinterpret_cast<const uint8_t*>(m_secondaryContent->data() + requestOffset),
@@ -430,7 +430,7 @@ namespace Azure { namespace Storage { namespace Test {
     auto blobClient = Azure::Storage::Blobs::BlobClient::CreateFromConnectionString(
         StandardStorageConnectionString(), RandomString(), RandomString(), clientOptions);
     std::string downloadBuffer;
-    downloadBuffer.resize(std::max(primaryContent.size(), secondaryContent.size()));
+    downloadBuffer.resize((std::max)(primaryContent.size(), secondaryContent.size()));
     Blobs::DownloadBlobToOptions options;
     options.TransferOptions.InitialChunkSize = 2;
     options.TransferOptions.ChunkSize = 2;

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/concurrent_transfer.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/concurrent_transfer.hpp
@@ -36,7 +36,7 @@ namespace Azure { namespace Storage { namespace _internal {
           break;
         }
         int64_t chunkOffset = offset + chunkSize * chunkId;
-        int64_t chunkLength = std::min(length - chunkSize * chunkId, chunkSize);
+        int64_t chunkLength = (std::min)(length - chunkSize * chunkId, chunkSize);
         try
         {
           transferFunc(chunkOffset, chunkLength, chunkId, numChunks);

--- a/sdk/storage/azure-storage-common/src/crypt.cpp
+++ b/sdk/storage/azure-storage-common/src/crypt.cpp
@@ -152,7 +152,7 @@ namespace Azure { namespace Storage {
         const std::vector<uint8_t>& data,
         const std::vector<uint8_t>& key)
     {
-      AZURE_ASSERT_MSG(data.size() <= std::numeric_limits<ULONG>::max(), "Data size is too big.");
+      AZURE_ASSERT_MSG(data.size() <= (std::numeric_limits<ULONG>::max)(), "Data size is too big.");
 
       static AlgorithmProviderInstance AlgorithmProvider(AlgorithmType::HmacSha256);
 

--- a/sdk/storage/azure-storage-common/src/file_io.cpp
+++ b/sdk/storage/azure-storage-common/src/file_io.cpp
@@ -141,7 +141,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   void FileWriter::Write(const uint8_t* buffer, size_t length, int64_t offset)
   {
-    if (length > std::numeric_limits<DWORD>::max())
+    if (length > (std::numeric_limits<DWORD>::max)())
     {
       throw std::runtime_error("Failed to write file.");
     }
@@ -195,7 +195,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   void FileWriter::Write(const uint8_t* buffer, size_t length, int64_t offset)
   {
-    if (offset > static_cast<int64_t>(std::numeric_limits<off_t>::max()))
+    if (offset > static_cast<int64_t>((std::numeric_limits<off_t>::max)()))
     {
       throw std::runtime_error("Failed to write file.");
     }

--- a/sdk/storage/azure-storage-common/src/storage_per_retry_policy.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_per_retry_policy.cpp
@@ -30,7 +30,7 @@ namespace Azure { namespace Storage { namespace _internal {
     }
 
     auto cancelTimepoint = context.GetDeadline();
-    if (cancelTimepoint == Azure::DateTime::max())
+    if (cancelTimepoint == (Azure::DateTime::max)())
     {
       request.GetUrl().RemoveQueryParameter(HttpQueryTimeout);
     }
@@ -42,7 +42,7 @@ namespace Azure { namespace Storage { namespace _internal {
                 .count()
           : -1;
       request.GetUrl().AppendQueryParameter(
-          HttpQueryTimeout, std::to_string(std::max(numSeconds, int64_t(1))));
+          HttpQueryTimeout, std::to_string((std::max)(numSeconds, int64_t(1))));
     }
 
     std::string client_request_id;

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -60,7 +60,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   XmlReader::XmlReader(const char* data, size_t length)
   {
-    if (length > static_cast<size_t>(std::numeric_limits<ULONG>::max()))
+    if (length > static_cast<size_t>((std::numeric_limits<ULONG>::max)()))
     {
       throw std::runtime_error("Xml data too big.");
     }
@@ -411,7 +411,7 @@ namespace Azure { namespace Storage { namespace _internal {
   {
     XmlGlobalInitialize();
 
-    if (length > static_cast<size_t>(std::numeric_limits<int>::max()))
+    if (length > static_cast<size_t>((std::numeric_limits<int>::max)()))
     {
       throw std::runtime_error("Xml data too big.");
     }

--- a/sdk/storage/azure-storage-common/test/ut/crypt_functions_test.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/crypt_functions_test.cpp
@@ -55,7 +55,7 @@ namespace Azure { namespace Storage { namespace Test {
       while (length < data.size())
       {
         size_t s = static_cast<size_t>(RandomInt(0, 4_MB));
-        s = std::min(s, data.size() - length);
+        s = (std::min)(s, data.size() - length);
         crc64Streaming.Append(&data[length], s);
         crc64Streaming.Append(&data[length], 0);
         length += s;

--- a/sdk/storage/azure-storage-common/test/ut/test_base.cpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.cpp
@@ -220,7 +220,7 @@ namespace Azure { namespace Storage { namespace Test {
   uint64_t StorageTest::RandomInt(uint64_t minNumber, uint64_t maxNumber)
   {
     uint64_t val = m_randomGenerator();
-    if (minNumber == 0 && maxNumber == std::numeric_limits<decltype(maxNumber)>::max())
+    if (minNumber == 0 && maxNumber == (std::numeric_limits<decltype(maxNumber)>::max)())
     {
       return val;
     }
@@ -271,7 +271,7 @@ namespace Azure { namespace Storage { namespace Test {
     while (start_addr + rand_int_size <= end_addr)
     {
       *reinterpret_cast<uint64_t*>(start_addr)
-          = RandomInt(0ULL, std::numeric_limits<uint64_t>::max());
+          = RandomInt(0ULL, (std::numeric_limits<uint64_t>::max)());
       start_addr += rand_int_size;
     }
     while (start_addr < end_addr)

--- a/sdk/storage/azure-storage-common/test/ut/test_base.hpp
+++ b/sdk/storage/azure-storage-common/test/ut/test_base.hpp
@@ -118,8 +118,8 @@ namespace Azure { namespace Storage {
        * `auto ret = function1(RandomInt()) + function2(RandomInt());`
        */
       uint64_t RandomInt(
-          uint64_t minNumber = std::numeric_limits<uint64_t>::min(),
-          uint64_t maxNumber = std::numeric_limits<uint64_t>::max());
+          uint64_t minNumber = (std::numeric_limits<uint64_t>::min)(),
+          uint64_t maxNumber = (std::numeric_limits<uint64_t>::max)());
       char RandomChar();
       std::string RandomString(size_t size = 10);
       std::string LowercaseRandomString(size_t size = 10);

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_client_test.cpp
@@ -777,10 +777,10 @@ namespace Azure { namespace Storage { namespace Test {
       std::vector<uint8_t> downloadBuffer;
       std::vector<uint8_t> expectedData = blobContent;
       int64_t blobSize = blobContent.size();
-      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
+      int64_t actualDownloadSize = (std::min)(downloadSize, blobSize);
       if (offset.HasValue() && length.HasValue())
       {
-        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
+        actualDownloadSize = (std::min)(length.Value(), blobSize - offset.Value());
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
@@ -852,10 +852,10 @@ namespace Azure { namespace Storage { namespace Test {
       }
       std::vector<uint8_t> expectedData = blobContent;
       int64_t blobSize = blobContent.size();
-      int64_t actualDownloadSize = std::min(downloadSize, blobSize);
+      int64_t actualDownloadSize = (std::min)(downloadSize, blobSize);
       if (offset.HasValue() && length.HasValue())
       {
-        actualDownloadSize = std::min(length.Value(), blobSize - offset.Value());
+        actualDownloadSize = (std::min)(length.Value(), blobSize - offset.Value());
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -784,7 +784,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
     {
-      firstChunkLength = std::min(firstChunkLength, options.Range.Value().Length.Value());
+      firstChunkLength = (std::min)(firstChunkLength, options.Range.Value().Length.Value());
     }
 
     DownloadFileOptions firstChunkOptions;
@@ -805,7 +805,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       fileRangeSize = fileSize - firstChunkOffset;
       if (options.Range.Value().Length.HasValue())
       {
-        fileRangeSize = std::min(fileRangeSize, options.Range.Value().Length.Value());
+        fileRangeSize = (std::min)(fileRangeSize, options.Range.Value().Length.Value());
       }
     }
     else
@@ -813,9 +813,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       fileSize = firstChunk.Value.BodyStream->Length();
       fileRangeSize = fileSize;
     }
-    firstChunkLength = std::min(firstChunkLength, fileRangeSize);
+    firstChunkLength = (std::min)(firstChunkLength, fileRangeSize);
 
-    if (static_cast<uint64_t>(fileRangeSize) > std::numeric_limits<size_t>::max()
+    if (static_cast<uint64_t>(fileRangeSize) > (std::numeric_limits<size_t>::max)()
         || static_cast<size_t>(fileRangeSize) > bufferSize)
     {
       throw Azure::Core::RequestFailedException(
@@ -894,7 +894,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     int64_t firstChunkLength = options.TransferOptions.InitialChunkSize;
     if (options.Range.HasValue() && options.Range.Value().Length.HasValue())
     {
-      firstChunkLength = std::min(firstChunkLength, options.Range.Value().Length.Value());
+      firstChunkLength = (std::min)(firstChunkLength, options.Range.Value().Length.Value());
     }
 
     DownloadFileOptions firstChunkOptions;
@@ -915,7 +915,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       fileRangeSize = fileSize - firstChunkOffset;
       if (options.Range.Value().Length.HasValue())
       {
-        fileRangeSize = std::min(fileRangeSize, options.Range.Value().Length.Value());
+        fileRangeSize = (std::min)(fileRangeSize, options.Range.Value().Length.Value());
       }
     }
     else
@@ -923,7 +923,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       fileSize = firstChunk.Value.BodyStream->Length();
       fileRangeSize = fileSize;
     }
-    firstChunkLength = std::min(firstChunkLength, fileRangeSize);
+    firstChunkLength = (std::min)(firstChunkLength, fileRangeSize);
 
     auto bodyStreamToFile = [](Azure::Core::IO::BodyStream& stream,
                                _internal::FileWriter& fileWriter,

--- a/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
+++ b/sdk/storage/azure-storage-files-shares/test/ut/share_file_client_test.cpp
@@ -484,10 +484,10 @@ namespace Azure { namespace Storage { namespace Test {
       std::vector<uint8_t> downloadBuffer;
       std::vector<uint8_t> expectedData = fileContent;
       int64_t fileSize = fileContent.size();
-      int64_t actualDownloadSize = std::min(downloadSize, fileSize);
+      int64_t actualDownloadSize = (std::min)(downloadSize, fileSize);
       if (offset.HasValue() && length.HasValue())
       {
-        actualDownloadSize = std::min(length.Value(), fileSize - offset.Value());
+        actualDownloadSize = (std::min)(length.Value(), fileSize - offset.Value());
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(
@@ -553,10 +553,10 @@ namespace Azure { namespace Storage { namespace Test {
       std::string tempFilename = RandomString();
       std::vector<uint8_t> expectedData = fileContent;
       int64_t fileSize = fileContent.size();
-      int64_t actualDownloadSize = std::min(downloadSize, fileSize);
+      int64_t actualDownloadSize = (std::min)(downloadSize, fileSize);
       if (offset.HasValue() && length.HasValue())
       {
-        actualDownloadSize = std::min(length.Value(), fileSize - offset.Value());
+        actualDownloadSize = (std::min)(length.Value(), fileSize - offset.Value());
         if (actualDownloadSize >= 0)
         {
           expectedData.assign(

--- a/sdk/tables/azure-data-tables/src/cryptography/hmacsha256.cpp
+++ b/sdk/tables/azure-data-tables/src/cryptography/hmacsha256.cpp
@@ -7,6 +7,8 @@
 #include <azure/core/cryptography/hash.hpp>
 #include <azure/core/platform.hpp>
 #if defined(AZ_PLATFORM_WINDOWS)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 // Windows needs to go before bcrypt
 #include <windows.h>
 

--- a/sdk/tables/azure-data-tables/src/policies/timeout_policy.cpp
+++ b/sdk/tables/azure-data-tables/src/policies/timeout_policy.cpp
@@ -27,7 +27,7 @@ namespace Azure { namespace Data { namespace Tables { namespace _detail { namesp
     }
 
     auto cancelTimepoint = context.GetDeadline();
-    if (cancelTimepoint == Azure::DateTime::max())
+    if (cancelTimepoint == (Azure::DateTime::max)())
     {
       request.GetUrl().RemoveQueryParameter(HttpQueryTimeout);
     }
@@ -39,7 +39,7 @@ namespace Azure { namespace Data { namespace Tables { namespace _detail { namesp
                 .count()
           : -1;
       request.GetUrl().AppendQueryParameter(
-          HttpQueryTimeout, std::to_string(std::max(numSeconds, int64_t(1))));
+          HttpQueryTimeout, std::to_string((std::max)(numSeconds, int64_t(1))));
     }
 
     return nextPolicy.Send(request, context);

--- a/sdk/tables/azure-data-tables/src/xml_wrapper.cpp
+++ b/sdk/tables/azure-data-tables/src/xml_wrapper.cpp
@@ -60,7 +60,7 @@ namespace Azure { namespace Data { namespace Tables { namespace _detail { namesp
 
   XmlReader::XmlReader(const char* data, size_t length)
   {
-    if (length > static_cast<size_t>(std::numeric_limits<ULONG>::max()))
+    if (length > static_cast<size_t>((std::numeric_limits<ULONG>::max)()))
     {
       throw std::runtime_error("Xml data too big.");
     }
@@ -411,7 +411,7 @@ namespace Azure { namespace Data { namespace Tables { namespace _detail { namesp
   {
     XmlGlobalInitialize();
 
-    if (length > static_cast<size_t>(std::numeric_limits<int>::max()))
+    if (length > static_cast<size_t>((std::numeric_limits<int>::max)()))
     {
       throw std::runtime_error("Xml data too big.");
     }


### PR DESCRIPTION
Without this, we can't bring vcpkg baseline up to date (#5347).

It looks like one of our upstream dependencies ended up including `windows.h` without `#define NOMINMAX`, which absolutely can happen at any time - even without an upstream dependency, customer's code can have that include.

And I went and updated all our code to guard it against min/max macro expansion.
We do already some places guarded, but over all this time, we forgot about this, and added instances of it without the `()`. I updated all the instances.
I also added `#define NOMINMAX` and `#define WIN32_LEAN_AND_MEAN` to all the places, where we `#include <Windows.h>`. Most such places in the SDK code do define them already.

From https://dev.azure.com/azure-sdk/public/_build/results?buildId=3489702&view=logs&j=97f19394-1a2e-56f4-6b20-b9674826b151&t=1eb8b588-040a-5ab0-2acf-c712a2c821f7:

```
D:\a\_work\1\s\sdk\core\azure-core-test\inc\azure/core/test/test_proxy_manager.hpp(43,41): error C2220: the following warning is treated as an error [D:\a\_work\1\s\build\sdk\core\azure-core-tracing-opentelemetry\test\ut\azure-core-tracing-opentelemetry-test.vcxproj]
D:\a\_work\1\s\sdk\core\azure-core-test\inc\azure/core/test/test_proxy_manager.hpp(43,41): warning C4003: not enough arguments for function-like macro invocation 'max' [D:\a\_work\1\s\build\sdk\core\azure-core-tracing-opentelemetry\test\ut\azure-core-tracing-opentelemetry-test.vcxproj]
D:\a\_work\1\s\sdk\core\azure-core-test\inc\azure/core/test/test_proxy_manager.hpp(47,43): warning C4003: not enough arguments for function-like macro invocation 'min' [D:\a\_work\1\s\build\sdk\core\azure-core-tracing-opentelemetry\test\ut\azure-core-tracing-opentelemetry-test.vcxproj]
D:\a\_work\1\s\sdk\core\azure-core-test\inc\azure/core/test/test_proxy_manager.hpp(43,41): error C2589: '(': illegal token on right side of '::' [D:\a\_work\1\s\build\sdk\core\azure-core-tracing-opentelemetry\test\ut\azure-core-tracing-opentelemetry-test.vcxproj]
D:\a\_work\1\s\sdk\core\azure-core-test\inc\azure/core/test/test_proxy_manager.hpp(43): error C2062: type 'unknown-type' unexpected [D:\a\_work\1\s\build\sdk\core\azure-core-tracing-opentelemetry\test\ut\azure-core-tracing-opentelemetry-test.vcxproj]
```