### PR TITLE
Disable static analysis for live test pipelines.

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -81,8 +81,6 @@ jobs:
       value: "%g-test-results.xml"
     - name: CMOCKA_MESSAGE_OUTPUT
       value: "xml"
-    - name: AZURE_ENABLE_STATIC_ANALYSIS
-      value: 0
     - name: BuildArgs
       value: ""
     - name: VcpkgArgs

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -82,7 +82,7 @@ jobs:
     - name: CMOCKA_MESSAGE_OUTPUT
       value: "xml"
     - name: AZURE_ENABLE_STATIC_ANALYSIS
-      value: 1
+      value: 0
     - name: BuildArgs
       value: ""
     - name: VcpkgArgs


### PR DESCRIPTION
There seems to be an issue with MSVC/Visual Studio's code analysis tool, specific to VS 2022 (thus impacting Windows 2022 legs). Disabling it as a stop gap to unblock releases while investigation is pending.

It seems related to a known issue: https://developercommunity.visualstudio.com/t/VS2022-17110-GA-Internal-Compiler-Erro/10722445?q=fbtctree.cpp&fTime=6m&sort=newest

MSVC version: 
> C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120

Snippet from https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4162060&view=logs&j=b480f431-cfd9-5d07-f486-b73452ab58e9&t=5ea22915-a3c9-5c1a-a8a9-195d378c0fcc

```text
2024-09-23T18:12:26.1784202Z     40>ClCompile:
2024-09-23T18:12:27.4788613Z          import_key_options.cpp
2024-09-23T18:12:27.6825382Z     36>D:\a\_work\1\s\sdk\core\azure-core\inc\azure/core/internal/json/json.hpp(24636,1): fatal  error C1001: Internal compiler error. [D:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\azure-security-keyvault-administration.vcxproj]
2024-09-23T18:12:27.8820771Z          (compiler file 'D:\a\_work\1\s\src\vctools\Compiler\CxxFE\sl\p1\c\fbtctree.cpp', line 4467)
2024-09-23T18:12:28.1005200Z           To work around this problem, try simplifying or changing the program near the locations listed above.
2024-09-23T18:12:28.4442855Z          If possible please provide a repro here: https://developercommunity.visualstudio.com
2024-09-23T18:12:30.7236220Z          Please choose the Technical Support command on the Visual C++
2024-09-23T18:12:30.9753238Z           Help menu, or open the Technical Support help file for more information
2024-09-23T18:12:31.2301259Z     36>D:\a\_work\1\s\sdk\core\azure-core\inc\azure/core/http/policies/policy.hpp(599,1): error C2220: the following warning is treated as an error [D:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\azure-security-keyvault-administration.vcxproj]
2024-09-23T18:12:31.6443693Z     36>d:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\predefined c++ types (compiler internal)(33): warning C28241: The annotation 'SAL_name' for 'new' on 'return' is not recognized. [D:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\azure-security-keyvault-administration.vcxproj]
2024-09-23T18:12:31.9874925Z     36>d:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\predefined c++ types (compiler internal)(33): warning C28285: For function 'new' 'return' syntax error in '("_Ret_notnull_","","2")' near '("_Ret_notnull_",""'. [D:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\azure-security-keyvault-administration.vcxproj]
2024-09-23T18:12:32.2689609Z     36>d:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\predefined c++ types (compiler internal)(33): warning C28241: The annotation 'SAL_name' for 'new' on 'return' is not recognized. [D:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\azure-security-keyvault-administration.vcxproj]
2024-09-23T18:12:32.3683678Z     36>d:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\predefined c++ types (compiler internal)(33): warning C28285: For function 'new' 'return' syntax error in '("_Post_writable_byte_size_","","2")' near '("_Post_writable_byte_size_",""'. [D:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\azure-security-keyvault-administration.vcxproj]
2024-09-23T18:12:32.4461349Z     36>d:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\predefined c++ types (compiler internal)(33): warning C28241: The annotation 'SAL_writableTo' for 'new' on 'return' is not recognized. [D:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\azure-security-keyvault-administration.vcxproj]
2024-09-23T18:12:32.8041192Z     36>d:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\predefined c++ types (compiler internal)(33): warning C28285: For function 'new' 'return' syntax error in '(byteCount(__formal(0,_Size)))' near '(byteCount(__formal(0'. [D:\a\_work\1\s\build\sdk\keyvault\azure-security-keyvault-administration\azure-security-keyvault-administration.vcxproj]
2024-09-23T18:12:33.0536560Z        ClCompile:
```