### PR TITLE
Fix possible endless loop while polling curl socket

### DIFF
--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -161,6 +161,7 @@ int pollSocketUntilEventOrTimeout(
     result = poll(&poller, 1, pollTimeoutMs);
     if (result < 0 && EINTR == errno)
     {
+      now = std::chrono::steady_clock::now();
       continue;
     }
 #elif defined(AZ_PLATFORM_WINDOWS)


### PR DESCRIPTION
In case of high frequency of received signals (more than once per second) the field `now` will never be updated and it can lead to exceeding of timeout or endless loop if socket will never be ready. For instance in ClickHouse signals `SIGUSR1` and `SIGUSR2` are being sent each second by internal query profiler and we faced this issue.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [ ] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
