### PR TITLE
Updated tests to support -UserAuth test resources switch to enable non-corpnet access.

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -182,6 +182,9 @@ jobs:
       if [[ -f "./${{ parameters.ServiceDirectory }}-samples.txt" ]]; then
         for sample in `cat ./${{ parameters.ServiceDirectory }}-samples.txt`
         do
+          export AZURE_CLIENT_ID=$(${{parameters.ServiceDirectory}}_CLIENT_ID)
+          export AZURE_TENANT_ID=$(${{parameters.ServiceDirectory}}_TENANT_ID)
+          export AZURE_CLIENT_SECRET=$(${{parameters.ServiceDirectory}}_CLIENT_SECRET)
           echo "**********Running sample: ${sample}"
           bash -c "$sample"
           status=$?

--- a/sdk/attestation/azure-security-attestation/test/ut/attestation_metadata.cpp
+++ b/sdk/attestation/azure-security-attestation/test/ut/attestation_metadata.cpp
@@ -64,9 +64,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
     {
       // `InitClientOptions` takes care of setting up Record&Playback.
       AttestationClientOptions options = InitClientOptions<AttestationClientOptions>();
-      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
-          = std::make_shared<Azure::Identity::ClientSecretCredential>(
-              GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
+      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential = GetTestCredential();
 
       return AttestationClient::Create(m_endpoint, credential, options);
     }

--- a/sdk/attestation/azure-security-attestation/test/ut/attestation_test.cpp
+++ b/sdk/attestation/azure-security-attestation/test/ut/attestation_test.cpp
@@ -83,9 +83,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
       // `InitClientOptions` takes care of setting up Record&Playback.
       AttestationClientOptions options = InitClientOptions<AttestationClientOptions>();
       options.TokenValidationOptions = GetTokenValidationOptions();
-      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
-          = CreateClientSecretCredential(
-              GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
+      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential = GetTestCredential();
 
       return AttestationClient::Create(m_endpoint, credential, options);
     }

--- a/sdk/attestation/azure-security-attestation/test/ut/policycertmgmt_test.cpp
+++ b/sdk/attestation/azure-security-attestation/test/ut/policycertmgmt_test.cpp
@@ -82,9 +82,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
           = InitClientOptions<AttestationAdministrationClientOptions>();
       options.TokenValidationOptions = GetTokenValidationOptions();
 
-      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
-          = CreateClientSecretCredential(
-              GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
+      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential = GetTestCredential();
 
       return AttestationAdministrationClient::Create(
           GetServiceEndpoint(instanceType), credential, options);

--- a/sdk/attestation/azure-security-attestation/test/ut/policygetset_test.cpp
+++ b/sdk/attestation/azure-security-attestation/test/ut/policygetset_test.cpp
@@ -95,9 +95,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
           = InitClientOptions<AttestationAdministrationClientOptions>();
       options.TokenValidationOptions = GetTokenValidationOptions();
 
-      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
-          = CreateClientSecretCredential(
-              GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
+      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential = GetTestCredential();
 
       return AttestationAdministrationClient::Create(m_endpoint, credential, options);
     }

--- a/sdk/attestation/azure-security-attestation/test/ut/tpmattestation_test.cpp
+++ b/sdk/attestation/azure-security-attestation/test/ut/tpmattestation_test.cpp
@@ -104,9 +104,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
       // `InitClientOptions` takes care of setting up Record&Playback.
       AttestationClientOptions options = InitClientOptions<AttestationClientOptions>();
       options.TokenValidationOptions = GetTokenValidationOptions();
-      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
-          = CreateClientSecretCredential(
-              GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
+      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential = GetTestCredential();
       return AttestationClient::Create(GetInstanceUri(instanceType), credential, options);
     }
 
@@ -116,9 +114,7 @@ namespace Azure { namespace Security { namespace Attestation { namespace Test {
       AttestationAdministrationClientOptions options
           = InitClientOptions<AttestationAdministrationClientOptions>();
       options.TokenValidationOptions = GetTokenValidationOptions();
-      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential
-          = CreateClientSecretCredential(
-              GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
+      std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential = GetTestCredential();
       return AttestationAdministrationClient::Create(
           GetInstanceUri(instanceType), credential, options);
     }

--- a/sdk/attestation/ci.yml
+++ b/sdk/attestation/ci.yml
@@ -57,7 +57,3 @@ stages:
         Value: "Bogus Certificate"
       - Name: ISOLATED_SIGNING_KEY
         Value: "Bogus Key"
-      EnvVars:
-        AZURE_CLIENT_ID: ${ATTESTATION_CLIENT_ID}
-        AZURE_TENANT_ID: ${ATTESTATION_TENANT_ID}
-        AZURE_CLIENT_SECRET: ${ATTESTATION_CLIENT_SECRET}

--- a/sdk/attestation/ci.yml
+++ b/sdk/attestation/ci.yml
@@ -57,3 +57,7 @@ stages:
         Value: "Bogus Certificate"
       - Name: ISOLATED_SIGNING_KEY
         Value: "Bogus Key"
+      EnvVars:
+        AZURE_CLIENT_ID: ${ATTESTATION_CLIENT_ID}
+        AZURE_TENANT_ID: ${ATTESTATION_TENANT_ID}
+        AZURE_CLIENT_SECRET: ${ATTESTATION_CLIENT_SECRET}

--- a/sdk/attestation/test-resources.json
+++ b/sdk/attestation/test-resources.json
@@ -36,12 +36,6 @@
       "metadata": {
         "description": "The application client ID used to run tests."
       }
-    },
-    "testApplicationSecret": {
-      "type": "string",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
     }
   },
   "variables": {
@@ -92,10 +86,6 @@
     "AZURE_CLIENT_ID": {
       "type": "string",
       "value": "[parameters('testApplicationId')]"
-    },
-    "AZURE_CLIENT_SECRET": {
-      "type": "string",
-      "value": "[parameters('testApplicationSecret')]"
     }
   }
 }

--- a/sdk/core/azure-core-amqp/samples/test-resources.json
+++ b/sdk/core/azure-core-amqp/samples/test-resources.json
@@ -35,12 +35,6 @@
         "description": "The application client ID used to run tests."
       }
     },
-    "testApplicationSecret": {
-      "type": "string",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
-    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",

--- a/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
@@ -243,7 +243,7 @@ namespace Azure { namespace Core { namespace Test {
         }
         catch (std::runtime_error const&)
         {
-		}
+        }
         if (clientSecret.empty())
         {
           m_testCredential = std::make_shared<Azure::Identity::DefaultAzureCredential>();

--- a/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
@@ -16,6 +16,7 @@
 #include <azure/core/internal/diagnostics/log.hpp>
 #include <azure/core/internal/environment.hpp>
 #include <azure/identity/client_secret_credential.hpp>
+#include <azure/identity/default_azure_credential.hpp>
 
 #include <chrono>
 #include <memory>
@@ -41,6 +42,8 @@ namespace Azure { namespace Core { namespace Test {
      *
      */
     bool m_wasSkipped = false;
+
+    std::shared_ptr<Azure::Core::Credentials::TokenCredential> m_testCredential;
 
     void PrepareOptions(Azure::Core::_internal::ClientOptions& options)
     {
@@ -219,11 +222,12 @@ namespace Azure { namespace Core { namespace Test {
       return options;
     }
 
-    std::shared_ptr<Azure::Core::Credentials::TokenCredential> CreateClientSecretCredential(
-        std::string const& tenantId,
-        std::string const& clientId,
-        std::string const& clientSecret)
+    std::shared_ptr<Azure::Core::Credentials::TokenCredential> GetTestCredential()
     {
+      if (m_testCredential)
+      {
+        return m_testCredential;
+      }
       if (m_testContext.IsPlaybackMode())
       {
         // Playback mode uses:
@@ -232,8 +236,25 @@ namespace Azure { namespace Core { namespace Test {
       }
       else
       {
-        return std::make_shared<Azure::Identity::ClientSecretCredential>(
-            tenantId, clientId, clientSecret);
+        std::string clientSecret;
+        try
+        {
+          clientSecret = GetEnv("AZURE_CLIENT_SECRET");
+        }
+        catch (std::runtime_error const&)
+        {
+		}
+        if (clientSecret.empty())
+        {
+          m_testCredential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+        }
+        else
+        {
+          m_testCredential = std::make_shared<Azure::Identity::ClientSecretCredential>(
+              GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), clientSecret);
+        }
+
+        return m_testCredential;
       }
     }
 

--- a/sdk/core/perf/CMakeLists.txt
+++ b/sdk/core/perf/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 
 # make sure that users can consume the project as a library.
 add_library (Azure::Perf ALIAS azure-perf)
-target_link_libraries(azure-perf PUBLIC azure-core)
+target_link_libraries(azure-perf PUBLIC azure-core azure-identity)
 create_map_file(azure-perf azure-perf.map)
 
 set_target_properties(azure-perf PROPERTIES FOLDER "Core")

--- a/sdk/core/perf/inc/azure/perf/base_test.hpp
+++ b/sdk/core/perf/inc/azure/perf/base_test.hpp
@@ -40,6 +40,7 @@ namespace Azure { namespace Perf {
     std::string m_proxy;
     bool m_isPlayBackMode = false;
     bool m_isInsecureEnabled = false;
+    std::shared_ptr<Azure::Core::Credentials::TokenCredential> m_testCredential;
 
     /**
      * @brief Updates the performance test to use a test-proxy for running.
@@ -92,8 +93,28 @@ namespace Azure { namespace Perf {
 
     void ConfigureInsecureConnection(Azure::Core::_internal::ClientOptions& clientOptions);
 
+    /**
+     * @brief Utility function used by tests to retrieve env vars
+     *
+     * @param name Environment variable name to retrieve.
+     *
+     * @return The value of the environment variable retrieved.
+     *
+     * @note If AZURE_TENANT_ID, AZURE_CLIENT_ID, or AZURE_CLIENT_SECRET are not available in the
+     * environment, the AZURE_SERVICE_DIRECTORY environment variable is used to set those values
+     * with the values emitted by the New-TestResources.ps1 script.
+     *
+     * @note The Azure CI pipeline upper cases all environment variables defined in the pipeline.
+     * Since some operating systems have case sensitive environment variables, on debug builds,
+     * this function ensures that the environment variable being retrieved is all upper case.
+     *
+     */
+    std::string GetEnv(std::string const& name);
+
   protected:
     Azure::Perf::TestOptions m_options;
+
+    std::shared_ptr<Azure::Core::Credentials::TokenCredential> GetTestCredential();
 
   public:
     BaseTest(Azure::Perf::TestOptions options) : m_options(options) {}

--- a/sdk/core/perf/src/base_test.cpp
+++ b/sdk/core/perf/src/base_test.cpp
@@ -257,7 +257,6 @@ namespace Azure { namespace Perf {
     }
   };
 
-
   std::shared_ptr<Azure::Core::Credentials::TokenCredential> BaseTest::GetTestCredential()
   {
     if (m_testCredential)
@@ -298,7 +297,7 @@ namespace Azure { namespace Perf {
     }
   }
 
-      /**
+  /**
    * @brief Utility function used by tests to retrieve env vars
    *
    * @param name Environment variable name to retrieve.
@@ -359,6 +358,5 @@ namespace Azure { namespace Perf {
 
     return ret;
   }
-
 
 }} // namespace Azure::Perf

--- a/sdk/core/perf/src/base_test.cpp
+++ b/sdk/core/perf/src/base_test.cpp
@@ -11,6 +11,8 @@
 #endif
 #include <azure/core/http/policies/policy.hpp>
 #include <azure/core/internal/http/pipeline.hpp>
+#include <azure/identity/client_secret_credential.hpp>
+#include <azure/identity/default_azure_credential.hpp>
 
 #include <functional>
 #include <string>
@@ -233,5 +235,130 @@ namespace Azure { namespace Perf {
       }
     }
   }
+
+  class TestNonExpiringCredential final : public Core::Credentials::TokenCredential {
+  public:
+    TestNonExpiringCredential() : TokenCredential("TestNonExpiringCredential") {}
+
+    Core::Credentials::AccessToken GetToken(
+        Core::Credentials::TokenRequestContext const& tokenRequestContext,
+        Core::Context const& context) const override
+    {
+      Core::Credentials::AccessToken accessToken;
+      accessToken.Token = "magicToken";
+      accessToken.ExpiresOn = (DateTime::max)();
+
+      if (context.IsCancelled() || tokenRequestContext.Scopes.size() == 0)
+      {
+        accessToken.ExpiresOn = (DateTime::min)();
+      }
+
+      return accessToken;
+    }
+  };
+
+
+  std::shared_ptr<Azure::Core::Credentials::TokenCredential> BaseTest::GetTestCredential()
+  {
+    if (m_testCredential)
+    {
+      return m_testCredential;
+    }
+    if (m_isPlayBackMode)
+    {
+      // Playback mode uses:
+      //  - never-expiring test credential to never require a token
+      return std::make_shared<TestNonExpiringCredential>();
+    }
+    else
+    {
+      std::string clientSecret;
+      try
+      {
+        clientSecret = GetEnv("AZURE_CLIENT_SECRET");
+      }
+      catch (std::runtime_error&)
+      {
+      }
+      catch (...)
+      {
+        throw;
+      }
+      if (clientSecret.empty())
+      {
+        m_testCredential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+      }
+      else
+      {
+        m_testCredential = std::make_shared<Azure::Identity::ClientSecretCredential>(
+            GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), clientSecret);
+      }
+
+      return m_testCredential;
+    }
+  }
+
+      /**
+   * @brief Utility function used by tests to retrieve env vars
+   *
+   * @param name Environment variable name to retrieve.
+   *
+   * @return The value of the environment variable retrieved.
+   *
+   * @note If AZURE_TENANT_ID, AZURE_CLIENT_ID, or AZURE_CLIENT_SECRET are not available in the
+   * environment, the AZURE_SERVICE_DIRECTORY environment variable is used to set those values
+   * with the values emitted by the New-TestResources.ps1 script.
+   *
+   * @note The Azure CI pipeline upper cases all environment variables defined in the pipeline.
+   * Since some operating systems have case sensitive environment variables, on debug builds,
+   * this function ensures that the environment variable being retrieved is all upper case.
+   *
+   */
+  std::string BaseTest::GetEnv(std::string const& name)
+  {
+#if !defined(NDEBUG)
+    // The azure CI pipeline uppercases all EnvVar values from ci.yml files.
+    // That means that any mixed case strings will not be found when run from the CI
+    // pipeline. Check to make sure that the developer only passed in an upper case environment
+    // variable.
+    {
+      if (name != Azure::Core::_internal::StringExtensions::ToUpper(name))
+      {
+        throw std::runtime_error("All Azure SDK environment variables must be all upper case.");
+      }
+    }
+#endif
+    auto ret = Azure::Core::_internal::Environment::GetVariable(name.c_str());
+    if (ret.empty())
+    {
+      static const char azurePrefix[] = "AZURE_";
+      if (!m_isPlayBackMode && name.find(azurePrefix) == 0)
+      {
+        std::string serviceDirectory
+            = Azure::Core::_internal::Environment::GetVariable("AZURE_SERVICE_DIRECTORY");
+        if (serviceDirectory.empty())
+        {
+          throw std::runtime_error(
+              "Could not find a value for " + name
+              + " and AZURE_SERVICE_DIRECTORY was not defined. Define either " + name
+              + " or AZURE_SERVICE_DIRECTORY to resolve.");
+        }
+        // Upper case the serviceName environment variable because all ci.yml environment
+        // variables are upper cased.
+        std::string serviceDirectoryEnvVar
+            = Azure::Core::_internal::StringExtensions::ToUpper(serviceDirectory);
+        serviceDirectoryEnvVar += name.substr(sizeof(azurePrefix) - 2);
+        ret = Azure::Core::_internal::Environment::GetVariable(serviceDirectoryEnvVar.c_str());
+        if (!ret.empty())
+        {
+          return ret;
+        }
+      }
+      throw std::runtime_error("Missing required environment variable: " + name);
+    }
+
+    return ret;
+  }
+
 
 }} // namespace Azure::Perf

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
@@ -92,7 +92,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
         std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential,
         ProducerClientOptions options = {});
 
-    ~ProducerClient() {}
+    ~ProducerClient() { Close(); }
 
     /** @brief Close all the connections and sessions.
      *
@@ -105,8 +105,9 @@ namespace Azure { namespace Messaging { namespace EventHubs {
         sender.second.Close(context);
       }
       m_senders.clear();
-      // Other possible things we might want to do in close, but cannot quite do yet because it
-      // doesn't necessarily work correctly.
+
+      // Close needs to tear down all outstanding sessions and connections, but the functionality to
+      // tear these down isn't complete yet.
       //    for (auto& session : m_sessions)
       //    {
       // session.second.Close(context);

--- a/sdk/eventhubs/azure-messaging-eventhubs/test-resources-post.ps1
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test-resources-post.ps1
@@ -8,8 +8,7 @@
 param (
     [hashtable] $DeploymentOutputs,
     [string] $TenantId,
-    [string] $TestApplicationId,
-    [string] $TestApplicationSecret
+    [string] $TestApplicationId
 )
 
 Write-Verbose "Sleeping for 60 seconds to let RBAC replicate"

--- a/sdk/eventhubs/azure-messaging-eventhubs/test-resources.json
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test-resources.json
@@ -35,12 +35,6 @@
         "description": "The application client ID used to run tests."
       }
     },
-    "testApplicationSecret": {
-      "type": "string",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
-    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
@@ -268,10 +262,6 @@
     "AZURE_CLIENT_ID": {
       "type": "string",
       "value": "[parameters('testApplicationId')]"
-    },
-    "AZURE_CLIENT_SECRET": {
-      "type": "string",
-      "value": "[parameters('testApplicationSecret')]"
     }
   }
 }

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/perf/inc/azure/messaging/eventhubs/test/eventhubs_batch_perf_test.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/perf/inc/azure/messaging/eventhubs/test/eventhubs_batch_perf_test.hpp
@@ -32,9 +32,6 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace PerfTest
     std::string m_eventHubConnectionString;
     std::string m_partitionId;
     std::string m_checkpointStoreConnectionString;
-    std::string m_tenantId;
-    std::string m_clientId;
-    std::string m_secret;
     uint32_t m_numberToSend;
     uint32_t m_batchSize;
     uint32_t m_prefetchCount;
@@ -42,7 +39,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace PerfTest
     uint32_t m_paddingBytes{};
     uint32_t m_maxDeadlineExceeded{};
 
-    std::shared_ptr<Azure::Identity::ClientSecretCredential> m_credential;
+    std::shared_ptr<Azure::Core::Credentials::TokenCredential> m_credential;
     std::unique_ptr<Azure::Messaging::EventHubs::ProducerClient> m_client;
 
   public:
@@ -69,17 +66,9 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace PerfTest
       m_partitionId = m_options.GetOptionOrDefault<std::string>("PartitionId", "0");
       m_maxDeadlineExceeded = m_options.GetOptionOrDefault<uint32_t>("MaxTimeouts", 10);
 
-      m_tenantId = m_options.GetOptionOrDefault<std::string>(
-          "TenantId", Azure::Core::_internal::Environment::GetVariable("AZURE_TENANT_ID"));
-      m_clientId = m_options.GetOptionOrDefault<std::string>(
-          "ClientId", Azure::Core::_internal::Environment::GetVariable("AZURE_CLIENT_ID"));
-      m_secret = m_options.GetOptionOrDefault<std::string>(
-          "Secret", Azure::Core::_internal::Environment::GetVariable("AZURE_CLIENT_SECRET"));
-
       if (m_eventHubConnectionString.empty())
       {
-        m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-            m_tenantId, m_clientId, m_secret);
+        m_credential = GetTestCredential();
 
         m_client = std::make_unique<Azure::Messaging::EventHubs::ProducerClient>(
             m_eventHubConnectionString, m_eventHubName, m_credential);

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/consumer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/consumer_client_test.cpp
@@ -158,17 +158,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
 
   TEST_F(ConsumerClientTest, GetPartitionPropertiesClientSecret_LIVEONLY_)
   {
-    auto credentials
-    {
-#if 0
-        std::make_shared<Azure::Identity::ClientSecretCredential>(
-        GetEnv("EVENTHUBS_TENANT_ID"),
-        GetEnv("EVENTHUBS_CLIENT_ID"),
-        GetEnv("EVENTHUBS_CLIENT_SECRET"))
-#else
-      std::make_shared<Azure::Identity::DefaultAzureCredential>()
-#endif
-    };
+    auto credentials{GetTestCredential()};
     std::string eventHubName{GetEnv("EVENTHUB_NAME")};
     std::string hostName{GetEnv("EVENTHUBS_HOST")};
     std::string consumerGroup{GetEnv("EVENTHUB_CONSUMER_GROUP")};

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
@@ -38,10 +38,7 @@ TEST_F(ProducerClientTest, ConnectionStringEntityPath)
 
 TEST_F(ProducerClientTest, TokenCredential_LIVEONLY_)
 {
-  auto credential{std::make_shared<Azure::Identity::ClientSecretCredential>(
-      GetEnv("EVENTHUBS_TENANT_ID"),
-      GetEnv("EVENTHUBS_CLIENT_ID"),
-      GetEnv("EVENTHUBS_CLIENT_SECRET"))};
+  auto credential{GetTestCredential()};
   std::string eventHubName{GetEnv("EVENTHUB_NAME")};
   Azure::Messaging::EventHubs::ProducerClientOptions producerOptions;
   producerOptions.ApplicationID = "appId";

--- a/sdk/eventhubs/ci.yml
+++ b/sdk/eventhubs/ci.yml
@@ -79,7 +79,3 @@ stages:
   # Disabling DISABLE_AZURE_CORE_OPENTELEMETRY because eventhubs does not have a dependency on azure-core-opentelemetry, but azure core includes 
   # azure-core-opentelemetry in builds unless disabled.
           Value: '-DFETCH_SOURCE_DEPS=OFF -DDISABLE_AZURE_CORE_OPENTELEMETRY=ON'
-      EnvVars:
-        AZURE_CLIENT_ID: ${EVENTHUBS_CLIENT_ID}
-        AZURE_TENANT_ID: ${EVENTHUBS_TENANT_ID}
-        AZURE_CLIENT_SECRET: ${EVENTHUBS_CLIENT_SECRET}

--- a/sdk/eventhubs/ci.yml
+++ b/sdk/eventhubs/ci.yml
@@ -79,3 +79,7 @@ stages:
   # Disabling DISABLE_AZURE_CORE_OPENTELEMETRY because eventhubs does not have a dependency on azure-core-opentelemetry, but azure core includes 
   # azure-core-opentelemetry in builds unless disabled.
           Value: '-DFETCH_SOURCE_DEPS=OFF -DDISABLE_AZURE_CORE_OPENTELEMETRY=ON'
+      EnvVars:
+        AZURE_CLIENT_ID: ${EVENTHUBS_CLIENT_ID}
+        AZURE_TENANT_ID: ${EVENTHUBS_TENANT_ID}
+        AZURE_CLIENT_SECRET: ${EVENTHUBS_CLIENT_SECRET}

--- a/sdk/keyvault/azure-security-keyvault-administration/test/ut/settings_client_base_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-administration/test/ut/settings_client_base_test.hpp
@@ -59,8 +59,7 @@ namespace Azure {
       m_keyVaultHsmUrl = GetEnv("AZURE_KEYVAULT_HSM_URL");
       // Options and credential for the client
       SettingsClientOptions options;
-      m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-          GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
+      m_credential = GetTestCredential();
 
       // `InitTestClient` takes care of setting up Record&Playback.
       m_client = InitTestClient<

--- a/sdk/keyvault/azure-security-keyvault-certificates/perf-resources.json
+++ b/sdk/keyvault/azure-security-keyvault-certificates/perf-resources.json
@@ -36,12 +36,6 @@
         "description": "The application client ID used to run tests."
       }
     },
-    "testApplicationSecret": {
-      "type": "String",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
-    },
     "testApplicationOid": {
       "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
       "type": "String",
@@ -266,10 +260,6 @@
     "AZURE_CLIENT_ID": {
       "type": "String",
       "value": "[parameters('testApplicationId')]"
-    },
-    "AZURE_CLIENT_SECRET": {
-      "type": "String",
-      "value": "[parameters('testApplicationSecret')]"
     },
     "KEYVAULT_SKU": {
       "type": "String",

--- a/sdk/keyvault/azure-security-keyvault-certificates/test/perf/inc/azure/keyvault/certificates/test/get_certificate_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/test/perf/inc/azure/keyvault/certificates/test/get_certificate_test.hpp
@@ -48,7 +48,7 @@ namespace Azure {
       m_vaultUrl = m_options.GetOptionOrDefault<std::string>(
           "vaultUrl", Environment::GetVariable("AZURE_KEYVAULT_URL"));
       m_credential = GetTestCredential();
-      
+
       m_client = std::make_unique<Azure::Security::KeyVault::Certificates::CertificateClient>(
           m_vaultUrl,
           m_credential,

--- a/sdk/keyvault/azure-security-keyvault-certificates/test/perf/inc/azure/keyvault/certificates/test/get_certificate_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/test/perf/inc/azure/keyvault/certificates/test/get_certificate_test.hpp
@@ -35,10 +35,7 @@ namespace Azure {
   private:
     std::string m_vaultUrl;
     std::string m_certificateName;
-    std::string m_tenantId;
-    std::string m_clientId;
-    std::string m_secret;
-    std::shared_ptr<Azure::Identity::ClientSecretCredential> m_credential;
+    std::shared_ptr<Azure::Core::Credentials::TokenCredential> m_credential;
     std::unique_ptr<Azure::Security::KeyVault::Certificates::CertificateClient> m_client;
 
   public:
@@ -50,14 +47,8 @@ namespace Azure {
     {
       m_vaultUrl = m_options.GetOptionOrDefault<std::string>(
           "vaultUrl", Environment::GetVariable("AZURE_KEYVAULT_URL"));
-      m_tenantId = m_options.GetOptionOrDefault<std::string>(
-          "TenantId", Environment::GetVariable("AZURE_TENANT_ID"));
-      m_clientId = m_options.GetOptionOrDefault<std::string>(
-          "ClientId", Environment::GetVariable("AZURE_CLIENT_ID"));
-      m_secret = m_options.GetOptionOrDefault<std::string>(
-          "Secret", Environment::GetVariable("AZURE_CLIENT_SECRET"));
-      m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-          m_tenantId, m_clientId, m_secret);
+      m_credential = GetTestCredential();
+      
       m_client = std::make_unique<Azure::Security::KeyVault::Certificates::CertificateClient>(
           m_vaultUrl,
           m_credential,

--- a/sdk/keyvault/azure-security-keyvault-certificates/test/ut/certificate_client_base_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/test/ut/certificate_client_base_test.hpp
@@ -74,8 +74,7 @@ namespace Azure {
 
       // Options and credential for the client
       CertificateClientOptions options;
-      m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-          GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
+      m_credential = GetTestCredential();
 
       // `InitTestClient` takes care of setting up Record&Playback.
       m_client = InitTestClient<

--- a/sdk/keyvault/azure-security-keyvault-keys/perf-resources.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/perf-resources.json
@@ -36,12 +36,6 @@
         "description": "The application client ID used to run tests."
       }
     },
-    "testApplicationSecret": {
-      "type": "String",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
-    },
     "testApplicationOid": {
       "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
       "type": "String",
@@ -266,10 +260,6 @@
     "AZURE_CLIENT_ID": {
       "type": "String",
       "value": "[parameters('testApplicationId')]"
-    },
-    "AZURE_CLIENT_SECRET": {
-      "type": "String",
-      "value": "[parameters('testApplicationSecret')]"
     },
     "KEYVAULT_SKU": {
       "type": "String",

--- a/sdk/keyvault/azure-security-keyvault-keys/test/perf/inc/azure/keyvault/keys/test/get_key_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/perf/inc/azure/keyvault/keys/test/get_key_test.hpp
@@ -29,10 +29,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
   private:
     std::string m_vaultUrl;
     std::string m_keyName;
-    std::string m_tenantId;
-    std::string m_clientId;
-    std::string m_secret;
-    std::shared_ptr<Azure::Identity::ClientSecretCredential> m_credential;
+    std::shared_ptr<Azure::Core::Credentials::TokenCredential> m_credential;
     std::unique_ptr<Azure::Security::KeyVault::Keys::KeyClient> m_client;
 
   public:
@@ -44,14 +41,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
     {
       m_vaultUrl = m_options.GetOptionOrDefault<std::string>(
           "vaultUrl", Environment::GetVariable("AZURE_KEYVAULT_URL"));
-      m_tenantId = m_options.GetOptionOrDefault<std::string>(
-          "TenantId", Environment::GetVariable("AZURE_TENANT_ID"));
-      m_clientId = m_options.GetOptionOrDefault<std::string>(
-          "ClientId", Environment::GetVariable("AZURE_CLIENT_ID"));
-      m_secret = m_options.GetOptionOrDefault<std::string>(
-          "Secret", Environment::GetVariable("AZURE_CLIENT_SECRET"));
-      m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-          m_tenantId, m_clientId, m_secret);
+      m_credential = GetTestCredential();
       m_client = std::make_unique<Azure::Security::KeyVault::Keys::KeyClient>(
           m_vaultUrl,
           m_credential,

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut-hsm/key_client_test_hsm_live.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut-hsm/key_client_test_hsm_live.hpp
@@ -53,9 +53,8 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
 
       // Options and credential for the client
       KeyClientOptions options;
-      m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-          GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
-
+      m_credential = GetTestCredential();
+      
       // `InitTestClient` takes care of setting up Record&Playback.
       m_client = InitTestClient<
           Azure::Security::KeyVault::Keys::KeyClient,

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut-hsm/key_client_test_hsm_live.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut-hsm/key_client_test_hsm_live.hpp
@@ -54,7 +54,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
       // Options and credential for the client
       KeyClientOptions options;
       m_credential = GetTestCredential();
-      
+
       // `InitTestClient` takes care of setting up Record&Playback.
       m_client = InitTestClient<
           Azure::Security::KeyVault::Keys::KeyClient,

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_base_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_base_test.hpp
@@ -72,8 +72,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys { nam
 
       // Options and credential for the client
       KeyClientOptions options;
-      m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-          GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
+      m_credential = GetTestCredential();
 
       // `InitTestClient` takes care of setting up Record&Playback.
       m_client = InitTestClient<

--- a/sdk/keyvault/azure-security-keyvault-secrets/perf-resources.json
+++ b/sdk/keyvault/azure-security-keyvault-secrets/perf-resources.json
@@ -36,12 +36,6 @@
         "description": "The application client ID used to run tests."
       }
     },
-    "testApplicationSecret": {
-      "type": "String",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
-    },
     "testApplicationOid": {
       "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
       "type": "String",
@@ -266,10 +260,6 @@
     "AZURE_CLIENT_ID": {
       "type": "String",
       "value": "[parameters('testApplicationId')]"
-    },
-    "AZURE_CLIENT_SECRET": {
-      "type": "String",
-      "value": "[parameters('testApplicationSecret')]"
     },
     "KEYVAULT_SKU": {
       "type": "String",

--- a/sdk/keyvault/azure-security-keyvault-secrets/test/perf/inc/azure/keyvault/secrets/test/get_secret_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/test/perf/inc/azure/keyvault/secrets/test/get_secret_test.hpp
@@ -29,10 +29,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets { 
   private:
     std::string m_vaultUrl;
     std::string m_secretName;
-    std::string m_tenantId;
-    std::string m_clientId;
-    std::string m_secret;
-    std::shared_ptr<Azure::Identity::ClientSecretCredential> m_credential;
+    std::shared_ptr<Azure::Core::Credentials::TokenCredential> m_credential;
     std::unique_ptr<Azure::Security::KeyVault::Secrets::SecretClient> m_client;
 
   public:
@@ -44,14 +41,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets { 
     {
       m_vaultUrl = m_options.GetOptionOrDefault<std::string>(
           "vaultUrl", Environment::GetVariable("AZURE_KEYVAULT_URL"));
-      m_tenantId = m_options.GetOptionOrDefault<std::string>(
-          "TenantId", Environment::GetVariable("AZURE_TENANT_ID"));
-      m_clientId = m_options.GetOptionOrDefault<std::string>(
-          "ClientId", Environment::GetVariable("AZURE_CLIENT_ID"));
-      m_secret = m_options.GetOptionOrDefault<std::string>(
-          "Secret", Environment::GetVariable("AZURE_CLIENT_SECRET"));
-      m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-          m_tenantId, m_clientId, m_secret);
+      m_credential = GetTestCredential();
       m_client = std::make_unique<Azure::Security::KeyVault::Secrets::SecretClient>(
           m_vaultUrl,
           m_credential,

--- a/sdk/keyvault/azure-security-keyvault-secrets/test/ut/secret_client_base_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/test/ut/secret_client_base_test.hpp
@@ -49,9 +49,8 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets { 
 
       // Options and credential for the client
       SecretClientOptions options;
-      m_credential = std::make_shared<Azure::Identity::ClientSecretCredential>(
-          GetEnv("AZURE_TENANT_ID"), GetEnv("AZURE_CLIENT_ID"), GetEnv("AZURE_CLIENT_SECRET"));
-
+      m_credential = GetTestCredential();
+      
       // `InitTestClient` takes care of setting up Record&Playback.
       m_client = InitTestClient<
           Azure::Security::KeyVault::Secrets::SecretClient,

--- a/sdk/keyvault/azure-security-keyvault-secrets/test/ut/secret_client_base_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/test/ut/secret_client_base_test.hpp
@@ -50,7 +50,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets { 
       // Options and credential for the client
       SecretClientOptions options;
       m_credential = GetTestCredential();
-      
+
       // `InitTestClient` takes care of setting up Record&Playback.
       m_client = InitTestClient<
           Azure::Security::KeyVault::Secrets::SecretClient,

--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -36,12 +36,6 @@
         "description": "The application client ID used to run tests."
       }
     },
-    "testApplicationSecret": {
-      "type": "String",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
-    },
     "testApplicationOid": {
       "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
       "type": "String",
@@ -316,10 +310,6 @@
     "AZURE_CLIENT_ID": {
       "type": "String",
       "value": "[parameters('testApplicationId')]"
-    },
-    "AZURE_CLIENT_SECRET": {
-      "type": "String",
-      "value": "[parameters('testApplicationSecret')]"
     },
     "KEYVAULT_SKU": {
       "type": "String",

--- a/sdk/tables/azure-data-tables/test/ut/table_client_test.cpp
+++ b/sdk/tables/azure-data-tables/test/ut/table_client_test.cpp
@@ -42,10 +42,7 @@ namespace Azure { namespace Data { namespace Test {
                   GetEnv("STANDARD_STORAGE_CONNECTION_STRING"), m_tableName, tableClientOptions));
           break;
         case AuthType::Key:
-          m_credential = CreateClientSecretCredential(
-              GetEnv("STORAGE_TENANT_ID"),
-              GetEnv("STORAGE_CLIENT_ID"),
-              GetEnv("STORAGE_CLIENT_SECRET"));
+          m_credential = GetTestCredential();
           m_tableServiceClient = std::make_shared<Tables::TableServicesClient>(
               Azure::Data::Tables::TableServicesClient(
                   "https://" + GetAccountName() + ".table.core.windows.net/",

--- a/sdk/tables/test-resources.json
+++ b/sdk/tables/test-resources.json
@@ -27,12 +27,6 @@
         "description": "The application client ID used to run tests."
       }
     },
-    "testApplicationSecret": {
-      "type": "string",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
-    },
     "enableVersioning": {
       "type": "bool",
       "defaultValue": true
@@ -305,10 +299,6 @@
       "type": "string",
       "value": "[parameters('testApplicationId')]"
     },
-    "STORAGE_CLIENT_SECRET": {
-      "type": "string",
-      "value": "[parameters('testApplicationSecret')]"
-    },
     "ACCOUNT_NAME": {
       "type": "string",
       "value": "[variables('accountName')]"
@@ -352,10 +342,6 @@
     "AAD_CLIENT_ID": {
       "type": "string",
       "value": "[parameters('testApplicationId')]"
-    },
-    "AAD_CLIENT_SECRET": {
-      "type": "string",
-      "value": "[parameters('testApplicationSecret')]"
     },
     "RESOURCE_GROUP": {
       "type": "string",


### PR DESCRIPTION
Recent policy changes to our tenant effectively block the use of ClientSecretCredential on non-corpnet joined machines. This PR makes the changes necessary to support the new -UserAuth switch which is needed to work around the policy changes.


# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
