### PR TITLE
Fix REF replacement in vcpkg daily runs

### DIFF
--- a/eng/scripts/Initialize-VcpkgRelease.ps1
+++ b/eng/scripts/Initialize-VcpkgRelease.ps1
@@ -69,7 +69,7 @@ $newContent = $portFileContent -replace '(SHA512\s+)0', "`${1}$sha512"
 
 if ($DailyReleaseRef) {
     Write-Verbose "Overriding REF with test release ref: $DailyReleaseRef"
-    $newContent = $newContent -replace '(?m)^(\s+)REF \"azure.*\"$', "`${1}REF $DailyReleaseRef"
+    $newContent = $newContent -replace '(?m)^(\s+)REF .+$', "`${1}REF $DailyReleaseRef"
 }
 
 $newContent | Set-Content $portfileLocation -NoNewLine


### PR DESCRIPTION
I could've fixed the quote characters alone (`"`s need to be escaped with `` ` ``s instead of `\`s), but I think it is better to just capture everything, this way it is compatible with both `REF azure-core_1234` and `REF "azure-core_1234"`, as well as `REF foo`.
