### PR TITLE
Update sdk vcpkg portfile with VERSION and HEAD_REF

### DIFF
--- a/eng/scripts/Initialize-VcpkgRelease.ps1
+++ b/eng/scripts/Initialize-VcpkgRelease.ps1
@@ -69,7 +69,7 @@ $newContent = $portFileContent -replace '(SHA512\s+)0', "`${1}$sha512"
 
 if ($DailyReleaseRef) {
     Write-Verbose "Overriding REF with test release ref: $DailyReleaseRef"
-    $newContent = $newContent -replace '(?m)^(\s+)REF azure.*$', "`${1}REF $DailyReleaseRef"
+    $newContent = $newContent -replace '(?m)^(\s+)REF \"azure.*\"$', "`${1}REF $DailyReleaseRef"
 }
 
 $newContent | Set-Content $portfileLocation -NoNewLine

--- a/eng/scripts/Initialize-VcpkgRelease.ps1
+++ b/eng/scripts/Initialize-VcpkgRelease.ps1
@@ -14,7 +14,7 @@ Name of the GitHub repo (of the form Azure/azure-sdk-for-cpp)
 
 .PARAMETER DailyReleaseRef
 If supplied update the portfile.cmake file's REF and SHA512 with values
-associated with the given ref.
+associated with the given ref. 
 
 #>
 [CmdletBinding()]

--- a/eng/scripts/Initialize-VcpkgRelease.ps1
+++ b/eng/scripts/Initialize-VcpkgRelease.ps1
@@ -14,7 +14,7 @@ Name of the GitHub repo (of the form Azure/azure-sdk-for-cpp)
 
 .PARAMETER DailyReleaseRef
 If supplied update the portfile.cmake file's REF and SHA512 with values
-associated with the given ref. 
+associated with the given ref.
 
 #>
 [CmdletBinding()]

--- a/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
+++ b/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-attestation_@AZ_LIBRARY_VERSION@
+    REF "azure-security-attestation_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
+++ b/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-security-attestation_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/attestation/azure-security-attestation")

--- a/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-core-amqp_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/core/azure-core-amqp")

--- a/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-core-amqp_@AZ_LIBRARY_VERSION@
+    REF "azure-core-amqp_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-core-tracing-opentelemetry_@AZ_LIBRARY_VERSION@
+    REF "azure-core-tracing-opentelemetry_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-core-tracing-opentelemetry_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/core/azure-core-tracing-opentelemetry")

--- a/sdk/core/azure-core/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-core_@AZ_LIBRARY_VERSION@
+    REF "azure-core_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/core/azure-core/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-core_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 vcpkg_check_features(

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/vcpkg/portfile.cmake
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-messaging-eventhubs-checkpointstore-blob_@AZ_LIBRARY_VERSION@
+    REF "azure-messaging-eventhubs-checkpointstore-blob_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/vcpkg/portfile.cmake
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-messaging-eventhubs-checkpointstore-blob_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob")

--- a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
+++ b/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-messaging-eventhubs_@AZ_LIBRARY_VERSION@
+    REF "azure-messaging-eventhubs_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
+++ b/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-messaging-eventhubs_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs")

--- a/sdk/identity/azure-identity/vcpkg/portfile.cmake
+++ b/sdk/identity/azure-identity/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-identity_@AZ_LIBRARY_VERSION@
+    REF "azure-identity_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/identity/azure-identity/vcpkg/portfile.cmake
+++ b/sdk/identity/azure-identity/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-identity_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/identity/azure-identity")

--- a/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-security-keyvault-administration_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-administration")

--- a/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-administration_@AZ_LIBRARY_VERSION@
+    REF "azure-security-keyvault-administration_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-security-keyvault-certificates_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-certificates")

--- a/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-certificates_@AZ_LIBRARY_VERSION@
+    REF "azure-security-keyvault-certificates_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-security-keyvault-keys_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys")

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-keys_@AZ_LIBRARY_VERSION@
+    REF "azure-security-keyvault-keys_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-security-keyvault-secrets_@AZ_LIBRARY_VERSION@
+    REF "azure-security-keyvault-secrets_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-security-keyvault-secrets_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-secrets")

--- a/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-storage-blobs_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-blobs")

--- a/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-blobs_@AZ_LIBRARY_VERSION@
+    REF "azure-storage-blobs_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-storage-common_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-common")

--- a/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-common_@AZ_LIBRARY_VERSION@
+    REF "azure-storage-common_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-storage-files-datalake_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-files-datalake")

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-files-datalake_@AZ_LIBRARY_VERSION@
+    REF "azure-storage-files-datalake_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-files-shares_@AZ_LIBRARY_VERSION@
+    REF "azure-storage-files-shares_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-storage-files-shares_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-files-shares")

--- a/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-storage-queues_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-queues")

--- a/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-storage-queues_@AZ_LIBRARY_VERSION@
+    REF "azure-storage-queues_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/tables/azure-data-tables/vcpkg/portfile.cmake
+++ b/sdk/tables/azure-data-tables/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-data-tables_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/tables/azure-data-tables")

--- a/sdk/tables/azure-data-tables/vcpkg/portfile.cmake
+++ b/sdk/tables/azure-data-tables/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-data-tables_@AZ_LIBRARY_VERSION@
+    REF "azure-data-tables_${VERSION}"
     SHA512 0
     HEAD_REF main
 )

--- a/sdk/template/azure-template/vcpkg/portfile.cmake
+++ b/sdk/template/azure-template/vcpkg/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-template_@AZ_LIBRARY_VERSION@
     SHA512 0
+    HEAD_REF main
 )
 
 if(EXISTS "${SOURCE_PATH}/sdk/template/azure-template")

--- a/sdk/template/azure-template/vcpkg/portfile.cmake
+++ b/sdk/template/azure-template/vcpkg/portfile.cmake
@@ -7,7 +7,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Azure/azure-sdk-for-cpp
-    REF azure-template_@AZ_LIBRARY_VERSION@
+    REF "azure-template_${VERSION}"
     SHA512 0
     HEAD_REF main
 )


### PR DESCRIPTION
Update 18 sdk vcpkg `portfile.cmake`, and update `Initialize-VcpkgRelease.ps1` regex.

Reference updates PR https://github.com/microsoft/vcpkg/pull/38085 and https://github.com/microsoft/vcpkg/pull/29514 and daily validation PR https://github.com/microsoft/vcpkg/pull/34835

### Changes

* Update all 18 `sdk\**\vcpkg\portfile.cmake`
  * Append parameter `HEAD_REF` to [allow HEAD builds](https://learn.microsoft.com/en-us/vcpkg/maintainers/functions/vcpkg_from_github#head_ref) by matching `(?<=\s{4})SHA512 0\n\)` with `SHA512 0\n    HEAD_REF main\n)`
  * Replace variable `REF` to [use variable](https://learn.microsoft.com/en-us/vcpkg/maintainers/variables#version) `${VERSION}` and be quoted by matching `(?<=\s{4})REF (azure.+)@AZ_LIBRARY_VERSION@$` with `REF "$1${VERSION}"`
* Update [Initialize-VcpkgRelease.ps1#L70-L73](https://github.com/Azure/azure-sdk-for-cpp/blob/a74ecaad3dfd5f94d8c6a69209845dda294ad8ef/eng/scripts/Initialize-VcpkgRelease.ps1#L70-L73) from `REF azure.*` to `REF \"azure.*\"` to keep "Overriding REF with test release ref" for `PublishDailyVcpkg` in [archetype-cpp-release.yml#L266-L302](https://github.com/Azure/azure-sdk-for-cpp/blob/a74ecaad3dfd5f94d8c6a69209845dda294ad8ef/eng/pipelines/templates/stages/archetype-cpp-release.yml#L266-L302)