### PR TITLE
Update CodeOwners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,8 +32,8 @@
 /sdk/attestation/        @gkostal @anilba06 @ahmadmsft @LarryOsterman @rickwinter
 
 # AzureSDKOwners: @LarryOsterman
-# ServiceLabel: %Tables
-# PRLabel: %Tables
+# ServiceLabel: %Event Hubs
+# PRLabel: %Event Hubs
 /sdk/eventhubs/           @LarryOsterman @antkmsft @ahsonkhan @gearama @RickWinter
 
 # AzureSDKOwners: @gearama
@@ -49,7 +49,7 @@
 # AzureSDKOwners: @gearama
 # ServiceLabel: %Tables
 # PRLabel: %Tables
-/sdk/tables/            @gearama @LarryOsterman
+/sdk/tables/            @gearama @LarryOsterman @antkmsft @ahsonkhan
 
 # AzureSDKOwners: @danieljurek
 # PRLabel: %EngSys

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,11 +41,6 @@
 # PRLabel: %KeyVault
 /sdk/keyvault/           @gearama @antkmsft @rickwinter @LarryOsterman
 
-# AzureSDKOwners: @LarryOsterman
-# ServiceLabel: %ServiceBus
-# PRLabel: %ServiceBus
-/sdk/servicebus/           @LarryOsterman @antkmsft @ahsonkhan @gearama @RickWinter
-
 # AzureSDKOwners: @gearama
 # ServiceLabel: %Storage
 # PRLabel: %Storage

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,15 +31,30 @@
 # PRLabel: %Attestation
 /sdk/attestation/        @gkostal @anilba06 @ahmadmsft @LarryOsterman @rickwinter
 
+# AzureSDKOwners: @LarryOsterman
+# ServiceLabel: %Tables
+# PRLabel: %Tables
+/sdk/eventhubs/           @LarryOsterman @antkmsft @ahsonkhan @gearama @RickWinter
+
 # AzureSDKOwners: @gearama
 # ServiceLabel:  %KeyVault
 # PRLabel: %KeyVault
 /sdk/keyvault/           @gearama @antkmsft @rickwinter @LarryOsterman
 
+# AzureSDKOwners: @LarryOsterman
+# ServiceLabel: %ServiceBus
+# PRLabel: %ServiceBus
+/sdk/servicebus/           @LarryOsterman @antkmsft @ahsonkhan @gearama @RickWinter
+
 # AzureSDKOwners: @gearama
 # ServiceLabel: %Storage
 # PRLabel: %Storage
 /sdk/storage/            @vinjiang @Jinming-Hu @EmmaZhu @antkmsft @gearama @LarryOsterman @microzchang
+
+# AzureSDKOwners: @gearama
+# ServiceLabel: %Tables
+# PRLabel: %Tables
+/sdk/tables/            @gearama @LarryOsterman
 
 # AzureSDKOwners: @danieljurek
 # PRLabel: %EngSys


### PR DESCRIPTION
Add missing AzureSdkOwners, ServiceLabel, and PRLabel metadata for the directories owned by the central azure sdk team

This data will be used by the engsys github bot to now auto-assign and tag owners in issue/pr comments (in addition to the auto-labeling it already does today)

Notes for code reviewers:

ServiceLabel is the label applied to issues, in nearly every single case this will be identical to PRLabel which is the label applied to pull requests.
AzureSdkOwners | ServiceOwners these fields control who the bot will auto-assign incoming issues to. Note that AzureSdkOwners has an overloaded significant meaning for PM team reporting purposes; it also means these owners work on the Central Azure SDK team (both dataplane and management plane) where as ServiceOwners means everyone else for their reporting. Don't shoot the messenger here.
