### PR TITLE
Update vcpkg SHA

### DIFF
--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -18,7 +18,7 @@ macro(az_vcpkg_integrate)
       message("AZURE_SDK_DISABLE_AUTO_VCPKG is not defined. Fetch a local copy of vcpkg.")
       # GET VCPKG FROM SOURCE
       #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
-      set(VCPKG_COMMIT_STRING 8150939b69720adc475461978e07c2d2bf5fb76e) # default SDK tested commit
+      set(VCPKG_COMMIT_STRING f61a294e765b257926ae9e9d85f96468a0af74e7) # default SDK tested commit
       if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
         message("AZURE_SDK_VCPKG_COMMIT is defined. Using that instead of the default.")
         set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-sdk-for-cpp",
   "version": "1.5.0",
-  "builtin-baseline": "8150939b69720adc475461978e07c2d2bf5fb76e",
+  "builtin-baseline": "f61a294e765b257926ae9e9d85f96468a0af74e7",
   "dependencies": [
     {
       "name": "curl"


### PR DESCRIPTION
Our last update was more than 2 months ago - on April 23th, so it is time to update to the latest (https://github.com/microsoft/vcpkg/tree/f61a294e765b257926ae9e9d85f96468a0af74e7).