### PR TITLE
Update vcpkg SHA

### DIFF
--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -18,7 +18,7 @@ macro(az_vcpkg_integrate)
       message("AZURE_SDK_DISABLE_AUTO_VCPKG is not defined. Fetch a local copy of vcpkg.")
       # GET VCPKG FROM SOURCE
       #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
-      set(VCPKG_COMMIT_STRING 9854d1d92200d81dde189e53b64c9ba6a305dc9f) # default SDK tested commit
+      set(VCPKG_COMMIT_STRING 8150939b69720adc475461978e07c2d2bf5fb76e) # default SDK tested commit
       if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
         message("AZURE_SDK_VCPKG_COMMIT is defined. Using that instead of the default.")
         set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-sdk-for-cpp",
   "version": "1.5.0",
-  "builtin-baseline": "9854d1d92200d81dde189e53b64c9ba6a305dc9f",
+  "builtin-baseline": "8150939b69720adc475461978e07c2d2bf5fb76e",
   "dependencies": [
     {
       "name": "curl"


### PR DESCRIPTION
Updates vcpkg commit SHA to the current, which includes our latest releases and port manifest fixes: https://github.com/microsoft/vcpkg/tree/8150939b69720adc475461978e07c2d2bf5fb76e

There is no urgent reason, we just should be doing it periodically.