### PR TITLE
Strengthen the client_secret sanitizer regex

### DIFF
--- a/sdk/core/azure-core-test/src/test_proxy_manager.cpp
+++ b/sdk/core/azure-core-test/src/test_proxy_manager.cpp
@@ -241,10 +241,7 @@ void TestProxyManager::SetProxySanitizer()
   };
 
   addSanitizer(SanitizerType::General, g_accountRegex, "account");
-  addSanitizer(
-      SanitizerType::Body,
-      "client_secret=(?<clientsecret>[^&]+)",
-      "clientsecret");
+  addSanitizer(SanitizerType::Body, "client_secret=(?<clientsecret>[^&]+)", "clientsecret");
   const std::string storageSasSignatureRegex = "\\?.*sig=(?<sassig>[a-zA-Z0-9\\%\\/+=]+)";
   addSanitizer(SanitizerType::Uri, storageSasSignatureRegex, "sassig");
   addSanitizer(SanitizerType::Header, storageSasSignatureRegex, "sassig", "x-ms-copy-source");

--- a/sdk/core/azure-core-test/src/test_proxy_manager.cpp
+++ b/sdk/core/azure-core-test/src/test_proxy_manager.cpp
@@ -243,7 +243,7 @@ void TestProxyManager::SetProxySanitizer()
   addSanitizer(SanitizerType::General, g_accountRegex, "account");
   addSanitizer(
       SanitizerType::Body,
-      "client_secret=(?<clientsecret>[a-zA-Z0-9\\%_~\\-\\.]+)",
+      "client_secret=(?<clientsecret>[^&]+)",
       "clientsecret");
   const std::string storageSasSignatureRegex = "\\?.*sig=(?<sassig>[a-zA-Z0-9\\%\\/+=]+)";
   addSanitizer(SanitizerType::Uri, storageSasSignatureRegex, "sassig");


### PR DESCRIPTION
Once we do find `client_secret=`, we want to match anything up to the next `&` and redact everything in between. Therefore, it is valuable to strengthen the regex and include all non-`&` characters, even if they may not be strictly part of the valid character set.

The goal of the sanitizer isn't to validate correctness.

Brings consistency with other languages, like Java:
https://github.com/Azure/azure-sdk-for-java/pull/39476

cc @Jinming-Hu, @microzchang, @billwert  