### PR TITLE
Remove 'include windows.h' from inc/*

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -8,11 +8,13 @@
 
 #pragma once
 
-#include "azure/core/context.hpp"
-#include "azure/core/http/http.hpp"
 #include "azure/core/http/policies/policy.hpp"
 #include "azure/core/http/transport.hpp"
-#include "azure/core/platform.hpp"
+#include "azure/core/nullable.hpp"
+
+#include <chrono>
+#include <memory>
+#include <string>
 
 namespace Azure { namespace Core { namespace Http {
   class CurlNetworkConnection;

--- a/sdk/core/azure-core/inc/azure/core/http/transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/transport.hpp
@@ -10,6 +10,9 @@
 
 #include "azure/core/context.hpp"
 #include "azure/core/http/http.hpp"
+#include "azure/core/http/raw_response.hpp"
+
+#include <memory>
 
 namespace Azure { namespace Core { namespace Http {
 

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -11,13 +11,13 @@
 #include "azure/core/context.hpp"
 #include "azure/core/nullable.hpp"
 #include "azure/core/url.hpp
-#include "azure/core/internal/unique_handle.hpp"
 #include "azure/core/http/http.hpp"
-#include "azure/core/http/transport.hpp"
 #include "azure/core/http/policies/policy.hpp"
+#include "azure/core/http/transport.hpp"
+#include "azure/core/internal/unique_handle.hpp"
 
-#include <string>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace Azure { namespace Core {

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -9,12 +9,12 @@
 #pragma once
 
 #include "azure/core/context.hpp"
-#include "azure/core/nullable.hpp"
-#include "azure/core/url.hpp
 #include "azure/core/http/http.hpp"
 #include "azure/core/http/policies/policy.hpp"
 #include "azure/core/http/transport.hpp"
 #include "azure/core/internal/unique_handle.hpp"
+#include "azure/core/nullable.hpp"
+#include "azure/core/url.hpp"
 
 #include <memory>
 #include <string>
@@ -22,7 +22,6 @@
 
 namespace Azure { namespace Core {
   namespace _detail {
-    class WinHttpRequest;
     void FreeWinHttpHandleImpl(void* obj);
 
     /**
@@ -41,6 +40,10 @@ namespace Azure { namespace Core {
   } // namespace _detail
 
   namespace Http {
+    namespace _detail {
+      class WinHttpRequest;
+    }
+
     /**
      * @brief Sets the WinHTTP session and connection options used to customize the behavior of the
      * transport.
@@ -123,14 +126,15 @@ namespace Azure { namespace Core {
       Azure::Core::_internal::UniqueHandle<void*> CreateConnectionHandle(
           Azure::Core::Url const& url,
           Azure::Core::Context const& context);
-      std::unique_ptr<Core::_detail::WinHttpRequest> CreateRequestHandle(
+
+      std::unique_ptr<_detail::WinHttpRequest> CreateRequestHandle(
           Azure::Core::_internal::UniqueHandle<void*> const& connectionHandle,
           Azure::Core::Url const& url,
           Azure::Core::Http::HttpMethod const& method);
 
       // Callback to allow a derived transport to extract the request handle. Used for WebSocket
       // transports.
-      virtual void OnUpgradedConnection(std::unique_ptr<Core::_detail::WinHttpRequest> const&){};
+      virtual void OnUpgradedConnection(std::unique_ptr<_detail::WinHttpRequest> const&){};
 
     public:
       /**

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -123,14 +123,14 @@ namespace Azure { namespace Core {
       Azure::Core::_internal::UniqueHandle<void*> CreateConnectionHandle(
           Azure::Core::Url const& url,
           Azure::Core::Context const& context);
-      std::unique_ptr<_detail::WinHttpRequest> CreateRequestHandle(
+      std::unique_ptr<Core::_detail::WinHttpRequest> CreateRequestHandle(
           Azure::Core::_internal::UniqueHandle<void*> const& connectionHandle,
           Azure::Core::Url const& url,
           Azure::Core::Http::HttpMethod const& method);
 
       // Callback to allow a derived transport to extract the request handle. Used for WebSocket
       // transports.
-      virtual void OnUpgradedConnection(std::unique_ptr<_detail::WinHttpRequest> const&){};
+      virtual void OnUpgradedConnection(std::unique_ptr<Core::_detail::WinHttpRequest> const&){};
 
     public:
       /**

--- a/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/win_http_transport.hpp
@@ -20,154 +20,134 @@
 #include <string>
 #include <vector>
 
-namespace Azure { namespace Core {
+namespace Azure { namespace Core { namespace Http {
   namespace _detail {
-    void FreeWinHttpHandleImpl(void* obj);
+    class WinHttpRequest;
+  }
+
+  /**
+   * @brief Sets the WinHTTP session and connection options used to customize the behavior of the
+   * transport.
+   */
+  struct WinHttpTransportOptions final
+  {
+    /**
+     * @brief When `true`, allows an invalid certificate authority.
+     */
+    bool IgnoreUnknownCertificateAuthority{false};
 
     /**
-     * @brief Unique handle for WinHTTP HINTERNET handles.
+     * @brief When `true`, allows an invalid common name in a certificate.
+     */
+    bool IgnoreInvalidCertificateCommonName{false};
+
+    /**
+     * Proxy information.
+     */
+
+    /**
+     * @brief If True, enables the use of the system default proxy.
      *
-     * @note HINTERNET is declared as a "void *". This means that this definition subsumes all other
-     * `void *` types when used with Azure::Core::_internal::UniqueHandle.
+     * @remarks Set this to "true" if you would like to use a local HTTP proxy like "Fiddler" to
+     * capture and analyze HTTP traffic.
+     *
+     * Set to "false" by default because it is not recommended to use a proxy for production and
+     * Fiddler's proxy interferes with the HTTP functional tests.
+     */
+    bool EnableSystemDefaultProxy{false};
+
+    /**
+     * @brief If True, enables checks for certificate revocation.
+     */
+    bool EnableCertificateRevocationListCheck{false};
+
+    /**
+     * @brief Proxy information.
+     *
+     * @remark The Proxy Information string is composed of a set of elements
+     * formatted as follows:
+     *
+     * @code
+     * (\[\<scheme\>=\]\[\<scheme\>"://"\]\<server\>\[":"\<port\>\])
+     * @endcode
+     *
+     * Each element should be separated with semicolons or whitespace.
+     */
+    std::string ProxyInformation;
+
+    /**
+     * @brief User name for proxy authentication.
+     */
+    Azure::Nullable<std::string> ProxyUserName;
+
+    /**
+     * @brief Password for proxy authentication.
+     */
+    Azure::Nullable<std::string> ProxyPassword;
+
+    /**
+     * @brief Array of Base64 encoded DER encoded X.509 certificate.  These certificates should
+     * form a chain of certificates which will be used to validate the server certificate sent by
+     * the server.
+     */
+    std::vector<std::string> ExpectedTlsRootCertificates;
+  };
+
+  /**
+   * @brief Concrete implementation of an HTTP transport that uses WinHTTP when sending and
+   * receiving requests and responses over the wire.
+   */
+  class WinHttpTransport : public HttpTransport {
+  private:
+    WinHttpTransportOptions m_options;
+    // m_sessionhandle is const to ensure immutability.
+    const Azure::Core::_internal::UniqueHandle<void*> m_sessionHandle;
+
+    Azure::Core::_internal::UniqueHandle<void*> CreateSessionHandle();
+    Azure::Core::_internal::UniqueHandle<void*> CreateConnectionHandle(
+        Azure::Core::Url const& url,
+        Azure::Core::Context const& context);
+
+    std::unique_ptr<_detail::WinHttpRequest> CreateRequestHandle(
+        Azure::Core::_internal::UniqueHandle<void*> const& connectionHandle,
+        Azure::Core::Url const& url,
+        Azure::Core::Http::HttpMethod const& method);
+
+    // Callback to allow a derived transport to extract the request handle. Used for WebSocket
+    // transports.
+    virtual void OnUpgradedConnection(std::unique_ptr<_detail::WinHttpRequest> const&){};
+
+  public:
+    /**
+     * @brief Constructs `%WinHttpTransport`.
+     *
+     * @param options Optional parameter to override the default settings.
+     */
+    WinHttpTransport(WinHttpTransportOptions const& options = WinHttpTransportOptions());
+
+    /**
+     * @brief Constructs `%WinHttpTransport`.
+     *
+     * @param options Optional parameter to override the default settings.
+     */
+    /**
+     * @brief Constructs `%WinHttpTransport` object based on common Azure HTTP Transport Options
      *
      */
-    template <> struct UniqueHandleHelper<void*>
-    {
-      static void FreeWinHttpHandle(void* obj) { FreeWinHttpHandleImpl(obj); }
-
-      using type = _internal::BasicUniqueHandle<void, FreeWinHttpHandle>;
-    };
-  } // namespace _detail
-
-  namespace Http {
-    namespace _detail {
-      class WinHttpRequest;
-    }
+    WinHttpTransport(Azure::Core::Http::Policies::TransportOptions const& options);
 
     /**
-     * @brief Sets the WinHTTP session and connection options used to customize the behavior of the
-     * transport.
+     * @brief Implements the HTTP transport interface to send an HTTP Request and produce an
+     * HTTP RawResponse.
+     *
      */
-    struct WinHttpTransportOptions final
-    {
-      /**
-       * @brief When `true`, allows an invalid certificate authority.
-       */
-      bool IgnoreUnknownCertificateAuthority{false};
+    virtual std::unique_ptr<RawResponse> Send(Request& request, Context const& context) override;
 
-      /**
-       * @brief When `true`, allows an invalid common name in a certificate.
-       */
-      bool IgnoreInvalidCertificateCommonName{false};
+    // See also:
+    // [Core Guidelines C.35: "A base class destructor should be either public
+    // and virtual or protected and
+    // non-virtual"](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual)
+    virtual ~WinHttpTransport();
+  };
 
-      /**
-       * Proxy information.
-       */
-
-      /**
-       * @brief If True, enables the use of the system default proxy.
-       *
-       * @remarks Set this to "true" if you would like to use a local HTTP proxy like "Fiddler" to
-       * capture and analyze HTTP traffic.
-       *
-       * Set to "false" by default because it is not recommended to use a proxy for production and
-       * Fiddler's proxy interferes with the HTTP functional tests.
-       */
-      bool EnableSystemDefaultProxy{false};
-
-      /**
-       * @brief If True, enables checks for certificate revocation.
-       */
-      bool EnableCertificateRevocationListCheck{false};
-
-      /**
-       * @brief Proxy information.
-       *
-       * @remark The Proxy Information string is composed of a set of elements
-       * formatted as follows:
-       *
-       * @code
-       * (\[\<scheme\>=\]\[\<scheme\>"://"\]\<server\>\[":"\<port\>\])
-       * @endcode
-       *
-       * Each element should be separated with semicolons or whitespace.
-       */
-      std::string ProxyInformation;
-
-      /**
-       * @brief User name for proxy authentication.
-       */
-      Azure::Nullable<std::string> ProxyUserName;
-
-      /**
-       * @brief Password for proxy authentication.
-       */
-      Azure::Nullable<std::string> ProxyPassword;
-
-      /**
-       * @brief Array of Base64 encoded DER encoded X.509 certificate.  These certificates should
-       * form a chain of certificates which will be used to validate the server certificate sent by
-       * the server.
-       */
-      std::vector<std::string> ExpectedTlsRootCertificates;
-    };
-
-    /**
-     * @brief Concrete implementation of an HTTP transport that uses WinHTTP when sending and
-     * receiving requests and responses over the wire.
-     */
-    class WinHttpTransport : public HttpTransport {
-    private:
-      WinHttpTransportOptions m_options;
-      // m_sessionhandle is const to ensure immutability.
-      const Azure::Core::_internal::UniqueHandle<void*> m_sessionHandle;
-
-      Azure::Core::_internal::UniqueHandle<void*> CreateSessionHandle();
-      Azure::Core::_internal::UniqueHandle<void*> CreateConnectionHandle(
-          Azure::Core::Url const& url,
-          Azure::Core::Context const& context);
-
-      std::unique_ptr<_detail::WinHttpRequest> CreateRequestHandle(
-          Azure::Core::_internal::UniqueHandle<void*> const& connectionHandle,
-          Azure::Core::Url const& url,
-          Azure::Core::Http::HttpMethod const& method);
-
-      // Callback to allow a derived transport to extract the request handle. Used for WebSocket
-      // transports.
-      virtual void OnUpgradedConnection(std::unique_ptr<_detail::WinHttpRequest> const&){};
-
-    public:
-      /**
-       * @brief Constructs `%WinHttpTransport`.
-       *
-       * @param options Optional parameter to override the default settings.
-       */
-      WinHttpTransport(WinHttpTransportOptions const& options = WinHttpTransportOptions());
-
-      /**
-       * @brief Constructs `%WinHttpTransport`.
-       *
-       * @param options Optional parameter to override the default settings.
-       */
-      /**
-       * @brief Constructs `%WinHttpTransport` object based on common Azure HTTP Transport Options
-       *
-       */
-      WinHttpTransport(Azure::Core::Http::Policies::TransportOptions const& options);
-
-      /**
-       * @brief Implements the HTTP transport interface to send an HTTP Request and produce an
-       * HTTP RawResponse.
-       *
-       */
-      virtual std::unique_ptr<RawResponse> Send(Request& request, Context const& context) override;
-
-      // See also:
-      // [Core Guidelines C.35: "A base class destructor should be either public
-      // and virtual or protected and
-      // non-virtual"](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual)
-      virtual ~WinHttpTransport();
-    };
-
-  } // namespace Http
-}} // namespace Azure::Core
+}}} // namespace Azure::Core::Http

--- a/sdk/core/azure-core/inc/azure/core/internal/unique_handle.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/unique_handle.hpp
@@ -67,4 +67,22 @@ namespace Azure { namespace Core {
     template <typename T, template <typename> class U = _detail::UniqueHandleHelper>
     using UniqueHandle = typename U<T>::type;
   } // namespace _internal
+
+  namespace _detail {
+    void FreeWinHttpHandleImpl(void* obj);
+
+    /**
+     * @brief Unique handle for WinHTTP HINTERNET handles.
+     *
+     * @note HINTERNET is declared as a "void *". This means that this definition subsumes all other
+     * `void *` types when used with Azure::Core::_internal::UniqueHandle.
+     *
+     */
+    template <> struct UniqueHandleHelper<void*>
+    {
+      static void FreeWinHttpHandle(void* obj) { FreeWinHttpHandleImpl(obj); }
+
+      using type = _internal::BasicUniqueHandle<void, FreeWinHttpHandle>;
+    };
+  } // namespace _detail
 }} // namespace Azure::Core

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -30,8 +30,8 @@
                                 // 'GetProcAddress'.
 #include <wil\resource.h>
 #pragma warning(pop)
-#include <winhttp.h>
 #include <wincrypt.h>
+#include <winhttp.h>
 
 namespace Azure { namespace Core { namespace Http { namespace _detail {
 

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -20,7 +20,7 @@
 #define NOMINMAX
 #endif
 
-#include <Windows.h>
+#include <windows.h>
 
 #include <memory>
 #include <mutex>
@@ -31,6 +31,7 @@
 #include <wil\resource.h>
 #pragma warning(pop)
 #include <winhttp.h>
+#include <wincrypt.h>
 
 namespace Azure { namespace Core { namespace Http { namespace _detail {
 

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -169,13 +169,6 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     bool VerifyCertificatesInChain(
         std::vector<std::string> const& trustedCertificates,
         PCCERT_CONTEXT serverCertificate) const;
-    /**
-     * @brief Throw an exception based on the Win32 Error code
-     *
-     * @param exceptionMessage Message describing error.
-     * @param error Win32 Error code.
-     */
-    void GetErrorAndThrow(const std::string& exceptionMessage, DWORD error = GetLastError()) const;
 
   public:
     WinHttpRequest(

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -54,7 +54,6 @@ void GetErrorAndThrow(const std::string& exceptionMessage, DWORD error = GetLast
   throw Azure::Core::Http::TransportException(exceptionMessage + GetErrorMessage(error));
 }
 
-
 const std::string HttpScheme = "http";
 const std::string WebSocketScheme = "ws";
 


### PR DESCRIPTION
In the light of #5660 (closes #5660 ?).

WinHttpTransport is the only header in `sdk/**/inc/*` that has `#include <Windows.h>`.

If we remove this, further discussion on whether to have `NOMINMAX` defined in public header or not becomes hypothetical.

(We still should write `min` and `max` as `(min)` and `(max)` in the `sdk/**/inc/*` files, and I recommend we do keep defining `NOMINMAX` and `WIN32_LEAN_AND_MEAN` in `sdk/**/src/*` and `sdk/**/test/*` files).

The PR #5682, which is currently a Draft and has `#include <windows.h>` in a new `sdk/**/inc/*` file in its latest iteration as of now, the author agreed to move `#include <windows.h>` into a .cpp file in the next iteration.