### PR TITLE
Add back-ticks around the WWW-Authenticate header name in exception message.

### DIFF
--- a/sdk/identity/azure-identity/src/managed_identity_source.cpp
+++ b/sdk/identity/azure-identity/src/managed_identity_source.cpp
@@ -406,7 +406,7 @@ Azure::Core::Credentials::AccessToken AzureArcManagedIdentitySource::GetToken(
           if (authHeader == headers.end())
           {
             throw AuthenticationException(
-                "Did not receive expected WWW-Authenticate header "
+                "Did not receive expected 'WWW-Authenticate' header "
                 "in the response from Azure Arc Managed Identity Endpoint.");
           }
 
@@ -417,7 +417,7 @@ Azure::Core::Credentials::AccessToken AzureArcManagedIdentitySource::GetToken(
               || challenge.find(ChallengeValueSeparator, eq + 1) != std::string::npos)
           {
             throw AuthenticationException(
-                "The WWW-Authenticate header in the response from Azure Arc "
+                "The 'WWW-Authenticate' header in the response from Azure Arc "
                 "Managed Identity Endpoint did not match the expected format.");
           }
 


### PR DESCRIPTION
Address the following nit feedback across the whole file to be consistent:
https://github.com/Azure/azure-sdk-for-cpp/pull/5695#discussion_r1635447114