### PR TITLE
Remove the final macro to investigate doxygen issue

### DIFF
--- a/cmake-modules/AzureDoxygen.cmake
+++ b/cmake-modules/AzureDoxygen.cmake
@@ -26,7 +26,7 @@ function(generate_documentation PROJECT_NAME PROJECT_VERSION)
         # classes and enums directly into the documentation.
         set(DOXYGEN_INLINE_SOURCES NO)
         set(DOXYGEN_MARKDOWN_ID_STYLE GITHUB)
-        # Used to correctly expand macros like _azure_NON_FINAL_FOR_TESTS when generated docs.
+        # Used to correctly expand macros like _azure_NON_FINAL_FOR_TESTS when generating docs.
         set(DOXYGEN_MACRO_EXPANSION YES)
         # Skip generating docs for json, test, samples, and private files.
         set(DOXYGEN_EXCLUDE_PATTERNS

--- a/cmake-modules/AzureDoxygen.cmake
+++ b/cmake-modules/AzureDoxygen.cmake
@@ -26,6 +26,8 @@ function(generate_documentation PROJECT_NAME PROJECT_VERSION)
         # classes and enums directly into the documentation.
         set(DOXYGEN_INLINE_SOURCES NO)
         set(DOXYGEN_MARKDOWN_ID_STYLE GITHUB)
+        # Used to correctly expand macros like _azure_NON_FINAL_FOR_TESTS when generated docs.
+        set(DOXYGEN_MACRO_EXPANSION YES)
         # Skip generating docs for json, test, samples, and private files.
         set(DOXYGEN_EXCLUDE_PATTERNS
             json.hpp

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -96,6 +96,7 @@ set(
     inc/azure/core/internal/json/json_optional.hpp
     inc/azure/core/internal/json/json_serializable.hpp
     inc/azure/core/internal/strings.hpp
+    inc/azure/core/internal/testing_macro.hpp
     inc/azure/core/internal/tracing/service_tracing.hpp
     inc/azure/core/internal/tracing/tracing_impl.hpp
     inc/azure/core/internal/unique_handle.hpp
@@ -205,6 +206,7 @@ az_rtti_setup(
 if(BUILD_TESTING)
   # define a symbol that enables some test hooks in code
   add_compile_definitions(TESTING_BUILD)
+  add_compile_definitions(_azure_TESTING_BUILD)
   
   if (NOT AZ_ALL_LIBRARIES)
     include(AddGoogleTest)

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -372,7 +372,11 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     /**
      * @brief HTTP retry policy.
      */
-    class RetryPolicy _azure_NON_FINAL_FOR_TESTS : public HttpPolicy {
+    class RetryPolicy
+#if !defined(TESTING_BUILD)
+        final
+#endif
+        : public HttpPolicy {
 
 #if defined(_azure_TESTING_BUILD)
       // make tests classes friends to validate RetryPolicy

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -16,6 +16,7 @@
 #include "azure/core/http/transport.hpp"
 #include "azure/core/internal/http/http_sanitizer.hpp"
 #include "azure/core/internal/http/user_agent.hpp"
+#include "azure/core/internal/testing_macro.hpp"
 #include "azure/core/uuid.hpp"
 
 #include <atomic>
@@ -29,6 +30,14 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#if defined(_azure_TESTING_BUILD)
+// Define the class used from tests to validate retry policy
+namespace Azure { namespace Core { namespace Test {
+  class RetryPolicyTest;
+  class RetryLogic;
+}}} // namespace Azure::Core::Test
+#endif
 
 /**
  * A function that should be implemented and linked to the end-user application in order to override
@@ -363,11 +372,14 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     /**
      * @brief HTTP retry policy.
      */
-    class RetryPolicy
-#if !defined(TESTING_BUILD)
-        final
+    class RetryPolicy _azure_NON_FINAL_FOR_TESTS : public HttpPolicy {
+
+#if defined(_azure_TESTING_BUILD)
+      // make tests classes friends to validate RetryPolicy
+      friend class Azure::Core::Test::RetryPolicyTest;
+      friend class Azure::Core::Test::RetryLogic;
 #endif
-        : public HttpPolicy {
+
     private:
       RetryOptions m_retryOptions;
 
@@ -402,14 +414,14 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
        */
       static int32_t GetRetryCount(Context const& context);
 
-    protected:
-      virtual bool ShouldRetryOnTransportFailure(
+    private:
+      _azure_VIRTUAL_FOR_TESTS bool ShouldRetryOnTransportFailure(
           RetryOptions const& retryOptions,
           int32_t attempt,
           std::chrono::milliseconds& retryAfter,
           double jitterFactor = -1) const;
 
-      virtual bool ShouldRetryOnResponse(
+      _azure_VIRTUAL_FOR_TESTS bool ShouldRetryOnResponse(
           RawResponse const& response,
           RetryOptions const& retryOptions,
           int32_t attempt,

--- a/sdk/core/azure-core/inc/azure/core/internal/testing_macro.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/testing_macro.hpp
@@ -14,25 +14,33 @@
 // mock it.
 #if defined(_azure_TESTING_BUILD)
 
+/**
+ * @brief If we are testing, we want to make sure that classes are not final, by default.
+ */
 #if !defined(_azure_NON_FINAL_FOR_TESTS)
-// If we are testing, we want to make sure that classes are not final, by default.
 #define _azure_NON_FINAL_FOR_TESTS
 #endif
 
+/**
+ * @brief If we are testing, we want to make sure methods can be made virtual, for mocking.
+ */
 #if !defined(_azure_VIRTUAL_FOR_TESTS)
-// If we are testing, we want to make sure methods can be made virtual, for mocking.
 #define _azure_VIRTUAL_FOR_TESTS virtual
 #endif
 
 #else
 
+/**
+ * @brief If we are not testing, we want to make sure that classes are final, by default.
+ */
 #if !defined(_azure_NON_FINAL_FOR_TESTS)
-// If we are not testing, we want to make sure that classes are final, by default.
 #define _azure_NON_FINAL_FOR_TESTS final
 #endif
 
+/**
+ * @brief If we are not testing, we don't need to make methods virtual for mocking.
+ */
 #if !defined(_azure_VIRTUAL_FOR_TESTS)
-// If we are not testing, we don't need to make methods virtual for mocking.
 #define _azure_VIRTUAL_FOR_TESTS
 #endif
 

--- a/sdk/core/azure-core/inc/azure/core/internal/testing_macro.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/testing_macro.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @file
+ * @brief This file is used to define internal-only macros that are used to control the behavior of
+ * the Azure SDK when running tests, to allow mocking within tests.
+ * The macros in this file should NOT be used by anyone outside this repo.
+ */
+
+#pragma once
+
+// When testing is enabled, we want to make sure that certain classes are not final, so that we can
+// mock it.
+#if defined(_azure_TESTING_BUILD)
+
+#if !defined(_azure_NON_FINAL_FOR_TESTS)
+// If we are testing, we want to make sure that classes are not final, by default.
+#define _azure_NON_FINAL_FOR_TESTS
+#endif
+
+#if !defined(_azure_VIRTUAL_FOR_TESTS)
+// If we are testing, we want to make sure methods can be made virtual, for mocking.
+#define _azure_VIRTUAL_FOR_TESTS virtual
+#endif
+
+#else
+
+#if !defined(_azure_NON_FINAL_FOR_TESTS)
+// If we are not testing, we want to make sure that classes are final, by default.
+#define _azure_NON_FINAL_FOR_TESTS final
+#endif
+
+#if !defined(_azure_VIRTUAL_FOR_TESTS)
+// If we are not testing, we don't need to make methods virtual for mocking.
+#define _azure_VIRTUAL_FOR_TESTS
+#endif
+
+#endif

--- a/sdk/core/azure-core/inc/azure/core/internal/testing_macro.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/testing_macro.hpp
@@ -15,13 +15,6 @@
 #if defined(_azure_TESTING_BUILD)
 
 /**
- * @brief If we are testing, we want to make sure that classes are not final, by default.
- */
-#if !defined(_azure_NON_FINAL_FOR_TESTS)
-#define _azure_NON_FINAL_FOR_TESTS
-#endif
-
-/**
  * @brief If we are testing, we want to make sure methods can be made virtual, for mocking.
  */
 #if !defined(_azure_VIRTUAL_FOR_TESTS)
@@ -29,13 +22,6 @@
 #endif
 
 #else
-
-/**
- * @brief If we are not testing, we want to make sure that classes are final, by default.
- */
-#if !defined(_azure_NON_FINAL_FOR_TESTS)
-#define _azure_NON_FINAL_FOR_TESTS final
-#endif
 
 /**
  * @brief If we are not testing, we don't need to make methods virtual for mocking.

--- a/sdk/core/azure-core/test/ut/retry_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/retry_policy_test.cpp
@@ -13,823 +13,825 @@ using namespace Azure::Core::Http;
 using namespace Azure::Core::Http::Policies;
 using namespace Azure::Core::Http::Policies::_internal;
 
-namespace {
-class TestTransportPolicy final : public HttpPolicy {
-private:
-  std::function<std::unique_ptr<RawResponse>()> m_send;
-
-public:
-  TestTransportPolicy(std::function<std::unique_ptr<RawResponse>()> send) : m_send(send) {}
-
-  std::unique_ptr<Azure::Core::Http::RawResponse> Send(
-      Request&,
-      NextHttpPolicy,
-      Azure::Core::Context const&) const override
-  {
-    return m_send();
-  }
-
-  std::unique_ptr<HttpPolicy> Clone() const override
-  {
-    return std::make_unique<TestTransportPolicy>(*this);
-  }
-};
-
-class RetryPolicyTest final : public RetryPolicy {
-private:
-  std::function<bool(RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
-      m_shouldRetryOnTransportFailure;
-
-  std::function<
-      bool(RawResponse const&, RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
-      m_shouldRetryOnResponse;
-
-public:
-  bool BaseShouldRetryOnTransportFailure(
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor) const
-  {
-    return RetryPolicy::ShouldRetryOnTransportFailure(
-        retryOptions, attempt, retryAfter, jitterFactor);
-  }
-
-  bool BaseShouldRetryOnResponse(
-      RawResponse const& response,
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor) const
-  {
-    return RetryPolicy::ShouldRetryOnResponse(
-        response, retryOptions, attempt, retryAfter, jitterFactor);
-  }
-
-  RetryPolicyTest(
-      RetryOptions const& retryOptions,
-      decltype(m_shouldRetryOnTransportFailure) shouldRetryOnTransportFailure,
-      decltype(m_shouldRetryOnResponse) shouldRetryOnResponse)
-      : RetryPolicy(retryOptions),
-        m_shouldRetryOnTransportFailure(
-            shouldRetryOnTransportFailure != nullptr //
-                ? shouldRetryOnTransportFailure
-                : static_cast<decltype(m_shouldRetryOnTransportFailure)>( //
-                    [this](auto options, auto attempt, auto retryAfter, auto jitter) {
-                      retryAfter = std::chrono::milliseconds(0);
-                      auto ignore = decltype(retryAfter)();
-                      return this->BaseShouldRetryOnTransportFailure(
-                          options, attempt, ignore, jitter);
-                    })),
-        m_shouldRetryOnResponse(
-            shouldRetryOnResponse != nullptr //
-                ? shouldRetryOnResponse
-                : static_cast<decltype(m_shouldRetryOnResponse)>( //
-                    [this](
-                        RawResponse const& response,
-                        auto options,
-                        auto attempt,
-                        auto retryAfter,
-                        auto jitter) {
-                      retryAfter = std::chrono::milliseconds(0);
-                      auto ignore = decltype(retryAfter)();
-                      return this->BaseShouldRetryOnResponse(
-                          response, options, attempt, ignore, jitter);
-                    }))
-  {
-  }
-
-  std::unique_ptr<HttpPolicy> Clone() const override
-  {
-    return std::make_unique<RetryPolicyTest>(*this);
-  }
-
-protected:
-  bool ShouldRetryOnTransportFailure(
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor) const override
-  {
-    return m_shouldRetryOnTransportFailure(retryOptions, attempt, retryAfter, jitterFactor);
-  }
-
-  bool ShouldRetryOnResponse(
-      RawResponse const& response,
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor) const override
-  {
-    return m_shouldRetryOnResponse(response, retryOptions, attempt, retryAfter, jitterFactor);
-  }
-};
-} // namespace
-
-TEST(RetryPolicy, ShouldRetryOnResponse)
-{
-  using namespace std::chrono_literals;
-  RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
-
-  RawResponse const* responsePtrSent = nullptr;
-
-  RawResponse const* responsePtrReceived = nullptr;
-  RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
-  int32_t attemptReceived = -1234;
-  double jitterReceived = -5678;
-
-  int onTransportFailureInvoked = 0;
-  int onResponseInvoked = 0;
-
-  {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(
-        retryOptions,
-        [&](auto options, auto attempt, auto, auto jitter) {
-          ++onTransportFailureInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        },
-        [&](RawResponse const& response, auto options, auto attempt, auto, auto jitter) {
-          ++onResponseInvoked;
-          responsePtrReceived = &response;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        }));
-
-    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
-      auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
-
-      responsePtrSent = response.get();
-
-      return response;
-    }));
-
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    pipeline.Send(request, Azure::Core::Context());
-  }
-
-  EXPECT_EQ(onTransportFailureInvoked, 0);
-  EXPECT_EQ(onResponseInvoked, 1);
-
-  EXPECT_NE(responsePtrSent, nullptr);
-  EXPECT_EQ(responsePtrSent, responsePtrReceived);
-
-  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-  EXPECT_EQ(attemptReceived, 1);
-  EXPECT_EQ(jitterReceived, -1);
-
-  // 3 attempts
-  responsePtrSent = nullptr;
-
-  responsePtrReceived = nullptr;
-  retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
-  attemptReceived = -1234;
-  jitterReceived = -5678;
-
-  onTransportFailureInvoked = 0;
-  onResponseInvoked = 0;
-
-  {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(
-        retryOptions,
-        [&](auto options, auto attempt, auto, auto jitter) {
-          ++onTransportFailureInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        },
-        [&](RawResponse const& response, auto options, auto attempt, auto retryAfter, auto jitter) {
-          ++onResponseInvoked;
-          responsePtrReceived = &response;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          retryAfter = 1ms;
-          return onResponseInvoked < 3;
-        }));
-
-    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
-      auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
-
-      responsePtrSent = response.get();
-
-      return response;
-    }));
-
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    pipeline.Send(request, Azure::Core::Context());
-  }
-
-  EXPECT_EQ(onTransportFailureInvoked, 0);
-  EXPECT_EQ(onResponseInvoked, 3);
-
-  EXPECT_NE(responsePtrSent, nullptr);
-  EXPECT_EQ(responsePtrSent, responsePtrReceived);
-
-  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-  EXPECT_EQ(attemptReceived, 3);
-  EXPECT_EQ(jitterReceived, -1);
-}
-
-TEST(RetryPolicy, ShouldRetryOnTransportFailure)
-{
-  using namespace std::chrono_literals;
-  RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
-
-  RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
-  int32_t attemptReceived = -1234;
-  double jitterReceived = -5678;
-
-  int onTransportFailureInvoked = 0;
-  int onResponseInvoked = 0;
-
-  {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(
-        retryOptions,
-        [&](auto options, auto attempt, auto, auto jitter) {
-          ++onTransportFailureInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        },
-        [&](auto, auto options, auto attempt, auto, auto jitter) {
-          ++onResponseInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        }));
-
-    policies.emplace_back(std::make_unique<TestTransportPolicy>(
-        []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
-
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
-  }
-
-  EXPECT_EQ(onTransportFailureInvoked, 1);
-  EXPECT_EQ(onResponseInvoked, 0);
-
-  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-  EXPECT_EQ(attemptReceived, 1);
-  EXPECT_EQ(jitterReceived, -1);
-
-  // 3 attempts
-  retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
-  attemptReceived = -1234;
-  jitterReceived = -5678;
-
-  onTransportFailureInvoked = 0;
-  onResponseInvoked = 0;
-
-  {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(
-        retryOptions,
-        [&](auto options, auto attempt, auto, auto jitter) {
-          ++onTransportFailureInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return onTransportFailureInvoked < 3;
-        },
-        [&](auto, auto options, auto attempt, auto retryAfter, auto jitter) {
-          ++onResponseInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          retryAfter = 1ms;
-          return false;
-        }));
-
-    policies.emplace_back(std::make_unique<TestTransportPolicy>(
-        []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
-
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
-  }
-
-  EXPECT_EQ(onTransportFailureInvoked, 3);
-  EXPECT_EQ(onResponseInvoked, 0);
-
-  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-  EXPECT_EQ(attemptReceived, 3);
-  EXPECT_EQ(jitterReceived, -1);
-}
-
-namespace {
-class RetryLogic final : private RetryPolicy {
-  RetryLogic() : RetryPolicy(RetryOptions()) {}
-  ~RetryLogic() {}
-
-  static RetryLogic const g_retryPolicy;
-
-public:
-  static bool TestShouldRetryOnTransportFailure(
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor)
-  {
-    return g_retryPolicy.ShouldRetryOnTransportFailure(
-        retryOptions, attempt, retryAfter, jitterFactor);
-  }
-
-  static bool TestShouldRetryOnResponse(
-      RawResponse const& response,
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor)
-  {
-    return g_retryPolicy.ShouldRetryOnResponse(
-        response, retryOptions, attempt, retryAfter, jitterFactor);
-  }
-};
-
-RetryLogic const RetryLogic::g_retryPolicy;
-} // namespace
-
-TEST(RetryPolicy, Exponential)
-{
-  using namespace std::chrono_literals;
-
-  RetryOptions const options{3, 1s, 2min, {}};
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 4s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, false);
-  }
-}
-
-TEST(RetryPolicy, LessThan2Retries)
-{
-  using namespace std::chrono_literals;
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({1, 1s, 2min, {}}, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({0, 1s, 2min, {}}, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, false);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({-1, 1s, 2min, {}}, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, false);
-  }
-}
-
-TEST(RetryPolicy, NotExceedingMaxRetryDelay)
-{
-  using namespace std::chrono_literals;
-
-  RetryOptions const options{7, 1s, 20s, {}};
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 4s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 8s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 5, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 16s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 6, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 20s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 7, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 20s);
-  }
-}
-
-TEST(RetryPolicy, NotExceedingInt32Max)
-{
-  using namespace std::chrono_literals;
-
-  RetryOptions const options{35, 1s, 9999999999999s, {}};
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 31, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1073741824s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 32, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2147483647s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 33, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2147483647s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 34, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2147483647s);
-  }
-}
-
-TEST(RetryPolicy, Jitter)
-{
-  using namespace std::chrono_literals;
-
-  RetryOptions const options{3, 10s, 20min, {}};
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 8s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 13s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 16s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 26s);
-  }
-}
-
-TEST(RetryPolicy, JitterExtremes)
-{
-  using namespace std::chrono_literals;
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({3, 1ms, 2min, {}}, 1, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 0ms);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({3, 2ms, 2min, {}}, 1, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1ms);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 2, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 21s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 3, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 21s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnTransportFailure(
-        {35, 1s, 9999999999999s, {}}, 33, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2791728741100ms);
-  }
-}
-
-TEST(RetryPolicy, HttpStatusCode)
-{
-  using namespace std::chrono_literals;
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
-        {3, 3210s, 3h, {HttpStatusCode::RequestTimeout}},
-        1,
-        retryAfter,
-        1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 3210s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
-        {3, 654s, 3h, {HttpStatusCode::Ok}},
-        1,
-        retryAfter,
-        1.0);
-
-    EXPECT_EQ(shouldRetry, false);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        RawResponse(1, 1, HttpStatusCode::Ok, ""),
-        {3, 987s, 3h, {HttpStatusCode::Ok}},
-        1,
-        retryAfter,
-        1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 987s);
-  }
-}
-
-TEST(RetryPolicy, RetryAfterMs)
-{
-  using namespace std::chrono_literals;
-
-  {
-    RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
-    response.SetHeader("rEtRy-aFtEr-mS", "1234");
-
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1234ms);
-  }
-
-  {
-    RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
-    response.SetHeader("X-mS-ReTrY-aFtEr-MS", "5678");
-
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 5678ms);
-  }
-}
-
-TEST(RetryPolicy, RetryAfter)
-{
-  using namespace std::chrono_literals;
-
-  {
-    RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
-    response.SetHeader("rEtRy-aFtEr", "90");
-
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.1);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 90s);
-  }
-}
-
-TEST(RetryPolicy, LogMessages)
-{
-  using Azure::Core::Diagnostics::Logger;
-
-  struct Log
-  {
-    struct Entry
+namespace Azure { namespace Core { namespace Test {
+  class TestTransportPolicy final : public HttpPolicy {
+  private:
+    std::function<std::unique_ptr<RawResponse>()> m_send;
+
+  public:
+    TestTransportPolicy(std::function<std::unique_ptr<RawResponse>()> send) : m_send(send) {}
+
+    std::unique_ptr<Azure::Core::Http::RawResponse> Send(
+        Request&,
+        NextHttpPolicy,
+        Azure::Core::Context const&) const override
     {
-      Logger::Level Level;
-      std::string Message;
-    };
-
-    std::vector<Entry> Entries;
-
-    Log()
-    {
-      Logger::SetLevel(Logger::Level::Informational);
-      Logger::SetListener([&](auto lvl, auto msg) { Entries.emplace_back(Entry{lvl, msg}); });
+      return m_send();
     }
 
-    ~Log()
+    std::unique_ptr<HttpPolicy> Clone() const override
     {
-      Logger::SetListener(nullptr);
-      Logger::SetLevel(Logger::Level::Warning);
+      return std::make_unique<TestTransportPolicy>(*this);
+    }
+  };
+
+  class RetryPolicyTest final : public RetryPolicy {
+  private:
+    std::function<bool(RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
+        m_shouldRetryOnTransportFailure;
+
+    std::function<
+        bool(RawResponse const&, RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
+        m_shouldRetryOnResponse;
+
+  public:
+    bool BaseShouldRetryOnTransportFailure(
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor) const
+    {
+      return RetryPolicy::ShouldRetryOnTransportFailure(
+          retryOptions, attempt, retryAfter, jitterFactor);
     }
 
-  } log;
+    bool BaseShouldRetryOnResponse(
+        RawResponse const& response,
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor) const
+    {
+      return RetryPolicy::ShouldRetryOnResponse(
+          response, retryOptions, attempt, retryAfter, jitterFactor);
+    }
 
+    RetryPolicyTest(
+        RetryOptions const& retryOptions,
+        decltype(m_shouldRetryOnTransportFailure) shouldRetryOnTransportFailure,
+        decltype(m_shouldRetryOnResponse) shouldRetryOnResponse)
+        : RetryPolicy(retryOptions),
+          m_shouldRetryOnTransportFailure(
+              shouldRetryOnTransportFailure != nullptr //
+                  ? shouldRetryOnTransportFailure
+                  : static_cast<decltype(m_shouldRetryOnTransportFailure)>( //
+                      [this](auto options, auto attempt, auto retryAfter, auto jitter) {
+                        retryAfter = std::chrono::milliseconds(0);
+                        auto ignore = decltype(retryAfter)();
+                        return this->BaseShouldRetryOnTransportFailure(
+                            options, attempt, ignore, jitter);
+                      })),
+          m_shouldRetryOnResponse(
+              shouldRetryOnResponse != nullptr //
+                  ? shouldRetryOnResponse
+                  : static_cast<decltype(m_shouldRetryOnResponse)>( //
+                      [this](
+                          RawResponse const& response,
+                          auto options,
+                          auto attempt,
+                          auto retryAfter,
+                          auto jitter) {
+                        retryAfter = std::chrono::milliseconds(0);
+                        auto ignore = decltype(retryAfter)();
+                        return this->BaseShouldRetryOnResponse(
+                            response, options, attempt, ignore, jitter);
+                      }))
+    {
+    }
+
+    std::unique_ptr<HttpPolicy> Clone() const override
+    {
+      return std::make_unique<RetryPolicyTest>(*this);
+    }
+
+  protected:
+    bool ShouldRetryOnTransportFailure(
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor) const override
+    {
+      return m_shouldRetryOnTransportFailure(retryOptions, attempt, retryAfter, jitterFactor);
+    }
+
+    bool ShouldRetryOnResponse(
+        RawResponse const& response,
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor) const override
+    {
+      return m_shouldRetryOnResponse(response, retryOptions, attempt, retryAfter, jitterFactor);
+    }
+  };
+
+  TEST(RetryPolicy, ShouldRetryOnResponse)
   {
     using namespace std::chrono_literals;
-    RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::InternalServerError}};
+    RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
 
-    auto requestNumber = 0;
+    RawResponse const* responsePtrSent = nullptr;
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(retryOptions, nullptr, nullptr));
-    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
-      ++requestNumber;
+    RawResponse const* responsePtrReceived = nullptr;
+    RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
+    int32_t attemptReceived = -1234;
+    double jitterReceived = -5678;
 
-      if (requestNumber == 1)
-      {
-        throw TransportException("Cable Unplugged");
-      }
+    int onTransportFailureInvoked = 0;
+    int onResponseInvoked = 0;
 
-      return std::make_unique<RawResponse>(
-          1,
-          1,
-          requestNumber == 2 ? HttpStatusCode::InternalServerError
-                             : HttpStatusCode::ServiceUnavailable,
-          "Test");
-    }));
+    {
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(
+          retryOptions,
+          [&](auto options, auto attempt, auto, auto jitter) {
+            ++onTransportFailureInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
 
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+            return false;
+          },
+          [&](RawResponse const& response, auto options, auto attempt, auto, auto jitter) {
+            ++onResponseInvoked;
+            responsePtrReceived = &response;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
 
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    pipeline.Send(request, Azure::Core::Context());
+            return false;
+          }));
+
+      policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+        auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
+
+        responsePtrSent = response.get();
+
+        return response;
+      }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      pipeline.Send(request, Azure::Core::Context());
+    }
+
+    EXPECT_EQ(onTransportFailureInvoked, 0);
+    EXPECT_EQ(onResponseInvoked, 1);
+
+    EXPECT_NE(responsePtrSent, nullptr);
+    EXPECT_EQ(responsePtrSent, responsePtrReceived);
+
+    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+    EXPECT_EQ(attemptReceived, 1);
+    EXPECT_EQ(jitterReceived, -1);
+
+    // 3 attempts
+    responsePtrSent = nullptr;
+
+    responsePtrReceived = nullptr;
+    retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
+    attemptReceived = -1234;
+    jitterReceived = -5678;
+
+    onTransportFailureInvoked = 0;
+    onResponseInvoked = 0;
+
+    {
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(
+          retryOptions,
+          [&](auto options, auto attempt, auto, auto jitter) {
+            ++onTransportFailureInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
+
+            return false;
+          },
+          [&](RawResponse const& response,
+              auto options,
+              auto attempt,
+              auto retryAfter,
+              auto jitter) {
+            ++onResponseInvoked;
+            responsePtrReceived = &response;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
+
+            retryAfter = 1ms;
+            return onResponseInvoked < 3;
+          }));
+
+      policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+        auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
+
+        responsePtrSent = response.get();
+
+        return response;
+      }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      pipeline.Send(request, Azure::Core::Context());
+    }
+
+    EXPECT_EQ(onTransportFailureInvoked, 0);
+    EXPECT_EQ(onResponseInvoked, 3);
+
+    EXPECT_NE(responsePtrSent, nullptr);
+    EXPECT_EQ(responsePtrSent, responsePtrReceived);
+
+    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+    EXPECT_EQ(attemptReceived, 3);
+    EXPECT_EQ(jitterReceived, -1);
   }
 
-  EXPECT_EQ(log.Entries.size(), 5);
+  TEST(RetryPolicy, ShouldRetryOnTransportFailure)
+  {
+    using namespace std::chrono_literals;
+    RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
 
-  EXPECT_EQ(log.Entries[0].Level, Logger::Level::Warning);
-  EXPECT_EQ(log.Entries[0].Message, "HTTP Transport error: Cable Unplugged");
+    RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
+    int32_t attemptReceived = -1234;
+    double jitterReceived = -5678;
 
-  EXPECT_EQ(log.Entries[1].Level, Logger::Level::Informational);
-  EXPECT_EQ(log.Entries[1].Message, "HTTP Retry attempt #1 will be made in 0ms.");
+    int onTransportFailureInvoked = 0;
+    int onResponseInvoked = 0;
 
-  EXPECT_EQ(log.Entries[2].Level, Logger::Level::Informational);
-  EXPECT_EQ(log.Entries[2].Message, "HTTP status code 500 will be retried.");
+    {
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(
+          retryOptions,
+          [&](auto options, auto attempt, auto, auto jitter) {
+            ++onTransportFailureInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
 
-  EXPECT_EQ(log.Entries[3].Level, Logger::Level::Informational);
-  EXPECT_EQ(log.Entries[3].Message, "HTTP Retry attempt #2 will be made in 0ms.");
+            return false;
+          },
+          [&](auto, auto options, auto attempt, auto, auto jitter) {
+            ++onResponseInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
 
-  EXPECT_EQ(log.Entries[4].Level, Logger::Level::Informational);
-  EXPECT_EQ(log.Entries[4].Message, "HTTP status code 503 won't be retried.");
-}
+            return false;
+          }));
+
+      policies.emplace_back(std::make_unique<TestTransportPolicy>(
+          []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
+    }
+
+    EXPECT_EQ(onTransportFailureInvoked, 1);
+    EXPECT_EQ(onResponseInvoked, 0);
+
+    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+    EXPECT_EQ(attemptReceived, 1);
+    EXPECT_EQ(jitterReceived, -1);
+
+    // 3 attempts
+    retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
+    attemptReceived = -1234;
+    jitterReceived = -5678;
+
+    onTransportFailureInvoked = 0;
+    onResponseInvoked = 0;
+
+    {
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(
+          retryOptions,
+          [&](auto options, auto attempt, auto, auto jitter) {
+            ++onTransportFailureInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
+
+            return onTransportFailureInvoked < 3;
+          },
+          [&](auto, auto options, auto attempt, auto retryAfter, auto jitter) {
+            ++onResponseInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
+
+            retryAfter = 1ms;
+            return false;
+          }));
+
+      policies.emplace_back(std::make_unique<TestTransportPolicy>(
+          []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
+    }
+
+    EXPECT_EQ(onTransportFailureInvoked, 3);
+    EXPECT_EQ(onResponseInvoked, 0);
+
+    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+    EXPECT_EQ(attemptReceived, 3);
+    EXPECT_EQ(jitterReceived, -1);
+  }
+
+  class RetryLogic final : private RetryPolicy {
+    RetryLogic() : RetryPolicy(RetryOptions()) {}
+    ~RetryLogic() {}
+
+    static RetryLogic const g_retryPolicy;
+
+  public:
+    static bool TestShouldRetryOnTransportFailure(
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor)
+    {
+      return g_retryPolicy.ShouldRetryOnTransportFailure(
+          retryOptions, attempt, retryAfter, jitterFactor);
+    }
+
+    static bool TestShouldRetryOnResponse(
+        RawResponse const& response,
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor)
+    {
+      return g_retryPolicy.ShouldRetryOnResponse(
+          response, retryOptions, attempt, retryAfter, jitterFactor);
+    }
+  };
+
+  RetryLogic const RetryLogic::g_retryPolicy;
+
+  TEST(RetryPolicy, Exponential)
+  {
+    using namespace std::chrono_literals;
+
+    RetryOptions const options{3, 1s, 2min, {}};
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 4s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, false);
+    }
+  }
+
+  TEST(RetryPolicy, LessThan2Retries)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({1, 1s, 2min, {}}, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({0, 1s, 2min, {}}, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, false);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({-1, 1s, 2min, {}}, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, false);
+    }
+  }
+
+  TEST(RetryPolicy, NotExceedingMaxRetryDelay)
+  {
+    using namespace std::chrono_literals;
+
+    RetryOptions const options{7, 1s, 20s, {}};
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 4s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 8s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 5, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 16s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 6, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 20s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 7, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 20s);
+    }
+  }
+
+  TEST(RetryPolicy, NotExceedingInt32Max)
+  {
+    using namespace std::chrono_literals;
+
+    RetryOptions const options{35, 1s, 9999999999999s, {}};
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 31, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1073741824s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 32, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2147483647s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 33, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2147483647s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 34, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2147483647s);
+    }
+  }
+
+  TEST(RetryPolicy, Jitter)
+  {
+    using namespace std::chrono_literals;
+
+    RetryOptions const options{3, 10s, 20min, {}};
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 8s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 13s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 16s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 26s);
+    }
+  }
+
+  TEST(RetryPolicy, JitterExtremes)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({3, 1ms, 2min, {}}, 1, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 0ms);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({3, 2ms, 2min, {}}, 1, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1ms);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 2, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 21s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 3, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 21s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnTransportFailure(
+          {35, 1s, 9999999999999s, {}}, 33, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2791728741100ms);
+    }
+  }
+
+  TEST(RetryPolicy, HttpStatusCode)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
+          {3, 3210s, 3h, {HttpStatusCode::RequestTimeout}},
+          1,
+          retryAfter,
+          1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 3210s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
+          {3, 654s, 3h, {HttpStatusCode::Ok}},
+          1,
+          retryAfter,
+          1.0);
+
+      EXPECT_EQ(shouldRetry, false);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          RawResponse(1, 1, HttpStatusCode::Ok, ""),
+          {3, 987s, 3h, {HttpStatusCode::Ok}},
+          1,
+          retryAfter,
+          1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 987s);
+    }
+  }
+
+  TEST(RetryPolicy, RetryAfterMs)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
+      response.SetHeader("rEtRy-aFtEr-mS", "1234");
+
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1234ms);
+    }
+
+    {
+      RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
+      response.SetHeader("X-mS-ReTrY-aFtEr-MS", "5678");
+
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 5678ms);
+    }
+  }
+
+  TEST(RetryPolicy, RetryAfter)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
+      response.SetHeader("rEtRy-aFtEr", "90");
+
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.1);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 90s);
+    }
+  }
+
+  TEST(RetryPolicy, LogMessages)
+  {
+    using Azure::Core::Diagnostics::Logger;
+
+    struct Log
+    {
+      struct Entry
+      {
+        Logger::Level Level;
+        std::string Message;
+      };
+
+      std::vector<Entry> Entries;
+
+      Log()
+      {
+        Logger::SetLevel(Logger::Level::Informational);
+        Logger::SetListener([&](auto lvl, auto msg) { Entries.emplace_back(Entry{lvl, msg}); });
+      }
+
+      ~Log()
+      {
+        Logger::SetListener(nullptr);
+        Logger::SetLevel(Logger::Level::Warning);
+      }
+
+    } log;
+
+    {
+      using namespace std::chrono_literals;
+      RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::InternalServerError}};
+
+      auto requestNumber = 0;
+
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(retryOptions, nullptr, nullptr));
+      policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+        ++requestNumber;
+
+        if (requestNumber == 1)
+        {
+          throw TransportException("Cable Unplugged");
+        }
+
+        return std::make_unique<RawResponse>(
+            1,
+            1,
+            requestNumber == 2 ? HttpStatusCode::InternalServerError
+                               : HttpStatusCode::ServiceUnavailable,
+            "Test");
+      }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      pipeline.Send(request, Azure::Core::Context());
+    }
+
+    EXPECT_EQ(log.Entries.size(), 5);
+
+    EXPECT_EQ(log.Entries[0].Level, Logger::Level::Warning);
+    EXPECT_EQ(log.Entries[0].Message, "HTTP Transport error: Cable Unplugged");
+
+    EXPECT_EQ(log.Entries[1].Level, Logger::Level::Informational);
+    EXPECT_EQ(log.Entries[1].Message, "HTTP Retry attempt #1 will be made in 0ms.");
+
+    EXPECT_EQ(log.Entries[2].Level, Logger::Level::Informational);
+    EXPECT_EQ(log.Entries[2].Message, "HTTP status code 500 will be retried.");
+
+    EXPECT_EQ(log.Entries[3].Level, Logger::Level::Informational);
+    EXPECT_EQ(log.Entries[3].Message, "HTTP Retry attempt #2 will be made in 0ms.");
+
+    EXPECT_EQ(log.Entries[4].Level, Logger::Level::Informational);
+    EXPECT_EQ(log.Entries[4].Message, "HTTP status code 503 won't be retried.");
+  }
+}}} // namespace Azure::Core::Test

--- a/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
@@ -9,11 +9,11 @@
 #pragma once
 
 #include "azure/identity/detail/token_cache.hpp"
-#include "azure/identity/dll_import_export.hpp"
 
 #include <azure/core/credentials/credentials.hpp>
 #include <azure/core/credentials/token_credential_options.hpp>
 #include <azure/core/datetime.hpp>
+#include <azure/core/internal/testing_macro.hpp>
 
 #include <chrono>
 #include <string>
@@ -56,11 +56,7 @@ namespace Azure { namespace Identity {
    * @brief Enables authentication to Microsoft Entra ID using Azure CLI to obtain an access
    * token.
    */
-  class AzureCliCredential
-#if !defined(_azure_TESTING_BUILD)
-      final
-#endif
-      : public Core::Credentials::TokenCredential {
+  class AzureCliCredential _azure_NON_FINAL_FOR_TESTS : public Core::Credentials::TokenCredential {
 
 #if defined(_azure_TESTING_BUILD)
     friend class Azure::Identity::Test::AzureCliTestCredential;

--- a/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
@@ -56,7 +56,11 @@ namespace Azure { namespace Identity {
    * @brief Enables authentication to Microsoft Entra ID using Azure CLI to obtain an access
    * token.
    */
-  class AzureCliCredential _azure_NON_FINAL_FOR_TESTS : public Core::Credentials::TokenCredential {
+  class AzureCliCredential
+#if !defined(TESTING_BUILD)
+      final
+#endif
+      : public Core::Credentials::TokenCredential {
 
 #if defined(_azure_TESTING_BUILD)
     friend class Azure::Identity::Test::AzureCliTestCredential;

--- a/sdk/identity/azure-identity/inc/azure/identity/detail/token_cache.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/detail/token_cache.hpp
@@ -25,7 +25,11 @@ namespace Azure { namespace Identity { namespace _detail {
    * @brief Access token cache.
    *
    */
-  class TokenCache _azure_NON_FINAL_FOR_TESTS {
+  class TokenCache
+#if !defined(TESTING_BUILD)
+      final
+#endif
+  {
 #if !defined(_azure_TESTING_BUILD)
   private:
 #else

--- a/sdk/identity/azure-identity/inc/azure/identity/detail/token_cache.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/detail/token_cache.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <azure/core/credentials/credentials.hpp>
+#include <azure/core/internal/testing_macro.hpp>
 
 #include <chrono>
 #include <functional>
@@ -24,21 +25,17 @@ namespace Azure { namespace Identity { namespace _detail {
    * @brief Access token cache.
    *
    */
-  class TokenCache
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
-#if !defined(TESTING_BUILD)
+  class TokenCache _azure_NON_FINAL_FOR_TESTS {
+#if !defined(_azure_TESTING_BUILD)
   private:
 #else
   protected:
 #endif
     // A test hook that gets invoked before cache write lock gets acquired.
-    virtual void OnBeforeCacheWriteLock() const {};
+    _azure_VIRTUAL_FOR_TESTS void OnBeforeCacheWriteLock() const {};
 
     // A test hook that gets invoked before item write lock gets acquired.
-    virtual void OnBeforeItemWriteLock() const {};
+    _azure_VIRTUAL_FOR_TESTS void OnBeforeItemWriteLock() const {};
 
     struct CacheKey
     {

--- a/sdk/identity/azure-identity/inc/azure/identity/dll_import_export.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/dll_import_export.hpp
@@ -38,16 +38,6 @@
 
 #undef AZ_IDENTITY_BUILT_AS_DLL
 
-#if defined(_azure_TESTING_BUILD)
-#if !defined(_azure_VIRTUAL_FOR_TESTS)
-#define _azure_VIRTUAL_FOR_TESTS virtual
-#endif
-#else
-#if !defined(_azure_VIRTUAL_FOR_TESTS)
-#define _azure_VIRTUAL_FOR_TESTS
-#endif
-#endif
-
 /**
  * @brief Azure SDK abstractions.
  *

--- a/sdk/keyvault/CMakeLists.txt
+++ b/sdk/keyvault/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(BUILD_TESTING)
   # define a symbol that enables some test hooks in code
   add_compile_definitions(TESTING_BUILD)
+  add_compile_definitions(_azure_TESTING_BUILD)
 endif()
 
 add_subdirectory(azure-security-keyvault-keys)

--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
@@ -34,7 +34,11 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Certificat
    *
    * @details The client supports retrieving KeyVaultCertificate.
    */
-  class CertificateClient _azure_NON_FINAL_FOR_TESTS {
+  class CertificateClient
+#if !defined(TESTING_BUILD)
+      final
+#endif
+  {
     friend class CreateCertificateOperation;
 
 #if defined(TESTING_BUILD)

--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
@@ -16,6 +16,7 @@
 #include <azure/core/context.hpp>
 #include <azure/core/http/http.hpp>
 #include <azure/core/internal/http/pipeline.hpp>
+#include <azure/core/internal/testing_macro.hpp>
 #include <azure/core/response.hpp>
 
 #include <memory>
@@ -33,11 +34,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Certificat
    *
    * @details The client supports retrieving KeyVaultCertificate.
    */
-  class CertificateClient
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
+  class CertificateClient _azure_NON_FINAL_FOR_TESTS {
     friend class CreateCertificateOperation;
 
 #if defined(TESTING_BUILD)

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
@@ -17,6 +17,7 @@
 #include <azure/core/credentials/credentials.hpp>
 #include <azure/core/http/http.hpp>
 #include <azure/core/internal/http/pipeline.hpp>
+#include <azure/core/internal/testing_macro.hpp>
 #include <azure/core/io/body_stream.hpp>
 #include <azure/core/response.hpp>
 
@@ -34,11 +35,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * Vault. The client supports creating, retrieving, updating, deleting, purging, backing up,
    * restoring, and listing the KeyVaultKey.
    */
-  class KeyClient
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
+  class KeyClient _azure_NON_FINAL_FOR_TESTS {
   protected:
     // Using a shared pipeline for a client to share it with LRO (like delete key)
     /** @brief the base URL for this keyvault instance. */

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
@@ -35,7 +35,11 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * Vault. The client supports creating, retrieving, updating, deleting, purging, backing up,
    * restoring, and listing the KeyVaultKey.
    */
-  class KeyClient _azure_NON_FINAL_FOR_TESTS {
+  class KeyClient
+#if !defined(TESTING_BUILD)
+      final
+#endif
+  {
   protected:
     // Using a shared pipeline for a client to share it with LRO (like delete key)
     /** @brief the base URL for this keyvault instance. */

--- a/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
@@ -43,8 +43,11 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets {
    * Vault. The client supports creating, retrieving, updating, deleting, purging, backing up,
    * restoring, and listing the secret.
    */
-  class SecretClient _azure_NON_FINAL_FOR_TESTS {
-
+  class SecretClient
+#if !defined(TESTING_BUILD)
+      final
+#endif
+  {
   private:
     // Using a shared pipeline for a client to share it with LRO (like delete key)
     Azure::Core::Url m_vaultUrl;

--- a/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
@@ -18,6 +18,7 @@
 
 #include <azure/core/http/http.hpp>
 #include <azure/core/internal/http/pipeline.hpp>
+#include <azure/core/internal/testing_macro.hpp>
 #include <azure/core/response.hpp>
 
 #include <stdint.h>
@@ -42,11 +43,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets {
    * Vault. The client supports creating, retrieving, updating, deleting, purging, backing up,
    * restoring, and listing the secret.
    */
-  class SecretClient
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
+  class SecretClient _azure_NON_FINAL_FOR_TESTS {
 
   private:
     // Using a shared pipeline for a client to share it with LRO (like delete key)


### PR DESCRIPTION
Investigating issues with https://github.com/Azure/azure-sdk-for-cpp/pull/5389 by removing the macro used for final.