### PR TITLE
Clean-up the HTTP versions check in response parsing, and don't reuse connections on any response other than HTTP/1.1

### DIFF
--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -954,7 +954,7 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
     // /3 containing a "Connection" header should be considered malformed. (HTTP/2:
     // https://httpwg.org/specs/rfc9113.html#ConnectionSpecific
     //  HTTP/3: https://httpwg.org/specs/rfc9114.html#rfc.section.4.2)
-    if (m_response->GetMajorVersion() == 1 && m_response->GetMinorVersion() == 1)
+    if (m_response->GetMajorVersion() == 1 && m_response->GetMinorVersion() >= 1)
     {
       // HTTP/1.1
       m_httpKeepAlive = (!hasConnectionClose || hasConnectionKeepAlive);

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -954,8 +954,6 @@ CURLcode CurlSession::ReadStatusLineAndHeadersFromRawResponse(
     // /3 containing a "Connection" header should be considered malformed. (HTTP/2:
     // https://httpwg.org/specs/rfc9113.html#ConnectionSpecific
     //  HTTP/3: https://httpwg.org/specs/rfc9114.html#rfc.section.4.2)
-    // We assume that the server is not sending malformed responses,
-    // so we are not considering HTTP/2 or HTTP/3 here.
     if (m_response->GetMajorVersion() == 1 && m_response->GetMinorVersion() == 1)
     {
       // HTTP/1.1


### PR DESCRIPTION
**Update:** Other than making the HTTP version checks a bit easier to understand (using single conditional if, as suggested by @LarryOsterman), the **primary** change here is to not persist a connection if we received an invalid/unsupported HTTP version in the response, i.e. if the HTTP version does not start with 1.x. We could throw here instead, but at least marking it as don't re-use, is a good thing to do.
The logic for 1.x remains unchanged, the semantics are the same, just written in a way that's easier to understand.

These are the particular HTTP versions: 0.9, 1.0, 1.1, 2.0, 3.0.
1.1 is supported by the SDK, 2.0/3.0 are currently not supported. We can make 1.0 work, in this case, regarding connection persistence defaults.

~There's no HTTP 1.1+, so hardening the version checks to pick the concrete protocol versions. And rejecting others (including the case which indicates a malformed response).~

