### PR TITLE
Remove unused included header from core within Identity that isn't available from the GA'd version of core

### DIFF
--- a/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
+++ b/sdk/identity/azure-identity/inc/azure/identity/managed_identity_credential.hpp
@@ -10,7 +10,6 @@
 
 #include <azure/core/credentials/credentials.hpp>
 #include <azure/core/credentials/token_credential_options.hpp>
-#include <azure/core/resource_identifier.hpp>
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
Remnant of the type move from earlier. The MICred API surface currently doesn't use this type and hence can be removed safely:
https://github.com/Azure/azure-sdk-for-cpp/pull/5864

Currently the identity package depends on azure-core-cpp 1.9.0, which doesn't include this header:
https://github.com/Azure/azure-sdk-for-cpp/blob/32db80516ba7978ba30738a8338596bd40155ac5/sdk/identity/azure-identity/vcpkg/vcpkg.json#L21

cc @4xicom