### PR TITLE
Remove unneeded `<regex>` includes

### DIFF
--- a/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
@@ -22,7 +22,6 @@
 
 #include <chrono>
 #include <memory>
-#include <regex>
 #include <thread>
 
 #include <gtest/gtest.h>

--- a/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
+++ b/sdk/core/azure-core-test/inc/azure/core/test/test_base.hpp
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <memory>
+#include <regex>
 #include <thread>
 
 #include <gtest/gtest.h>

--- a/sdk/core/azure-core-test/src/test_proxy_manager.cpp
+++ b/sdk/core/azure-core-test/src/test_proxy_manager.cpp
@@ -9,7 +9,6 @@
 
 #include <fstream>
 #include <iostream>
-#include <regex>
 #include <stdexcept>
 #include <string>
 

--- a/sdk/core/azure-core-tracing-opentelemetry/test/ut/service_support_test.cpp
+++ b/sdk/core/azure-core-tracing-opentelemetry/test/ut/service_support_test.cpp
@@ -10,7 +10,6 @@
 #include <azure/core/tracing/opentelemetry/opentelemetry.hpp>
 
 #include <chrono>
-#include <regex>
 
 #include <gtest/gtest.h>
 #if defined(_MSC_VER)

--- a/sdk/core/azure-core/src/http/http_sanitizer.cpp
+++ b/sdk/core/azure-core/src/http/http_sanitizer.cpp
@@ -6,7 +6,6 @@
 #include "azure/core/url.hpp"
 
 #include <iterator>
-#include <regex>
 #include <sstream>
 
 namespace {


### PR DESCRIPTION
We (ClickHouse) disallow usage of the `<regex>` header in our code (https://github.com/ClickHouse/ClickHouse/pull/58681) because the standard library's regexp implementation is generally perceived as slow. Whenever we upgrade the Azure submodule in ClickHouse, we manually remove all includes of `<regex>`, and (if needed) rewrite std regular expressions to [re2](https://github.com/google/re2/) regular expressions. In the case of Azure, `<regexp>` is included but the functionality is not used, so we can get away with simply removing the includes.

We are not proposing that Azure should require a similar rule as ClickHouse, please consider this PR as a mere header cleanup.