### PR TITLE
Update Preview Test Sub to use new connection

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -61,9 +61,7 @@ parameters:
           - eng/common/TestResources/sub-config/AzurePublicMsft.json
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-        ServiceConnection: azure-sdk-tests
-        # Temporary fix until an eng/common config for Preview can be merged
-        SubscriptionConfigurationFilePaths: []
+        ServiceConnection: azure-sdk-tests-preview
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         ServiceConnection: azure-sdk-tests


### PR DESCRIPTION
In order to get both deployment and clean-up working we need to have a connection that points at the right subscription. Today azure-sdk-tests points to the name Test Sub but I created azure-sdk-tests-preview connection which points to the Preview Test Sub.

This will fix the clean-up step which is currently failing for things deployed in Preview.