### PR TITLE
Update core changelog with attribution for a curl endless loop bug fix.

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -89,6 +89,7 @@
     "Contoso",
     "countof",
     "ctest",
+    "Curtiz"
     "cuse",
     "CUSEUAP",
     "DCMAKE",

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -89,7 +89,7 @@
     "Contoso",
     "countof",
     "ctest",
-    "Curtiz"
+    "Curtiz",
     "cuse",
     "CUSEUAP",
     "DCMAKE",

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,7 +8,15 @@
 
 ### Bugs Fixed
 
+- [[#5589]](https://github.com/Azure/azure-sdk-for-cpp/pull/5589) Fix possible endless loop while polling curl socket.  (A community contribution, courtesy of _[CurtizJ](https://github.com/CurtizJ)_)
+
 ### Other Changes
+
+### Acknowledgments
+
+Thank you to our developer community members who helped to make Azure Core better with their contributions to this release:
+
+- Anton Popov _([GitHub](https://github.com/CurtizJ))_
 
 ## 1.12.0 (2024-05-09)
 


### PR DESCRIPTION
Here's the fix:
https://github.com/Azure/azure-sdk-for-cpp/pull/5589

cc @CurtizJ