### PR TITLE
Don't warn on folders that aren't actually packages

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -338,10 +338,15 @@ jobs:
           parameters:
             ArtifactPath: $(Build.ArtifactStagingDirectory)/packages
             ArtifactName: packages
+            ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
+              SbomEnabled: false
 
         - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
           parameters:
             ArtifactPath: $(Build.ArtifactStagingDirectory)/docs
             ArtifactName: docs
+            ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
+              SbomEnabled: false
+
 
         - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -338,15 +338,10 @@ jobs:
           parameters:
             ArtifactPath: $(Build.ArtifactStagingDirectory)/packages
             ArtifactName: packages
-            ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
-              SbomEnabled: false
 
         - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
           parameters:
             ArtifactPath: $(Build.ArtifactStagingDirectory)/docs
             ArtifactName: docs
-            ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
-              SbomEnabled: false
-
 
         - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -75,6 +75,7 @@ jobs:
     matrix: $[ ${{ parameters.Matrix }} ]
 
   variables:
+    - template: /eng/pipelines/templates/variables/globals.yml@self
     - template: /eng/pipelines/templates/variables/image.yml@self
     - name: CMOCKA_XML_FILE
       value: "%g-test-results.xml"

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -265,6 +265,7 @@ stages:
           )
         )
       variables:
+        - template: /eng/pipelines/templates/variables/globals.yml
         - template: /eng/pipelines/templates/variables/image.yml
 
       jobs:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -133,6 +133,7 @@ extends:
     stages:
       - stage: CMakeGeneration
         variables:
+          - template: /eng/pipelines/templates/variables/globals.yml@self
           - template: /eng/pipelines/templates/variables/image.yml@self
         jobs:
           - template: /eng/pipelines/templates/jobs/cmake-generate-jobs.yml@self
@@ -148,6 +149,7 @@ extends:
       # Integration can launch immediately without awaiting more build and test jobs
       - stage: PrePublishBuild
         variables:
+          - template: /eng/pipelines/templates/variables/globals.yml@self
           - template: /eng/pipelines/templates/variables/image.yml@self
         dependsOn: []
         jobs:
@@ -172,6 +174,7 @@ extends:
 
       - stage: Build
         variables:
+          - template: /eng/pipelines/templates/variables/globals.yml@self
           - template: /eng/pipelines/templates/variables/image.yml@self
         dependsOn: []
         jobs:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -132,7 +132,6 @@ extends:
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
-    sdl.sbom.enabled, true
 
     stages:
       - stage: CMakeGeneration

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -106,6 +106,9 @@ extends:
     settings:
       skipBuildTagsForGitHubPullRequests: true
     sdl:
+      ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
+        sbom:
+          enabled: false
       sourceAnalysisPool:
         name: azsdk-pool-mms-win-2022-general
         image: azsdk-pool-mms-win-2022-1espt
@@ -129,6 +132,7 @@ extends:
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
+    sdl.sbom.enabled, true
 
     stages:
       - stage: CMakeGeneration

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -106,9 +106,6 @@ extends:
     settings:
       skipBuildTagsForGitHubPullRequests: true
     sdl:
-      ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
-        sbom:
-          enabled: false
       sourceAnalysisPool:
         name: azsdk-pool-mms-win-2022-general
         image: azsdk-pool-mms-win-2022-1espt

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -2,12 +2,7 @@ variables:
   # True if 'Enable system diagnostics' is checked when running a pipeline manually
   IsDebug: $[coalesce(variables['System.Debug'], 'false')]
 
-  skipComponentGovernanceDetection: true
-  DisableDockerDetector: true
-  Package.EnableSBOMSigning: true
-
-  # Disable CodeQL injections except for where we specifically enable it
-  Codeql.SkipTaskAutoInjection: true
-
-  # Disable warning for tools that are disabled for forked builds
-  GDN_SUPPRESS_FORKED_BUILD_WARNING: true
+  ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
+    # Disable warning for tools that are disabled for forked builds
+    GDN_SUPPRESS_FORKED_BUILD_WARNING: true
+    Package.EnableSBOMSigning: false

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -23,3 +23,6 @@ variables:
 
   # Disable CodeQL injections except for where we specifically enable it
   Codeql.SkipTaskAutoInjection: true
+
+  # Disable warning for tools that are disabled for forked builds
+  GDN_SUPPRESS_FORKED_BUILD_WARNING: true

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -5,4 +5,3 @@ variables:
   ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
     # Disable warning for tools that are disabled for forked builds
     GDN_SUPPRESS_FORKED_BUILD_WARNING: true
-    Package.EnableSBOMSigning: false

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -2,21 +2,6 @@ variables:
   # True if 'Enable system diagnostics' is checked when running a pipeline manually
   IsDebug: $[coalesce(variables['System.Debug'], 'false')]
 
-  AdditionalOptions: ''
-
-  # Exists if needed in coalesce situations.
-  DefaultTestGoals: 'surefire:test'
-  # This will be overwritten by the test matrix, if configured.
-  TestGoals: $(DefaultTestGoals)
-
-  # This will be overwritten by the test matrix, if configured.
-  TestOptions: ''
-  # TestFromSource is one of the cache keys but isn't set until the test matrix
-  # has been processed. Without a default value it'll be treated as a string literal
-  # "$(TestFromSource)" instead of true/false. It'll be overwritten when the test
-  # matrix has been processed
-  TestFromSource: false
-
   skipComponentGovernanceDetection: true
   DisableDockerDetector: true
   Package.EnableSBOMSigning: true

--- a/eng/scripts/Get-PkgVersion.ps1
+++ b/eng/scripts/Get-PkgVersion.ps1
@@ -13,7 +13,7 @@ $versionFileLocation = Get-VersionHppLocation `
     -PackageName $PackageName
 
 if (!$versionFileLocation) {
-    LogWarning "Failed to retrieve package version for '$ServiceDirectory/$PackageName'. No version file found."
+    Write-Verbose "Didn't find a version file for '$ServiceDirectory/$PackageName', so assuming it is not a package."
     return $null
 }
 


### PR DESCRIPTION
This should stop the build warnings around "core/perf" not having a version as it isn't a real package.