### PR TITLE
Make a change to Azure.Core within the http header to test what pipelines are triggered.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -315,7 +315,7 @@ namespace Azure { namespace Core { namespace Http {
      * @brief Get HTTP body as #Azure::Core::IO::BodyStream.
      *
      */
-    Azure::Core::IO::BodyStream* GetBodyStream() { return this->m_bodyStream; }
+    Azure::Core::IO::BodyStream* GetBodyStream() { return nullptr; }
 
     /**
      * @brief Get HTTP body as #Azure::Core::IO::BodyStream.


### PR DESCRIPTION
This header file is, in theory, used by most packages.