### PR TITLE
Use env job template for data tables stress tests

### DIFF
--- a/sdk/tables/azure-data-tables/test/stress/templates/deploy-job.yaml
+++ b/sdk/tables/azure-data-tables/test/stress/templates/deploy-job.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-{{- include "stress-test-addons.deploy-job-template.from-pod" (list . "stress.deploy-example") -}}
+{{- include "stress-test-addons.env-job-template.from-pod" (list . "stress.deploy-example") -}}
 {{- define "stress.deploy-example" -}}
 metadata:
   labels:


### PR DESCRIPTION
The stress deployment pipeline is currently broken because these stress tests use the deploy job template but do not include a bicep file. This PR switches the tests to use the env job template instead, as they don't appear to require any live resources for testing.
