### PR TITLE
Update Azure AD Learn links in Identity

### DIFF
--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -1,5 +1,5 @@
 # Azure Identity client library for C++
-The Azure Identity library provides Microsoft Entra ID ([formerly Azure Active Directory](https://learn.microsoft.com/azure/active-directory/fundamentals/new-name)) token authentication support across the Azure SDK. It provides a set of `TokenCredential` implementations which can be used to construct Azure SDK clients which support Microsoft Entra token authentication.
+The Azure Identity library provides Microsoft Entra ID ([formerly Azure Active Directory](https://learn.microsoft.com/entra/fundamentals/new-name)) token authentication support across the Azure SDK. It provides a set of `TokenCredential` implementations which can be used to construct Azure SDK clients which support Microsoft Entra token authentication.
 This library follows the [Azure SDK Design Guidelines for C++][azure_sdk_cpp_development_guidelines].
 
   [Source code][source] | [API reference documentation][doxygen] | [Microsoft Entra ID documentation][meid_doc]
@@ -74,6 +74,7 @@ See the [code samples](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/
 `ChainedTokenCredential` allows users to set up custom authentication flow consisting of multiple credentials.
 
 An example below demonstrates using `ChainedTokenCredential` which will attempt to authenticate using `EnvironmentCredential`, and fall back to authenticate using `ManagedIdentityCredential`.
+
 ```cpp
 // A configuration demonstrated below would authenticate using EnvironmentCredential if it is
 // available, and if it is not available, would fall back to use AzureCliCredential, and then to
@@ -89,11 +90,11 @@ Azure::Service::Client azureServiceClient("serviceUrl", chainedTokenCredential);
 
 ## Managed Identity Support
 
-The [Managed identity authentication](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) is supported via the `ManagedIdentityCredential` for the following Azure Services:
-* [Azure App Service and Azure Functions](https://docs.microsoft.com/azure/app-service/overview-managed-identity)
-* [Azure Cloud Shell](https://docs.microsoft.com/azure/cloud-shell/msi-authorization)
-* [Azure Arc](https://docs.microsoft.com/azure/azure-arc/servers/managed-identity-authentication)
-* [Azure Virtual Machines](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token)
+The [Managed identity authentication](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview) is supported via the `ManagedIdentityCredential` for the following Azure Services:
+* [Azure App Service and Azure Functions](https://learn.microsoft.com/azure/app-service/overview-managed-identity)
+* [Azure Cloud Shell](https://learn.microsoft.com/azure/cloud-shell/msi-authorization)
+* [Azure Arc](https://learn.microsoft.com/azure/azure-arc/servers/managed-identity-authentication)
+* [Azure Virtual Machines](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/how-to-use-vm-token)
 
 ## Environment Variables
 
@@ -106,7 +107,7 @@ The [Managed identity authentication](https://docs.microsoft.com/azure/active-di
 |`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
 |`AZURE_CLIENT_ID`|ID of a Microsoft Entra application
 |`AZURE_CLIENT_SECRET`|one of the application's client secrets
-|`AZURE_AUTHORITY_HOST`|(optional) [authentication authority URL](https://docs.microsoft.com/azure/active-directory/develop/authentication-national-cloud)
+|`AZURE_AUTHORITY_HOST`|(optional) [authentication authority URL](https://learn.microsoft.com/entra/identity-platform/authentication-national-cloud)
 
 ### Service principal with certificate
 
@@ -115,7 +116,7 @@ The [Managed identity authentication](https://docs.microsoft.com/azure/active-di
 |`AZURE_CLIENT_ID`|ID of a Microsoft Entra application
 |`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
 |`AZURE_CLIENT_CERTIFICATE_PATH`|path to a PFX or PEM-encoded certificate file including private key
-|`AZURE_AUTHORITY_HOST`|(optional) [authentication authority URL](https://docs.microsoft.com/azure/active-directory/develop/authentication-national-cloud)
+|`AZURE_AUTHORITY_HOST`|(optional) [authentication authority URL](https://learn.microsoft.com/entra/identity-platform/authentication-national-cloud)
 
 Configuration is attempted in the above order. For example, if values for a client secret and certificate are both present, the client secret will be used.
 
@@ -133,8 +134,8 @@ Configuration is attempted in the above order. For example, if values for a clie
 ### Authenticate service principals
 |Credential | Usage
 |-|-
-|`ClientSecretCredential`|Authenticates a service principal [using a secret](https://learn.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals).
-|`ClientCertificateCredential`|Authenticates a service principal [using a certificate](https://learn.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals).
+|`ClientSecretCredential`|Authenticates a service principal [using a secret](https://learn.microsoft.com/entra/identity-platform/app-objects-and-service-principals).
+|`ClientCertificateCredential`|Authenticates a service principal [using a certificate](https://learn.microsoft.com/entra/identity-platform/app-objects-and-service-principals).
 
 ### Authenticate via development tools
 |Credential | Usage
@@ -187,6 +188,6 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 [azure_sdk_cpp_development_guidelines]: https://azure.github.io/azure-sdk/cpp_introduction.html
 [default_azure_credential_auth_flow]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/identity/azure-identity/img/mermaidjs/DefaultAzureCredentialAuthFlow.svg
 [source]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity
-[meid_doc]: https://learn.microsoft.com/azure/active-directory/
+[meid_doc]: https://learn.microsoft.com/entra/identity/
 [azure_core_library]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/core
 [doxygen]: https://azure.github.io/azure-sdk-for-cpp/

--- a/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_certificate_credential.hpp
@@ -50,7 +50,7 @@ namespace Azure { namespace Identity {
      *
      * @note Example of an authority host string: "https://login.microsoftonline.us/". See national
      * clouds' Microsoft Entra authentication endpoints:
-     * https://learn.microsoft.com/azure/active-directory/develop/authentication-national-cloud.
+     * https://learn.microsoft.com/entra/identity-platform/authentication-national-cloud.
      */
     std::string AuthorityHost = _detail::DefaultOptionValues::GetAuthorityHost();
 

--- a/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/client_secret_credential.hpp
@@ -38,7 +38,7 @@ namespace Azure { namespace Identity {
      *
      * @note Example of an authority host string: "https://login.microsoftonline.us/". See national
      * clouds' Microsoft Entra authentication endpoints:
-     * https://learn.microsoft.com/azure/active-directory/develop/authentication-national-cloud.
+     * https://learn.microsoft.com/entra/identity-platform/authentication-national-cloud.
      */
     std::string AuthorityHost = _detail::DefaultOptionValues::GetAuthorityHost();
 

--- a/sdk/identity/azure-identity/inc/azure/identity/dll_import_export.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/dll_import_export.hpp
@@ -13,7 +13,7 @@
 /**
  * @def AZ_IDENTITY_DLLEXPORT
  * @brief Applies DLL export attribute, when applicable.
- * @note See https://docs.microsoft.com/cpp/cpp/dllexport-dllimport?view=msvc-160.
+ * @note See https://learn.microsoft.com/cpp/cpp/dllexport-dllimport?view=msvc-160.
  */
 
 #if defined(AZ_IDENTITY_DLL) || (0 /*@AZ_IDENTITY_DLL_INSTALLED_AS_PACKAGE@*/)

--- a/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
@@ -24,7 +24,7 @@ namespace Azure { namespace Identity {
    * deployment environment. This authentication type works in Azure VMs, App Service and Azure
    * Functions applications, as well as the Azure Cloud Shell. More information about configuring
    * managed identities can be found here:
-   * https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
+   * https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview
    */
   class ManagedIdentityCredential final : public Core::Credentials::TokenCredential {
   private:

--- a/sdk/identity/azure-identity/inc/azure/identity/workload_identity_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/workload_identity_credential.hpp
@@ -47,7 +47,7 @@ namespace Azure { namespace Identity {
      *
      * @note Example of an authority host string: "https://login.microsoftonline.us/". See national
      * clouds' Microsoft Entra authentication endpoints:
-     * https://learn.microsoft.com/azure/active-directory/develop/authentication-national-cloud.
+     * https://learn.microsoft.com/entra/identity-platform/authentication-national-cloud.
      */
     std::string AuthorityHost = _detail::DefaultOptionValues::GetAuthorityHost();
 


### PR DESCRIPTION
Replace Azure AD docs/learn.microsoft.com links with their Entra counterparts