### PR TITLE
Remove the use of ifdef for TESTING_BUILD in KeyVault clients, where they are not needed.

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
@@ -33,11 +33,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Certificat
    *
    * @details The client supports retrieving KeyVaultCertificate.
    */
-  class CertificateClient
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
+  class CertificateClient final {
     friend class CreateCertificateOperation;
 
 #if defined(TESTING_BUILD)

--- a/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
@@ -42,11 +42,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets {
    * Vault. The client supports creating, retrieving, updating, deleting, purging, backing up,
    * restoring, and listing the secret.
    */
-  class SecretClient
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
+  class SecretClient final {
 
   private:
     // Using a shared pipeline for a client to share it with LRO (like delete key)


### PR DESCRIPTION
Bringing this back https://github.com/Azure/azure-sdk-for-cpp/pull/5406 as part of https://github.com/Azure/azure-sdk-for-cpp/pull/5416#issue-2172734372