### PR TITLE
Use template condition instead of runtime condition

### DIFF
--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -4,12 +4,12 @@ steps:
       Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,,read"
     displayName: Set Vcpkg Variables
 
-  - task: AzurePowerShell@5
-    displayName: Set Vcpkg Write-mode Cache
-    condition: and(succeeded(), eq(variables['System.TeamProject'], 'internal'))
-    inputs:
-      azureSubscription: 'cpp Resource Group'
-      ScriptType: FilePath
-      ScriptPath: eng/scripts/Set-VcpkgWriteModeCache.ps1
-      azurePowerShellVersion: LatestVersion
-      pwsh: true
+  - ${{if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: AzurePowerShell@5
+      displayName: Set Vcpkg Write-mode Cache
+      inputs:
+        azureSubscription: 'cpp Resource Group'
+        ScriptType: FilePath
+        ScriptPath: eng/scripts/Set-VcpkgWriteModeCache.ps1
+        azurePowerShellVersion: LatestVersion
+        pwsh: true


### PR DESCRIPTION
"cpp Resource Group" is only available for internal builds so we need to condition this entire step out on non-internal builds.
