### PR TITLE
Fix building docs from subprojects by not using CMAKE_SOURCE_DIR

### DIFF
--- a/cmake-modules/AzureDoxygen.cmake
+++ b/cmake-modules/AzureDoxygen.cmake
@@ -14,8 +14,14 @@ function(generate_documentation PROJECT_NAME PROJECT_VERSION)
         set(DOXYGEN_PROJECT_NAME ${PROJECT_NAME})
         set(DOXYGEN_PROJECT_NUMBER ${PROJECT_VERSION})
 
+        # Doc assets are needed from the top-level SDK directory.
+        # CMAKE_SOURCE_DIR will not point there if building from a subproject
+        # like sdk/core/azure-core, so use PROJECT_SOURCE_DIR instead.
+        # Subprojects are assumed to always be 3 levels down from the root.
+        set(SDK_ROOT_DIR ${PROJECT_SOURCE_DIR}/../../..)
+
         set(DOXYGEN_OUTPUT_DIRECTORY docs)
-        set(DOXYGEN_LAYOUT_FILE ${CMAKE_SOURCE_DIR}/eng/docs/api/assets/DoxygenLayout.xml)
+        set(DOXYGEN_LAYOUT_FILE ${SDK_ROOT_DIR}/eng/docs/api/assets/DoxygenLayout.xml)
         set(DOXYGEN_RECURSIVE YES)
         if (MSVC)
           set(DOXYGEN_WARN_FORMAT "$file($line) : $text")
@@ -45,10 +51,10 @@ function(generate_documentation PROJECT_NAME PROJECT_VERSION)
             az_
             AZ_
         )
-        set(DOXYGEN_HTML_HEADER ${CMAKE_SOURCE_DIR}/eng/docs/api/assets/header.html)
-        set(DOXYGEN_HTML_FOOTER ${CMAKE_SOURCE_DIR}/eng/docs/api/assets/footer.html)
-        set(DOXYGEN_HTML_STYLESHEET ${CMAKE_SOURCE_DIR}/eng/docs/api/assets/style.css)
-        set(DOXYGEN_PROJECT_LOGO ${CMAKE_SOURCE_DIR}/eng/common/docgeneration/assets/logo.svg)
+        set(DOXYGEN_HTML_HEADER ${SDK_ROOT_DIR}/eng/docs/api/assets/header.html)
+        set(DOXYGEN_HTML_FOOTER ${SDK_ROOT_DIR}/eng/docs/api/assets/footer.html)
+        set(DOXYGEN_HTML_STYLESHEET ${SDK_ROOT_DIR}/eng/docs/api/assets/style.css)
+        set(DOXYGEN_PROJECT_LOGO ${SDK_ROOT_DIR}/eng/common/docgeneration/assets/logo.svg)
 
         set(DOXYGEN_GENERATE_XML YES)
         set(DOXYGEN_GENERATE_LATEX NO)


### PR DESCRIPTION
The `generate_documentation` function currently uses `CMAKE_SOURCE_DIR` to find documentation assets at the SDK top-level, but when building from a subproject like sdk/core/azure-core, the variable points to that directory instead.

Fix this by defining `SDK_ROOT_DIR`, which is based on `PROJECT_SOURCE_DIR`. This should always work as long as each subproject calling the function is always 3 levels down, which is currently the case.

I've tested this against the whole SDK and when building 5 of the subprojects separately.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html) -- **N/A**
- [X] Doxygen docs
- [ ] Unit tests -- **N/A**
- [X] No unwanted commits/changes
- [X] Descriptive title/description
  - [X] PR is single purpose
  - [ ] Related issue listed
- [X] Comments in source
- [X] No typos
- [ ] Update changelog -- **N/A**
- [X] Not work-in-progress
- [X] External references or docs updated
- [X] Self review of PR done
- [ ] Any breaking changes?
