### PR TITLE
Explicitly install python

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -157,6 +157,9 @@ jobs:
           parameters:
             ContinueOnError: false
 
+        # Install Python on the machine for verify-path-length script.
+        - task: UsePythonVersion@0
+
         # Base Path Length calculated based on Visual Studio's defaults for projects.
         # By default, Visual Studio puts projects in a folder structure like this:
         # C:\Users\<username>\source\repos\<project>. That is 34 characters before project.

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -159,6 +159,7 @@ jobs:
 
         # Install Python on the machine for verify-path-length script.
         - task: UsePythonVersion@0
+          displayName: Install Python Version
 
         # Base Path Length calculated based on Visual Studio's defaults for projects.
         # By default, Visual Studio puts projects in a folder structure like this:


### PR DESCRIPTION
Looks like the latest windows image failed to have python installed. Working around it for now until the agent is fixed. See https://github.com/actions/runner-images/issues/10327