### PR TITLE
XML: Use RAII wrappers instead of manual memory management

### DIFF
--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -37,36 +37,28 @@ namespace Azure { namespace Storage { namespace _internal {
 
   class XmlReader final {
   public:
-    explicit XmlReader(const char* data, size_t length);
+    XmlReader(const char* data, size_t length);
     XmlReader(const XmlReader& other) = delete;
     XmlReader& operator=(const XmlReader& other) = delete;
-    XmlReader(XmlReader&& other) noexcept { *this = std::move(other); }
-    XmlReader& operator=(XmlReader&& other) noexcept
-    {
-      m_context = other.m_context;
-      other.m_context = nullptr;
-      return *this;
-    }
+    XmlReader(XmlReader&& other) noexcept;
+    XmlReader& operator=(XmlReader&& other) noexcept;
     ~XmlReader();
 
     XmlNode Read();
 
   private:
-    void* m_context = nullptr;
+    struct XmlReaderContext;
+    std::unique_ptr<XmlReaderContext> m_context;
+
   };
 
   class XmlWriter final {
   public:
-    explicit XmlWriter();
+    XmlWriter();
     XmlWriter(const XmlWriter& other) = delete;
     XmlWriter& operator=(const XmlWriter& other) = delete;
-    XmlWriter(XmlWriter&& other) noexcept { *this = std::move(other); }
-    XmlWriter& operator=(XmlWriter&& other) noexcept
-    {
-      m_context = other.m_context;
-      other.m_context = nullptr;
-      return *this;
-    }
+    XmlWriter(XmlWriter&& other) noexcept;
+    XmlWriter& operator=(XmlWriter&& other) noexcept;
     ~XmlWriter();
 
     void Write(XmlNode node);
@@ -74,7 +66,8 @@ namespace Azure { namespace Storage { namespace _internal {
     std::string GetDocument();
 
   private:
-    void* m_context = nullptr;
+    struct XmlWriterContext;
+    std::unique_ptr<XmlWriterContext> m_context;
   };
 
 }}} // namespace Azure::Storage::_internal

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -70,4 +70,6 @@ namespace Azure { namespace Storage { namespace _internal {
     std::unique_ptr<XmlWriterContext> m_context;
   };
 
+  void XmlGlobalInitialize();
+
 }}} // namespace Azure::Storage::_internal

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -71,5 +71,6 @@ namespace Azure { namespace Storage { namespace _internal {
   };
 
   void XmlGlobalInitialize();
+  void XmlGlobalDeinitialize();
 
 }}} // namespace Azure::Storage::_internal

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 namespace Azure { namespace Storage { namespace _internal {
@@ -37,7 +38,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   class XmlReader final {
   public:
-    XmlReader(const char* data, size_t length);
+    explicit XmlReader(const char* data, size_t length);
     XmlReader(const XmlReader& other) = delete;
     XmlReader& operator=(const XmlReader& other) = delete;
     XmlReader(XmlReader&& other) noexcept;
@@ -53,7 +54,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   class XmlWriter final {
   public:
-    XmlWriter();
+    explicit XmlWriter();
     XmlWriter(const XmlWriter& other) = delete;
     XmlWriter& operator=(const XmlWriter& other) = delete;
     XmlWriter(XmlWriter&& other) noexcept;

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -70,7 +70,4 @@ namespace Azure { namespace Storage { namespace _internal {
     std::unique_ptr<XmlWriterContext> m_context;
   };
 
-  void XmlGlobalInitialize();
-  void XmlGlobalDeinitialize();
-
 }}} // namespace Azure::Storage::_internal

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp
@@ -49,7 +49,6 @@ namespace Azure { namespace Storage { namespace _internal {
   private:
     struct XmlReaderContext;
     std::unique_ptr<XmlReaderContext> m_context;
-
   };
 
   class XmlWriter final {

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -404,7 +404,6 @@ namespace Azure { namespace Storage { namespace _internal {
   XmlReader& XmlReader::operator=(XmlReader&& other) noexcept
   {
     m_context = std::move(other.m_context);
-    m_context.reset();
     return *this;
   }
 
@@ -539,7 +538,6 @@ namespace Azure { namespace Storage { namespace _internal {
   XmlWriter& XmlWriter::operator=(XmlWriter&& other) noexcept
   {
     m_context = std::move(other.m_context);
-    other.m_context = nullptr;
     return *this;
   }
 

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -400,9 +400,21 @@ namespace Azure { namespace Storage { namespace _internal {
 
   static void XmlGlobalInitialize() { static XmlGlobalInitializer globalInitializer; }
 
-  struct XmlReaderContext
+  XmlReader::XmlReader(XmlReader&& other) noexcept { *this = std::move(other); }
+  XmlReader& XmlReader::operator=(XmlReader&& other) noexcept
   {
-    xmlTextReaderPtr reader = nullptr;
+    m_context = std::move(other.m_context);
+    m_context.reset();
+    return *this;
+  }
+
+  using ReaderPtr = std::unique_ptr<xmlTextReader, decltype(&xmlFreeTextReader)>;
+  struct XmlReader::XmlReaderContext
+  {
+    explicit XmlReaderContext(ReaderPtr && reader_)
+      : reader(std::move(reader_))
+    {}
+    ReaderPtr reader;
     bool readingAttributes = false;
     bool readingEmptyTag = false;
   };
@@ -416,38 +428,30 @@ namespace Azure { namespace Storage { namespace _internal {
       throw std::runtime_error("Xml data too big.");
     }
 
-    xmlTextReaderPtr reader
-        = xmlReaderForMemory(data, static_cast<int>(length), nullptr, nullptr, 0);
+    auto reader
+        = ReaderPtr(xmlReaderForMemory(data, static_cast<int>(length), nullptr, nullptr, 0), xmlFreeTextReader);
+
     if (!reader)
     {
       throw std::runtime_error("Failed to parse xml.");
     }
 
-    XmlReaderContext* context = new XmlReaderContext();
-    context->reader = reader;
-    m_context = context;
+    m_context = std::make_unique<XmlReaderContext>(std::move(reader));
+    m_context->reader = std::move(reader);
   }
 
-  XmlReader::~XmlReader()
-  {
-    if (m_context)
-    {
-      auto context = static_cast<XmlReaderContext*>(m_context);
-      xmlFreeTextReader(static_cast<xmlTextReaderPtr>(context->reader));
-      delete context;
-    }
-  }
+  XmlReader::~XmlReader() = default;
 
   XmlNode XmlReader::Read()
   {
-    auto context = static_cast<XmlReaderContext*>(m_context);
+    auto context = m_context.get();
     if (context->readingAttributes)
     {
-      int ret = xmlTextReaderMoveToNextAttribute(context->reader);
+      int ret = xmlTextReaderMoveToNextAttribute(context->reader.get());
       if (ret == 1)
       {
-        const char* name = reinterpret_cast<const char*>(xmlTextReaderConstName(context->reader));
-        const char* value = reinterpret_cast<const char*>(xmlTextReaderConstValue(context->reader));
+        const char* name = reinterpret_cast<const char*>(xmlTextReaderConstName(context->reader.get()));
+        const char* value = reinterpret_cast<const char*>(xmlTextReaderConstValue(context->reader.get()));
         return XmlNode{XmlNodeType::Attribute, name, value};
       }
       else if (ret == 0)
@@ -465,7 +469,7 @@ namespace Azure { namespace Storage { namespace _internal {
       return XmlNode{XmlNodeType::EndTag};
     }
 
-    int ret = xmlTextReaderRead(context->reader);
+    int ret = xmlTextReaderRead(context->reader.get());
     if (ret == 0)
     {
       return XmlNode{XmlNodeType::End};
@@ -475,13 +479,13 @@ namespace Azure { namespace Storage { namespace _internal {
       throw std::runtime_error("Failed to parse xml.");
     }
 
-    int type = xmlTextReaderNodeType(context->reader);
-    bool is_empty = xmlTextReaderIsEmptyElement(context->reader) == 1;
-    bool has_value = xmlTextReaderHasValue(context->reader) == 1;
-    bool has_attributes = xmlTextReaderHasAttributes(context->reader) == 1;
+    int type = xmlTextReaderNodeType(context->reader.get());
+    bool is_empty = xmlTextReaderIsEmptyElement(context->reader.get()) == 1;
+    bool has_value = xmlTextReaderHasValue(context->reader.get()) == 1;
+    bool has_attributes = xmlTextReaderHasAttributes(context->reader.get()) == 1;
 
-    const char* name = reinterpret_cast<const char*>(xmlTextReaderConstName(context->reader));
-    const char* value = reinterpret_cast<const char*>(xmlTextReaderConstValue(context->reader));
+    const char* name = reinterpret_cast<const char*>(xmlTextReaderConstName(context->reader.get()));
+    const char* value = reinterpret_cast<const char*>(xmlTextReaderConstValue(context->reader.get()));
 
     if (has_attributes)
     {
@@ -520,48 +524,49 @@ namespace Azure { namespace Storage { namespace _internal {
     return Read();
   }
 
-  struct XmlWriterContext
+  using BufferPtr = std::unique_ptr<xmlBuffer, decltype(&xmlBufferFree)>;
+  using WriterPtr = std::unique_ptr<xmlTextWriter, decltype(&xmlFreeTextWriter)>;
+  struct XmlWriter::XmlWriterContext
   {
-    xmlBufferPtr buffer;
-    xmlTextWriterPtr writer;
+    XmlWriterContext(BufferPtr && buffer_, WriterPtr && writer_)
+      : buffer(std::move(buffer_))
+      , writer(std::move(writer_))
+    {}
+    BufferPtr buffer;
+    WriterPtr writer;
   };
+
+  XmlWriter::XmlWriter(XmlWriter&& other) noexcept { *this = std::move(other); }
+  XmlWriter& XmlWriter::operator=(XmlWriter&& other) noexcept
+  {
+    m_context = std::move(other.m_context);
+    other.m_context = nullptr;
+    return *this;
+  }
 
   XmlWriter::XmlWriter()
   {
     XmlGlobalInitialize();
-    auto buffer = xmlBufferCreate();
+    auto buffer = BufferPtr(xmlBufferCreate(), xmlBufferFree);
 
     if (!buffer)
     {
       throw std::runtime_error("Failed to initialize xml writer.");
     }
 
-    auto writer = xmlNewTextWriterMemory(static_cast<xmlBufferPtr>(buffer), 0);
+    auto writer = WriterPtr(xmlNewTextWriterMemory(buffer.get(), 0), xmlFreeTextWriter);
 
     if (!writer)
     {
-      xmlBufferFree(static_cast<xmlBufferPtr>(buffer));
       throw std::runtime_error("Failed to initialize xml writer.");
     }
 
-    xmlTextWriterStartDocument(static_cast<xmlTextWriterPtr>(writer), nullptr, nullptr, nullptr);
+    xmlTextWriterStartDocument(writer.get(), nullptr, nullptr, nullptr);
 
-    auto context = new XmlWriterContext;
-    context->buffer = buffer;
-    context->writer = writer;
-    m_context = context;
+    m_context = std::make_unique<XmlWriterContext>(std::move(buffer), std::move(writer));
   }
 
-  XmlWriter::~XmlWriter()
-  {
-    if (m_context)
-    {
-      auto context = static_cast<XmlWriterContext*>(m_context);
-      xmlFreeTextWriter(static_cast<xmlTextWriterPtr>(context->writer));
-      xmlBufferFree(static_cast<xmlBufferPtr>(context->buffer));
-      delete context;
-    }
-  }
+  XmlWriter::~XmlWriter() = default;
 
   namespace {
     inline xmlChar* BadCast(const char* x)
@@ -572,8 +577,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   void XmlWriter::Write(XmlNode node)
   {
-    auto context = static_cast<XmlWriterContext*>(m_context);
-    xmlTextWriterPtr writer = context->writer;
+    xmlTextWriterPtr writer = m_context->writer.get();
     if (node.Type == XmlNodeType::StartTag)
     {
       if (!node.HasValue)
@@ -611,9 +615,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   std::string XmlWriter::GetDocument()
   {
-    auto context = static_cast<XmlWriterContext*>(m_context);
-    xmlBufferPtr buffer = context->buffer;
-    return std::string(reinterpret_cast<const char*>(buffer->content), buffer->use);
+    return std::string(reinterpret_cast<const char*>(m_context->buffer->content), m_context->buffer->use);
   }
 
 #endif

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -27,6 +27,8 @@ namespace Azure { namespace Storage { namespace _internal {
 
 #if defined(AZ_PLATFORM_WINDOWS)
 
+  void XmlGlobalInitialize() {}
+
   struct XmlReaderContext
   {
     XmlReaderContext()
@@ -398,7 +400,7 @@ namespace Azure { namespace Storage { namespace _internal {
     ~XmlGlobalInitializer() { xmlCleanupParser(); }
   };
 
-  static void XmlGlobalInitialize() { static XmlGlobalInitializer globalInitializer; }
+  void XmlGlobalInitialize() { static XmlGlobalInitializer globalInitializer; }
 
   XmlReader::XmlReader(XmlReader&& other) noexcept { *this = std::move(other); }
   XmlReader& XmlReader::operator=(XmlReader&& other) noexcept

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -437,7 +437,6 @@ namespace Azure { namespace Storage { namespace _internal {
     }
 
     m_context = std::make_unique<XmlReaderContext>(std::move(reader));
-    m_context->reader = std::move(reader);
   }
 
   XmlReader::~XmlReader() = default;

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -542,7 +542,7 @@ namespace Azure { namespace Storage { namespace _internal {
     XmlBufferPtr buffer;
     XmlTextWriterPtr writer;
 
-    XmlWriterContext(XmlBufferPtr && buffer_, XmlTextWriterPtr && writer_)
+    explicit XmlWriterContext(XmlBufferPtr && buffer_, XmlTextWriterPtr && writer_)
       : buffer(std::move(buffer_))
       , writer(std::move(writer_))
     {}

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -8,8 +8,8 @@
 #include <cstring>
 #include <limits>
 #include <memory>
-#include <stdexcept>
 #include <mutex>
+#include <stdexcept>
 
 #if defined(AZ_PLATFORM_WINDOWS)
 #if !defined(WIN32_LEAN_AND_MEAN)
@@ -400,9 +400,7 @@ namespace Azure { namespace Storage { namespace _internal {
     bool readingAttributes = false;
     bool readingEmptyTag = false;
 
-    explicit XmlReaderContext(XmlTextReaderPtr && reader_)
-      : reader(std::move(reader_))
-    {}
+    explicit XmlReaderContext(XmlTextReaderPtr&& reader_) : reader(std::move(reader_)) {}
   };
 
   XmlReader::XmlReader(const char* data, size_t length)
@@ -414,8 +412,8 @@ namespace Azure { namespace Storage { namespace _internal {
       throw std::runtime_error("Xml data too big.");
     }
 
-    auto reader
-        = XmlReaderContext::XmlTextReaderPtr(xmlReaderForMemory(data, static_cast<int>(length), nullptr, nullptr, 0), xmlFreeTextReader);
+    auto reader = XmlReaderContext::XmlTextReaderPtr(
+        xmlReaderForMemory(data, static_cast<int>(length), nullptr, nullptr, 0), xmlFreeTextReader);
 
     if (!reader)
     {
@@ -437,8 +435,8 @@ namespace Azure { namespace Storage { namespace _internal {
 
   XmlNode XmlReader::Read()
   {
-    XmlReaderContext * context = m_context.get();
-    xmlTextReader * reader = m_context->reader.get();
+    XmlReaderContext* context = m_context.get();
+    xmlTextReader* reader = m_context->reader.get();
     if (context->readingAttributes)
     {
       int ret = xmlTextReaderMoveToNextAttribute(reader);
@@ -526,10 +524,10 @@ namespace Azure { namespace Storage { namespace _internal {
     XmlBufferPtr buffer;
     XmlTextWriterPtr writer;
 
-    explicit XmlWriterContext(XmlBufferPtr && buffer_, XmlTextWriterPtr && writer_)
-      : buffer(std::move(buffer_))
-      , writer(std::move(writer_))
-    {}
+    explicit XmlWriterContext(XmlBufferPtr&& buffer_, XmlTextWriterPtr&& writer_)
+        : buffer(std::move(buffer_)), writer(std::move(writer_))
+    {
+    }
   };
 
   XmlWriter::XmlWriter()
@@ -542,7 +540,8 @@ namespace Azure { namespace Storage { namespace _internal {
       throw std::runtime_error("Failed to initialize xml writer.");
     }
 
-    auto writer = XmlWriterContext::XmlTextWriterPtr(xmlNewTextWriterMemory(buffer.get(), 0), xmlFreeTextWriter);
+    auto writer = XmlWriterContext::XmlTextWriterPtr(
+        xmlNewTextWriterMemory(buffer.get(), 0), xmlFreeTextWriter);
 
     if (!writer)
     {
@@ -562,7 +561,6 @@ namespace Azure { namespace Storage { namespace _internal {
     return *this;
   }
 
-
   XmlWriter::~XmlWriter() = default;
 
   namespace {
@@ -574,7 +572,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   void XmlWriter::Write(XmlNode node)
   {
-    xmlTextWriter * writer = m_context->writer.get();
+    xmlTextWriter* writer = m_context->writer.get();
     if (node.Type == XmlNodeType::StartTag)
     {
       if (!node.HasValue)
@@ -612,7 +610,8 @@ namespace Azure { namespace Storage { namespace _internal {
 
   std::string XmlWriter::GetDocument()
   {
-    return std::string(reinterpret_cast<const char*>(m_context->buffer->content), m_context->buffer->use);
+    return std::string(
+        reinterpret_cast<const char*>(m_context->buffer->content), m_context->buffer->use);
   }
 
 #endif

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -384,17 +384,13 @@ namespace Azure { namespace Storage { namespace _internal {
 
 #else
 
-  void XmlGlobalInitialize()
+  struct XmlGlobalInitializer final
   {
-    static std::once_flag flag;
-    std::call_once(flag, [] { xmlInitParser(); });
-  }
+    XmlGlobalInitializer() { xmlInitParser(); }
+    ~XmlGlobalInitializer() { xmlCleanupParser(); }
+  };
 
-  void XmlGlobalDeinitialize()
-  {
-    static std::once_flag flag;
-    std::call_once(flag, [] { xmlCleanupParser(); });
-  }
+  static void XmlGlobalInitialize() { static XmlGlobalInitializer globalInitializer; }
 
   struct XmlReader::XmlReaderContext
   {

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -31,7 +31,7 @@ namespace Azure { namespace Storage { namespace _internal {
   void XmlGlobalInitialize() {}
   void XmlGlobalDeinitialize() {}
 
-  struct XmlReaderContext
+  struct XmlReader::XmlReaderContext
   {
     XmlReaderContext()
     {
@@ -99,20 +99,14 @@ namespace Azure { namespace Storage { namespace _internal {
       throw std::runtime_error("Unsupported xml encoding.");
     }
 
-    m_context = context.release();
+    m_context = std::move(context);
   }
 
-  XmlReader::~XmlReader()
-  {
-    if (m_context)
-    {
-      delete static_cast<XmlReaderContext*>(m_context);
-    }
-  }
+  XmlReader::~XmlReader() {}
 
   XmlNode XmlReader::Read()
   {
-    auto context = static_cast<XmlReaderContext*>(m_context);
+    auto& context = m_context;
 
     auto moveToNext = [&]() {
       HRESULT ret = WsReadNode(context->reader, context->error);
@@ -222,7 +216,7 @@ namespace Azure { namespace Storage { namespace _internal {
     }
   }
 
-  struct XmlWriterContext
+  struct XmlWriter::XmlWriterContext
   {
     XmlWriterContext()
     {
@@ -276,20 +270,14 @@ namespace Azure { namespace Storage { namespace _internal {
       throw std::runtime_error("Failed to initialize xml writer.");
     }
 
-    m_context = context.release();
+    m_context = std::move(context);
   }
 
-  XmlWriter::~XmlWriter()
-  {
-    if (m_context)
-    {
-      delete static_cast<XmlWriterContext*>(m_context);
-    }
-  }
+  XmlWriter::~XmlWriter() {}
 
   void XmlWriter::Write(XmlNode node)
   {
-    auto context = static_cast<XmlWriterContext*>(m_context);
+    auto& context = m_context;
     if (node.Type == XmlNodeType::StartTag)
     {
       if (node.HasValue)
@@ -363,7 +351,7 @@ namespace Azure { namespace Storage { namespace _internal {
 
   std::string XmlWriter::GetDocument()
   {
-    auto context = static_cast<XmlWriterContext*>(m_context);
+    auto& context = m_context;
 
     BOOL boolValueTrue = TRUE;
     WS_XML_WRITER_PROPERTY writerProperty[2];


### PR DESCRIPTION
We ([ClickHouse](https://github.com/ClickHouse/ClickHouse)) use azure-sdk-for-cpp as a submodule to connect to Azure Blob storage.

Our comprehensive suite of tests is run under thread/undefined/memory/address sanitizers to detect issues before they hit production. One particular issue detected was a memory leak found and fixed in January 2023 which this PR upstreams.

Notes:

The problem was first addressed in azure 1.6 by these PRs: https://github.com/ClickHouse/azure-sdk-for-cpp/pull/4, https://github.com/ClickHouse/azure-sdk-for-cpp/pull/5, https://github.com/ClickHouse/azure-sdk-for-cpp/pull/6.

Every time azure-sdk-for-cpp was upgraded, the fixes have been picked into the current release. ClickHouse currently pulls in azure-sdk-for-cpp 1.12, also with the fix. This is to say that the fix has been part of our production code for a long while.

There was a previous attempt to upstream the fix (https://github.com/Azure/azure-sdk-for-cpp/pull/4647) but 1. that other PR was sort of different from this fix and 2. the contributor unfortunately disappeared and the PR was abandoned.

I cannot determine which exact memory leak the fix originally addressed. The original fixes in ClickHouse's fork of azure-sdk-for-cpp only state that they fix a memory leak but they don't link to a defect report (sorry). I could spend some time doing code and Git archeology but it is probably not worth the trouble. The idea of this PR is to manage memory using RAII - that is generally a good idea as makes the code safer and less prone to errors. I could not find any obvious places where non-use of RAII would lead to errors.

The PR also makes setup/teardown functions `XmlGlobalInitialize` and `XmlGlobalDeinitialize` public. This is required for another fix that frees memory in TLS allocated by libxml when azure/libxml is used by multiple threads: https://github.com/ClickHouse/ClickHouse/blob/907a3659262e9029fd2c257913c62fadfc3bc433/programs/server/Server.cpp#L929 (see https://github.com/ClickHouse/ClickHouse/pull/45796).

Two more notes:
- For some weird reason, the XML wrapper code exists twice:
    - sdk/tables/azure-data-tables/inc/azure/data/tables/internal/xml_wrapper.hpp / sdk/tables/azure-data-tables/inc/azure/data/tables/internal/xml_wrapper.hpp
    - sdk/storage/azure-storage-common/inc/azure/storage/common/internal/xml_wrapper.hpp / sdk/storage/azure-storage-common/src/xml_wrapper.cpp
  
   This PR only addresses the second file(s). If you think we should rather apply the same fixes in both sets of files, please push another commit into this PR. My personal preference is to kill one of the copies (the other one, ideally) - feel free to do so.

- I am a Linux user and did not check or compile the code in the `AZ_PLATFORM_WINDOWS` ifdef. Perhaps the Windows code is good but kindly double-check.