### PR TITLE
Revert "Move the connection back to the connection pool when HTTP error 404 was received (#5308)"

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- [[#5450]](https://github.com/Azure/azure-sdk-for-cpp/issues/5450) Reverted libcurl connection pool to use more conservative caching strategy.
 - [[#4352]](https://github.com/Azure/azure-sdk-for-cpp/pull/5371) Fixed compilation error on Visual Studio 2017. (A community contribution, courtesy of _[morten-ofstad](https://github.com/morten-ofstad)_)
 
 ### Acknowledgments

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2132,7 +2132,8 @@ void CurlConnectionPool::MoveConnectionBackToPool(
     HttpStatusCode lastStatusCode)
 {
   auto code = static_cast<std::underlying_type<Http::HttpStatusCode>::type>(lastStatusCode);
-  if ((code < 200 || code >= 300) && lastStatusCode != HttpStatusCode::NotFound)
+  // laststatusCode = 0
+  if (code < 200 || code >= 300)
   {
     // A handler with previous response with Error can't be re-use.
     return;


### PR DESCRIPTION
This reverts commit 79cc06d004a7f8dfdc3ebcf65f0f8498b6b3e613 / PR #5308.

Fixes #5450, although PR #5473 should fix it better.
I propose to release this change as GA patch/minor, and then immediately release #5473 as Beta first.