### PR TITLE
Add retries to tests relying on Http bin to improve test resiliency.

### DIFF
--- a/sdk/core/azure-core/test/ut/curl_connection_pool_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_connection_pool_test.cpp
@@ -612,11 +612,11 @@ namespace Azure { namespace Core { namespace Test {
           EXPECT_EQ(CURLE_SEND_ERROR, r);
           break; // Test passed, no need to retry.
         }
-        catch (Azure::Core::Http::TransportException const&)
+        catch (Azure::Core::Http::TransportException const& ex)
         {
           // CURL returns a connection error which triggers a transport exception.
           GTEST_LOG_(INFO) << "resiliencyOnConnectionClosed test iteration " << i
-                           << " failed with a TransportException.";
+                           << " failed with a TransportException. " << ex.what();
           failedCounter++;
           // We allow 1 intermittent failure, due to networking issues.
           if (failedCounter > 1)
@@ -655,12 +655,12 @@ namespace Azure { namespace Core { namespace Test {
           EXPECT_EQ("close", response->GetHeaders().find("Connection")->second);
           break; // Test passed, no need to retry.
         }
-        catch (Azure::Core::Http::TransportException const&)
+        catch (Azure::Core::Http::TransportException const& ex)
         {
 
           // CURL returns a connection error which triggers a transport exception.
           GTEST_LOG_(INFO) << "forceConnectionClosed test iteration " << i
-                           << " failed with a TransportException.";
+                           << " failed with a TransportException. " << ex.what();
           failedCounter++;
           // We allow 1 intermittent failure, due to networking issues.
           if (failedCounter > 1)

--- a/sdk/core/azure-core/test/ut/curl_options_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_options_test.cpp
@@ -79,7 +79,29 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+
+    auto failedCounter = 0;
+    for (auto i = 0; i < _detail::AzureSdkHttpbinRetryCount; i++)
+    {
+      GTEST_LOG_(INFO) << "noRevoke test iteration " << i << ".";
+      try
+      {
+        EXPECT_NO_THROW(
+            response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+        break; // Test passed, no need to retry.
+      }
+      catch (Azure::Core::Http::TransportException const&)
+      {
+        // CURL returns a connection error which triggers a transport exception.
+        GTEST_LOG_(INFO) << "noRevoke test iteration " << i << " failed with a TransportException.";
+        failedCounter++;
+        // We allow 1 intermittent failure, due to networking issues.
+        if (failedCounter > 1)
+        {
+          throw;
+        }
+      }
+    }
     if (response)
     {
       auto responseCode = response->GetStatusCode();
@@ -220,7 +242,30 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+
+    auto failedCounter = 0;
+    for (auto i = 0; i < _detail::AzureSdkHttpbinRetryCount; i++)
+    {
+      GTEST_LOG_(INFO) << "sslVerifyOff test iteration " << i << ".";
+      try
+      {
+        EXPECT_NO_THROW(
+            response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+        break; // Test passed, no need to retry.
+      }
+      catch (Azure::Core::Http::TransportException const&)
+      {
+        // CURL returns a connection error which triggers a transport exception.
+        GTEST_LOG_(INFO) << "sslVerifyOff test iteration " << i
+                         << " failed with a TransportException.";
+        failedCounter++;
+        // We allow 1 intermittent failure, due to networking issues.
+        if (failedCounter > 1)
+        {
+          throw;
+        }
+      }
+    }
     auto responseCode = response->GetStatusCode();
     int expectedCode = 200;
     EXPECT_PRED2(
@@ -313,7 +358,30 @@ namespace Azure { namespace Core { namespace Test {
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
     std::unique_ptr<Azure::Core::Http::RawResponse> response;
-    EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+
+    auto failedCounter = 0;
+    for (auto i = 0; i < _detail::AzureSdkHttpbinRetryCount; i++)
+    {
+      GTEST_LOG_(INFO) << "httpsDefault test iteration " << i << ".";
+      try
+      {
+        EXPECT_NO_THROW(
+            response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+        break; // Test passed, no need to retry.
+      }
+      catch (Azure::Core::Http::TransportException const&)
+      {
+        // CURL returns a connection error which triggers a transport exception.
+        GTEST_LOG_(INFO) << "httpsDefault test iteration " << i
+                         << " failed with a TransportException.";
+        failedCounter++;
+        // We allow 1 intermittent failure, due to networking issues.
+        if (failedCounter > 1)
+        {
+          throw;
+        }
+      }
+    }
     auto responseCode = response->GetStatusCode();
     int expectedCode = 200;
     EXPECT_PRED2(
@@ -350,7 +418,29 @@ namespace Azure { namespace Core { namespace Test {
       Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, url);
 
       std::unique_ptr<Azure::Core::Http::RawResponse> response;
-      EXPECT_NO_THROW(response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+      auto failedCounter = 0;
+      for (auto i = 0; i < _detail::AzureSdkHttpbinRetryCount; i++)
+      {
+        GTEST_LOG_(INFO) << "disableKeepAlive test iteration " << i << ".";
+        try
+        {
+          EXPECT_NO_THROW(
+              response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
+          break; // Test passed, no need to retry.
+        }
+        catch (Azure::Core::Http::TransportException const&)
+        {
+          // CURL returns a connection error which triggers a transport exception.
+          GTEST_LOG_(INFO) << "disableKeepAlive test iteration " << i
+                           << " failed with a TransportException.";
+          failedCounter++;
+          // We allow 1 intermittent failure, due to networking issues.
+          if (failedCounter > 1)
+          {
+            throw;
+          }
+        }
+      }
       auto responseCode = response->GetStatusCode();
       int expectedCode = 200;
       EXPECT_PRED2(

--- a/sdk/core/azure-core/test/ut/curl_options_test.cpp
+++ b/sdk/core/azure-core/test/ut/curl_options_test.cpp
@@ -90,10 +90,11 @@ namespace Azure { namespace Core { namespace Test {
             response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
         break; // Test passed, no need to retry.
       }
-      catch (Azure::Core::Http::TransportException const&)
+      catch (Azure::Core::Http::TransportException const& ex)
       {
         // CURL returns a connection error which triggers a transport exception.
-        GTEST_LOG_(INFO) << "noRevoke test iteration " << i << " failed with a TransportException.";
+        GTEST_LOG_(INFO) << "noRevoke test iteration " << i << " failed with a TransportException. "
+                         << ex.what();
         failedCounter++;
         // We allow 1 intermittent failure, due to networking issues.
         if (failedCounter > 1)
@@ -253,11 +254,11 @@ namespace Azure { namespace Core { namespace Test {
             response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
         break; // Test passed, no need to retry.
       }
-      catch (Azure::Core::Http::TransportException const&)
+      catch (Azure::Core::Http::TransportException const& ex)
       {
         // CURL returns a connection error which triggers a transport exception.
         GTEST_LOG_(INFO) << "sslVerifyOff test iteration " << i
-                         << " failed with a TransportException.";
+                         << " failed with a TransportException. " << ex.what();
         failedCounter++;
         // We allow 1 intermittent failure, due to networking issues.
         if (failedCounter > 1)
@@ -369,11 +370,11 @@ namespace Azure { namespace Core { namespace Test {
             response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
         break; // Test passed, no need to retry.
       }
-      catch (Azure::Core::Http::TransportException const&)
+      catch (Azure::Core::Http::TransportException const& ex)
       {
         // CURL returns a connection error which triggers a transport exception.
         GTEST_LOG_(INFO) << "httpsDefault test iteration " << i
-                         << " failed with a TransportException.";
+                         << " failed with a TransportException. " << ex.what();
         failedCounter++;
         // We allow 1 intermittent failure, due to networking issues.
         if (failedCounter > 1)
@@ -428,11 +429,11 @@ namespace Azure { namespace Core { namespace Test {
               response = pipeline.Send(request, Azure::Core::Context::ApplicationContext));
           break; // Test passed, no need to retry.
         }
-        catch (Azure::Core::Http::TransportException const&)
+        catch (Azure::Core::Http::TransportException const& ex)
         {
           // CURL returns a connection error which triggers a transport exception.
           GTEST_LOG_(INFO) << "disableKeepAlive test iteration " << i
-                           << " failed with a TransportException.";
+                           << " failed with a TransportException. " << ex.what();
           failedCounter++;
           // We allow 1 intermittent failure, due to networking issues.
           if (failedCounter > 1)

--- a/sdk/core/azure-core/test/ut/transport_adapter_base_test.hpp
+++ b/sdk/core/azure-core/test/ut/transport_adapter_base_test.hpp
@@ -23,6 +23,10 @@ namespace Azure { namespace Core { namespace Test {
   namespace _detail {
     constexpr static const char AzureSdkHttpbinServerSchema[] = "https";
     constexpr static const char AzureSdkHttpbinServer[] = "azuresdkforcpp.azurewebsites.net";
+
+    // If we see intermittent test failures due to Httpbin reliability, even with a couple retries
+    // we'd revisit the use of this for tests, rather than increasing retries.
+    constexpr static const int AzureSdkHttpbinRetryCount = 2;
   } // namespace _detail
 
   struct AzureSdkHttpbinServer final

--- a/sdk/core/azure-core/test/ut/transport_policy_options.cpp
+++ b/sdk/core/azure-core/test/ut/transport_policy_options.cpp
@@ -458,7 +458,7 @@ namespace Azure { namespace Core { namespace Test {
       {
         // CURL returns a connection error which triggers a transport exception.
         GTEST_LOG_(INFO) << "DisableCrlValidation test iteration " << i
-                         << " failed with a TransportException.";
+                         << " failed with a TransportException. " << ex.what();
         failedCounter++;
         // We allow 1 intermittent failure, due to networking issues.
         if (failedCounter > 1)


### PR DESCRIPTION
Address a class of intermittent test failures due to transient failures caused by the reliability of http bin.

The issues below have more detail on the intermittent nature of the tests.

Fixes:
https://github.com/Azure/azure-sdk-for-cpp/issues/5652
https://github.com/Azure/azure-sdk-for-cpp/issues/5006
https://github.com/Azure/azure-sdk-for-cpp/issues/4634
https://github.com/Azure/azure-sdk-for-cpp/issues/5493

Similar fix to https://github.com/Azure/azure-sdk-for-cpp/pull/5537