### PR TITLE
Undo unnecessary Core vcpkg dependency version bump

### DIFF
--- a/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
+++ b/sdk/core/azure-core-amqp/vcpkg/vcpkg.json
@@ -20,7 +20,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.14.0-beta.1"
+      "version>=": "1.11.3"
     },
     "azure-macro-utils-c",
     "umock-c",

--- a/sdk/identity/azure-identity/vcpkg/vcpkg.json
+++ b/sdk/identity/azure-identity/vcpkg/vcpkg.json
@@ -18,7 +18,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.14.0-beta.1"
+      "version>=": "1.9.0"
     },
     {
       "name": "openssl",

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/vcpkg.json
@@ -18,7 +18,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.14.0-beta.1"
+      "version>=": "1.9.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
+++ b/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
@@ -18,7 +18,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.14.0-beta.1"
+      "version>=": "1.12.0"
     },
     {
       "name": "libxml2",


### PR DESCRIPTION
Reverting to the values that existed before #5676.
None of this is needed to release vcpkg, the code that is being published in vcpkg can still compile and work with previous versions. Plus, it saves us from having to release GAs of packages, and from accidental dependency on beta release of core in the GA registry.