### PR TITLE
Align eventhubs connection property names with Go

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -8,13 +8,15 @@
 
 ### Bugs Fixed
 
+- Fixed eventhub connection properties to better align with the names used by other Azure SDKs.
+
 ### Other Changes
 
 ## 1.0.0-beta.8 (2024-05-07)
 
 ### Features Added
 
-- Added new features for upcoming Event Hubs service release.
+- Added support for the EventHubs emulator.
 
 ## 1.0.0-beta.7 (2024-04-09)
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
@@ -263,7 +263,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
   public:
     template <typename T> static void SetUserAgent(T& options, std::string const& applicationId)
     {
-      constexpr const char* packageName = "cpp-azure-messaging-eventhubs-cpp";
+      constexpr const char* packageName = "azure-messaging-eventhubs-cpp";
 
       options.Properties.emplace("product", +packageName);
       options.Properties.emplace("version", PackageVersion::ToString());

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
@@ -265,7 +265,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
     {
       constexpr const char* packageName = "azure-messaging-eventhubs-cpp";
 
-      options.Properties.emplace("product", +packageName);
+      options.Properties.emplace("product", packageName);
       options.Properties.emplace("version", PackageVersion::ToString());
 #if defined(AZ_PLATFORM_WINDOWS)
       options.Properties.emplace("platform", "Windows");

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
@@ -265,17 +265,17 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
     {
       constexpr const char* packageName = "cpp-azure-messaging-eventhubs-cpp";
 
-      options.Properties.emplace("Product", +packageName);
-      options.Properties.emplace("Version", PackageVersion::ToString());
+      options.Properties.emplace("product", +packageName);
+      options.Properties.emplace("version", PackageVersion::ToString());
 #if defined(AZ_PLATFORM_WINDOWS)
-      options.Properties.emplace("Platform", "Windows");
+      options.Properties.emplace("platform", "Windows");
 #elif defined(AZ_PLATFORM_LINUX)
-      options.Properties.emplace("Platform", "Linux");
+      options.Properties.emplace("platform", "Linux");
 #elif defined(AZ_PLATFORM_MAC)
-      options.Properties.emplace("Platform", "Mac");
+      options.Properties.emplace("platform", "Mac");
 #endif
       options.Properties.emplace(
-          "User-Agent",
+          "user-agent",
           Azure::Core::Http::_detail::UserAgentGenerator::GenerateUserAgent(
               packageName, PackageVersion::ToString(), applicationId));
     }


### PR DESCRIPTION
Ronnie noticed that C++ Eventhubs isn't being reflected in the user-agent telemetry for eventhubs. Inspecting the Go SDK, there is an important difference between Go and C++. This reflects this change.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
