### PR TITLE
Uuid: add default ctor and Parse()

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Request logs to now include the `accept-range`, `content-range`, `range`, `WWW-Authenticate`, `x-ms-date`, `x-ms-error-code`, `x-ms-range`, and `x-ms-version` headers.
-- Added default constructor, `Parse()`, and comparison operators to `Azure::Core::Uuid`.
+- Added default constructor, `Parse()`, and equality comparison operators to `Azure::Core::Uuid`.
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Features Added
 
 - Request logs to now include the `accept-range`, `content-range`, `range`, `WWW-Authenticate`, `x-ms-date`, `x-ms-error-code`, `x-ms-range`, and `x-ms-version` headers.
+- Added default constructor, `Parse()`, and comparison operators to `Azure::Core::Uuid`.
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- `Azure::Core::Uuid::ToString()` is now `const`.
 
 ### Other Changes
 

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "azure/core/platform.hpp"
-
 #include <array>
 #include <cstdint>
 #include <string>
@@ -33,6 +31,8 @@ namespace Azure { namespace Core {
      * @brief Constructs a Nil UUID (`00000000-0000-0000-0000-000000000000`).
      *
      */
+    // Nil UUID, per RFC9562, consists of all zeros:
+    // https://www.rfc-editor.org/rfc/rfc9562.html#name-nil-uuid
     constexpr explicit Uuid() : m_uuid{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} {}
 
     /**
@@ -89,6 +89,8 @@ namespace Azure { namespace Core {
      */
     constexpr bool IsNil() const
     {
+      // Nil UUID, per RFC9562, consists of all zeros:
+      // https://www.rfc-editor.org/rfc/rfc9562.html#name-nil-uuid
       for (size_t i = 0; i < m_uuid.size(); ++i)
       {
         if (m_uuid[i] != 0)

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -87,6 +87,17 @@ namespace Azure { namespace Core {
      * @brief Checks if the value represents a Nil UUID (`00000000-0000-0000-0000-000000000000`).
      *
      */
-    constexpr bool IsNil() const { return *this == Uuid{}; }
+    constexpr bool IsNil() const
+    {
+      for (auto i = 0; i < m_uuid.size(); ++i)
+      {
+        if (m_uuid[i] != 0)
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
   };
 }} // namespace Azure::Core

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -18,6 +18,10 @@ namespace Azure { namespace Core {
    */
   class Uuid final {
   public:
+    /**
+     * @brief Represents a byte array where the UUID value can be stored.
+     *
+     */
     using ValueArray = std::array<std::uint8_t, 16>;
 
   private:
@@ -67,6 +71,12 @@ namespace Azure { namespace Core {
      */
     static Uuid Parse(std::string const& s);
 
+    /**
+     * @brief Compares with another instance of Uuid for equality.
+     * @param other another instance of Uuid.
+     * @return `true` if values of two Uuids are equal, `false` otherwise.
+     * 
+     */
     constexpr bool operator==(Uuid const& other) const
     {
       // std::array::operator==() is not a constexpr until C++20
@@ -81,6 +91,12 @@ namespace Azure { namespace Core {
       return true;
     }
 
+    /**
+     * @brief Compares with another instance of Uuid for inequality.
+     * @param other another instance of Uuid.
+     * @return `true` if values of two Uuids are not equal, `false` otherwise.
+     *
+     */
     constexpr bool operator!=(Uuid const& other) const { return !(*this == other); }
 
     /**

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -70,7 +70,7 @@ namespace Azure { namespace Core {
     constexpr bool operator==(Uuid const& other) const
     {
       // std::array::operator==() is not a constexpr until C++20
-      for (auto i = 0; i < m_uuid.size(); ++i)
+      for (size_t i = 0; i < m_uuid.size(); ++i)
       {
         if (m_uuid[i] != other.m_uuid[i])
         {
@@ -89,7 +89,7 @@ namespace Azure { namespace Core {
      */
     constexpr bool IsNil() const
     {
-      for (auto i = 0; i < m_uuid.size(); ++i)
+      for (size_t i = 0; i < m_uuid.size(); ++i)
       {
         if (m_uuid[i] != 0)
         {

--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -75,7 +75,7 @@ namespace Azure { namespace Core {
      * @brief Compares with another instance of Uuid for equality.
      * @param other another instance of Uuid.
      * @return `true` if values of two Uuids are equal, `false` otherwise.
-     * 
+     *
      */
     constexpr bool operator==(Uuid const& other) const
     {

--- a/sdk/core/azure-core/src/uuid.cpp
+++ b/sdk/core/azure-core/src/uuid.cpp
@@ -4,9 +4,12 @@
 #include "azure/core/uuid.hpp"
 
 #include "azure/core/azure_assert.hpp"
+#include "azure/core/internal/strings.hpp"
 
 #include <cstdio>
+#include <cstring>
 #include <random>
+#include <type_traits>
 
 #if defined(AZ_PLATFORM_POSIX)
 #include <thread>
@@ -17,6 +20,8 @@ namespace {
 static thread_local std::mt19937_64 randomGenerator(std::random_device{}());
 } // namespace
 #endif
+
+using Azure::Core::_internal::StringExtensions;
 
 namespace {
 static char ByteToHexChar(uint8_t byte)
@@ -57,22 +62,30 @@ namespace Azure { namespace Core {
 
   Uuid Uuid::CreateUuid()
   {
-    uint8_t uuid[UuidSize] = {};
+    Uuid result{};
+
+    using RngResultType = std::uint32_t;
+    static_assert(sizeof(RngResultType) == 4, "sizeof(RngResultType) must be 4.");
+    constexpr size_t RngResultSize = 4;
 
 #if defined(AZ_PLATFORM_WINDOWS)
     std::random_device rd;
+
+    static_assert(
+        std::is_same<RngResultType, decltype(rd())>::value,
+        "random_device::result_type must be of RngResultType.");
 #else
-    std::uniform_int_distribution<uint32_t> distribution;
+    std::uniform_int_distribution<RngResultType> distribution;
 #endif
 
-    for (size_t i = 0; i < UuidSize; i += 4)
+    for (size_t i = 0; i < result.m_uuid.size(); i += RngResultSize)
     {
 #if defined(AZ_PLATFORM_WINDOWS)
-      const uint32_t x = rd();
+      const RngResultType x = rd();
 #else
-      const uint32_t x = distribution(randomGenerator);
+      const RngResultType x = distribution(randomGenerator);
 #endif
-      std::memcpy(uuid + i, &x, 4);
+      std::memcpy(result.m_uuid.data() + i, &x, RngResultSize);
     }
 
     // The variant field consists of a variable number of the most significant bits of octet 8 of
@@ -83,19 +96,77 @@ namespace Azure { namespace Core {
     // values are reserved for backward compatibility. The C|c, D|d values are reserved for
     // Microsoft, and the E|e, F|f values are reserved for future use.
     // Therefore, we have to zero out the two high bits, and then set the highest bit to 1.
-    uuid[8] = (uuid[8] & 0x3F) | 0x80;
+    result.m_uuid.data()[8] = (result.m_uuid.data()[8] & 0x3F) | 0x80;
 
-    constexpr uint8_t version = 4; // Version 4: Pseudo-random number
+    {
+      constexpr std::uint8_t Version = 4; // Version 4: Pseudo-random number
+      result.m_uuid.data()[6] = (result.m_uuid.data()[6] & 0xF) | (Version << 4);
+    }
 
-    uuid[6] = (uuid[6] & 0xF) | (version << 4);
-
-    return Uuid(uuid);
+    return result;
   }
 
-  Uuid Uuid::CreateFromArray(std::array<uint8_t, UuidSize> const& uuid)
+  namespace {
+    constexpr size_t UuidStringLength = 36; // 00000000-0000-0000-0000-000000000000
+    constexpr bool IsDashIndex(size_t i) { return i == 8 || i == 13 || i == 18 || i == 23; }
+
+    constexpr std::uint8_t HexToNibble(char c) // does not check for errors
+    {
+      if (c >= 'a')
+      {
+        return 10 + (c - 'a');
+      }
+
+      if (c >= 'A')
+      {
+        return 10 + (c - 'A'); 
+      }
+
+      return c - '0';
+    }
+  } // namespace
+
+  Uuid Uuid::Parse(std::string const& s)
   {
-    Uuid rv{uuid.data()};
-    return rv;
+    bool parseError = false;
+    Uuid result;
+    if (s.size() != UuidStringLength)
+    {
+      parseError = true;
+    }
+    else
+    {
+      for (size_t i = 0, j = 0; i < UuidStringLength; ++i)
+      {
+        const auto c = s[i];
+        if (IsDashIndex(i))
+        {
+          if (c != '-')
+          {
+            parseError = true;
+            break;
+          }
+        }
+        else
+        {
+          const auto c2 = s[i + 1];
+          if (!StringExtensions::IsHexDigit(c) || !StringExtensions::IsHexDigit(c2))
+          {
+            parseError = true;
+            break;
+          }
+
+          result.m_uuid[j] = (HexToNibble(c) << 4) | HexToNibble(c2);
+          ++i;
+          ++j;
+        }
+      }
+    }
+
+    return parseError ? throw std::invalid_argument(
+               "Error parsing Uuid: '" + s
+               + "' is not in the '00112233-4455-6677-8899-aAbBcCdDeEfF' format.")
+                      : result;
   }
 
 }} // namespace Azure::Core

--- a/sdk/core/azure-core/src/uuid.cpp
+++ b/sdk/core/azure-core/src/uuid.cpp
@@ -51,7 +51,7 @@ constexpr std::uint8_t HexToNibble(char c) // does not check for errors
   return c - '0';
 }
 
-char NibbleToHex(std::uint8_t nibble) // does not check for errors
+constexpr char NibbleToHex(std::uint8_t nibble) // does not check for errors
 {
   if (nibble <= 9)
   {

--- a/sdk/core/azure-core/src/uuid.cpp
+++ b/sdk/core/azure-core/src/uuid.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstring>
 #include <random>
+#include <stdexcept>
 #include <type_traits>
 
 #if defined(AZ_PLATFORM_POSIX)

--- a/sdk/core/azure-core/test/ut/uuid_test.cpp
+++ b/sdk/core/azure-core/test/ut/uuid_test.cpp
@@ -164,20 +164,44 @@ TEST(Uuid, parse)
            0xEE,
            0xFF}));
 
+  // Empty string
+  ASSERT_THROW(Uuid::Parse(""), std::invalid_argument);
+
+  // Special characters - make sure we're not treating them as byte array
+  ASSERT_THROW(Uuid::Parse("\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a"), std::invalid_argument);
+
+  // Spaces before, after, and both.
   ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000-000000000000 "), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse(" 00000000-0000-0000-0000-000000000000"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000-00000000000"), std::invalid_argument);
+
+  // Valid characters, but in places where dashes should be
   ASSERT_THROW(Uuid::Parse("00000000a0000-0000-0000-000000000000"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000a0000-0000-000000000000"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000-0000a0000-000000000000"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000a000000000000"), std::invalid_argument);
+
+  // Another ToString() formats
+  // (https://learn.microsoft.com/dotnet/api/system.guid.tostring?view=net-8.0)
   ASSERT_THROW(Uuid::Parse("00000000000000000000000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("{00000000-0000-0000-0000-000000000000}"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("(00000000-0000-0000-0000-000000000000)"), std::invalid_argument);
+  ASSERT_THROW(
+      Uuid::Parse("{0x00000000,0x0000,0x0000,{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}}"),
+      std::invalid_argument);
+
+  // Correct length, invalid characters
+  ASSERT_THROW(Uuid::Parse("o000000000-0000-0000-0000-000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("0000000000-0000-0000-0000-00000000000o"), std::invalid_argument);
+
+  // Incorrect length, incorrect caracters
+  ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000-0000000000G"), std::invalid_argument);
+
+  // Less dashes
   ASSERT_THROW(Uuid::Parse("00000000-000000000000000000000000"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000-00000000000000000000"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000000000000000"), std::invalid_argument);
-  ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000-0000000000G"), std::invalid_argument);
-  ASSERT_THROW(Uuid::Parse("00000000-0000b0000-0000-000000000000"), std::invalid_argument);
-  ASSERT_THROW(Uuid::Parse("00000000-0000-0000c0000-000000000000"), std::invalid_argument);
-  ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000d000000000000"), std::invalid_argument);
-  ASSERT_THROW(Uuid::Parse("o000000000-0000-0000-0000-000000000000"), std::invalid_argument);
-  ASSERT_THROW(Uuid::Parse("0000000000-0000-0000-0000-00000000000o"), std::invalid_argument);
+
+  // Just a string of text
+  ASSERT_THROW(Uuid::Parse("The quick brown fox jumps over the lazy dog."), std::invalid_argument);
 }

--- a/sdk/core/azure-core/test/ut/uuid_test.cpp
+++ b/sdk/core/azure-core/test/ut/uuid_test.cpp
@@ -167,6 +167,14 @@ TEST(Uuid, parse)
   ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000-000000000000 "), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000-00000000000"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000a0000-0000-0000-000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000a0000-0000-000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000-0000a0000-000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000a000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000000000000000000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-000000000000000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000-00000000000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000-0000000000G"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000b0000-0000-000000000000"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000-0000c0000-000000000000"), std::invalid_argument);
   ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000d000000000000"), std::invalid_argument);

--- a/sdk/core/azure-core/test/ut/uuid_test.cpp
+++ b/sdk/core/azure-core/test/ut/uuid_test.cpp
@@ -127,3 +127,49 @@ TEST(Uuid, validChars)
       uuidKey,
       4);
 }
+
+TEST(Uuid, nilAndDefault)
+{
+  Uuid uuid;
+  ASSERT_TRUE(uuid.IsNil());
+  ASSERT_EQ(uuid.ToString(), "00000000-0000-0000-0000-000000000000");
+  ASSERT_EQ(uuid, Uuid{});
+  ASSERT_EQ(uuid.AsArray(), Uuid::ValueArray({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+}
+
+TEST(Uuid, parse)
+{
+  Uuid uuid1 = Uuid::Parse("00112233-4455-6677-8899-aAbBcCdDeEfF");
+
+  ASSERT_FALSE(uuid1.IsNil());
+  ASSERT_EQ(uuid1.ToString(), "00112233-4455-6677-8899-aabbccddeeff");
+  ASSERT_NE(uuid1, Uuid{});
+  ASSERT_EQ(
+      uuid1.AsArray(),
+      Uuid::ValueArray(
+          {0x00,
+           0x11,
+           0x22,
+           0x33,
+           0x44,
+           0x55,
+           0x66,
+           0x77,
+           0x88,
+           0x99,
+           0xAA,
+           0xBB,
+           0xCC,
+           0xDD,
+           0xEE,
+           0xFF}));
+
+  ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000-000000000000 "), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000-00000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000a0000-0000-0000-000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000b0000-0000-000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000-0000c0000-000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("00000000-0000-0000-0000d000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("o000000000-0000-0000-0000-000000000000"), std::invalid_argument);
+  ASSERT_THROW(Uuid::Parse("0000000000-0000-0000-0000-00000000000o"), std::invalid_argument);
+}


### PR DESCRIPTION
Interestingly, we could even make `Parse()` a `constexpr`, but I do not want the exception message to live in the header, so that the string message we pass to it does not live in multiple translation units.

`ToString()` can also be made `constexpr`, for the stdlib implementations where std::string constructors are constexpr (not until C++20?). But still, with some template magic, if we really wanted to, we could make it conditionally constexpr, where available.

I did not make either, sounds like an overkill, unless we really-really needed it.
But for other methods, I think we could make them constexpr without sacrificing much, so I made them constexpr.