### PR TITLE
If formatting fails in CI, print detailed diff

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -143,6 +143,11 @@ jobs:
             echo ""
             echo "List of files not formatted correctly:"
             git status | grep modified | awk '{print $2}'
+            echo ""
+            echo ""
+            echo "--- Differences (patch file): ---"
+            git diff
+            echo "--- (You can apply the diff above locally using the 'git apply --ignore-space-change <patch_file>' command) ---"
             exit 1
           fi
 


### PR DESCRIPTION
Closes #5666.

Aren't you tired when, for whatever reason, your local clang-format does format files a bit differently than it gets formatted in the CI, so CI fails on you, and you have to find creative ways to guess what that format might be, and, for example, spin up an Ubuntu machine, and run clang-format there? I am not saying we should not eventually find the root cause and eliminate possibilities for formatting discrepancies, if possible; but until then this fix will save you time.
I have tested this fix in the CodeGen repo (log: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3924247&view=logs&j=b5cdfb1e-c180-561f-918e-a169e451719e&t=a95f8d37-03f1-5b78-3f33-b1433acf4822), and when clang-format starts giving me troubles in the CI, I now I can have a follow-up commit with the right formatting basically within seconds. All I do, is I copy the part of the log file between `---`s, put it in `c:\src\patch.txt` (not forgetting to put empty line at the end of `patch.txt`), then I go to `c:\src\azure-sdk-for-cpp`, run `git apply --ignore-space-change ..\patch.txt`, add files to commit, review changes, and push them to my PR.