### PR TITLE
Update the retryAfter value when ShouldRetryOnResponse returns false.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -407,10 +407,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
 
       virtual bool ShouldRetryOnResponse(
           RawResponse const& response,
-          RetryOptions const& retryOptions,
-          int32_t attempt,
-          std::chrono::milliseconds& retryAfter,
-          double jitterFactor = -1) const;
+          RetryOptions const& retryOptions) const;
 
       /**
        * @brief Overriding this method customizes the logic of when the RetryPolicy will re-attempt


### PR DESCRIPTION
Without this change, the retryAfter value wasn't being set after the virtual `ShouldRetry` is called, resulting in the next request to be retried without a delay.

TODO:
I plan to simplify the implementation a bit so that I can clean-up the tests and add back the necessary coverage. The current functions result in a bit of complexity, initially written in that way for mocking and primarily to support test hooks such as the -1 jitter value.

cc @Jinming-Hu 