### PR TITLE
Minor tweaks to HTTP tests found during Rust HTTP testing

### DIFF
--- a/sdk/core/azure-core/test/ut/transport_adapter_base_test.cpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base_test.cpp
@@ -114,7 +114,7 @@ namespace Azure { namespace Core { namespace Test {
 
     json responseJson = json::parse(response->GetBody());
 
-    // The body was 1024 bytes, so the content-length should be 1024 bytes.
+    // Make sure the server gave us back the 1K we sent.
     std::string bodyAsString{
         requestBodyVector.data(), requestBodyVector.data() + requestBodyVector.size()};
     EXPECT_EQ(responseJson["data"].get<std::string>(), bodyAsString);
@@ -417,10 +417,9 @@ namespace Azure { namespace Core { namespace Test {
       {
         m_pipeline->Send(request, cancelThis);
       }
-      catch (Azure::Core::OperationCancelledException& e)
+      catch (Azure::Core::OperationCancelledException&)
       {
         // As soon as we hit the expected exception, exit the loop, the test is complete.
-        GTEST_LOG_(INFO) << "Caught expected OperationCancelledException: " << e.what();
         break;
       }
       catch (std::exception& e)


### PR DESCRIPTION
# Minor tweaks to HTTP tests found during testing.

While testing the Rust HTTP stack, a couple of bugs were discovered in the HTTP tests. Specifically, the tests which add a "123" header to the test assumed this would add 19 characters to the response buffer. This turns out to be an invalid assumption because the response includes the client IP address, and the client IP address is not stable if the client is using a VPN to access the azurehttpbin server. 

Also, the cancelRequest test should early-out once it receives the expected operation cancelled rather than iterating through all 10 loops. The point of the loop is to cover the fact that the internet is somewhat unreliable, so once we've verified that cancellation works correctly, we can complete the test.



## Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
