### PR TITLE
Fix vcpkg cache

### DIFF
--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -1,7 +1,7 @@
 steps:
   - pwsh: |
       Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
-      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,,read"
+      Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,,read"
     displayName: Set Vcpkg Variables
 
   - ${{if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -34,10 +34,10 @@ $vcpkgBinarySourceSas = New-AzStorageContainerSASToken `
     -Name $StorageAccountName `
     -Permission "rwcl" `
     -Context $ctx `
-    -ExpiryTime (Get-Date).AddHours(1)
+    -ExpiryTime (Get-Date).AddDays(1)
 
 Write-Host "Ensure redaction of SAS tokens in logs" 
-Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"
+#Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"
 
 Write-Host "Setting vcpkg binary cache to read and write"
 Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -1,7 +1,7 @@
 param(
-    [string] $StorageAccountName = 'cppvcpkgcache'
+    [string] $StorageAccountName = 'cppvcpkgcache',
+    [string] $StorageContainerName = 'public-vcpkg-container'
 )
-
 
 ."$PSScriptRoot/../common/scripts/Helpers/PSModule-Helpers.ps1"
 
@@ -31,14 +31,14 @@ $ctx = New-AzStorageContext `
     -UseConnectedAccount
 
 $vcpkgBinarySourceSas = New-AzStorageContainerSASToken `
-    -Name $StorageAccountName `
+    -Name $StorageContainerName `
     -Permission "rwcl" `
     -Context $ctx `
-    -ExpiryTime (Get-Date).AddDays(1)
+    -ExpiryTime (Get-Date).AddHours(1)
 
 Write-Host "Ensure redaction of SAS tokens in logs" 
-#Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"
+Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SAS_TOKEN;issecret=true;]$vcpkgBinarySourceSas"
 
 Write-Host "Setting vcpkg binary cache to read and write"
-Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-container,$vcpkgBinarySourceSas,readwrite"
-Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/public-vcpkg-asset-container/,?$vcpkgBinarySourceSas,readwrite"
+Write-Host "##vso[task.setvariable variable=VCPKG_BINARY_SOURCES_SECRET;issecret=true;]clear;x-azblob,https://cppvcpkgcache.blob.core.windows.net/$StorageContainerName,$vcpkgBinarySourceSas,readwrite"
+Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES_SECRET;issecret=true;]clear;x-azurl,https://cppvcpkgcache.blob.core.windows.net/$StorageContainerName,$vcpkgBinarySourceSas,readwrite"

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -32,7 +32,7 @@ $ctx = New-AzStorageContext `
 
 $vcpkgBinarySourceSas = New-AzStorageContainerSASToken `
     -Name $StorageAccountName `
-    -Permission "rwc" `
+    -Permission "rwcl" `
     -Context $ctx `
     -ExpiryTime (Get-Date).AddHours(1)
 


### PR DESCRIPTION
We need to specify the container name to get the correct SAS. Updated the binaries and assets to use the same container so we can use the same SAS token. 