### PR TITLE
Core June Beta Release

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Release History
 
-## 1.13.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.13.0-beta.1 (2024-06-06)
 
 ### Bugs Fixed
 


### PR DESCRIPTION
I think we want #5681 for this release as well, and it might be good to also Beta the #5676 (if we want and if it is ready at least for the Beta).
I wouldn't mind #5691 either.

#5680, #5682, and #5662 are nice to haves, but they likely won't be ready for this release (including that they most likely were not planned for this release).