### PR TITLE
Investigate if CI would succeed without binary caching on

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -15,6 +15,7 @@
           "Pool": "env:MACPOOL",
           "BuildArgs": "-j 10",
           "VCPKG_DEFAULT_TRIPLET": "x64-osx",
+          "VCPKG_FEATURE_FLAGS": "-binarycaching",
           "CmakeArgs": " -DBUILD_TESTING=ON -DENABLE_PROXY_TESTS=OFF -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DBUILD_TRANSPORT_CURL=ON",
           "PublishMapFiles": "true"
         }

--- a/sdk/core/azure-core/inc/azure/core/context.hpp
+++ b/sdk/core/azure-core/inc/azure/core/context.hpp
@@ -73,7 +73,7 @@ namespace Azure { namespace Core {
        * @param other Other `%Key` to compare with.
        * @return `false` if instances are equal; otherwise, `true`.
        */
-      bool operator!=(Key const& other) const { return !(*this == other); }
+      bool operator!=(Key const& other) const { return !!!(*this == other); }
     };
 
   private:


### PR DESCRIPTION
If it does, then maybe we could clean up the storage account "cppvcpkgcache" (https://github.com/Azure/azure-sdk-for-cpp/pull/3482/files#diff-d9f70915550fa0d07a6f905e179233668f30ebe8d2a4de7eea30b59692223bc9L7),
or, as a last resort, we could leave it disabled for some time, to get unblocked.