### PR TITLE
Add a virtual ShouldRetry method to the RetryPolicy for customization.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -39,13 +39,6 @@
  */
 extern std::shared_ptr<Azure::Core::Http::HttpTransport> AzureSdkGetCustomHttpTransport();
 
-#if defined(_azure_TESTING_BUILD)
-namespace Azure { namespace Core { namespace Http { namespace Policies { namespace Tests {
-  class RetryPolicyTest;
-  class RetryLogic;
-}}}}} // namespace Azure::Core::Http::Policies::Tests
-#endif // _azure_TESTING_BUILD
-
 namespace Azure { namespace Core { namespace Http { namespace Policies {
 
   struct TransportOptions;
@@ -371,21 +364,21 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * @brief HTTP retry policy.
      */
     class RetryPolicy : public HttpPolicy {
-#if defined(_azure_TESTING_BUILD)
-      friend class Azure::Core::Http::Policies::Tests::RetryPolicyTest;
-      friend class Azure::Core::Http::Policies::Tests::RetryLogic;
-#endif
-
     private:
       RetryOptions m_retryOptions;
 
-      bool ShouldRetryOnTransportFailure(
+#if defined(_azure_TESTING_BUILD)
+    protected:
+#else
+    private:
+#endif
+      virtual bool ShouldRetryOnTransportFailure(
           RetryOptions const& retryOptions,
           int32_t attempt,
           std::chrono::milliseconds& retryAfter,
           double jitterFactor = -1) const;
 
-      bool ShouldRetryOnResponse(
+      virtual bool ShouldRetryOnResponse(
           RawResponse const& response,
           RetryOptions const& retryOptions,
           int32_t attempt,

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -431,7 +431,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
        *
        * @param response An HTTP response returned corresponding to the request sent by the policy.
        * @param retryOptions The set of options provided to the RetryPolicy.
-       * @return Whether or not the HTTP request should be sent againg through the pipeline.
+       * @return Whether or not the HTTP request should be sent again through the pipeline.
        */
       virtual bool ShouldRetry(
           std::unique_ptr<RawResponse> const& response,

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -367,24 +367,6 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     private:
       RetryOptions m_retryOptions;
 
-#if defined(_azure_TESTING_BUILD)
-    protected:
-#else
-    private:
-#endif
-      virtual bool ShouldRetryOnTransportFailure(
-          RetryOptions const& retryOptions,
-          int32_t attempt,
-          std::chrono::milliseconds& retryAfter,
-          double jitterFactor = -1) const;
-
-      virtual bool ShouldRetryOnResponse(
-          RawResponse const& response,
-          RetryOptions const& retryOptions,
-          int32_t attempt,
-          std::chrono::milliseconds& retryAfter,
-          double jitterFactor = -1) const;
-
     public:
       /**
        * Constructs HTTP retry policy with the provided #Azure::Core::Http::Policies::RetryOptions.
@@ -417,6 +399,18 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
       static int32_t GetRetryCount(Context const& context);
 
     protected:
+      virtual bool ShouldRetryOnTransportFailure(
+          RetryOptions const& retryOptions,
+          int32_t attempt,
+          std::chrono::milliseconds& retryAfter,
+          double jitterFactor = -1) const;
+
+      virtual bool ShouldRetryOnResponse(
+          RawResponse const& response,
+          RetryOptions const& retryOptions,
+          int32_t attempt,
+          std::chrono::milliseconds& retryAfter,
+          double jitterFactor = -1) const;
       /**
        * @brief Overriding this method customizes the logic of when the RetryPolicy will re-attempt
        * a request, based on the returned HTTP response.

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -411,6 +411,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
           int32_t attempt,
           std::chrono::milliseconds& retryAfter,
           double jitterFactor = -1) const;
+
       /**
        * @brief Overriding this method customizes the logic of when the RetryPolicy will re-attempt
        * a request, based on the returned HTTP response.

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -118,12 +118,8 @@ int32_t RetryPolicy::GetRetryCount(Context const& context)
   return *ptr;
 }
 
-bool RetryPolicy::ShouldRetry(
-    std::unique_ptr<RawResponse> const& response,
-    RetryOptions const& retryOptions) const
+bool RetryPolicy::ShouldRetry(std::unique_ptr<RawResponse> const&, RetryOptions const&) const
 {
-  (void)response;
-  (void)retryOptions;
   return true;
 }
 

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -118,6 +118,15 @@ int32_t RetryPolicy::GetRetryCount(Context const& context)
   return *ptr;
 }
 
+bool RetryPolicy::ShouldRetry(
+    std::unique_ptr<RawResponse> const& response,
+    RetryOptions const& retryOptions) const
+{
+  (void)response;
+  (void)retryOptions;
+  return true;
+}
+
 std::unique_ptr<RawResponse> RetryPolicy::Send(
     Request& request,
     NextHttpPolicy nextPolicy,
@@ -141,11 +150,18 @@ std::unique_ptr<RawResponse> RetryPolicy::Send(
       auto response = nextPolicy.Send(request, retryContext);
 
       // If we are out of retry attempts, if a response is non-retriable (or simply 200 OK, i.e
-      // doesn't need to be retried), then ShouldRetry returns false.
+      // doesn't need to be retried), then ShouldRetryOnResponse returns false.
       if (!ShouldRetryOnResponse(*response.get(), m_retryOptions, attempt, retryAfter))
       {
         // If this is the second attempt and StartTry was called, we need to stop it. Otherwise
         // trying to perform same request would use last retry query/headers
+        return response;
+      }
+
+      // Service SDKs can inject custom logic to define whether the request should be retried,
+      // based on the response. The default is true.
+      if (!ShouldRetry(response, m_retryOptions))
+      {
         return response;
       }
     }

--- a/sdk/core/azure-core/test/ut/retry_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/retry_policy_test.cpp
@@ -13,825 +13,823 @@ using namespace Azure::Core::Http;
 using namespace Azure::Core::Http::Policies;
 using namespace Azure::Core::Http::Policies::_internal;
 
-namespace Azure { namespace Core { namespace Http { namespace Policies { namespace Tests {
-  class TestTransportPolicy final : public HttpPolicy {
-  private:
-    std::function<std::unique_ptr<RawResponse>()> m_send;
+namespace {
+class TestTransportPolicy final : public HttpPolicy {
+private:
+  std::function<std::unique_ptr<RawResponse>()> m_send;
 
-  public:
-    TestTransportPolicy(std::function<std::unique_ptr<RawResponse>()> send) : m_send(send) {}
+public:
+  TestTransportPolicy(std::function<std::unique_ptr<RawResponse>()> send) : m_send(send) {}
 
-    std::unique_ptr<Azure::Core::Http::RawResponse> Send(
-        Request&,
-        NextHttpPolicy,
-        Azure::Core::Context const&) const override
-    {
-      return m_send();
-    }
-
-    std::unique_ptr<HttpPolicy> Clone() const override
-    {
-      return std::make_unique<TestTransportPolicy>(*this);
-    }
-  };
-
-  class RetryPolicyTest final : public RetryPolicy {
-  private:
-    std::function<bool(RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
-        m_shouldRetryOnTransportFailure;
-
-    std::function<
-        bool(RawResponse const&, RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
-        m_shouldRetryOnResponse;
-
-  public:
-    bool BaseShouldRetryOnTransportFailure(
-        RetryOptions const& retryOptions,
-        int32_t attempt,
-        std::chrono::milliseconds& retryAfter,
-        double jitterFactor) const
-    {
-      return RetryPolicy::ShouldRetryOnTransportFailure(
-          retryOptions, attempt, retryAfter, jitterFactor);
-    }
-
-    bool BaseShouldRetryOnResponse(
-        RawResponse const& response,
-        RetryOptions const& retryOptions,
-        int32_t attempt,
-        std::chrono::milliseconds& retryAfter,
-        double jitterFactor) const
-    {
-      return RetryPolicy::ShouldRetryOnResponse(
-          response, retryOptions, attempt, retryAfter, jitterFactor);
-    }
-
-    RetryPolicyTest(
-        RetryOptions const& retryOptions,
-        decltype(m_shouldRetryOnTransportFailure) shouldRetryOnTransportFailure,
-        decltype(m_shouldRetryOnResponse) shouldRetryOnResponse)
-        : RetryPolicy(retryOptions),
-          m_shouldRetryOnTransportFailure(
-              shouldRetryOnTransportFailure != nullptr //
-                  ? shouldRetryOnTransportFailure
-                  : static_cast<decltype(m_shouldRetryOnTransportFailure)>( //
-                      [this](auto options, auto attempt, auto retryAfter, auto jitter) {
-                        retryAfter = std::chrono::milliseconds(0);
-                        auto ignore = decltype(retryAfter)();
-                        return this->BaseShouldRetryOnTransportFailure(
-                            options, attempt, ignore, jitter);
-                      })),
-          m_shouldRetryOnResponse(
-              shouldRetryOnResponse != nullptr //
-                  ? shouldRetryOnResponse
-                  : static_cast<decltype(m_shouldRetryOnResponse)>( //
-                      [this](
-                          RawResponse const& response,
-                          auto options,
-                          auto attempt,
-                          auto retryAfter,
-                          auto jitter) {
-                        retryAfter = std::chrono::milliseconds(0);
-                        auto ignore = decltype(retryAfter)();
-                        return this->BaseShouldRetryOnResponse(
-                            response, options, attempt, ignore, jitter);
-                      }))
-    {
-    }
-
-    std::unique_ptr<HttpPolicy> Clone() const override
-    {
-      return std::make_unique<RetryPolicyTest>(*this);
-    }
-
-    bool ShouldRetryOnTransportFailure(
-        RetryOptions const& retryOptions,
-        int32_t attempt,
-        std::chrono::milliseconds& retryAfter,
-        double jitterFactor) const
-    {
-      return m_shouldRetryOnTransportFailure(retryOptions, attempt, retryAfter, jitterFactor);
-    }
-
-    bool ShouldRetryOnResponse(
-        RawResponse const& response,
-        RetryOptions const& retryOptions,
-        int32_t attempt,
-        std::chrono::milliseconds& retryAfter,
-        double jitterFactor) const
-    {
-      return m_shouldRetryOnResponse(response, retryOptions, attempt, retryAfter, jitterFactor);
-    }
-  };
-
-  TEST(RetryPolicy, ShouldRetryOnResponse)
+  std::unique_ptr<Azure::Core::Http::RawResponse> Send(
+      Request&,
+      NextHttpPolicy,
+      Azure::Core::Context const&) const override
   {
-    using namespace std::chrono_literals;
-    RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
-
-    RawResponse const* responsePtrSent = nullptr;
-
-    RawResponse const* responsePtrReceived = nullptr;
-    RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
-    int32_t attemptReceived = -1234;
-    double jitterReceived = -5678;
-
-    int onTransportFailureInvoked = 0;
-    int onResponseInvoked = 0;
-
-    {
-      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-      policies.emplace_back(std::make_unique<RetryPolicyTest>(
-          retryOptions,
-          [&](auto options, auto attempt, auto, auto jitter) {
-            ++onTransportFailureInvoked;
-            retryOptionsReceived = options;
-            attemptReceived = attempt;
-            jitterReceived = jitter;
-
-            return false;
-          },
-          [&](RawResponse const& response, auto options, auto attempt, auto, auto jitter) {
-            ++onResponseInvoked;
-            responsePtrReceived = &response;
-            retryOptionsReceived = options;
-            attemptReceived = attempt;
-            jitterReceived = jitter;
-
-            return false;
-          }));
-
-      policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
-        auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
-
-        responsePtrSent = response.get();
-
-        return response;
-      }));
-
-      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-      pipeline.Send(request, Azure::Core::Context());
-    }
-
-    EXPECT_EQ(onTransportFailureInvoked, 0);
-    EXPECT_EQ(onResponseInvoked, 1);
-
-    EXPECT_NE(responsePtrSent, nullptr);
-    EXPECT_EQ(responsePtrSent, responsePtrReceived);
-
-    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-    EXPECT_EQ(attemptReceived, 1);
-    EXPECT_EQ(jitterReceived, -1);
-
-    // 3 attempts
-    responsePtrSent = nullptr;
-
-    responsePtrReceived = nullptr;
-    retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
-    attemptReceived = -1234;
-    jitterReceived = -5678;
-
-    onTransportFailureInvoked = 0;
-    onResponseInvoked = 0;
-
-    {
-      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-      policies.emplace_back(std::make_unique<RetryPolicyTest>(
-          retryOptions,
-          [&](auto options, auto attempt, auto, auto jitter) {
-            ++onTransportFailureInvoked;
-            retryOptionsReceived = options;
-            attemptReceived = attempt;
-            jitterReceived = jitter;
-
-            return false;
-          },
-          [&](RawResponse const& response,
-              auto options,
-              auto attempt,
-              auto retryAfter,
-              auto jitter) {
-            ++onResponseInvoked;
-            responsePtrReceived = &response;
-            retryOptionsReceived = options;
-            attemptReceived = attempt;
-            jitterReceived = jitter;
-
-            retryAfter = 1ms;
-            return onResponseInvoked < 3;
-          }));
-
-      policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
-        auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
-
-        responsePtrSent = response.get();
-
-        return response;
-      }));
-
-      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-      pipeline.Send(request, Azure::Core::Context());
-    }
-
-    EXPECT_EQ(onTransportFailureInvoked, 0);
-    EXPECT_EQ(onResponseInvoked, 3);
-
-    EXPECT_NE(responsePtrSent, nullptr);
-    EXPECT_EQ(responsePtrSent, responsePtrReceived);
-
-    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-    EXPECT_EQ(attemptReceived, 3);
-    EXPECT_EQ(jitterReceived, -1);
+    return m_send();
   }
 
-  TEST(RetryPolicy, ShouldRetryOnTransportFailure)
+  std::unique_ptr<HttpPolicy> Clone() const override
   {
-    using namespace std::chrono_literals;
-    RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
+    return std::make_unique<TestTransportPolicy>(*this);
+  }
+};
 
-    RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
-    int32_t attemptReceived = -1234;
-    double jitterReceived = -5678;
+class RetryPolicyTest final : public RetryPolicy {
+private:
+  std::function<bool(RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
+      m_shouldRetryOnTransportFailure;
 
-    int onTransportFailureInvoked = 0;
-    int onResponseInvoked = 0;
+  std::function<
+      bool(RawResponse const&, RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
+      m_shouldRetryOnResponse;
 
-    {
-      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-      policies.emplace_back(std::make_unique<RetryPolicyTest>(
-          retryOptions,
-          [&](auto options, auto attempt, auto, auto jitter) {
-            ++onTransportFailureInvoked;
-            retryOptionsReceived = options;
-            attemptReceived = attempt;
-            jitterReceived = jitter;
-
-            return false;
-          },
-          [&](auto, auto options, auto attempt, auto, auto jitter) {
-            ++onResponseInvoked;
-            retryOptionsReceived = options;
-            attemptReceived = attempt;
-            jitterReceived = jitter;
-
-            return false;
-          }));
-
-      policies.emplace_back(std::make_unique<TestTransportPolicy>(
-          []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
-
-      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-      EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
-    }
-
-    EXPECT_EQ(onTransportFailureInvoked, 1);
-    EXPECT_EQ(onResponseInvoked, 0);
-
-    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-    EXPECT_EQ(attemptReceived, 1);
-    EXPECT_EQ(jitterReceived, -1);
-
-    // 3 attempts
-    retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
-    attemptReceived = -1234;
-    jitterReceived = -5678;
-
-    onTransportFailureInvoked = 0;
-    onResponseInvoked = 0;
-
-    {
-      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-      policies.emplace_back(std::make_unique<RetryPolicyTest>(
-          retryOptions,
-          [&](auto options, auto attempt, auto, auto jitter) {
-            ++onTransportFailureInvoked;
-            retryOptionsReceived = options;
-            attemptReceived = attempt;
-            jitterReceived = jitter;
-
-            return onTransportFailureInvoked < 3;
-          },
-          [&](auto, auto options, auto attempt, auto retryAfter, auto jitter) {
-            ++onResponseInvoked;
-            retryOptionsReceived = options;
-            attemptReceived = attempt;
-            jitterReceived = jitter;
-
-            retryAfter = 1ms;
-            return false;
-          }));
-
-      policies.emplace_back(std::make_unique<TestTransportPolicy>(
-          []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
-
-      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-      EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
-    }
-
-    EXPECT_EQ(onTransportFailureInvoked, 3);
-    EXPECT_EQ(onResponseInvoked, 0);
-
-    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-    EXPECT_EQ(attemptReceived, 3);
-    EXPECT_EQ(jitterReceived, -1);
+public:
+  bool BaseShouldRetryOnTransportFailure(
+      RetryOptions const& retryOptions,
+      int32_t attempt,
+      std::chrono::milliseconds& retryAfter,
+      double jitterFactor) const
+  {
+    return RetryPolicy::ShouldRetryOnTransportFailure(
+        retryOptions, attempt, retryAfter, jitterFactor);
   }
 
-  class RetryLogic final : private RetryPolicy {
-    RetryLogic() : RetryPolicy(RetryOptions()) {}
-    ~RetryLogic() {}
-
-    static RetryLogic const g_retryPolicy;
-
-  public:
-    static bool TestShouldRetryOnTransportFailure(
-        RetryOptions const& retryOptions,
-        int32_t attempt,
-        std::chrono::milliseconds& retryAfter,
-        double jitterFactor)
-    {
-      return g_retryPolicy.ShouldRetryOnTransportFailure(
-          retryOptions, attempt, retryAfter, jitterFactor);
-    }
-
-    static bool TestShouldRetryOnResponse(
-        RawResponse const& response,
-        RetryOptions const& retryOptions,
-        int32_t attempt,
-        std::chrono::milliseconds& retryAfter,
-        double jitterFactor)
-    {
-      return g_retryPolicy.ShouldRetryOnResponse(
-          response, retryOptions, attempt, retryAfter, jitterFactor);
-    }
-  };
-
-  RetryLogic const RetryLogic::g_retryPolicy;
-
-  TEST(RetryPolicy, Exponential)
+  bool BaseShouldRetryOnResponse(
+      RawResponse const& response,
+      RetryOptions const& retryOptions,
+      int32_t attempt,
+      std::chrono::milliseconds& retryAfter,
+      double jitterFactor) const
   {
-    using namespace std::chrono_literals;
-
-    RetryOptions const options{3, 1s, 2min, {}};
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 1s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 2s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 4s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, false);
-    }
+    return RetryPolicy::ShouldRetryOnResponse(
+        response, retryOptions, attempt, retryAfter, jitterFactor);
   }
 
-  TEST(RetryPolicy, LessThan2Retries)
+  RetryPolicyTest(
+      RetryOptions const& retryOptions,
+      decltype(m_shouldRetryOnTransportFailure) shouldRetryOnTransportFailure,
+      decltype(m_shouldRetryOnResponse) shouldRetryOnResponse)
+      : RetryPolicy(retryOptions),
+        m_shouldRetryOnTransportFailure(
+            shouldRetryOnTransportFailure != nullptr //
+                ? shouldRetryOnTransportFailure
+                : static_cast<decltype(m_shouldRetryOnTransportFailure)>( //
+                    [this](auto options, auto attempt, auto retryAfter, auto jitter) {
+                      retryAfter = std::chrono::milliseconds(0);
+                      auto ignore = decltype(retryAfter)();
+                      return this->BaseShouldRetryOnTransportFailure(
+                          options, attempt, ignore, jitter);
+                    })),
+        m_shouldRetryOnResponse(
+            shouldRetryOnResponse != nullptr //
+                ? shouldRetryOnResponse
+                : static_cast<decltype(m_shouldRetryOnResponse)>( //
+                    [this](
+                        RawResponse const& response,
+                        auto options,
+                        auto attempt,
+                        auto retryAfter,
+                        auto jitter) {
+                      retryAfter = std::chrono::milliseconds(0);
+                      auto ignore = decltype(retryAfter)();
+                      return this->BaseShouldRetryOnResponse(
+                          response, options, attempt, ignore, jitter);
+                    }))
   {
-    using namespace std::chrono_literals;
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure({1, 1s, 2min, {}}, 1, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 1s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure({0, 1s, 2min, {}}, 1, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, false);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure({-1, 1s, 2min, {}}, 1, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, false);
-    }
   }
 
-  TEST(RetryPolicy, NotExceedingMaxRetryDelay)
+  std::unique_ptr<HttpPolicy> Clone() const override
   {
-    using namespace std::chrono_literals;
-
-    RetryOptions const options{7, 1s, 20s, {}};
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 1s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 2s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 4s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 8s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 5, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 16s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 6, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 20s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 7, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 20s);
-    }
+    return std::make_unique<RetryPolicyTest>(*this);
   }
 
-  TEST(RetryPolicy, NotExceedingInt32Max)
+protected:
+  bool ShouldRetryOnTransportFailure(
+      RetryOptions const& retryOptions,
+      int32_t attempt,
+      std::chrono::milliseconds& retryAfter,
+      double jitterFactor) const override
   {
-    using namespace std::chrono_literals;
-
-    RetryOptions const options{35, 1s, 9999999999999s, {}};
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 31, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 1073741824s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 32, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 2147483647s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 33, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 2147483647s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 34, retryAfter, 1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 2147483647s);
-    }
+    return m_shouldRetryOnTransportFailure(retryOptions, attempt, retryAfter, jitterFactor);
   }
 
-  TEST(RetryPolicy, Jitter)
+  bool ShouldRetryOnResponse(
+      RawResponse const& response,
+      RetryOptions const& retryOptions,
+      int32_t attempt,
+      std::chrono::milliseconds& retryAfter,
+      double jitterFactor) const override
   {
-    using namespace std::chrono_literals;
+    return m_shouldRetryOnResponse(response, retryOptions, attempt, retryAfter, jitterFactor);
+  }
+};
+} // namespace
 
-    RetryOptions const options{3, 10s, 20min, {}};
+TEST(RetryPolicy, ShouldRetryOnResponse)
+{
+  using namespace std::chrono_literals;
+  RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 0.8);
+  RawResponse const* responsePtrSent = nullptr;
 
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 8s);
-    }
+  RawResponse const* responsePtrReceived = nullptr;
+  RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
+  int32_t attemptReceived = -1234;
+  double jitterReceived = -5678;
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.3);
+  int onTransportFailureInvoked = 0;
+  int onResponseInvoked = 0;
 
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 13s);
-    }
+  {
+    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+    policies.emplace_back(std::make_unique<RetryPolicyTest>(
+        retryOptions,
+        [&](auto options, auto attempt, auto, auto jitter) {
+          ++onTransportFailureInvoked;
+          retryOptionsReceived = options;
+          attemptReceived = attempt;
+          jitterReceived = jitter;
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 0.8);
+          return false;
+        },
+        [&](RawResponse const& response, auto options, auto attempt, auto, auto jitter) {
+          ++onResponseInvoked;
+          responsePtrReceived = &response;
+          retryOptionsReceived = options;
+          attemptReceived = attempt;
+          jitterReceived = jitter;
 
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 16s);
-    }
+          return false;
+        }));
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.3);
+    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+      auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
 
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 26s);
-    }
+      responsePtrSent = response.get();
+
+      return response;
+    }));
+
+    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+    pipeline.Send(request, Azure::Core::Context());
   }
 
-  TEST(RetryPolicy, JitterExtremes)
+  EXPECT_EQ(onTransportFailureInvoked, 0);
+  EXPECT_EQ(onResponseInvoked, 1);
+
+  EXPECT_NE(responsePtrSent, nullptr);
+  EXPECT_EQ(responsePtrSent, responsePtrReceived);
+
+  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+  EXPECT_EQ(attemptReceived, 1);
+  EXPECT_EQ(jitterReceived, -1);
+
+  // 3 attempts
+  responsePtrSent = nullptr;
+
+  responsePtrReceived = nullptr;
+  retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
+  attemptReceived = -1234;
+  jitterReceived = -5678;
+
+  onTransportFailureInvoked = 0;
+  onResponseInvoked = 0;
+
   {
-    using namespace std::chrono_literals;
+    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+    policies.emplace_back(std::make_unique<RetryPolicyTest>(
+        retryOptions,
+        [&](auto options, auto attempt, auto, auto jitter) {
+          ++onTransportFailureInvoked;
+          retryOptionsReceived = options;
+          attemptReceived = attempt;
+          jitterReceived = jitter;
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure({3, 1ms, 2min, {}}, 1, retryAfter, 0.8);
+          return false;
+        },
+        [&](RawResponse const& response, auto options, auto attempt, auto retryAfter, auto jitter) {
+          ++onResponseInvoked;
+          responsePtrReceived = &response;
+          retryOptionsReceived = options;
+          attemptReceived = attempt;
+          jitterReceived = jitter;
 
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 0ms);
-    }
+          retryAfter = 1ms;
+          return onResponseInvoked < 3;
+        }));
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure({3, 2ms, 2min, {}}, 1, retryAfter, 0.8);
+    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+      auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
 
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 1ms);
-    }
+      responsePtrSent = response.get();
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 2, retryAfter, 1.3);
+      return response;
+    }));
 
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 21s);
-    }
+    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry
-          = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 3, retryAfter, 1.3);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 21s);
-    }
-
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry = RetryLogic::TestShouldRetryOnTransportFailure(
-          {35, 1s, 9999999999999s, {}}, 33, retryAfter, 1.3);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 2791728741100ms);
-    }
+    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+    pipeline.Send(request, Azure::Core::Context());
   }
 
-  TEST(RetryPolicy, HttpStatusCode)
+  EXPECT_EQ(onTransportFailureInvoked, 0);
+  EXPECT_EQ(onResponseInvoked, 3);
+
+  EXPECT_NE(responsePtrSent, nullptr);
+  EXPECT_EQ(responsePtrSent, responsePtrReceived);
+
+  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+  EXPECT_EQ(attemptReceived, 3);
+  EXPECT_EQ(jitterReceived, -1);
+}
+
+TEST(RetryPolicy, ShouldRetryOnTransportFailure)
+{
+  using namespace std::chrono_literals;
+  RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
+
+  RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
+  int32_t attemptReceived = -1234;
+  double jitterReceived = -5678;
+
+  int onTransportFailureInvoked = 0;
+  int onResponseInvoked = 0;
+
   {
-    using namespace std::chrono_literals;
+    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+    policies.emplace_back(std::make_unique<RetryPolicyTest>(
+        retryOptions,
+        [&](auto options, auto attempt, auto, auto jitter) {
+          ++onTransportFailureInvoked;
+          retryOptionsReceived = options;
+          attemptReceived = attempt;
+          jitterReceived = jitter;
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-          RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
-          {3, 3210s, 3h, {HttpStatusCode::RequestTimeout}},
-          1,
-          retryAfter,
-          1.0);
+          return false;
+        },
+        [&](auto, auto options, auto attempt, auto, auto jitter) {
+          ++onResponseInvoked;
+          retryOptionsReceived = options;
+          attemptReceived = attempt;
+          jitterReceived = jitter;
 
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 3210s);
-    }
+          return false;
+        }));
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-          RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
-          {3, 654s, 3h, {HttpStatusCode::Ok}},
-          1,
-          retryAfter,
-          1.0);
+    policies.emplace_back(std::make_unique<TestTransportPolicy>(
+        []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
 
-      EXPECT_EQ(shouldRetry, false);
-    }
+    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
 
-    {
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-          RawResponse(1, 1, HttpStatusCode::Ok, ""),
-          {3, 987s, 3h, {HttpStatusCode::Ok}},
-          1,
-          retryAfter,
-          1.0);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 987s);
-    }
+    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+    EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
   }
 
-  TEST(RetryPolicy, RetryAfterMs)
+  EXPECT_EQ(onTransportFailureInvoked, 1);
+  EXPECT_EQ(onResponseInvoked, 0);
+
+  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+  EXPECT_EQ(attemptReceived, 1);
+  EXPECT_EQ(jitterReceived, -1);
+
+  // 3 attempts
+  retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
+  attemptReceived = -1234;
+  jitterReceived = -5678;
+
+  onTransportFailureInvoked = 0;
+  onResponseInvoked = 0;
+
   {
-    using namespace std::chrono_literals;
+    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+    policies.emplace_back(std::make_unique<RetryPolicyTest>(
+        retryOptions,
+        [&](auto options, auto attempt, auto, auto jitter) {
+          ++onTransportFailureInvoked;
+          retryOptionsReceived = options;
+          attemptReceived = attempt;
+          jitterReceived = jitter;
 
-    {
-      RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
-      response.SetHeader("rEtRy-aFtEr-mS", "1234");
+          return onTransportFailureInvoked < 3;
+        },
+        [&](auto, auto options, auto attempt, auto retryAfter, auto jitter) {
+          ++onResponseInvoked;
+          retryOptionsReceived = options;
+          attemptReceived = attempt;
+          jitterReceived = jitter;
 
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-          response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.3);
+          retryAfter = 1ms;
+          return false;
+        }));
 
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 1234ms);
-    }
+    policies.emplace_back(std::make_unique<TestTransportPolicy>(
+        []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
 
-    {
-      RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
-      response.SetHeader("X-mS-ReTrY-aFtEr-MS", "5678");
+    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
 
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-          response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 0.8);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 5678ms);
-    }
+    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+    EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
   }
 
-  TEST(RetryPolicy, RetryAfter)
+  EXPECT_EQ(onTransportFailureInvoked, 3);
+  EXPECT_EQ(onResponseInvoked, 0);
+
+  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+  EXPECT_EQ(attemptReceived, 3);
+  EXPECT_EQ(jitterReceived, -1);
+}
+
+namespace {
+class RetryLogic final : private RetryPolicy {
+  RetryLogic() : RetryPolicy(RetryOptions()) {}
+  ~RetryLogic() {}
+
+  static RetryLogic const g_retryPolicy;
+
+public:
+  static bool TestShouldRetryOnTransportFailure(
+      RetryOptions const& retryOptions,
+      int32_t attempt,
+      std::chrono::milliseconds& retryAfter,
+      double jitterFactor)
   {
-    using namespace std::chrono_literals;
-
-    {
-      RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
-      response.SetHeader("rEtRy-aFtEr", "90");
-
-      std::chrono::milliseconds retryAfter{};
-      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-          response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.1);
-
-      EXPECT_EQ(shouldRetry, true);
-      EXPECT_EQ(retryAfter, 90s);
-    }
+    return g_retryPolicy.ShouldRetryOnTransportFailure(
+        retryOptions, attempt, retryAfter, jitterFactor);
   }
 
-  TEST(RetryPolicy, LogMessages)
+  static bool TestShouldRetryOnResponse(
+      RawResponse const& response,
+      RetryOptions const& retryOptions,
+      int32_t attempt,
+      std::chrono::milliseconds& retryAfter,
+      double jitterFactor)
   {
-    using Azure::Core::Diagnostics::Logger;
+    return g_retryPolicy.ShouldRetryOnResponse(
+        response, retryOptions, attempt, retryAfter, jitterFactor);
+  }
+};
 
-    struct Log
+RetryLogic const RetryLogic::g_retryPolicy;
+} // namespace
+
+TEST(RetryPolicy, Exponential)
+{
+  using namespace std::chrono_literals;
+
+  RetryOptions const options{3, 1s, 2min, {}};
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 1s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 2s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 4s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, false);
+  }
+}
+
+TEST(RetryPolicy, LessThan2Retries)
+{
+  using namespace std::chrono_literals;
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure({1, 1s, 2min, {}}, 1, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 1s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure({0, 1s, 2min, {}}, 1, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, false);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure({-1, 1s, 2min, {}}, 1, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, false);
+  }
+}
+
+TEST(RetryPolicy, NotExceedingMaxRetryDelay)
+{
+  using namespace std::chrono_literals;
+
+  RetryOptions const options{7, 1s, 20s, {}};
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 1s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 2s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 4s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 8s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 5, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 16s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 6, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 20s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 7, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 20s);
+  }
+}
+
+TEST(RetryPolicy, NotExceedingInt32Max)
+{
+  using namespace std::chrono_literals;
+
+  RetryOptions const options{35, 1s, 9999999999999s, {}};
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 31, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 1073741824s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 32, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 2147483647s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 33, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 2147483647s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 34, retryAfter, 1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 2147483647s);
+  }
+}
+
+TEST(RetryPolicy, Jitter)
+{
+  using namespace std::chrono_literals;
+
+  RetryOptions const options{3, 10s, 20min, {}};
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 0.8);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 8s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.3);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 13s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 0.8);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 16s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.3);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 26s);
+  }
+}
+
+TEST(RetryPolicy, JitterExtremes)
+{
+  using namespace std::chrono_literals;
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure({3, 1ms, 2min, {}}, 1, retryAfter, 0.8);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 0ms);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure({3, 2ms, 2min, {}}, 1, retryAfter, 0.8);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 1ms);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 2, retryAfter, 1.3);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 21s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry
+        = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 3, retryAfter, 1.3);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 21s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry = RetryLogic::TestShouldRetryOnTransportFailure(
+        {35, 1s, 9999999999999s, {}}, 33, retryAfter, 1.3);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 2791728741100ms);
+  }
+}
+
+TEST(RetryPolicy, HttpStatusCode)
+{
+  using namespace std::chrono_literals;
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+        RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
+        {3, 3210s, 3h, {HttpStatusCode::RequestTimeout}},
+        1,
+        retryAfter,
+        1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 3210s);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+        RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
+        {3, 654s, 3h, {HttpStatusCode::Ok}},
+        1,
+        retryAfter,
+        1.0);
+
+    EXPECT_EQ(shouldRetry, false);
+  }
+
+  {
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+        RawResponse(1, 1, HttpStatusCode::Ok, ""),
+        {3, 987s, 3h, {HttpStatusCode::Ok}},
+        1,
+        retryAfter,
+        1.0);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 987s);
+  }
+}
+
+TEST(RetryPolicy, RetryAfterMs)
+{
+  using namespace std::chrono_literals;
+
+  {
+    RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
+    response.SetHeader("rEtRy-aFtEr-mS", "1234");
+
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+        response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.3);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 1234ms);
+  }
+
+  {
+    RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
+    response.SetHeader("X-mS-ReTrY-aFtEr-MS", "5678");
+
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+        response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 0.8);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 5678ms);
+  }
+}
+
+TEST(RetryPolicy, RetryAfter)
+{
+  using namespace std::chrono_literals;
+
+  {
+    RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
+    response.SetHeader("rEtRy-aFtEr", "90");
+
+    std::chrono::milliseconds retryAfter{};
+    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+        response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.1);
+
+    EXPECT_EQ(shouldRetry, true);
+    EXPECT_EQ(retryAfter, 90s);
+  }
+}
+
+TEST(RetryPolicy, LogMessages)
+{
+  using Azure::Core::Diagnostics::Logger;
+
+  struct Log
+  {
+    struct Entry
     {
-      struct Entry
+      Logger::Level Level;
+      std::string Message;
+    };
+
+    std::vector<Entry> Entries;
+
+    Log()
+    {
+      Logger::SetLevel(Logger::Level::Informational);
+      Logger::SetListener([&](auto lvl, auto msg) { Entries.emplace_back(Entry{lvl, msg}); });
+    }
+
+    ~Log()
+    {
+      Logger::SetListener(nullptr);
+      Logger::SetLevel(Logger::Level::Warning);
+    }
+
+  } log;
+
+  {
+    using namespace std::chrono_literals;
+    RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::InternalServerError}};
+
+    auto requestNumber = 0;
+
+    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+    policies.emplace_back(std::make_unique<RetryPolicyTest>(retryOptions, nullptr, nullptr));
+    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+      ++requestNumber;
+
+      if (requestNumber == 1)
       {
-        Logger::Level Level;
-        std::string Message;
-      };
-
-      std::vector<Entry> Entries;
-
-      Log()
-      {
-        Logger::SetLevel(Logger::Level::Informational);
-        Logger::SetListener([&](auto lvl, auto msg) { Entries.emplace_back(Entry{lvl, msg}); });
+        throw TransportException("Cable Unplugged");
       }
 
-      ~Log()
-      {
-        Logger::SetListener(nullptr);
-        Logger::SetLevel(Logger::Level::Warning);
-      }
+      return std::make_unique<RawResponse>(
+          1,
+          1,
+          requestNumber == 2 ? HttpStatusCode::InternalServerError
+                             : HttpStatusCode::ServiceUnavailable,
+          "Test");
+    }));
 
-    } log;
+    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
 
-    {
-      using namespace std::chrono_literals;
-      RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::InternalServerError}};
-
-      auto requestNumber = 0;
-
-      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-      policies.emplace_back(std::make_unique<RetryPolicyTest>(retryOptions, nullptr, nullptr));
-      policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
-        ++requestNumber;
-
-        if (requestNumber == 1)
-        {
-          throw TransportException("Cable Unplugged");
-        }
-
-        return std::make_unique<RawResponse>(
-            1,
-            1,
-            requestNumber == 2 ? HttpStatusCode::InternalServerError
-                               : HttpStatusCode::ServiceUnavailable,
-            "Test");
-      }));
-
-      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-      pipeline.Send(request, Azure::Core::Context());
-    }
-
-    EXPECT_EQ(log.Entries.size(), 5);
-
-    EXPECT_EQ(log.Entries[0].Level, Logger::Level::Warning);
-    EXPECT_EQ(log.Entries[0].Message, "HTTP Transport error: Cable Unplugged");
-
-    EXPECT_EQ(log.Entries[1].Level, Logger::Level::Informational);
-    EXPECT_EQ(log.Entries[1].Message, "HTTP Retry attempt #1 will be made in 0ms.");
-
-    EXPECT_EQ(log.Entries[2].Level, Logger::Level::Informational);
-    EXPECT_EQ(log.Entries[2].Message, "HTTP status code 500 will be retried.");
-
-    EXPECT_EQ(log.Entries[3].Level, Logger::Level::Informational);
-    EXPECT_EQ(log.Entries[3].Message, "HTTP Retry attempt #2 will be made in 0ms.");
-
-    EXPECT_EQ(log.Entries[4].Level, Logger::Level::Informational);
-    EXPECT_EQ(log.Entries[4].Message, "HTTP status code 503 won't be retried.");
+    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+    pipeline.Send(request, Azure::Core::Context());
   }
 
-}}}}} // namespace Azure::Core::Http::Policies::Tests
+  EXPECT_EQ(log.Entries.size(), 5);
+
+  EXPECT_EQ(log.Entries[0].Level, Logger::Level::Warning);
+  EXPECT_EQ(log.Entries[0].Message, "HTTP Transport error: Cable Unplugged");
+
+  EXPECT_EQ(log.Entries[1].Level, Logger::Level::Informational);
+  EXPECT_EQ(log.Entries[1].Message, "HTTP Retry attempt #1 will be made in 0ms.");
+
+  EXPECT_EQ(log.Entries[2].Level, Logger::Level::Informational);
+  EXPECT_EQ(log.Entries[2].Message, "HTTP status code 500 will be retried.");
+
+  EXPECT_EQ(log.Entries[3].Level, Logger::Level::Informational);
+  EXPECT_EQ(log.Entries[3].Message, "HTTP Retry attempt #2 will be made in 0ms.");
+
+  EXPECT_EQ(log.Entries[4].Level, Logger::Level::Informational);
+  EXPECT_EQ(log.Entries[4].Message, "HTTP status code 503 won't be retried.");
+}

--- a/sdk/core/azure-core/test/ut/retry_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/retry_policy_test.cpp
@@ -13,823 +13,825 @@ using namespace Azure::Core::Http;
 using namespace Azure::Core::Http::Policies;
 using namespace Azure::Core::Http::Policies::_internal;
 
-namespace {
-class TestTransportPolicy final : public HttpPolicy {
-private:
-  std::function<std::unique_ptr<RawResponse>()> m_send;
-
-public:
-  TestTransportPolicy(std::function<std::unique_ptr<RawResponse>()> send) : m_send(send) {}
-
-  std::unique_ptr<Azure::Core::Http::RawResponse> Send(
-      Request&,
-      NextHttpPolicy,
-      Azure::Core::Context const&) const override
-  {
-    return m_send();
-  }
-
-  std::unique_ptr<HttpPolicy> Clone() const override
-  {
-    return std::make_unique<TestTransportPolicy>(*this);
-  }
-};
-
-class RetryPolicyTest final : public RetryPolicy {
-private:
-  std::function<bool(RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
-      m_shouldRetryOnTransportFailure;
-
-  std::function<
-      bool(RawResponse const&, RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
-      m_shouldRetryOnResponse;
-
-public:
-  bool BaseShouldRetryOnTransportFailure(
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor) const
-  {
-    return RetryPolicy::ShouldRetryOnTransportFailure(
-        retryOptions, attempt, retryAfter, jitterFactor);
-  }
-
-  bool BaseShouldRetryOnResponse(
-      RawResponse const& response,
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor) const
-  {
-    return RetryPolicy::ShouldRetryOnResponse(
-        response, retryOptions, attempt, retryAfter, jitterFactor);
-  }
-
-  RetryPolicyTest(
-      RetryOptions const& retryOptions,
-      decltype(m_shouldRetryOnTransportFailure) shouldRetryOnTransportFailure,
-      decltype(m_shouldRetryOnResponse) shouldRetryOnResponse)
-      : RetryPolicy(retryOptions),
-        m_shouldRetryOnTransportFailure(
-            shouldRetryOnTransportFailure != nullptr //
-                ? shouldRetryOnTransportFailure
-                : static_cast<decltype(m_shouldRetryOnTransportFailure)>( //
-                    [this](auto options, auto attempt, auto retryAfter, auto jitter) {
-                      retryAfter = std::chrono::milliseconds(0);
-                      auto ignore = decltype(retryAfter)();
-                      return this->BaseShouldRetryOnTransportFailure(
-                          options, attempt, ignore, jitter);
-                    })),
-        m_shouldRetryOnResponse(
-            shouldRetryOnResponse != nullptr //
-                ? shouldRetryOnResponse
-                : static_cast<decltype(m_shouldRetryOnResponse)>( //
-                    [this](
-                        RawResponse const& response,
-                        auto options,
-                        auto attempt,
-                        auto retryAfter,
-                        auto jitter) {
-                      retryAfter = std::chrono::milliseconds(0);
-                      auto ignore = decltype(retryAfter)();
-                      return this->BaseShouldRetryOnResponse(
-                          response, options, attempt, ignore, jitter);
-                    }))
-  {
-  }
-
-  std::unique_ptr<HttpPolicy> Clone() const override
-  {
-    return std::make_unique<RetryPolicyTest>(*this);
-  }
-
-protected:
-  bool ShouldRetryOnTransportFailure(
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor) const override
-  {
-    return m_shouldRetryOnTransportFailure(retryOptions, attempt, retryAfter, jitterFactor);
-  }
-
-  bool ShouldRetryOnResponse(
-      RawResponse const& response,
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor) const override
-  {
-    return m_shouldRetryOnResponse(response, retryOptions, attempt, retryAfter, jitterFactor);
-  }
-};
-} // namespace
-
-TEST(RetryPolicy, ShouldRetryOnResponse)
-{
-  using namespace std::chrono_literals;
-  RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
-
-  RawResponse const* responsePtrSent = nullptr;
-
-  RawResponse const* responsePtrReceived = nullptr;
-  RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
-  int32_t attemptReceived = -1234;
-  double jitterReceived = -5678;
-
-  int onTransportFailureInvoked = 0;
-  int onResponseInvoked = 0;
-
-  {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(
-        retryOptions,
-        [&](auto options, auto attempt, auto, auto jitter) {
-          ++onTransportFailureInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        },
-        [&](RawResponse const& response, auto options, auto attempt, auto, auto jitter) {
-          ++onResponseInvoked;
-          responsePtrReceived = &response;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        }));
-
-    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
-      auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
-
-      responsePtrSent = response.get();
-
-      return response;
-    }));
-
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    pipeline.Send(request, Azure::Core::Context());
-  }
-
-  EXPECT_EQ(onTransportFailureInvoked, 0);
-  EXPECT_EQ(onResponseInvoked, 1);
-
-  EXPECT_NE(responsePtrSent, nullptr);
-  EXPECT_EQ(responsePtrSent, responsePtrReceived);
-
-  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-  EXPECT_EQ(attemptReceived, 1);
-  EXPECT_EQ(jitterReceived, -1);
-
-  // 3 attempts
-  responsePtrSent = nullptr;
-
-  responsePtrReceived = nullptr;
-  retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
-  attemptReceived = -1234;
-  jitterReceived = -5678;
-
-  onTransportFailureInvoked = 0;
-  onResponseInvoked = 0;
-
-  {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(
-        retryOptions,
-        [&](auto options, auto attempt, auto, auto jitter) {
-          ++onTransportFailureInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        },
-        [&](RawResponse const& response, auto options, auto attempt, auto retryAfter, auto jitter) {
-          ++onResponseInvoked;
-          responsePtrReceived = &response;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          retryAfter = 1ms;
-          return onResponseInvoked < 3;
-        }));
-
-    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
-      auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
-
-      responsePtrSent = response.get();
-
-      return response;
-    }));
-
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    pipeline.Send(request, Azure::Core::Context());
-  }
-
-  EXPECT_EQ(onTransportFailureInvoked, 0);
-  EXPECT_EQ(onResponseInvoked, 3);
-
-  EXPECT_NE(responsePtrSent, nullptr);
-  EXPECT_EQ(responsePtrSent, responsePtrReceived);
-
-  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-  EXPECT_EQ(attemptReceived, 3);
-  EXPECT_EQ(jitterReceived, -1);
-}
-
-TEST(RetryPolicy, ShouldRetryOnTransportFailure)
-{
-  using namespace std::chrono_literals;
-  RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
-
-  RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
-  int32_t attemptReceived = -1234;
-  double jitterReceived = -5678;
-
-  int onTransportFailureInvoked = 0;
-  int onResponseInvoked = 0;
-
-  {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(
-        retryOptions,
-        [&](auto options, auto attempt, auto, auto jitter) {
-          ++onTransportFailureInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        },
-        [&](auto, auto options, auto attempt, auto, auto jitter) {
-          ++onResponseInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return false;
-        }));
-
-    policies.emplace_back(std::make_unique<TestTransportPolicy>(
-        []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
-
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
-  }
-
-  EXPECT_EQ(onTransportFailureInvoked, 1);
-  EXPECT_EQ(onResponseInvoked, 0);
-
-  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-  EXPECT_EQ(attemptReceived, 1);
-  EXPECT_EQ(jitterReceived, -1);
-
-  // 3 attempts
-  retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
-  attemptReceived = -1234;
-  jitterReceived = -5678;
-
-  onTransportFailureInvoked = 0;
-  onResponseInvoked = 0;
-
-  {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(
-        retryOptions,
-        [&](auto options, auto attempt, auto, auto jitter) {
-          ++onTransportFailureInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          return onTransportFailureInvoked < 3;
-        },
-        [&](auto, auto options, auto attempt, auto retryAfter, auto jitter) {
-          ++onResponseInvoked;
-          retryOptionsReceived = options;
-          attemptReceived = attempt;
-          jitterReceived = jitter;
-
-          retryAfter = 1ms;
-          return false;
-        }));
-
-    policies.emplace_back(std::make_unique<TestTransportPolicy>(
-        []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
-
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
-
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
-  }
-
-  EXPECT_EQ(onTransportFailureInvoked, 3);
-  EXPECT_EQ(onResponseInvoked, 0);
-
-  EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
-  EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
-  EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
-  EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
-
-  EXPECT_EQ(attemptReceived, 3);
-  EXPECT_EQ(jitterReceived, -1);
-}
-
-namespace {
-class RetryLogic final : private RetryPolicy {
-  RetryLogic() : RetryPolicy(RetryOptions()) {}
-  ~RetryLogic() {}
-
-  static RetryLogic const g_retryPolicy;
-
-public:
-  static bool TestShouldRetryOnTransportFailure(
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor)
-  {
-    return g_retryPolicy.ShouldRetryOnTransportFailure(
-        retryOptions, attempt, retryAfter, jitterFactor);
-  }
-
-  static bool TestShouldRetryOnResponse(
-      RawResponse const& response,
-      RetryOptions const& retryOptions,
-      int32_t attempt,
-      std::chrono::milliseconds& retryAfter,
-      double jitterFactor)
-  {
-    return g_retryPolicy.ShouldRetryOnResponse(
-        response, retryOptions, attempt, retryAfter, jitterFactor);
-  }
-};
-
-RetryLogic const RetryLogic::g_retryPolicy;
-} // namespace
-
-TEST(RetryPolicy, Exponential)
-{
-  using namespace std::chrono_literals;
-
-  RetryOptions const options{3, 1s, 2min, {}};
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 4s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, false);
-  }
-}
-
-TEST(RetryPolicy, LessThan2Retries)
-{
-  using namespace std::chrono_literals;
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({1, 1s, 2min, {}}, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({0, 1s, 2min, {}}, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, false);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({-1, 1s, 2min, {}}, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, false);
-  }
-}
-
-TEST(RetryPolicy, NotExceedingMaxRetryDelay)
-{
-  using namespace std::chrono_literals;
-
-  RetryOptions const options{7, 1s, 20s, {}};
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 4s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 8s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 5, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 16s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 6, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 20s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 7, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 20s);
-  }
-}
-
-TEST(RetryPolicy, NotExceedingInt32Max)
-{
-  using namespace std::chrono_literals;
-
-  RetryOptions const options{35, 1s, 9999999999999s, {}};
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 31, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1073741824s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 32, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2147483647s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 33, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2147483647s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 34, retryAfter, 1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2147483647s);
-  }
-}
-
-TEST(RetryPolicy, Jitter)
-{
-  using namespace std::chrono_literals;
-
-  RetryOptions const options{3, 10s, 20min, {}};
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 8s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 13s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 16s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 26s);
-  }
-}
-
-TEST(RetryPolicy, JitterExtremes)
-{
-  using namespace std::chrono_literals;
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({3, 1ms, 2min, {}}, 1, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 0ms);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({3, 2ms, 2min, {}}, 1, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1ms);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 2, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 21s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry
-        = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 3, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 21s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnTransportFailure(
-        {35, 1s, 9999999999999s, {}}, 33, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 2791728741100ms);
-  }
-}
-
-TEST(RetryPolicy, HttpStatusCode)
-{
-  using namespace std::chrono_literals;
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
-        {3, 3210s, 3h, {HttpStatusCode::RequestTimeout}},
-        1,
-        retryAfter,
-        1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 3210s);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
-        {3, 654s, 3h, {HttpStatusCode::Ok}},
-        1,
-        retryAfter,
-        1.0);
-
-    EXPECT_EQ(shouldRetry, false);
-  }
-
-  {
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        RawResponse(1, 1, HttpStatusCode::Ok, ""),
-        {3, 987s, 3h, {HttpStatusCode::Ok}},
-        1,
-        retryAfter,
-        1.0);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 987s);
-  }
-}
-
-TEST(RetryPolicy, RetryAfterMs)
-{
-  using namespace std::chrono_literals;
-
-  {
-    RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
-    response.SetHeader("rEtRy-aFtEr-mS", "1234");
-
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.3);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 1234ms);
-  }
-
-  {
-    RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
-    response.SetHeader("X-mS-ReTrY-aFtEr-MS", "5678");
-
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 0.8);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 5678ms);
-  }
-}
-
-TEST(RetryPolicy, RetryAfter)
-{
-  using namespace std::chrono_literals;
-
-  {
-    RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
-    response.SetHeader("rEtRy-aFtEr", "90");
-
-    std::chrono::milliseconds retryAfter{};
-    bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
-        response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.1);
-
-    EXPECT_EQ(shouldRetry, true);
-    EXPECT_EQ(retryAfter, 90s);
-  }
-}
-
-TEST(RetryPolicy, LogMessages)
-{
-  using Azure::Core::Diagnostics::Logger;
-
-  struct Log
-  {
-    struct Entry
+namespace Azure { namespace Core { namespace Http { namespace Policies { namespace Tests {
+  class TestTransportPolicy final : public HttpPolicy {
+  private:
+    std::function<std::unique_ptr<RawResponse>()> m_send;
+
+  public:
+    TestTransportPolicy(std::function<std::unique_ptr<RawResponse>()> send) : m_send(send) {}
+
+    std::unique_ptr<Azure::Core::Http::RawResponse> Send(
+        Request&,
+        NextHttpPolicy,
+        Azure::Core::Context const&) const override
     {
-      Logger::Level Level;
-      std::string Message;
-    };
-
-    std::vector<Entry> Entries;
-
-    Log()
-    {
-      Logger::SetLevel(Logger::Level::Informational);
-      Logger::SetListener([&](auto lvl, auto msg) { Entries.emplace_back(Entry{lvl, msg}); });
+      return m_send();
     }
 
-    ~Log()
+    std::unique_ptr<HttpPolicy> Clone() const override
     {
-      Logger::SetListener(nullptr);
-      Logger::SetLevel(Logger::Level::Warning);
+      return std::make_unique<TestTransportPolicy>(*this);
+    }
+  };
+
+  class RetryPolicyTest final : public RetryPolicy {
+  private:
+    std::function<bool(RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
+        m_shouldRetryOnTransportFailure;
+
+    std::function<
+        bool(RawResponse const&, RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
+        m_shouldRetryOnResponse;
+
+  public:
+    bool BaseShouldRetryOnTransportFailure(
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor) const
+    {
+      return RetryPolicy::ShouldRetryOnTransportFailure(
+          retryOptions, attempt, retryAfter, jitterFactor);
     }
 
-  } log;
+    bool BaseShouldRetryOnResponse(
+        RawResponse const& response,
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor) const
+    {
+      return RetryPolicy::ShouldRetryOnResponse(
+          response, retryOptions, attempt, retryAfter, jitterFactor);
+    }
 
+    RetryPolicyTest(
+        RetryOptions const& retryOptions,
+        decltype(m_shouldRetryOnTransportFailure) shouldRetryOnTransportFailure,
+        decltype(m_shouldRetryOnResponse) shouldRetryOnResponse)
+        : RetryPolicy(retryOptions),
+          m_shouldRetryOnTransportFailure(
+              shouldRetryOnTransportFailure != nullptr //
+                  ? shouldRetryOnTransportFailure
+                  : static_cast<decltype(m_shouldRetryOnTransportFailure)>( //
+                      [this](auto options, auto attempt, auto retryAfter, auto jitter) {
+                        retryAfter = std::chrono::milliseconds(0);
+                        auto ignore = decltype(retryAfter)();
+                        return this->BaseShouldRetryOnTransportFailure(
+                            options, attempt, ignore, jitter);
+                      })),
+          m_shouldRetryOnResponse(
+              shouldRetryOnResponse != nullptr //
+                  ? shouldRetryOnResponse
+                  : static_cast<decltype(m_shouldRetryOnResponse)>( //
+                      [this](
+                          RawResponse const& response,
+                          auto options,
+                          auto attempt,
+                          auto retryAfter,
+                          auto jitter) {
+                        retryAfter = std::chrono::milliseconds(0);
+                        auto ignore = decltype(retryAfter)();
+                        return this->BaseShouldRetryOnResponse(
+                            response, options, attempt, ignore, jitter);
+                      }))
+    {
+    }
+
+    std::unique_ptr<HttpPolicy> Clone() const override
+    {
+      return std::make_unique<RetryPolicyTest>(*this);
+    }
+
+    bool ShouldRetryOnTransportFailure(
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor) const
+    {
+      return m_shouldRetryOnTransportFailure(retryOptions, attempt, retryAfter, jitterFactor);
+    }
+
+    bool ShouldRetryOnResponse(
+        RawResponse const& response,
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor) const
+    {
+      return m_shouldRetryOnResponse(response, retryOptions, attempt, retryAfter, jitterFactor);
+    }
+  };
+
+  TEST(RetryPolicy, ShouldRetryOnResponse)
   {
     using namespace std::chrono_literals;
-    RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::InternalServerError}};
+    RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
 
-    auto requestNumber = 0;
+    RawResponse const* responsePtrSent = nullptr;
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
-    policies.emplace_back(std::make_unique<RetryPolicyTest>(retryOptions, nullptr, nullptr));
-    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
-      ++requestNumber;
+    RawResponse const* responsePtrReceived = nullptr;
+    RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
+    int32_t attemptReceived = -1234;
+    double jitterReceived = -5678;
 
-      if (requestNumber == 1)
-      {
-        throw TransportException("Cable Unplugged");
-      }
+    int onTransportFailureInvoked = 0;
+    int onResponseInvoked = 0;
 
-      return std::make_unique<RawResponse>(
-          1,
-          1,
-          requestNumber == 2 ? HttpStatusCode::InternalServerError
-                             : HttpStatusCode::ServiceUnavailable,
-          "Test");
-    }));
+    {
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(
+          retryOptions,
+          [&](auto options, auto attempt, auto, auto jitter) {
+            ++onTransportFailureInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
 
-    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+            return false;
+          },
+          [&](RawResponse const& response, auto options, auto attempt, auto, auto jitter) {
+            ++onResponseInvoked;
+            responsePtrReceived = &response;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
 
-    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
-    pipeline.Send(request, Azure::Core::Context());
+            return false;
+          }));
+
+      policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+        auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
+
+        responsePtrSent = response.get();
+
+        return response;
+      }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      pipeline.Send(request, Azure::Core::Context());
+    }
+
+    EXPECT_EQ(onTransportFailureInvoked, 0);
+    EXPECT_EQ(onResponseInvoked, 1);
+
+    EXPECT_NE(responsePtrSent, nullptr);
+    EXPECT_EQ(responsePtrSent, responsePtrReceived);
+
+    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+    EXPECT_EQ(attemptReceived, 1);
+    EXPECT_EQ(jitterReceived, -1);
+
+    // 3 attempts
+    responsePtrSent = nullptr;
+
+    responsePtrReceived = nullptr;
+    retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
+    attemptReceived = -1234;
+    jitterReceived = -5678;
+
+    onTransportFailureInvoked = 0;
+    onResponseInvoked = 0;
+
+    {
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(
+          retryOptions,
+          [&](auto options, auto attempt, auto, auto jitter) {
+            ++onTransportFailureInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
+
+            return false;
+          },
+          [&](RawResponse const& response,
+              auto options,
+              auto attempt,
+              auto retryAfter,
+              auto jitter) {
+            ++onResponseInvoked;
+            responsePtrReceived = &response;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
+
+            retryAfter = 1ms;
+            return onResponseInvoked < 3;
+          }));
+
+      policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+        auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
+
+        responsePtrSent = response.get();
+
+        return response;
+      }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      pipeline.Send(request, Azure::Core::Context());
+    }
+
+    EXPECT_EQ(onTransportFailureInvoked, 0);
+    EXPECT_EQ(onResponseInvoked, 3);
+
+    EXPECT_NE(responsePtrSent, nullptr);
+    EXPECT_EQ(responsePtrSent, responsePtrReceived);
+
+    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+    EXPECT_EQ(attemptReceived, 3);
+    EXPECT_EQ(jitterReceived, -1);
   }
 
-  EXPECT_EQ(log.Entries.size(), 5);
+  TEST(RetryPolicy, ShouldRetryOnTransportFailure)
+  {
+    using namespace std::chrono_literals;
+    RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::Ok}};
 
-  EXPECT_EQ(log.Entries[0].Level, Logger::Level::Warning);
-  EXPECT_EQ(log.Entries[0].Message, "HTTP Transport error: Cable Unplugged");
+    RetryOptions retryOptionsReceived{0, 0ms, 0ms, {}};
+    int32_t attemptReceived = -1234;
+    double jitterReceived = -5678;
 
-  EXPECT_EQ(log.Entries[1].Level, Logger::Level::Informational);
-  EXPECT_EQ(log.Entries[1].Message, "HTTP Retry attempt #1 will be made in 0ms.");
+    int onTransportFailureInvoked = 0;
+    int onResponseInvoked = 0;
 
-  EXPECT_EQ(log.Entries[2].Level, Logger::Level::Informational);
-  EXPECT_EQ(log.Entries[2].Message, "HTTP status code 500 will be retried.");
+    {
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(
+          retryOptions,
+          [&](auto options, auto attempt, auto, auto jitter) {
+            ++onTransportFailureInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
 
-  EXPECT_EQ(log.Entries[3].Level, Logger::Level::Informational);
-  EXPECT_EQ(log.Entries[3].Message, "HTTP Retry attempt #2 will be made in 0ms.");
+            return false;
+          },
+          [&](auto, auto options, auto attempt, auto, auto jitter) {
+            ++onResponseInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
 
-  EXPECT_EQ(log.Entries[4].Level, Logger::Level::Informational);
-  EXPECT_EQ(log.Entries[4].Message, "HTTP status code 503 won't be retried.");
-}
+            return false;
+          }));
+
+      policies.emplace_back(std::make_unique<TestTransportPolicy>(
+          []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
+    }
+
+    EXPECT_EQ(onTransportFailureInvoked, 1);
+    EXPECT_EQ(onResponseInvoked, 0);
+
+    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+    EXPECT_EQ(attemptReceived, 1);
+    EXPECT_EQ(jitterReceived, -1);
+
+    // 3 attempts
+    retryOptionsReceived = RetryOptions{0, 0ms, 0ms, {}};
+    attemptReceived = -1234;
+    jitterReceived = -5678;
+
+    onTransportFailureInvoked = 0;
+    onResponseInvoked = 0;
+
+    {
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(
+          retryOptions,
+          [&](auto options, auto attempt, auto, auto jitter) {
+            ++onTransportFailureInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
+
+            return onTransportFailureInvoked < 3;
+          },
+          [&](auto, auto options, auto attempt, auto retryAfter, auto jitter) {
+            ++onResponseInvoked;
+            retryOptionsReceived = options;
+            attemptReceived = attempt;
+            jitterReceived = jitter;
+
+            retryAfter = 1ms;
+            return false;
+          }));
+
+      policies.emplace_back(std::make_unique<TestTransportPolicy>(
+          []() -> std::unique_ptr<RawResponse> { throw TransportException("Test"); }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      EXPECT_THROW(pipeline.Send(request, Azure::Core::Context()), TransportException);
+    }
+
+    EXPECT_EQ(onTransportFailureInvoked, 3);
+    EXPECT_EQ(onResponseInvoked, 0);
+
+    EXPECT_EQ(retryOptionsReceived.MaxRetries, retryOptions.MaxRetries);
+    EXPECT_EQ(retryOptionsReceived.RetryDelay, retryOptions.RetryDelay);
+    EXPECT_EQ(retryOptionsReceived.MaxRetryDelay, retryOptions.MaxRetryDelay);
+    EXPECT_EQ(retryOptionsReceived.StatusCodes, retryOptions.StatusCodes);
+
+    EXPECT_EQ(attemptReceived, 3);
+    EXPECT_EQ(jitterReceived, -1);
+  }
+
+  class RetryLogic final : private RetryPolicy {
+    RetryLogic() : RetryPolicy(RetryOptions()) {}
+    ~RetryLogic() {}
+
+    static RetryLogic const g_retryPolicy;
+
+  public:
+    static bool TestShouldRetryOnTransportFailure(
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor)
+    {
+      return g_retryPolicy.ShouldRetryOnTransportFailure(
+          retryOptions, attempt, retryAfter, jitterFactor);
+    }
+
+    static bool TestShouldRetryOnResponse(
+        RawResponse const& response,
+        RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor)
+    {
+      return g_retryPolicy.ShouldRetryOnResponse(
+          response, retryOptions, attempt, retryAfter, jitterFactor);
+    }
+  };
+
+  RetryLogic const RetryLogic::g_retryPolicy;
+
+  TEST(RetryPolicy, Exponential)
+  {
+    using namespace std::chrono_literals;
+
+    RetryOptions const options{3, 1s, 2min, {}};
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 4s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, false);
+    }
+  }
+
+  TEST(RetryPolicy, LessThan2Retries)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({1, 1s, 2min, {}}, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({0, 1s, 2min, {}}, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, false);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({-1, 1s, 2min, {}}, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, false);
+    }
+  }
+
+  TEST(RetryPolicy, NotExceedingMaxRetryDelay)
+  {
+    using namespace std::chrono_literals;
+
+    RetryOptions const options{7, 1s, 20s, {}};
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 3, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 4s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 4, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 8s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 5, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 16s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 6, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 20s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 7, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 20s);
+    }
+  }
+
+  TEST(RetryPolicy, NotExceedingInt32Max)
+  {
+    using namespace std::chrono_literals;
+
+    RetryOptions const options{35, 1s, 9999999999999s, {}};
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 31, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1073741824s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 32, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2147483647s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 33, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2147483647s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 34, retryAfter, 1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2147483647s);
+    }
+  }
+
+  TEST(RetryPolicy, Jitter)
+  {
+    using namespace std::chrono_literals;
+
+    RetryOptions const options{3, 10s, 20min, {}};
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 8s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 1, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 13s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 16s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure(options, 2, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 26s);
+    }
+  }
+
+  TEST(RetryPolicy, JitterExtremes)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({3, 1ms, 2min, {}}, 1, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 0ms);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({3, 2ms, 2min, {}}, 1, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1ms);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 2, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 21s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry
+          = RetryLogic::TestShouldRetryOnTransportFailure({3, 10s, 21s, {}}, 3, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 21s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnTransportFailure(
+          {35, 1s, 9999999999999s, {}}, 33, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 2791728741100ms);
+    }
+  }
+
+  TEST(RetryPolicy, HttpStatusCode)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
+          {3, 3210s, 3h, {HttpStatusCode::RequestTimeout}},
+          1,
+          retryAfter,
+          1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 3210s);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          RawResponse(1, 1, HttpStatusCode::RequestTimeout, ""),
+          {3, 654s, 3h, {HttpStatusCode::Ok}},
+          1,
+          retryAfter,
+          1.0);
+
+      EXPECT_EQ(shouldRetry, false);
+    }
+
+    {
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          RawResponse(1, 1, HttpStatusCode::Ok, ""),
+          {3, 987s, 3h, {HttpStatusCode::Ok}},
+          1,
+          retryAfter,
+          1.0);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 987s);
+    }
+  }
+
+  TEST(RetryPolicy, RetryAfterMs)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
+      response.SetHeader("rEtRy-aFtEr-mS", "1234");
+
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.3);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 1234ms);
+    }
+
+    {
+      RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
+      response.SetHeader("X-mS-ReTrY-aFtEr-MS", "5678");
+
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 0.8);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 5678ms);
+    }
+  }
+
+  TEST(RetryPolicy, RetryAfter)
+  {
+    using namespace std::chrono_literals;
+
+    {
+      RawResponse response(1, 1, HttpStatusCode::RequestTimeout, "");
+      response.SetHeader("rEtRy-aFtEr", "90");
+
+      std::chrono::milliseconds retryAfter{};
+      bool const shouldRetry = RetryLogic::TestShouldRetryOnResponse(
+          response, {3, 1s, 2min, {HttpStatusCode::RequestTimeout}}, 1, retryAfter, 1.1);
+
+      EXPECT_EQ(shouldRetry, true);
+      EXPECT_EQ(retryAfter, 90s);
+    }
+  }
+
+  TEST(RetryPolicy, LogMessages)
+  {
+    using Azure::Core::Diagnostics::Logger;
+
+    struct Log
+    {
+      struct Entry
+      {
+        Logger::Level Level;
+        std::string Message;
+      };
+
+      std::vector<Entry> Entries;
+
+      Log()
+      {
+        Logger::SetLevel(Logger::Level::Informational);
+        Logger::SetListener([&](auto lvl, auto msg) { Entries.emplace_back(Entry{lvl, msg}); });
+      }
+
+      ~Log()
+      {
+        Logger::SetListener(nullptr);
+        Logger::SetLevel(Logger::Level::Warning);
+      }
+
+    } log;
+
+    {
+      using namespace std::chrono_literals;
+      RetryOptions const retryOptions{5, 10s, 5min, {HttpStatusCode::InternalServerError}};
+
+      auto requestNumber = 0;
+
+      std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+      policies.emplace_back(std::make_unique<RetryPolicyTest>(retryOptions, nullptr, nullptr));
+      policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+        ++requestNumber;
+
+        if (requestNumber == 1)
+        {
+          throw TransportException("Cable Unplugged");
+        }
+
+        return std::make_unique<RawResponse>(
+            1,
+            1,
+            requestNumber == 2 ? HttpStatusCode::InternalServerError
+                               : HttpStatusCode::ServiceUnavailable,
+            "Test");
+      }));
+
+      Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+      Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+      pipeline.Send(request, Azure::Core::Context());
+    }
+
+    EXPECT_EQ(log.Entries.size(), 5);
+
+    EXPECT_EQ(log.Entries[0].Level, Logger::Level::Warning);
+    EXPECT_EQ(log.Entries[0].Message, "HTTP Transport error: Cable Unplugged");
+
+    EXPECT_EQ(log.Entries[1].Level, Logger::Level::Informational);
+    EXPECT_EQ(log.Entries[1].Message, "HTTP Retry attempt #1 will be made in 0ms.");
+
+    EXPECT_EQ(log.Entries[2].Level, Logger::Level::Informational);
+    EXPECT_EQ(log.Entries[2].Message, "HTTP status code 500 will be retried.");
+
+    EXPECT_EQ(log.Entries[3].Level, Logger::Level::Informational);
+    EXPECT_EQ(log.Entries[3].Message, "HTTP Retry attempt #2 will be made in 0ms.");
+
+    EXPECT_EQ(log.Entries[4].Level, Logger::Level::Informational);
+    EXPECT_EQ(log.Entries[4].Message, "HTTP status code 503 won't be retried.");
+  }
+
+}}}}} // namespace Azure::Core::Http::Policies::Tests

--- a/sdk/core/azure-core/test/ut/retry_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/retry_policy_test.cpp
@@ -124,7 +124,88 @@ protected:
     return m_shouldRetryOnResponse(response, retryOptions, attempt, retryAfter, jitterFactor);
   }
 };
+
+class RetryPolicyTest_CustomRetry_False final : public RetryPolicy {
+public:
+  RetryPolicyTest_CustomRetry_False(RetryOptions const& retryOptions) : RetryPolicy(retryOptions) {}
+
+  std::unique_ptr<HttpPolicy> Clone() const override
+  {
+    return std::make_unique<RetryPolicyTest_CustomRetry_False>(*this);
+  }
+
+protected:
+  bool ShouldRetry(std::unique_ptr<RawResponse> const& response, RetryOptions const& retryOptions)
+      const override
+  {
+    (void)response;
+    (void)retryOptions;
+    return false;
+  }
+};
 } // namespace
+
+TEST(RetryPolicy, ShouldRetry)
+{
+  using namespace std::chrono_literals;
+  RetryOptions const retryOptions{3, 10ms, 60s, {HttpStatusCode::Ok}};
+
+  // The default ShouldRetry implementation is to always return true,
+  // which means we will retry up to the retry count in the options.
+  {
+    Azure::Core::Context context = Azure::Core::Context::ApplicationContext;
+    auto policy = RetryPolicy(retryOptions);
+
+    RawResponse const* responsePtrSent = nullptr;
+    int32_t retryCounter = -1;
+
+    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+    policies.emplace_back(std::make_unique<RetryPolicy>(policy));
+    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+      auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
+
+      responsePtrSent = response.get();
+      retryCounter++;
+      return response;
+    }));
+
+    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+    pipeline.Send(request, context);
+
+    EXPECT_NE(responsePtrSent, nullptr);
+    EXPECT_EQ(retryCounter, 3);
+  }
+
+  // Overriding ShouldRetry to return false will mean we won't retry.
+  {
+    Azure::Core::Context context = Azure::Core::Context();
+    auto policy = RetryPolicyTest_CustomRetry_False(retryOptions);
+
+    RawResponse const* responsePtrSent = nullptr;
+    int32_t retryCounter = -1;
+
+    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> policies;
+    policies.emplace_back(std::make_unique<RetryPolicyTest_CustomRetry_False>(policy));
+
+    policies.emplace_back(std::make_unique<TestTransportPolicy>([&]() {
+      auto response = std::make_unique<RawResponse>(1, 1, HttpStatusCode::Ok, "Test");
+
+      responsePtrSent = response.get();
+      retryCounter++;
+      return response;
+    }));
+
+    Azure::Core::Http::_internal::HttpPipeline pipeline(policies);
+
+    Request request(HttpMethod::Get, Azure::Core::Url("https://www.microsoft.com"));
+    pipeline.Send(request, context);
+
+    EXPECT_NE(responsePtrSent, nullptr);
+    EXPECT_EQ(retryCounter, 0);
+  }
+}
 
 TEST(RetryPolicy, ShouldRetryOnResponse)
 {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/5515

Related discussion:
https://github.com/Azure/azure-sdk-for-cpp/pull/5530#issuecomment-2076038171

Given this is not meant for end customers to modify, I did not add it to the changelog to avoid highlighting it.

cc @Jinming-Hu 

Here is how I would expect the storage use case to be implemented. The `StorageRetryPolicy` would inherit from `RetryPolicy`, and override the `ShouldRetry` method:
```C++
  bool ShouldRetry(std::unique_ptr<RawResponse> const& response, RetryOptions const& retryOptions)
      const override
  {
    if (response == nullptr)
    {
      return true;
    }

    if (static_cast<std::underlying_type_t<Azure::Core::Http::HttpStatusCode>>(
            response->GetStatusCode())
        >= 400)
    {
      const auto& headers = response->GetHeaders();
      auto ite = headers.find("x-ms-copy-source-status-code");
      if (ite != headers.end())
      {
        const auto innerStatusCodeInt = std::stoi(ite->second);
        const auto innerStatusCode
            = static_cast<Azure::Core::Http::HttpStatusCode>(innerStatusCodeInt);

        const bool shouldRetry
            = retryOptions.StatusCodes.find(innerStatusCode) != retryOptions.StatusCodes.end();

        if (Azure::Core::Diagnostics::_internal::Log::ShouldWrite(
                Azure::Core::Diagnostics::Logger::Level::Informational))
        {
          Azure::Core::Diagnostics::_internal::Log::Write(
              Azure::Core::Diagnostics::Logger::Level::Informational,
              std::string("x-ms-copy-source-status-code ") + std::to_string(innerStatusCodeInt)
                  + (shouldRetry ? " will be retried" : " won't be retried"));
        }
        if (shouldRetry)
        {
          return true;
        }
      }
    }
    return false;
  }
```

Follow-up improvement to remove such tight coupling in existing tests: https://github.com/Azure/azure-sdk-for-cpp/issues/5585