### PR TITLE
Rename the _azure_TESTING_BUILD_AMQP compile definition to the more common _azure_TESTING_BUILD.

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor.hpp
@@ -14,7 +14,7 @@
 #include <chrono>
 #include <thread>
 
-#ifdef _azure_TESTING_BUILD_AMQP
+#ifdef _azure_TESTING_BUILD
 namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   class ProcessorTest_LoadBalancing_Test;
 }}}} // namespace Azure::Messaging::EventHubs::Test
@@ -82,7 +82,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
    * between multiple Processor instances, even in separate processes or on separate machines.
    */
   class Processor final {
-#ifdef _azure_TESTING_BUILD_AMQP
+#ifdef _azure_TESTING_BUILD
     friend class Test::ProcessorTest_LoadBalancing_Test;
 #endif
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/private/processor_load_balancer.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/private/processor_load_balancer.hpp
@@ -12,7 +12,7 @@
 
 #include <chrono>
 
-#ifdef _azure_TESTING_BUILD_AMQP
+#ifdef _azure_TESTING_BUILD
 namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   class ProcessorLoadBalancerTest_Greedy_EnoughUnownedPartitions_Test;
   class ProcessorLoadBalancerTest_Balanced_UnownedPartitions_Test;
@@ -63,7 +63,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
    * between multiple Processor instances, even in separate processes or on separate machines.
    */
   class ProcessorLoadBalancer final {
-#ifdef _azure_TESTING_BUILD_AMQP
+#ifdef _azure_TESTING_BUILD
     friend class Test::ProcessorLoadBalancerTest_Greedy_EnoughUnownedPartitions_Test;
     friend class Test::ProcessorLoadBalancerTest_Balanced_UnownedPartitions_Test;
     friend class Test::ProcessorLoadBalancerTest_Greedy_ForcedToSteal_Test;

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/private/retry_operation.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/private/retry_operation.hpp
@@ -7,7 +7,7 @@
 #include <chrono>
 #include <functional>
 
-#if defined(_azure_TESTING_BUILD_AMQP)
+#if defined(_azure_TESTING_BUILD)
 // Define the class used from tests to validate retry enabled
 namespace Azure { namespace Messaging { namespace EventHubs { namespace _internal { namespace Test {
   class RetryOperationTest_ShouldRetryTrue1_Test;
@@ -18,7 +18,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _interna
 #endif
 namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail {
   class RetryOperation {
-#if defined(_azure_TESTING_BUILD_AMQP)
+#if defined(_azure_TESTING_BUILD)
     // make tests classes friends to validate set Retry
     friend class Azure::Messaging::EventHubs::_internal::Test::
         RetryOperationTest_ShouldRetryTrue1_Test;

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required (VERSION 3.13)
 
 if(BUILD_TESTING)
-  add_compile_definitions(_azure_TESTING_BUILD_AMQP)
+  add_compile_definitions(_azure_TESTING_BUILD)
   if (NOT AZ_ALL_LIBRARIES OR FETCH_SOURCE_DEPS)
     include(AddGoogleTest)
     enable_testing ()


### PR DESCRIPTION
Bringing consistency across all C++ SDKs.
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/5402