### PR TITLE
Remove the use of ifdef for TESTING_BUILD in KeyVault clients, where they are not needed.

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
@@ -33,11 +33,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Certificat
    *
    * @details The client supports retrieving KeyVaultCertificate.
    */
-  class CertificateClient
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
+  class CertificateClient final {
     friend class CreateCertificateOperation;
 
 #if defined(TESTING_BUILD)

--- a/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
@@ -42,11 +42,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets {
    * Vault. The client supports creating, retrieving, updating, deleting, purging, backing up,
    * restoring, and listing the secret.
    */
-  class SecretClient
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
+  class SecretClient final {
 
   private:
     // Using a shared pipeline for a client to share it with LRO (like delete key)


### PR DESCRIPTION
`KeyClient` is the only one that needs to be conditionally marked as final since `KeyClientWithNoAuthenticationPolicy` inherits from it in tests. The other clients can be marked final, out-right.

https://github.com/Azure/azure-sdk-for-cpp/blob/61f5ce00c2908d9017b2ad3e7891ced99fe67de0/sdk/keyvault/azure-security-keyvault-keys/test/ut/mocked_transport_adapter_test.hpp#L109-L112