### PR TITLE
Fix etag.hpp comment that breaks Doxygen 1.12.0

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/etag.hpp
+++ b/sdk/core/azure-core/inc/azure/core/etag.hpp
@@ -181,7 +181,7 @@ public:
 
   /**
    * @brief #Azure::ETag representing everything.
-   * @note The any #Azure::ETag is *, (unquoted).  It is NOT the same as "*".
+   * @note The any #Azure::ETag is *, (unquoted).  It is NOT the same as * in quotes.
    */
   static const ETag& Any();
 };


### PR DESCRIPTION
Unfortunately, `"*"` breaks Doxygen 1.12.0 with the following error:

    error: end of comment block while expecting command </em>

I have no idea why. Anything else like `'*'` or `"x"` works, but `"*"` was clearly intended here. The best I can suggest is: `* in quotes`.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html) -- **N/A**
- [X] Doxygen docs
- [ ] Unit tests -- **N/A**
- [X] No unwanted commits/changes
- [X] Descriptive title/description
  - [X] PR is single purpose
  - [ ] Related issue listed
- [X] Comments in source
- [X] No typos
- [ ] Update changelog -- **N/A**
- [X] Not work-in-progress
- [X] External references or docs updated
- [X] Self review of PR done
- [ ] Any breaking changes?