### PR TITLE
Remove custom logic in Curl Transport for keep alive to support HTTP responses below version 1.1 (and remove unnecessary public methods on RawResponse).

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/raw_response.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/raw_response.hpp
@@ -139,18 +139,6 @@ namespace Azure { namespace Core { namespace Http {
     // fields in a class
 
     /**
-     * @brief Get HTTP protocol major version.
-     *
-     */
-    int32_t GetMajorVersion() const { return m_majorVersion; }
-
-    /**
-     * @brief Get HTTP protocol minor version.
-     *
-     */
-    int32_t GetMinorVersion() const { return m_minorVersion; }
-
-    /**
      * @brief Get HTTP status code of the HTTP response.
      *
      */

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -954,18 +954,12 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
     // /3 containing a "Connection" header should be considered malformed. (HTTP/2:
     // https://httpwg.org/specs/rfc9113.html#ConnectionSpecific
     //  HTTP/3: https://httpwg.org/specs/rfc9114.html#rfc.section.4.2)
-    if (m_response->GetMajorVersion() == 1 && m_response->GetMinorVersion() >= 1)
-    {
-      m_httpKeepAlive = (!hasConnectionClose || hasConnectionKeepAlive);
-    }
-    else if (m_response->GetMajorVersion() <= 1)
-    {
-      m_httpKeepAlive = hasConnectionKeepAlive;
-    }
-    else
-    {
-      m_httpKeepAlive = true;
-    }
+    // We assume that the server is not sending malformed responses,
+    // so we are not considering HTTP/2 or HTTP/3 here.
+    // We currently only support HTTP/1.1 requests and responses. Even if the response is HTTP/1.0,
+    // if it has a "Connection" header, with just "close", we dont keep the connection alive.
+
+    m_httpKeepAlive = (!hasConnectionClose || hasConnectionKeepAlive);
   }
 
   // For Head request, set the length of body response to 0.

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -957,7 +957,7 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
     // We assume that the server is not sending malformed responses,
     // so we are not considering HTTP/2 or HTTP/3 here.
     // We currently only support HTTP/1.1 requests and responses. Even if the response is HTTP/1.0,
-    // if it has a "Connection" header, with just "close", we dont keep the connection alive.
+    // if it has a "Connection" header, with just "close", we do not keep the connection alive.
 
     m_httpKeepAlive = (!hasConnectionClose || hasConnectionKeepAlive);
   }

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -933,6 +933,7 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
   else
   {
     bool hasConnectionKeepAlive = false;
+    bool hasConnectionClose = false;
     {
       const Core::CaseInsensitiveMap& responseHeaders = m_response->GetHeaders();
       const auto connectionHeader = responseHeaders.find("Connection");
@@ -941,6 +942,7 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
         const std::string headerValueLowercase
             = Core::_internal::StringExtensions::ToLower(connectionHeader->second);
         hasConnectionKeepAlive = headerValueLowercase.find("keep-alive") != std::string::npos;
+        hasConnectionClose = headerValueLowercase.find("close") != std::string::npos;
       }
     }
 
@@ -957,7 +959,7 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
     // We currently only support HTTP/1.1 requests and responses. Even if the response is HTTP/1.0,
     // if it has a "Connection" header, with just "close", we do not keep the connection alive.
 
-    m_httpKeepAlive = hasConnectionKeepAlive;
+    m_httpKeepAlive = (!hasConnectionClose || hasConnectionKeepAlive);
   }
 
   // For Head request, set the length of body response to 0.

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -933,7 +933,6 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
   else
   {
     bool hasConnectionKeepAlive = false;
-    bool hasConnectionClose = false;
     {
       const Core::CaseInsensitiveMap& responseHeaders = m_response->GetHeaders();
       const auto connectionHeader = responseHeaders.find("Connection");
@@ -942,7 +941,6 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
         const std::string headerValueLowercase
             = Core::_internal::StringExtensions::ToLower(connectionHeader->second);
         hasConnectionKeepAlive = headerValueLowercase.find("keep-alive") != std::string::npos;
-        hasConnectionClose = headerValueLowercase.find("close") != std::string::npos;
       }
     }
 
@@ -959,7 +957,7 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
     // We currently only support HTTP/1.1 requests and responses. Even if the response is HTTP/1.0,
     // if it has a "Connection" header, with just "close", we do not keep the connection alive.
 
-    m_httpKeepAlive = (!hasConnectionClose || hasConnectionKeepAlive);
+    m_httpKeepAlive = hasConnectionKeepAlive;
   }
 
   // For Head request, set the length of body response to 0.

--- a/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_pool_private.hpp
@@ -91,8 +91,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
      * @brief Moves a connection back to the pool to be re-used.
      *
      * @param connection CURL HTTP connection to add to the pool.
-     * @param httpKeepAlive The status of keep-alive behavior, based on HTTP protocol version and
-     * the most recent response header received through the \p connection.
+     * @param httpKeepAlive The status of keep-alive behavior, based on the most recent response
+     * header received through the \p connection.
      */
     void MoveConnectionBackToPool(
         std::unique_ptr<CurlNetworkConnection> connection,

--- a/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_session_private.hpp
@@ -340,8 +340,8 @@ namespace Azure { namespace Core { namespace Http {
     Http::HttpStatusCode m_lastStatusCode = Http::HttpStatusCode::BadRequest;
 
     /**
-     * @brief Holds information on whether the connection can be kept alive, based on HTTP protocol
-     * version and the "Connection" HTTP header.
+     * @brief Holds information on whether the connection can be kept alive, based on the
+     * "Connection" HTTP header.
      *
      */
     bool m_httpKeepAlive = false;


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk-for-cpp/pull/5473

There is currently no customer scenario where they'd benefit from exposing the HTTP protocol version from the `RawResponse()`. 

Furthermore, there is no known scenario where a supported Azure service returns a response using HTTP version 1.0, so we do not need to complicate the curl transport HTTP Keep Alive logic any further to support the defaults from HTTP/1.0. Since that was the only user of those methods, removing them from `RawResponse`. When it comes to the HTTP request, we currently always specify HTTP 1.1 in the request line.

If a scenario comes up in the future, where we do need to support non-HTTP 1.1 protocol versions, we could update the `ResponseBufferParser` within the curl transport to capture the major/minor version of the protocol while parsing the response, instead of saving it and then later fetching it from the `RawResponse`. This way, we wouldn't need to add new public surface area to `RawResponse` that isn't intended for end customers.

cc @Jinming-Hu, @mchelnokov