### PR TITLE
AMQP: do not use scope.MinimumExpiration when getting SAS Token

### DIFF
--- a/sdk/core/azure-core-amqp/src/amqp/connection.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/connection.cpp
@@ -661,7 +661,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       try
       {
         Credentials::TokenRequestContext requestContext;
-        bool isSasToken = IsSasCredential();
 
         requestContext.Scopes = m_options.AuthenticationScopes;
         auto accessToken{GetCredential()->GetToken(requestContext, context)};

--- a/sdk/core/azure-core-amqp/src/amqp/connection.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/connection.cpp
@@ -662,10 +662,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       {
         Credentials::TokenRequestContext requestContext;
         bool isSasToken = IsSasCredential();
-        if (isSasToken)
-        {
-          requestContext.MinimumExpiration = std::chrono::minutes(60);
-        }
+
         requestContext.Scopes = m_options.AuthenticationScopes;
         auto accessToken{GetCredential()->GetToken(requestContext, context)};
 

--- a/sdk/core/azure-core-amqp/src/amqp/connection_string_credential.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/connection_string_credential.cpp
@@ -129,7 +129,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
       Context const& context) const
   {
     Credentials::AccessToken rv;
-    rv.ExpiresOn = Azure::DateTime::clock::now() + tokenRequestContext.MinimumExpiration;
+    rv.ExpiresOn = Azure::DateTime::clock::now() + std::chrono::minutes(60);
     rv.Token = GenerateSasToken(static_cast<std::chrono::system_clock::time_point>(rv.ExpiresOn));
     (void)context;
     return rv;

--- a/sdk/core/azure-core-amqp/src/amqp/connection_string_credential.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/connection_string_credential.cpp
@@ -128,11 +128,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
       Credentials::TokenRequestContext const& tokenRequestContext,
       Context const& context) const
   {
-    (void)tokenRequestContext;
-
     Credentials::AccessToken rv;
     rv.ExpiresOn = Azure::DateTime::clock::now() + std::chrono::minutes(60);
     rv.Token = GenerateSasToken(static_cast<std::chrono::system_clock::time_point>(rv.ExpiresOn));
+    (void)tokenRequestContext;
     (void)context;
     return rv;
   }

--- a/sdk/core/azure-core-amqp/src/amqp/connection_string_credential.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/connection_string_credential.cpp
@@ -128,6 +128,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
       Credentials::TokenRequestContext const& tokenRequestContext,
       Context const& context) const
   {
+    (void)tokenRequestContext;
+
     Credentials::AccessToken rv;
     rv.ExpiresOn = Azure::DateTime::clock::now() + std::chrono::minutes(60);
     rv.Token = GenerateSasToken(static_cast<std::chrono::system_clock::time_point>(rv.ExpiresOn));


### PR DESCRIPTION
Closes #5320.