### PR TITLE
Turn federated auth on for Identity tests.

### DIFF
--- a/sdk/identity/azure-identity/test/ut/azure_pipelines_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_pipelines_credential_test.cpp
@@ -644,7 +644,7 @@ TEST(AzurePipelinesCredential, InvalidServiceConnectionId_LIVEONLY_)
   }
 }
 
-TEST(AzurePipelinesCredential, InvalidSystemAccessToken_LIVEONLY_)
+TEST(AzurePipelinesCredential, DISABLED_InvalidSystemAccessToken_LIVEONLY_)
 {
   std::string tenantId = Environment::GetVariable("AZURESUBSCRIPTION_TENANT_ID");
   std::string clientId = Environment::GetVariable("AZURESUBSCRIPTION_CLIENT_ID");

--- a/sdk/identity/azure-identity/test/ut/token_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/token_credential_test.cpp
@@ -55,6 +55,12 @@ using namespace Azure::Identity;
 
 TEST_F(TokenCredentialTest, ClientSecret)
 {
+  if (m_testContext.IsLiveMode())
+  {
+    GTEST_SKIP_(
+        "Skipping ClientSecret test since it requires env vars that aren't set in live mode.");
+  }
+
   std::string const testName(GetTestName());
   auto const clientSecretCredential = GetClientSecretCredential(testName);
 
@@ -71,6 +77,12 @@ TEST_F(TokenCredentialTest, ClientSecret)
 
 TEST_F(TokenCredentialTest, EnvironmentCredential)
 {
+  if (m_testContext.IsLiveMode())
+  {
+    GTEST_SKIP_("Skipping EnvironmentCredential test since it requires env vars that aren't set in "
+                "live mode.");
+  }
+
   std::string const testName(GetTestName());
   auto const clientSecretCredential = GetEnvironmentCredential(testName);
 

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -30,6 +30,7 @@ extends:
       LiveTestCtestRegex: azure-identity.
       LineCoverageTarget: 95
       BranchCoverageTarget: 56
+      UseFederatedAuth: true
       Artifacts:
         - Name: azure-identity
           Path: azure-identity

--- a/sdk/identity/test-resources.json
+++ b/sdk/identity/test-resources.json
@@ -14,12 +14,6 @@
       "metadata": {
         "description": "The application client ID used to run tests."
       }
-    },
-    "testApplicationSecret": {
-      "type": "string",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
     }
   },
   "resources": [],
@@ -31,10 +25,6 @@
     "AZURE_CLIENT_ID": {
       "type": "string",
       "value": "[parameters('testApplicationId')]"
-    },
-    "AZURE_CLIENT_SECRET": {
-      "type": "string",
-      "value": "[parameters('testApplicationSecret')]"
     }
   }
 }


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk-for-cpp/pull/5740#discussion_r1659213420

The liveonly test is being disabled with tracking issue https://github.com/Azure/azure-sdk-for-cpp/issues/5786