### PR TITLE
Harden Show-FailureLogs.ps1 against failures where the files are not present between Get-ChildItem and the output of the file

### DIFF
--- a/eng/scripts/Show-FailureLogs.ps1
+++ b/eng/scripts/Show-FailureLogs.ps1
@@ -8,6 +8,8 @@
 $logFiles = Get-ChildItem -Recurse -Filter *.log
 $filteredLogs = $logFiles.Where({ $_.Name -in ('vcpkg-bootstrap.log', 'vcpkg-manifest-install.log') })
 
+$filteredLogs.FullName | Write-Host
+
 if (!$filteredLogs) {
     Write-Host "No logs found"
     exit 0
@@ -19,7 +21,7 @@ foreach ($logFile in $filteredLogs)
     Write-Host "=============================================================================================================================="
     Write-Host "Log file: $logFile"
     Write-Host "=============================================================================================================================="
-    try { 
+    try {
         Get-Content $logFile | Write-Host
     } catch { 
         Write-Host "Could not locate file found using Get-ChildItem $logFile"

--- a/eng/scripts/Show-FailureLogs.ps1
+++ b/eng/scripts/Show-FailureLogs.ps1
@@ -19,7 +19,11 @@ foreach ($logFile in $filteredLogs)
     Write-Host "=============================================================================================================================="
     Write-Host "Log file: $logFile"
     Write-Host "=============================================================================================================================="
-    Get-Content $logFile | Write-Host
+    try { 
+        Get-Content $logFile | Write-Host
+    } catch { 
+        Write-Host "Could not locate file found using Get-ChildItem $logFile"
+    }
 }
 
 exit 0


### PR DESCRIPTION
# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
