### PR TITLE
Add missing include

### DIFF
--- a/sdk/core/azure-core/src/http/http_sanitizer.cpp
+++ b/sdk/core/azure-core/src/http/http_sanitizer.cpp
@@ -5,6 +5,7 @@
 
 #include "azure/core/url.hpp"
 
+#include <iterator>
 #include <regex>
 #include <sstream>
 


### PR DESCRIPTION
Found while working on [ClickHouse](https://github.com/ClickHouse/ClickHouse) which includes azure-sdk-for-cpp as a submodule.

`std::inserter` is defined in `<iterator>`. libcxx 16 no longer includes this header transitively, therefore add it explicitly.