### PR TITLE
Optimize Uuid.ToString() by avoiding using sprintf to do the basic string transformation

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -26,6 +26,7 @@ namespace Azure { namespace Core {
     static constexpr size_t UuidSize = 16;
 
     std::array<uint8_t, UuidSize> m_uuid{};
+    std::string m_uuidString = {};
 
   private:
     Uuid(uint8_t const uuid[UuidSize]) { std::memcpy(m_uuid.data(), uuid, UuidSize); }
@@ -35,7 +36,7 @@ namespace Azure { namespace Core {
      * @brief Gets Uuid as a string.
      * @details A string is in canonical format (8-4-4-4-12 lowercase hex and dashes only).
      */
-    std::string ToString() const;
+    std::string ToString();
 
     /**
      * @brief Returns the binary value of the Uuid for consumption by clients who need non-string

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -26,7 +26,6 @@ namespace Azure { namespace Core {
     static constexpr size_t UuidSize = 16;
 
     std::array<uint8_t, UuidSize> m_uuid{};
-    std::string m_uuidString = {};
 
   private:
     Uuid(uint8_t const uuid[UuidSize]) { std::memcpy(m_uuid.data(), uuid, UuidSize); }
@@ -36,7 +35,7 @@ namespace Azure { namespace Core {
      * @brief Gets Uuid as a string.
      * @details A string is in canonical format (8-4-4-4-12 lowercase hex and dashes only).
      */
-    std::string ToString();
+    std::string ToString() const;
 
     /**
      * @brief Returns the binary value of the Uuid for consumption by clients who need non-string

--- a/sdk/core/azure-core/src/uuid.cpp
+++ b/sdk/core/azure-core/src/uuid.cpp
@@ -3,6 +3,8 @@
 
 #include "azure/core/uuid.hpp"
 
+#include "azure/core/azure_assert.hpp"
+
 #include <cstdio>
 #include <random>
 
@@ -20,10 +22,16 @@ namespace {
 static char ByteToHexChar(uint8_t byte)
 {
   if (byte <= 9)
+  {
     return '0' + byte;
-  if (byte >= 10 && byte <= 15)
-    return 'a' + (byte - 10);
-  throw std::out_of_range("Byte value out of range for hexadecimal character.");
+  }
+
+  AZURE_ASSERT_MSG(
+      byte >= 10 && byte <= 15,
+      "It is expected, for a valid Uuid, to have byte values, where each of the two nibbles fit "
+      "into a hexadecimal character");
+
+  return 'a' + (byte - 10);
 }
 } // namespace
 

--- a/sdk/core/azure-core/src/uuid.cpp
+++ b/sdk/core/azure-core/src/uuid.cpp
@@ -17,8 +17,12 @@ static thread_local std::mt19937_64 randomGenerator(std::random_device{}());
 #endif
 
 namespace Azure { namespace Core {
-  std::string Uuid::ToString() const
+  std::string Uuid::ToString()
   {
+    if (!m_uuidString.empty())
+    {
+      return m_uuidString;
+    }
     // Guid is 36 characters
     //  Add one byte for the \0
     char s[37];
@@ -44,7 +48,8 @@ namespace Azure { namespace Core {
         m_uuid[14],
         m_uuid[15]);
 
-    return std::string(s);
+    m_uuidString = std::string(s);
+    return m_uuidString;
   }
 
   Uuid Uuid::CreateUuid()

--- a/sdk/core/azure-core/src/uuid.cpp
+++ b/sdk/core/azure-core/src/uuid.cpp
@@ -16,40 +16,35 @@ static thread_local std::mt19937_64 randomGenerator(std::random_device{}());
 } // namespace
 #endif
 
+namespace {
+static char ByteToHexChar(uint8_t byte)
+{
+  if (byte <= 9)
+    return '0' + byte;
+  if (byte >= 10 && byte <= 15)
+    return 'a' + (byte - 10);
+  throw std::out_of_range("Byte value out of range for hexadecimal character.");
+}
+} // namespace
+
 namespace Azure { namespace Core {
-  std::string Uuid::ToString()
+  std::string Uuid::ToString() const
   {
-    if (!m_uuidString.empty())
+    std::string s(36, '-');
+
+    for (size_t i = 0, j = 0; j < s.size() && i < UuidSize; i++)
     {
-      return m_uuidString;
+      if (i == 4 || i == 6 || i == 8 || i == 10)
+      {
+        j++; // Add hyphens at the appropriate places
+      }
+
+      uint8_t highNibble = (m_uuid[i] >> 4) & 0x0F;
+      uint8_t lowNibble = m_uuid[i] & 0x0F;
+      s[j++] = ByteToHexChar(highNibble);
+      s[j++] = ByteToHexChar(lowNibble);
     }
-    // Guid is 36 characters
-    //  Add one byte for the \0
-    char s[37];
-
-    std::snprintf(
-        s,
-        sizeof(s),
-        "%2.2x%2.2x%2.2x%2.2x-%2.2x%2.2x-%2.2x%2.2x-%2.2x%2.2x-%2.2x%2.2x%2.2x%2.2x%2.2x%2.2x",
-        m_uuid[0],
-        m_uuid[1],
-        m_uuid[2],
-        m_uuid[3],
-        m_uuid[4],
-        m_uuid[5],
-        m_uuid[6],
-        m_uuid[7],
-        m_uuid[8],
-        m_uuid[9],
-        m_uuid[10],
-        m_uuid[11],
-        m_uuid[12],
-        m_uuid[13],
-        m_uuid[14],
-        m_uuid[15]);
-
-    m_uuidString = std::string(s);
-    return m_uuidString;
+    return s;
   }
 
   Uuid Uuid::CreateUuid()

--- a/sdk/core/azure-core/test/ut/uuid_test.cpp
+++ b/sdk/core/azure-core/test/ut/uuid_test.cpp
@@ -16,6 +16,20 @@ TEST(Uuid, Basic)
   EXPECT_EQ(uuid.ToString().length(), 36);
 }
 
+TEST(Uuid, Roundtrip)
+{
+  std::array<uint8_t, 16U> uuidArray
+      = {97, 126, 195, 45, 41, 178, 70, 23, 142, 131, 221, 245, 20, 45, 215, 15};
+
+  auto uuid = Uuid::CreateFromArray(uuidArray);
+  std::string uuidString = uuid.ToString();
+  std::string expectedString = "617ec32d-29b2-4617-8e83-ddf5142dd70f";
+  EXPECT_EQ(expectedString, uuidString);
+
+  auto roundTrip = uuid.AsArray();
+  EXPECT_EQ(uuidArray, roundTrip);
+}
+
 TEST(Uuid, Transparent)
 {
   auto uuid1 = Uuid::CreateUuid();

--- a/sdk/core/azure-core/test/ut/uuid_test.cpp
+++ b/sdk/core/azure-core/test/ut/uuid_test.cpp
@@ -22,6 +22,11 @@ TEST(Uuid, Transparent)
   auto arrayUuid1(uuid1.AsArray());
   auto uuid2 = Azure::Core::Uuid::CreateFromArray(arrayUuid1);
   EXPECT_EQ(uuid1.ToString(), uuid2.ToString());
+
+  // Repeated calls of ToString() to validate caching results in the exact value.
+  EXPECT_EQ(uuid1.ToString(), uuid2.ToString());
+  EXPECT_EQ(uuid1.ToString(), uuid1.ToString());
+  EXPECT_EQ(uuid2.ToString(), uuid2.ToString());
 }
 
 TEST(Uuid, Randomness)

--- a/sdk/core/azure-core/test/ut/uuid_test.cpp
+++ b/sdk/core/azure-core/test/ut/uuid_test.cpp
@@ -37,7 +37,8 @@ TEST(Uuid, Transparent)
   auto uuid2 = Azure::Core::Uuid::CreateFromArray(arrayUuid1);
   EXPECT_EQ(uuid1.ToString(), uuid2.ToString());
 
-  // Repeated calls of ToString() to validate caching results in the exact value.
+  // Repeated calls of ToString() to validate the same values are returned, whether it is cached or
+  // not.
   EXPECT_EQ(uuid1.ToString(), uuid2.ToString());
   EXPECT_EQ(uuid1.ToString(), uuid1.ToString());
   EXPECT_EQ(uuid2.ToString(), uuid2.ToString());


### PR DESCRIPTION
Updated to measure the performance of the following:
```C++
auto uuidString = Azure::Core::Uuid::CreateUuid().ToString();
```
**Before:**
Completed 279,236 operations in a weighted-average of 10s (27,913.582653 ops/s, 3.58249e-05 s/op)

**After:**
Completed 920,677 operations in a weighted-average of 10s (91,995.810794 ops/s, 1.08701e-05 s/op)

New implementation results in **3.3x improvement**

Inspired by the conversation here: https://github.com/Azure/azure-sdk-for-cpp/pull/5914#discussion_r1718125489