### PR TITLE
Rename the TESTING_BUILD macro to be _azure_TESTING_BUILD to highlight this is internal only and reduce chances of collision.

### DIFF
--- a/sdk/core/azure-core-amqp/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/CMakeLists.txt
@@ -192,7 +192,7 @@ az_rtti_setup(
 
 if(BUILD_TESTING)
   # define a symbol that enables some test hooks in code
-  add_compile_definitions(TESTING_BUILD)
+  add_compile_definitions(_azure_TESTING_BUILD)
   
   if (NOT AZ_ALL_LIBRARIES)
     include(AddGoogleTest)

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/claims_based_security.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/claims_based_security.hpp
@@ -37,7 +37,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     Jwt,
   };
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
   /** @brief Implementation of AMQP 1.0 Claims-based Security (CBS) protocol.
    *
    * This class allows AMQP clients to implement the CBS protocol for authentication and
@@ -74,5 +74,5 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   private:
     std::shared_ptr<ClaimsBasedSecurityImpl> m_impl;
   };
-#endif // TESTING_BUILD
+#endif // _azure_TESTING_BUILD
 }}}} // namespace Azure::Core::Amqp::_detail

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
@@ -21,7 +21,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   class ConnectionFactory;
 }}}} // namespace Azure::Core::Amqp::_detail
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
 // Define the test classes dependant on this class here.
 namespace Azure { namespace Core { namespace Amqp { namespace Tests {
   namespace MessageTests {
@@ -44,7 +44,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
   class TestMessages_ReceiverReceiveAsync_Test;
 
 }}}} // namespace Azure::Core::Amqp::Tests
-#endif // TESTING_BUILD
+#endif // _azure_TESTING_BUILD
 #if defined(SAMPLES_BUILD)
 namespace LocalServerSample {
 int LocalServerSampleMain();
@@ -452,7 +452,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
 
     std::shared_ptr<_detail::ConnectionImpl> m_impl;
     friend class _detail::ConnectionFactory;
-#if TESTING_BUILD
+#if _azure_TESTING_BUILD
     friend class Azure::Core::Amqp::Tests::MessageTests::AmqpServerMock;
     friend class Azure::Core::Amqp::Tests::MessageTests::MessageListenerEvents;
     friend class Azure::Core::Amqp::Tests::TestSocketListenerEvents;
@@ -467,7 +467,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     friend class Azure::Core::Amqp::Tests::TestMessages_SenderSendAsync_Test;
     friend class Azure::Core::Amqp::Tests::TestMessages_SenderOpenClose_Test;
 
-#endif // TESTING_BUILD
+#endif // _azure_TESTING_BUILD
 #if SAMPLES_BUILD
     friend int LocalServerSample::LocalServerSampleMain();
 #endif // SAMPLES_BUILD

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/link.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/link.hpp
@@ -70,7 +70,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   class LinkEvents {
   public:
     virtual Models::AmqpValue OnTransferReceived(
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
         Link const& link,
 #else
         std::shared_ptr<LinkImpl> link,
@@ -80,7 +80,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         const unsigned char* payloadBytes)
         = 0;
     virtual void OnLinkStateChanged(
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
         Link const& link,
 #else
         std::shared_ptr<LinkImpl> link,
@@ -89,7 +89,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         LinkState previousLinkState)
         = 0;
     virtual void OnLinkFlowOn(
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
         Link const& link
 #else
         std::shared_ptr<LinkImpl> link
@@ -99,7 +99,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     virtual ~LinkEvents() = default;
   };
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
 
   class Link final {
   public:
@@ -172,5 +172,5 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     std::shared_ptr<LinkImpl> m_impl;
   };
-#endif // defined(TESTING_BUILD)
+#endif // defined(_azure_TESTING_BUILD)
 }}}} // namespace Azure::Core::Amqp::_detail

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/session.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/session.hpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
 // Define the test classes dependant on this class here.
 namespace Azure { namespace Core { namespace Amqp { namespace Tests {
   namespace MessageTests {
@@ -34,7 +34,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
   class LinkSocketListenerEvents;
   class TestMessages_SenderSendAsync_Test;
 }}}} // namespace Azure::Core::Amqp::Tests
-#endif // TESTING_BUILD
+#endif // _azure_TESTING_BUILD
 #if defined(SAMPLES_BUILD)
 namespace LocalServerSample {
 class SampleEvents;
@@ -245,7 +245,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
 
     friend class _detail::SessionFactory;
 
-#if TESTING_BUILD
+#if _azure_TESTING_BUILD
     friend class Azure::Core::Amqp::Tests::MessageTests::AmqpServerMock;
     friend class Azure::Core::Amqp::Tests::MessageTests::MockServiceEndpoint;
     friend class Azure::Core::Amqp::Tests::MessageTests::MessageListenerEvents;
@@ -258,7 +258,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     friend class Azure::Core::Amqp::Tests::TestLinks_LinkAttachDetach_Test;
 
     friend class Azure::Core::Amqp::Tests::TestMessages_SenderSendAsync_Test;
-#endif // TESTING_BUILD
+#endif // _azure_TESTING_BUILD
 #if SAMPLES_BUILD
     friend class LocalServerSample::SampleEvents;
 #endif // SAMPLES_BUILD

--- a/sdk/core/azure-core-amqp/src/amqp/claim_based_security.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/claim_based_security.cpp
@@ -16,7 +16,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using namespace Azure::Core::Amqp::_internal;
 
   // The non-Impl types for CBS exist only for testing purposes.
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
   ClaimsBasedSecurity::ClaimsBasedSecurity(Session const& session)
       : m_impl{std::make_shared<_detail::ClaimsBasedSecurityImpl>(SessionFactory::GetImpl(session))}
   {
@@ -37,7 +37,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     return m_impl->PutToken(tokenType, audience, token, context);
   }
 
-#endif // TESTING_BUILD
+#endif // _azure_TESTING_BUILD
 
   ClaimsBasedSecurityImpl::ClaimsBasedSecurityImpl(std::shared_ptr<_detail::SessionImpl> session)
       : m_session{session}

--- a/sdk/core/azure-core-amqp/src/amqp/link.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/link.cpp
@@ -15,7 +15,7 @@
 #include <azure_uamqp_c/link.h>
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
   Link::Link(
       _internal::Session const& session,
       std::string const& name,
@@ -475,7 +475,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     {
 
       return Models::_detail::AmqpValueFactory::ToUamqp(link->m_eventHandler->OnTransferReceived(
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
           Link{link->shared_from_this()},
 #else
           link->shared_from_this(),

--- a/sdk/core/azure-core-tracing-opentelemetry/CMakeLists.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 
 if(BUILD_AZURE_CORE_TRACING_OPENTELEMETRY AND BUILD_TESTING)
   # define a symbol that enables some test hooks in code
-  add_compile_definitions(TESTING_BUILD)
+  add_compile_definitions(_azure_TESTING_BUILD)
   
   if (NOT AZ_ALL_LIBRARIES)
     include(AddGoogleTest)

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -204,7 +204,7 @@ az_rtti_setup(
 
 if(BUILD_TESTING)
   # define a symbol that enables some test hooks in code
-  add_compile_definitions(TESTING_BUILD)
+  add_compile_definitions(_azure_TESTING_BUILD)
   
   if (NOT AZ_ALL_LIBRARIES)
     include(AddGoogleTest)

--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -28,7 +28,7 @@
 #include <unordered_set>
 #include <vector>
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
 // Define the class used from tests to validate retry enabled
 namespace Azure { namespace Core { namespace Test {
   class TestHttp_getters_Test;
@@ -181,7 +181,7 @@ namespace Azure { namespace Core { namespace Http {
    */
   class Request final {
     friend class Azure::Core::Http::Policies::_internal::RetryPolicy;
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
     // make tests classes friends to validate set Retry
     friend class Azure::Core::Test::TestHttp_getters_Test;
     friend class Azure::Core::Test::TestHttp_query_parameter_Test;

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -364,7 +364,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * @brief HTTP retry policy.
      */
     class RetryPolicy
-#if !defined(TESTING_BUILD)
+#if !defined(_azure_TESTING_BUILD)
         final
 #endif
         : public HttpPolicy {

--- a/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
@@ -23,7 +23,7 @@
 #include <thread>
 #include <unordered_map>
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
 // Define the class name that reads from ConnectionPool private members
 namespace Azure { namespace Core { namespace Test {
   class CurlConnectionPool_connectionPoolTest_Test;
@@ -43,7 +43,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
    * connection pool per application.
    */
   class CurlConnectionPool final {
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
     // Give access to private to this tests class
     friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
     friend class Azure::Core::Test::CurlConnectionPool_uniquePort_Test;

--- a/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <string>
 
-#ifdef TESTING_BUILD
+#ifdef _azure_TESTING_BUILD
 // Define the class name that reads from ConnectionPool private members
 namespace Azure { namespace Core { namespace Test {
   class CurlConnectionPool_connectionPoolTest_Test;
@@ -40,7 +40,7 @@ namespace Azure { namespace Core { namespace Http {
    * transporter to be reusable in multiple pipelines while every call to network is unique.
    */
   class CurlSession final : public Azure::Core::IO::BodyStream {
-#ifdef TESTING_BUILD
+#ifdef _azure_TESTING_BUILD
     // Give access to private to this tests class
     friend class Azure::Core::Test::CurlConnectionPool_connectionPoolTest_Test;
     friend class Azure::Core::Test::SdkWithLibcurl_DISABLED_globalCleanUp_Test;

--- a/sdk/identity/azure-identity/CMakeLists.txt
+++ b/sdk/identity/azure-identity/CMakeLists.txt
@@ -126,7 +126,7 @@ az_rtti_setup(
 
 if(BUILD_TESTING)
   # define a symbol that enables some test hooks in code
-  add_compile_definitions(TESTING_BUILD)
+  add_compile_definitions(_azure_TESTING_BUILD)
 
   # tests
   if (NOT AZ_ALL_LIBRARIES OR FETCH_SOURCE_DEPS)

--- a/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/azure_cli_credential.hpp
@@ -50,7 +50,7 @@ namespace Azure { namespace Identity {
    * token.
    */
   class AzureCliCredential
-#if !defined(TESTING_BUILD)
+#if !defined(_azure_TESTING_BUILD)
       final
 #endif
       : public Core::Credentials::TokenCredential {
@@ -106,7 +106,7 @@ namespace Azure { namespace Identity {
         Core::Credentials::TokenRequestContext const& tokenRequestContext,
         Core::Context const& context) const override;
 
-#if !defined(TESTING_BUILD)
+#if !defined(_azure_TESTING_BUILD)
   private:
 #else
   protected:

--- a/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/default_azure_credential.hpp
@@ -13,7 +13,7 @@
 
 #include <memory>
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
 class DefaultAzureCredential_CachingCredential_Test;
 #endif
 
@@ -42,7 +42,7 @@ namespace Azure { namespace Identity {
    */
   class DefaultAzureCredential final : public Core::Credentials::TokenCredential {
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
     //  make tests classes friends to validate caching
     friend class ::DefaultAzureCredential_CachingCredential_Test;
 #endif

--- a/sdk/identity/azure-identity/inc/azure/identity/detail/token_cache.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/detail/token_cache.hpp
@@ -25,11 +25,11 @@ namespace Azure { namespace Identity { namespace _detail {
    *
    */
   class TokenCache
-#if !defined(TESTING_BUILD)
+#if !defined(_azure_TESTING_BUILD)
       final
 #endif
   {
-#if !defined(TESTING_BUILD)
+#if !defined(_azure_TESTING_BUILD)
   private:
 #else
   protected:

--- a/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
+++ b/sdk/identity/azure-identity/src/private/chained_token_credential_impl.hpp
@@ -9,7 +9,7 @@
 #include <limits>
 #include <mutex>
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
 class DefaultAzureCredential_CachingCredential_Test;
 #endif
 
@@ -17,7 +17,7 @@ namespace Azure { namespace Identity { namespace _detail {
 
   class ChainedTokenCredentialImpl final {
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
     //  make tests classes friends to validate caching
     friend class ::DefaultAzureCredential_CachingCredential_Test;
 #endif

--- a/sdk/identity/azure-identity/src/token_cache.cpp
+++ b/sdk/identity/azure-identity/src/token_cache.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<TokenCache::CacheValue> TokenCache::GetOrCreateValue(
     }
   }
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
   OnBeforeCacheWriteLock();
 #endif
 
@@ -101,7 +101,7 @@ AccessToken TokenCache::GetToken(
     }
   }
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
   OnBeforeItemWriteLock();
 #endif
 

--- a/sdk/keyvault/CMakeLists.txt
+++ b/sdk/keyvault/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(BUILD_TESTING)
   # define a symbol that enables some test hooks in code
-  add_compile_definitions(TESTING_BUILD)
+  add_compile_definitions(_azure_TESTING_BUILD)
 endif()
 
 add_subdirectory(azure-security-keyvault-keys)

--- a/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
@@ -102,7 +102,7 @@ generate_documentation(azure-security-keyvault-certificates ${AZ_LIBRARY_VERSION
 
 if(BUILD_TESTING)
   # define a symbol that enables some test hooks in code
-  add_compile_definitions(TESTING_BUILD)
+  add_compile_definitions(_azure_TESTING_BUILD)
 
   if (NOT AZ_ALL_LIBRARIES OR FETCH_SOURCE_DEPS)
     include(AddGoogleTest)

--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
@@ -22,7 +22,7 @@
 #include <string>
 
 namespace Azure { namespace Security { namespace KeyVault { namespace Certificates {
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
   namespace Test {
     class KeyVaultCertificateClientTest;
   }
@@ -36,7 +36,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Certificat
   class CertificateClient final {
     friend class CreateCertificateOperation;
 
-#if defined(TESTING_BUILD)
+#if defined(_azure_TESTING_BUILD)
     friend class Test::KeyVaultCertificateClientTest;
 #endif
 

--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client.hpp
@@ -33,11 +33,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Certificat
    *
    * @details The client supports retrieving KeyVaultCertificate.
    */
-  class CertificateClient
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
+  class CertificateClient final {
     friend class CreateCertificateOperation;
 
 #if defined(TESTING_BUILD)

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client.hpp
@@ -35,7 +35,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
    * restoring, and listing the KeyVaultKey.
    */
   class KeyClient
-#if !defined(TESTING_BUILD)
+#if !defined(_azure_TESTING_BUILD)
       final
 #endif
   {

--- a/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/secret_client.hpp
@@ -42,11 +42,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets {
    * Vault. The client supports creating, retrieving, updating, deleting, purging, backing up,
    * restoring, and listing the secret.
    */
-  class SecretClient
-#if !defined(TESTING_BUILD)
-      final
-#endif
-  {
+  class SecretClient final {
 
   private:
     // Using a shared pipeline for a client to share it with LRO (like delete key)


### PR DESCRIPTION
Bringing back https://github.com/Azure/azure-sdk-for-cpp/pull/5390 as part of https://github.com/Azure/azure-sdk-for-cpp/pull/5416#issue-2172734372