### PR TITLE
Fix azure-data-tables Config.cmake.in dependency on WIN32

### DIFF
--- a/sdk/tables/azure-data-tables/vcpkg/Config.cmake.in
+++ b/sdk/tables/azure-data-tables/vcpkg/Config.cmake.in
@@ -8,7 +8,10 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(azure-core-cpp)
-find_dependency(LibXml2)
+if(NOT WIN32)
+  find_dependency(LibXml2)
+  find_dependency(OpenSSL)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/azure-data-tables-cppTargets.cmake")
 

--- a/sdk/tables/azure-data-tables/vcpkg/vcpkg.json
+++ b/sdk/tables/azure-data-tables/vcpkg/vcpkg.json
@@ -26,6 +26,10 @@
       "platform": "!windows"
     },
     {
+      "name": "openssl",
+      "platform": "!windows"
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },


### PR DESCRIPTION
Add corresponding conditions `WIN32` for dependencies `LibXml2` and `OpenSSL` of `azure-data-tables/vcpkg/Config.cmake.in` from [sdk/tables/azure-data-tables/CMakeLists.txt#L85-L91]( https://github.com/Azure/azure-sdk-for-cpp/blob/azure-data-tables_1.0.0-beta.2/sdk/tables/azure-data-tables/CMakeLists.txt#L85-L91).