### PR TITLE
Optimize DateTime.ToString() to use a cached value on multiple calls.

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/datetime.hpp
+++ b/sdk/core/azure-core/inc/azure/core/datetime.hpp
@@ -63,6 +63,7 @@ private:
   static constexpr size_t Rfc1123DateTimeMaxSize = 30;
   std::array<char, Rfc1123DateTimeMaxSize> m_dateTimeRfc1123String = {};
 
+  // cspell:ignore DDTHH
   // The maximum length of an RFC 3339 compatible datetime, with nanosecond precision is 35.
   // Given Zulu time is referenced by Z, and we always use that smaller form instead of HH:MM, we'll
   // use that for max length. YYYY-MM-DDTHH:MM:SS.sssssssssZ =

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -855,7 +855,7 @@ std::string DateTime::ToString(DateFormat format)
       return std::string(m_dateTimeRfc1123String.data());
     }
     std::string str = DateTime::ToStringRfc1123();
-    std::size_t length = std::min(str.size(), Rfc1123DateTimeMaxSize);
+    std::size_t length = std::min(str.size(), Azure::DateTime::Rfc1123DateTimeMaxSize);
     std::memcpy(m_dateTimeRfc1123String.data(), str.data(), length);
     return str;
   }
@@ -956,7 +956,7 @@ std::string DateTime::ToString(DateFormat format, TimeFractionFormat fractionFor
   }
 
   std::string str = DateTime::ToStringRfc3339(fractionFormat);
-  std::size_t length = std::min(str.size(), Rfc3339DateTimeMaxSize);
+  std::size_t length = std::min(str.size(), Azure::DateTime::Rfc3339DateTimeMaxSize);
   switch (fractionFormat)
   {
     case TimeFractionFormat::DropTrailingZeros:

--- a/sdk/core/azure-core/test/ut/datetime_test.cpp
+++ b/sdk/core/azure-core/test/ut/datetime_test.cpp
@@ -38,6 +38,7 @@ TEST(DateTime, ParseDateBasic)
     auto dt = DateTime::Parse("20130517", DateTime::DateFormat::Rfc3339);
     EXPECT_NE(0, dt.time_since_epoch().count());
     EXPECT_EQ(dt.ToString(), "2013-05-17T00:00:00Z");
+    EXPECT_EQ(dt.ToString(), "2013-05-17T00:00:00Z");
   }
 }
 
@@ -54,6 +55,7 @@ void TestDateTimeRoundtrip(std::string const& str, std::string const& strExpecte
   auto dt = DateTime::Parse(str, DateTime::DateFormat::Rfc3339);
   auto const str2 = dt.ToString(DateTime::DateFormat::Rfc3339, TF);
   EXPECT_EQ(str2, strExpected);
+  EXPECT_EQ(dt.ToString(DateTime::DateFormat::Rfc3339, TF), strExpected);
 }
 
 template <DateTime::TimeFractionFormat TF = DateTime::TimeFractionFormat::DropTrailingZeros>
@@ -92,6 +94,9 @@ TEST(DateTime, decimals)
     auto const str2
         = dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     EXPECT_EQ(str2, strExpected);
+    EXPECT_EQ(
+        dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits),
+        strExpected);
   }
 
   {
@@ -100,6 +105,9 @@ TEST(DateTime, decimals)
     auto const str2
         = dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     EXPECT_EQ(str2, strExpected);
+    EXPECT_EQ(
+        dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits),
+        strExpected);
   }
 
   {
@@ -108,6 +116,9 @@ TEST(DateTime, decimals)
     auto const str2
         = dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     EXPECT_EQ(str2, strExpected);
+    EXPECT_EQ(
+        dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits),
+        strExpected);
   }
 }
 
@@ -119,6 +130,9 @@ TEST(DateTime, noDecimals)
     auto const str2
         = dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::Truncate);
     EXPECT_EQ(str2, strExpected);
+    EXPECT_EQ(
+        dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::Truncate),
+        strExpected);
   }
 
   {
@@ -127,6 +141,9 @@ TEST(DateTime, noDecimals)
     auto const str2
         = dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::Truncate);
     EXPECT_EQ(str2, strExpected);
+    EXPECT_EQ(
+        dt.ToString(DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::Truncate),
+        strExpected);
   }
 }
 
@@ -139,7 +156,12 @@ TEST(DateTime, sameResultFromDefaultRfc3339)
         DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::DropTrailingZeros);
     auto const str2 = dt2.ToString(DateTime::DateFormat::Rfc3339);
     EXPECT_EQ(str1, str2);
+    EXPECT_EQ(
+        str1,
+        dt.ToString(
+            DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::DropTrailingZeros));
     EXPECT_EQ(str1, dt2.ToString());
+    EXPECT_EQ(str1, dt2.ToString(DateTime::DateFormat::Rfc3339));
   }
 }
 
@@ -178,6 +200,7 @@ TEST(DateTime, EmittingTimeCorrectDay)
   auto const actual = test.ToString(DateTime::DateFormat::Rfc1123);
   std::string const expected("Mon");
   EXPECT_EQ(actual.substr(0, 3), expected);
+  EXPECT_EQ(test.ToString(DateTime::DateFormat::Rfc1123).substr(0, 3), expected);
 }
 
 namespace {
@@ -467,12 +490,15 @@ TEST(DateTime, ToStringNoArg)
 {
   auto dt = DateTime::Parse("2013-05-17T01:02:03.1230000Z", DateTime::DateFormat::Rfc3339);
   EXPECT_EQ(dt.ToString(), "2013-05-17T01:02:03.123Z");
+  EXPECT_EQ(dt.ToString(), "2013-05-17T01:02:03.123Z");
 }
 
 TEST(DateTime, ToStringOneArg)
 {
   auto dt = DateTime::Parse("2013-05-17T01:02:03.1230000Z", DateTime::DateFormat::Rfc3339);
   EXPECT_EQ(dt.ToString(DateTime::DateFormat::Rfc3339), "2013-05-17T01:02:03.123Z");
+  EXPECT_EQ(dt.ToString(DateTime::DateFormat::Rfc3339), "2013-05-17T01:02:03.123Z");
+  EXPECT_EQ(dt.ToString(DateTime::DateFormat::Rfc1123), "Fri, 17 May 2013 01:02:03 GMT");
   EXPECT_EQ(dt.ToString(DateTime::DateFormat::Rfc1123), "Fri, 17 May 2013 01:02:03 GMT");
 }
 
@@ -900,5 +926,6 @@ TEST(DateTime, Rfc3339Space)
 {
   auto const datetime
       = DateTime::Parse("2022-08-24 00:43:08.0004308Z", DateTime::DateFormat::Rfc3339);
+  EXPECT_EQ(datetime.ToString(DateTime::DateFormat::Rfc3339), "2022-08-24T00:43:08.0004308Z");
   EXPECT_EQ(datetime.ToString(DateTime::DateFormat::Rfc3339), "2022-08-24T00:43:08.0004308Z");
 }


### PR DESCRIPTION
**Before:**
Completed 261,312 operations in a weighted-average of 10s (26,103.550858 ops/s, 3.8309e-05 s/op)

**After:**
Completed 10,024,257 operations in a weighted-average of 10s (1,001,638.652412 ops/s, 9.98364e-07 s/op)

Caching results in **38x improvement**