### PR TITLE
Remove the ResourceIdentifier accepting ctor overload for ManagedIdentityCredential.

### DIFF
--- a/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
@@ -175,17 +175,6 @@ namespace Azure { namespace Identity {
         Azure::Identity::ManagedIdentityCredentialOptions const& options);
 
     /**
-     * @brief Constructs an instance of ManagedIdentityCredential capable of authenticating a
-     * resource with a user-assigned managed identity.
-     *
-     * @param resourceId The resource ID to authenticate for a user-assigned managed identity.
-     * @param options Options for token retrieval.
-     */
-    explicit ManagedIdentityCredential(
-        ResourceIdentifier const& resourceId,
-        Azure::Core::Credentials::TokenCredentialOptions const& options = {});
-
-    /**
      * @brief Constructs a Managed Identity Credential.
      *
      * @param options Options for token retrieval.

--- a/sdk/identity/azure-identity/src/managed_identity_credential.cpp
+++ b/sdk/identity/azure-identity/src/managed_identity_credential.cpp
@@ -86,15 +86,6 @@ ManagedIdentityCredential::ManagedIdentityCredential(
 }
 
 ManagedIdentityCredential::ManagedIdentityCredential(
-    ResourceIdentifier const& resourceId,
-    Azure::Core::Credentials::TokenCredentialOptions const& options)
-    : TokenCredential("ManagedIdentityCredential")
-{
-  m_managedIdentitySource
-      = CreateManagedIdentitySource(GetCredentialName(), {}, {}, resourceId.ToString(), options);
-}
-
-ManagedIdentityCredential::ManagedIdentityCredential(
     Azure::Core::Credentials::TokenCredentialOptions const& options)
     : ManagedIdentityCredential(std::string(), options)
 {

--- a/sdk/identity/azure-identity/test/ut/managed_identity_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/managed_identity_credential_test.cpp
@@ -34,7 +34,6 @@ using Azure::Identity::ManagedIdentityCredential;
 using Azure::Identity::ManagedIdentityCredentialOptions;
 using Azure::Identity::ManagedIdentityIdType;
 using Azure::Identity::ManagedIdentityType;
-using Azure::Identity::ResourceIdentifier;
 using Azure::Identity::Test::_detail::CredentialTestHelper;
 
 TEST(ManagedIdentityType, Basic)
@@ -303,8 +302,10 @@ TEST(ManagedIdentityCredential, AppServiceV2019ResourceId)
 {
   auto const actual = CredentialTestHelper::SimulateTokenRequest(
       [](auto transport) {
-        TokenCredentialOptions options;
+        ManagedIdentityCredentialOptions options;
         options.Transport.Transport = transport;
+        options.IdentityType = ManagedIdentityType(
+            ManagedIdentityIdType::ResourceId, "abcdef01-2345-6789-9876-543210fedcba");
 
         CredentialTestHelper::EnvironmentOverride const env({
             {"MSI_ENDPOINT", "https://microsoft.com/"},
@@ -315,8 +316,7 @@ TEST(ManagedIdentityCredential, AppServiceV2019ResourceId)
             {"IDENTITY_SERVER_THUMBPRINT", "0123456789abcdef0123456789abcdef01234567"},
         });
 
-        return std::make_unique<ManagedIdentityCredential>(
-            ResourceIdentifier("abcdef01-2345-6789-9876-543210fedcba"), options);
+        return std::make_unique<ManagedIdentityCredential>(options);
       },
       {{"https://azure.com/.default"}, {"https://outlook.com/.default"}, {}},
       std::vector<std::string>{
@@ -766,8 +766,10 @@ TEST(ManagedIdentityCredential, AppServiceV2017ResourceId)
 {
   auto const actual = CredentialTestHelper::SimulateTokenRequest(
       [](auto transport) {
-        TokenCredentialOptions options;
+        ManagedIdentityCredentialOptions options;
         options.Transport.Transport = transport;
+        options.IdentityType = ManagedIdentityType(
+            ManagedIdentityIdType::ResourceId, "abcdef01-2345-6789-9876-543210fedcba");
 
         CredentialTestHelper::EnvironmentOverride const env({
             {"MSI_ENDPOINT", "https://microsoft.com/"},
@@ -778,8 +780,7 @@ TEST(ManagedIdentityCredential, AppServiceV2017ResourceId)
             {"IDENTITY_SERVER_THUMBPRINT", "0123456789abcdef0123456789abcdef01234567"},
         });
 
-        return std::make_unique<ManagedIdentityCredential>(
-            ResourceIdentifier("abcdef01-2345-6789-9876-543210fedcba"), options);
+        return std::make_unique<ManagedIdentityCredential>(options);
       },
       {{"https://azure.com/.default"}, {"https://outlook.com/.default"}, {}},
       std::vector<std::string>{
@@ -1147,8 +1148,10 @@ TEST(ManagedIdentityCredential, CloudShellResourceId)
 
   static_cast<void>(CredentialTestHelper::SimulateTokenRequest(
       [](auto transport) {
-        TokenCredentialOptions options;
+        ManagedIdentityCredentialOptions options;
         options.Transport.Transport = transport;
+        options.IdentityType = ManagedIdentityType(
+            ManagedIdentityIdType::ResourceId, "abcdef01-2345-6789-9876-543210fedcba");
 
         CredentialTestHelper::EnvironmentOverride const env({
             {"MSI_ENDPOINT", "https://microsoft.com/"},
@@ -1161,8 +1164,8 @@ TEST(ManagedIdentityCredential, CloudShellResourceId)
 
         std::unique_ptr<ManagedIdentityCredential const> cloudShellManagedIdentityCredential;
         EXPECT_THROW(
-            cloudShellManagedIdentityCredential = std::make_unique<ManagedIdentityCredential>(
-                ResourceIdentifier("abcdef01-2345-6789-9876-543210fedcba"), options),
+            cloudShellManagedIdentityCredential
+            = std::make_unique<ManagedIdentityCredential>(options),
             AuthenticationException);
 
         return cloudShellManagedIdentityCredential;
@@ -1632,8 +1635,10 @@ TEST(ManagedIdentityCredential, AzureArcObjectId)
 
   static_cast<void>(CredentialTestHelper::SimulateTokenRequest(
       [](auto transport) {
-        TokenCredentialOptions options;
+        ManagedIdentityCredentialOptions options;
         options.Transport.Transport = transport;
+        options.IdentityType = ManagedIdentityType(
+            ManagedIdentityIdType::ResourceId, "abcdef01-2345-6789-9876-543210fedcba");
 
         CredentialTestHelper::EnvironmentOverride const env({
             {"MSI_ENDPOINT", ""},
@@ -1646,8 +1651,8 @@ TEST(ManagedIdentityCredential, AzureArcObjectId)
 
         std::unique_ptr<ManagedIdentityCredential const> azureArcManagedIdentityCredential;
         EXPECT_THROW(
-            azureArcManagedIdentityCredential = std::make_unique<ManagedIdentityCredential>(
-                ResourceIdentifier("abcdef01-2345-6789-9876-543210fedcba"), options),
+            azureArcManagedIdentityCredential
+            = std::make_unique<ManagedIdentityCredential>(options),
             AuthenticationException);
 
         return azureArcManagedIdentityCredential;
@@ -2599,183 +2604,93 @@ TEST(ManagedIdentityCredential, ImdsClientId)
 
 TEST(ManagedIdentityCredential, ImdsResourceId)
 {
+  auto const actual = CredentialTestHelper::SimulateTokenRequest(
+      [](auto transport) {
+        ManagedIdentityCredentialOptions options;
+        options.Transport.Transport = transport;
+        options.IdentityType = ManagedIdentityType(
+            ManagedIdentityIdType::ResourceId, "abcdef01-2345-6789-9876-543210fedcba");
+
+        CredentialTestHelper::EnvironmentOverride const env({
+            {"MSI_ENDPOINT", ""},
+            {"MSI_SECRET", ""},
+            {"IDENTITY_ENDPOINT", ""},
+            {"IMDS_ENDPOINT", ""},
+            {"IDENTITY_HEADER", ""},
+            {"IDENTITY_SERVER_THUMBPRINT", ""},
+        });
+
+        return std::make_unique<ManagedIdentityCredential>(options);
+      },
+      {{"https://azure.com/.default"}, {"https://outlook.com/.default"}, {}},
+      std::vector<std::string>{
+          "{\"expires_in\":3600, \"access_token\":\"ACCESSTOKEN1\"}",
+          "{\"expires_in\":7200, \"access_token\":\"ACCESSTOKEN2\"}",
+          "{\"expires_in\":9999, \"access_token\":\"ACCESSTOKEN3\"}"});
+
+  EXPECT_EQ(actual.Requests.size(), 3U);
+  EXPECT_EQ(actual.Responses.size(), 3U);
+
+  auto const& request0 = actual.Requests.at(0);
+  auto const& request1 = actual.Requests.at(1);
+  auto const& request2 = actual.Requests.at(2);
+
+  auto const& response0 = actual.Responses.at(0);
+  auto const& response1 = actual.Responses.at(1);
+  auto const& response2 = actual.Responses.at(2);
+
+  EXPECT_EQ(request0.HttpMethod, HttpMethod::Get);
+  EXPECT_EQ(request1.HttpMethod, HttpMethod::Get);
+  EXPECT_EQ(request2.HttpMethod, HttpMethod::Get);
+
+  EXPECT_EQ(
+      request0.AbsoluteUrl,
+      "http://169.254.169.254/metadata/identity/oauth2/token"
+      "?api-version=2018-02-01"
+      "&msi_res_id=abcdef01-2345-6789-9876-543210fedcba"
+      "&resource=https%3A%2F%2Fazure.com"); // cspell:disable-line
+
+  EXPECT_EQ(
+      request1.AbsoluteUrl,
+      "http://169.254.169.254/metadata/identity/oauth2/token"
+      "?api-version=2018-02-01"
+      "&msi_res_id=abcdef01-2345-6789-9876-543210fedcba"
+      "&resource=https%3A%2F%2Foutlook.com"); // cspell:disable-line
+
+  EXPECT_EQ(
+      request2.AbsoluteUrl,
+      "http://169.254.169.254/metadata/identity/oauth2/token"
+      "?api-version=2018-02-01"
+      "&msi_res_id=abcdef01-2345-6789-9876-543210fedcba");
+
+  EXPECT_TRUE(request0.Body.empty());
+  EXPECT_TRUE(request1.Body.empty());
+  EXPECT_TRUE(request2.Body.empty());
+
   {
-    auto const actual = CredentialTestHelper::SimulateTokenRequest(
-        [](auto transport) {
-          TokenCredentialOptions options;
-          options.Transport.Transport = transport;
+    EXPECT_NE(request0.Headers.find("Metadata"), request0.Headers.end());
+    EXPECT_EQ(request0.Headers.at("Metadata"), "true");
 
-          CredentialTestHelper::EnvironmentOverride const env({
-              {"MSI_ENDPOINT", ""},
-              {"MSI_SECRET", ""},
-              {"IDENTITY_ENDPOINT", ""},
-              {"IMDS_ENDPOINT", ""},
-              {"IDENTITY_HEADER", ""},
-              {"IDENTITY_SERVER_THUMBPRINT", ""},
-          });
+    EXPECT_NE(request1.Headers.find("Metadata"), request1.Headers.end());
+    EXPECT_EQ(request1.Headers.at("Metadata"), "true");
 
-          return std::make_unique<ManagedIdentityCredential>(
-              ResourceIdentifier("abcdef01-2345-6789-9876-543210fedcba"), options);
-        },
-        {{"https://azure.com/.default"}, {"https://outlook.com/.default"}, {}},
-        std::vector<std::string>{
-            "{\"expires_in\":3600, \"access_token\":\"ACCESSTOKEN1\"}",
-            "{\"expires_in\":7200, \"access_token\":\"ACCESSTOKEN2\"}",
-            "{\"expires_in\":9999, \"access_token\":\"ACCESSTOKEN3\"}"});
-
-    EXPECT_EQ(actual.Requests.size(), 3U);
-    EXPECT_EQ(actual.Responses.size(), 3U);
-
-    auto const& request0 = actual.Requests.at(0);
-    auto const& request1 = actual.Requests.at(1);
-    auto const& request2 = actual.Requests.at(2);
-
-    auto const& response0 = actual.Responses.at(0);
-    auto const& response1 = actual.Responses.at(1);
-    auto const& response2 = actual.Responses.at(2);
-
-    EXPECT_EQ(request0.HttpMethod, HttpMethod::Get);
-    EXPECT_EQ(request1.HttpMethod, HttpMethod::Get);
-    EXPECT_EQ(request2.HttpMethod, HttpMethod::Get);
-
-    EXPECT_EQ(
-        request0.AbsoluteUrl,
-        "http://169.254.169.254/metadata/identity/oauth2/token"
-        "?api-version=2018-02-01"
-        "&msi_res_id=abcdef01-2345-6789-9876-543210fedcba"
-        "&resource=https%3A%2F%2Fazure.com"); // cspell:disable-line
-
-    EXPECT_EQ(
-        request1.AbsoluteUrl,
-        "http://169.254.169.254/metadata/identity/oauth2/token"
-        "?api-version=2018-02-01"
-        "&msi_res_id=abcdef01-2345-6789-9876-543210fedcba"
-        "&resource=https%3A%2F%2Foutlook.com"); // cspell:disable-line
-
-    EXPECT_EQ(
-        request2.AbsoluteUrl,
-        "http://169.254.169.254/metadata/identity/oauth2/token"
-        "?api-version=2018-02-01"
-        "&msi_res_id=abcdef01-2345-6789-9876-543210fedcba");
-
-    EXPECT_TRUE(request0.Body.empty());
-    EXPECT_TRUE(request1.Body.empty());
-    EXPECT_TRUE(request2.Body.empty());
-
-    {
-      EXPECT_NE(request0.Headers.find("Metadata"), request0.Headers.end());
-      EXPECT_EQ(request0.Headers.at("Metadata"), "true");
-
-      EXPECT_NE(request1.Headers.find("Metadata"), request1.Headers.end());
-      EXPECT_EQ(request1.Headers.at("Metadata"), "true");
-
-      EXPECT_NE(request2.Headers.find("Metadata"), request2.Headers.end());
-      EXPECT_EQ(request2.Headers.at("Metadata"), "true");
-    }
-
-    EXPECT_EQ(response0.AccessToken.Token, "ACCESSTOKEN1");
-    EXPECT_EQ(response1.AccessToken.Token, "ACCESSTOKEN2");
-    EXPECT_EQ(response2.AccessToken.Token, "ACCESSTOKEN3");
-
-    using namespace std::chrono_literals;
-    EXPECT_GE(response0.AccessToken.ExpiresOn, response0.EarliestExpiration + 3600s);
-    EXPECT_LE(response0.AccessToken.ExpiresOn, response0.LatestExpiration + 3600s);
-
-    EXPECT_GE(response1.AccessToken.ExpiresOn, response1.EarliestExpiration + 3600s);
-    EXPECT_LE(response1.AccessToken.ExpiresOn, response1.LatestExpiration + 3600s);
-
-    EXPECT_GE(response2.AccessToken.ExpiresOn, response2.EarliestExpiration + 4999s);
-    EXPECT_LE(response2.AccessToken.ExpiresOn, response2.LatestExpiration + 4999s);
+    EXPECT_NE(request2.Headers.find("Metadata"), request2.Headers.end());
+    EXPECT_EQ(request2.Headers.at("Metadata"), "true");
   }
-  {
-    auto const actual = CredentialTestHelper::SimulateTokenRequest(
-        [](auto transport) {
-          ManagedIdentityCredentialOptions options;
-          options.Transport.Transport = transport;
-          options.IdentityType = ManagedIdentityType(
-              ManagedIdentityIdType::ResourceId, "abcdef01-2345-6789-9876-543210fedcba");
 
-          CredentialTestHelper::EnvironmentOverride const env({
-              {"MSI_ENDPOINT", ""},
-              {"MSI_SECRET", ""},
-              {"IDENTITY_ENDPOINT", ""},
-              {"IMDS_ENDPOINT", ""},
-              {"IDENTITY_HEADER", ""},
-              {"IDENTITY_SERVER_THUMBPRINT", ""},
-          });
+  EXPECT_EQ(response0.AccessToken.Token, "ACCESSTOKEN1");
+  EXPECT_EQ(response1.AccessToken.Token, "ACCESSTOKEN2");
+  EXPECT_EQ(response2.AccessToken.Token, "ACCESSTOKEN3");
 
-          return std::make_unique<ManagedIdentityCredential>(options);
-        },
-        {{"https://azure.com/.default"}, {"https://outlook.com/.default"}, {}},
-        std::vector<std::string>{
-            "{\"expires_in\":3600, \"access_token\":\"ACCESSTOKEN1\"}",
-            "{\"expires_in\":7200, \"access_token\":\"ACCESSTOKEN2\"}",
-            "{\"expires_in\":9999, \"access_token\":\"ACCESSTOKEN3\"}"});
+  using namespace std::chrono_literals;
+  EXPECT_GE(response0.AccessToken.ExpiresOn, response0.EarliestExpiration + 3600s);
+  EXPECT_LE(response0.AccessToken.ExpiresOn, response0.LatestExpiration + 3600s);
 
-    EXPECT_EQ(actual.Requests.size(), 3U);
-    EXPECT_EQ(actual.Responses.size(), 3U);
+  EXPECT_GE(response1.AccessToken.ExpiresOn, response1.EarliestExpiration + 3600s);
+  EXPECT_LE(response1.AccessToken.ExpiresOn, response1.LatestExpiration + 3600s);
 
-    auto const& request0 = actual.Requests.at(0);
-    auto const& request1 = actual.Requests.at(1);
-    auto const& request2 = actual.Requests.at(2);
-
-    auto const& response0 = actual.Responses.at(0);
-    auto const& response1 = actual.Responses.at(1);
-    auto const& response2 = actual.Responses.at(2);
-
-    EXPECT_EQ(request0.HttpMethod, HttpMethod::Get);
-    EXPECT_EQ(request1.HttpMethod, HttpMethod::Get);
-    EXPECT_EQ(request2.HttpMethod, HttpMethod::Get);
-
-    EXPECT_EQ(
-        request0.AbsoluteUrl,
-        "http://169.254.169.254/metadata/identity/oauth2/token"
-        "?api-version=2018-02-01"
-        "&msi_res_id=abcdef01-2345-6789-9876-543210fedcba"
-        "&resource=https%3A%2F%2Fazure.com"); // cspell:disable-line
-
-    EXPECT_EQ(
-        request1.AbsoluteUrl,
-        "http://169.254.169.254/metadata/identity/oauth2/token"
-        "?api-version=2018-02-01"
-        "&msi_res_id=abcdef01-2345-6789-9876-543210fedcba"
-        "&resource=https%3A%2F%2Foutlook.com"); // cspell:disable-line
-
-    EXPECT_EQ(
-        request2.AbsoluteUrl,
-        "http://169.254.169.254/metadata/identity/oauth2/token"
-        "?api-version=2018-02-01"
-        "&msi_res_id=abcdef01-2345-6789-9876-543210fedcba");
-
-    EXPECT_TRUE(request0.Body.empty());
-    EXPECT_TRUE(request1.Body.empty());
-    EXPECT_TRUE(request2.Body.empty());
-
-    {
-      EXPECT_NE(request0.Headers.find("Metadata"), request0.Headers.end());
-      EXPECT_EQ(request0.Headers.at("Metadata"), "true");
-
-      EXPECT_NE(request1.Headers.find("Metadata"), request1.Headers.end());
-      EXPECT_EQ(request1.Headers.at("Metadata"), "true");
-
-      EXPECT_NE(request2.Headers.find("Metadata"), request2.Headers.end());
-      EXPECT_EQ(request2.Headers.at("Metadata"), "true");
-    }
-
-    EXPECT_EQ(response0.AccessToken.Token, "ACCESSTOKEN1");
-    EXPECT_EQ(response1.AccessToken.Token, "ACCESSTOKEN2");
-    EXPECT_EQ(response2.AccessToken.Token, "ACCESSTOKEN3");
-
-    using namespace std::chrono_literals;
-    EXPECT_GE(response0.AccessToken.ExpiresOn, response0.EarliestExpiration + 3600s);
-    EXPECT_LE(response0.AccessToken.ExpiresOn, response0.LatestExpiration + 3600s);
-
-    EXPECT_GE(response1.AccessToken.ExpiresOn, response1.EarliestExpiration + 3600s);
-    EXPECT_LE(response1.AccessToken.ExpiresOn, response1.LatestExpiration + 3600s);
-
-    EXPECT_GE(response2.AccessToken.ExpiresOn, response2.EarliestExpiration + 4999s);
-    EXPECT_LE(response2.AccessToken.ExpiresOn, response2.LatestExpiration + 4999s);
-  }
+  EXPECT_GE(response2.AccessToken.ExpiresOn, response2.EarliestExpiration + 4999s);
+  EXPECT_LE(response2.AccessToken.ExpiresOn, response2.LatestExpiration + 4999s);
 }
 
 TEST(ManagedIdentityCredential, ImdsObjectId)


### PR DESCRIPTION
The `ManagedIdentityCredentialOptions` accepting ctor covers all the input scenarios (including provided resourceId support).
Removing this is motivated by the principal of not having multiple ways to do the same thing, within the SDK.

This isn't a breaking change since it was introduced in a 1.9.0 beta release, but removed before the 1.9.0 GA.