### PR TITLE
Move the ResourceIdentifier type from Azure::Identity to Azure::Core.

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added new constructor for `Azure::Core::Context` that takes a `std::chrono::system_clock::time_point` deadline. This enables creating a new context directly with a deadline.
+- Added an `Azure::Core::ResourceIdentifier` type.
  
 ### Breaking Changes
 

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -108,6 +108,7 @@ set(
     inc/azure/core/paged_response.hpp
     inc/azure/core/platform.hpp
     inc/azure/core/response.hpp
+    inc/azure/core/resource_identifier.hpp
     inc/azure/core/rtti.hpp
     inc/azure/core/tracing/tracing.hpp
     inc/azure/core/url.hpp

--- a/sdk/core/azure-core/inc/azure/core/resource_identifier.hpp
+++ b/sdk/core/azure-core/inc/azure/core/resource_identifier.hpp
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @file
+ * @brief An Azure Resource Manager resource identifier.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace Azure { namespace Core {
+
+  /**
+   * @brief An Azure Resource Manager resource identifier.
+   */
+  class ResourceIdentifier final {
+    std::string m_resourceId;
+
+  public:
+    /**
+     * @brief Constructs a resource identifier.
+     *
+     * @param resourceId The id string to create the ResourceIdentifier from.
+     */
+    explicit ResourceIdentifier(std::string const& resourceId) : m_resourceId(resourceId){};
+
+    /**
+     * @brief The string representation of this resource identifier.
+     *
+     * @return The resource identifier string.
+     */
+    std::string ToString() const { return m_resourceId; }
+  };
+
+}} // namespace Azure::Core

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable (
     policy_test.cpp
     request_activity_policy_test.cpp
     request_id_policy_test.cpp
+    resource_identifier_test
     response_t_test.cpp
     retry_policy_test.cpp
     service_tracing_test.cpp

--- a/sdk/core/azure-core/test/ut/resource_identifier_test.cpp
+++ b/sdk/core/azure-core/test/ut/resource_identifier_test.cpp
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include "azure/identity/managed_identity_credential.hpp"
+#include "azure/core/resource_identifier.hpp"
 
 #include <string>
 
 #include <gtest/gtest.h>
 
-using namespace Azure::Identity;
+using namespace Azure::Core;
 
 TEST(ResourceIdentifier, Basic)
 {

--- a/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
@@ -10,6 +10,7 @@
 
 #include <azure/core/credentials/credentials.hpp>
 #include <azure/core/credentials/token_credential_options.hpp>
+#include <azure/core/resource_identifier.hpp>
 
 #include <memory>
 #include <string>
@@ -18,29 +19,6 @@ namespace Azure { namespace Identity {
   namespace _detail {
     class ManagedIdentitySource;
   }
-
-  // This will move to Azure::Core.
-  /**
-   * @brief An Azure Resource Manager resource identifier.
-   */
-  class ResourceIdentifier final {
-    std::string m_resourceId;
-
-  public:
-    /**
-     * @brief Constructs a resource identifier.
-     *
-     * @param resourceId The id string to create the ResourceIdentifier from.
-     */
-    explicit ResourceIdentifier(std::string const& resourceId) : m_resourceId(resourceId){};
-
-    /**
-     * @brief The string representation of this resource identifier.
-     *
-     * @return The resource identifier string.
-     */
-    std::string ToString() const { return m_resourceId; }
-  };
 
   /**
    * @brief Attempts authentication using a managed identity that has been assigned to the
@@ -79,7 +57,7 @@ namespace Azure { namespace Identity {
      * @param options Options for token retrieval.
      */
     explicit ManagedIdentityCredential(
-        ResourceIdentifier const& resourceId,
+        Azure::Core::ResourceIdentifier const& resourceId,
         Azure::Core::Credentials::TokenCredentialOptions const& options = {});
 
     /**

--- a/sdk/identity/azure-identity/test/ut/CMakeLists.txt
+++ b/sdk/identity/azure-identity/test/ut/CMakeLists.txt
@@ -28,7 +28,6 @@ add_executable (
     environment_credential_test.cpp
     macro_guard_test.cpp
     managed_identity_credential_test.cpp
-    resource_identifier_test.cpp
     simplified_header_test.cpp
     tenant_id_resolver_test.cpp
     token_cache_test.cpp


### PR DESCRIPTION
Follow-up to https://github.com/Azure/azure-sdk-for-cpp/pull/5832#discussion_r1687110651

cc @m-nash 