### PR TITLE
Added rust per-call context

### DIFF
--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/global_state.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/global_state.hpp
@@ -41,6 +41,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
   };
 
 #endif
+
   class GlobalStateHolder final {
     GlobalStateHolder();
     ~GlobalStateHolder();

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
@@ -6,13 +6,9 @@
 #include "../src/amqp/private/unique_handle.hpp"
 #include "rust_amqp_wrapper.h"
 
-#include <azure/core/azure_assert.hpp>
+#include <azure/core/context.hpp>
 
-#include <atomic>
-#include <list>
 #include <memory>
-#include <mutex>
-#include <thread>
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
@@ -74,8 +70,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
 
   class CallContext final {
   public:
-    CallContext(Azure::Core::Amqp::_detail::RustInterop::RuntimeContext* runtimeContext)
-        : m_callContext{Azure::Core::Amqp::_detail::RustInterop::call_context_new(runtimeContext)}
+    CallContext(
+        Azure::Core::Amqp::_detail::RustInterop::RuntimeContext* runtimeContext,
+        Azure::Core::Context const& context)
+        : m_callContext{Azure::Core::Amqp::_detail::RustInterop::call_context_new(runtimeContext)},
+          m_context(context)
     {
     }
 
@@ -96,6 +95,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
 
   private:
     UniqueRustCallContext m_callContext;
+    Azure::Core::Context m_context;
   };
 
 }}}}} // namespace Azure::Core::Amqp::Common::_detail

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
@@ -70,6 +70,17 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
 
   class CallContext final {
   public:
+    /** Construct a new CallContext object.
+     *
+     * @param runtimeContext - pointer to the Rust runtime for this process.
+     * @param context - Azure Context for this operation.
+     *
+     * @note This class does *NOT* take ownership of the runtime - that is because the lifetime of
+     * all CallContext objects MUST be shorter than the lifetime of the GlobalState object which
+     * actually holds the RustRuntimeContext.
+     *
+     */
+
     CallContext(
         Azure::Core::Amqp::_detail::RustInterop::RuntimeContext* runtimeContext,
         Azure::Core::Context const& context)

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
@@ -17,6 +17,8 @@
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
   using RustRuntimeContext = RustInterop::RuntimeContext;
+  using RustCallContext = RustInterop::RustCallContext;
+  using RustAmqpError = RustInterop::RustError;
 
   template <> struct UniqueHandleHelper<RustRuntimeContext>
   {
@@ -24,12 +26,30 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     using type = Core::_internal::BasicUniqueHandle<RustRuntimeContext, FreeRuntimeContext>;
   };
+  template <> struct UniqueHandleHelper<RustCallContext>
+  {
+    static void FreeCallContext(RustCallContext* obj);
+
+    using type = Core::_internal::BasicUniqueHandle<RustCallContext, FreeCallContext>;
+  };
+  template <> struct UniqueHandleHelper<RustAmqpError>
+  {
+    static void FreeRustError(RustAmqpError* obj);
+
+    using type = Core::_internal::BasicUniqueHandle<RustAmqpError, FreeRustError>;
+  };
+
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace _detail {
 
   using UniqueRustRuntimeContext = Azure::Core::Amqp::_detail::UniqueHandleHelper<
       Azure::Core::Amqp::_detail::RustRuntimeContext>::type;
+
+  using UniqueRustCallContext = Azure::Core::Amqp::_detail::UniqueHandleHelper<
+      Azure::Core::Amqp::_detail::RustCallContext>::type;
+  using UniqueRustError = Azure::Core::Amqp::_detail::UniqueHandleHelper<
+      Azure::Core::Amqp::_detail::RustAmqpError>::type;
 
   /**
    * @brief Represents the an implementation of the rust multithreaded runtime.
@@ -46,10 +66,36 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
     {
     }
 
-    Azure::Core::Amqp::_detail::RustRuntimeContext* GetRuntimeContext()
+    Azure::Core::Amqp::_detail::RustRuntimeContext* GetRuntimeContext() const
     {
       return m_runtimeContext.get();
     }
+  };
+
+  class CallContext final {
+  public:
+    CallContext(Azure::Core::Amqp::_detail::RustInterop::RuntimeContext* runtimeContext)
+        : m_callContext{Azure::Core::Amqp::_detail::RustInterop::call_context_new(runtimeContext)}
+    {
+    }
+
+    Azure::Core::Amqp::_detail::RustCallContext* GetCallContext() const
+    {
+      return m_callContext.get();
+    }
+
+    std::string GetError() const
+    {
+      UniqueRustError error{call_context_get_error(GetCallContext())};
+
+      auto err{rust_error_get_message(error.get())};
+      std::string errorString{err};
+      Azure::Core::Amqp::_detail::RustInterop::rust_string_delete(err);
+      return errorString;
+    }
+
+  private:
+    UniqueRustCallContext m_callContext;
   };
 
 }}}}} // namespace Azure::Core::Amqp::Common::_detail

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
@@ -438,15 +438,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
 
     /** @brief Closes the current connection.
      *
-     * @param context Context for closing the connection.
-     * @param description The description for closing the connection.
-     * @param info Additional information for closing the connection.
      * @param context Context for the operation.
      *
      * @remarks If you have NOT called Open() or Listen(), then calling this is an error.
      *
      */
-    void Close(Azure::Core::Context const& connection = {});
+    void Close(Azure::Core::Context const& context = {});
 
     /** @brief Closes the current connection.
      *

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
@@ -313,7 +313,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     bool EnableTrace{false};
   };
 
-  /// @brief
   class Connection final {
   public:
     // Delete copy constructor and copy assignment operator

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
@@ -412,6 +412,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * @remarks In general, a customer will not need to call this method, instead the connection
      * will be opened implicitly by a Session object derived from the connection. It primarily
      * exists as a test hook.
+     * @param context Context for the operation.
      *
      * @remarks If you call Open() or Listen(), then you MUST call Close() when you are done with
      * the connection, BEFORE destroying it.
@@ -440,6 +441,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * @param context Context for closing the connection.
      * @param description The description for closing the connection.
      * @param info Additional information for closing the connection.
+     * @param context Context for the operation.
      *
      * @remarks If you have NOT called Open() or Listen(), then calling this is an error.
      *
@@ -451,6 +453,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * @param condition The condition for closing the connection.
      * @param description The description for closing the connection.
      * @param info Additional information for closing the connection.
+     * @param context Context for the operation.
      *
      * @remarks In general, a customer will not need to call this method, instead the connection
      * will be closed implicitly by a Session object derived from the connection. It primarily

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
@@ -417,7 +417,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * the connection, BEFORE destroying it.
      *
      */
-    void Open();
+    void Open(Azure::Core::Context const& context = {});
 
 #if ENABLE_UAMQP
     /** @brief Starts listening for incoming connections.
@@ -437,6 +437,17 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
 
     /** @brief Closes the current connection.
      *
+     * @param context Context for closing the connection.
+     * @param description The description for closing the connection.
+     * @param info Additional information for closing the connection.
+     *
+     * @remarks If you have NOT called Open() or Listen(), then calling this is an error.
+     *
+     */
+    void Close(Azure::Core::Context const& connection = {});
+
+    /** @brief Closes the current connection.
+     *
      * @param condition The condition for closing the connection.
      * @param description The description for closing the connection.
      * @param info Additional information for closing the connection.
@@ -449,9 +460,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      *
      */
     void Close(
-        std::string const& condition = {},
-        std::string const& description = {},
-        Models::AmqpValue info = {});
+        std::string const& condition,
+        std::string const& description,
+        Models::AmqpValue info,
+        Azure::Core::Context const& context = {});
+
 #if ENABLE_RUST_AMQP
   private:
 #endif

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp
@@ -313,8 +313,16 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     bool EnableTrace{false};
   };
 
+  /// @brief
   class Connection final {
   public:
+    // Delete copy constructor and copy assignment operator
+    Connection(const Connection&) = delete;
+    Connection& operator=(const Connection&) = delete;
+
+    // Define move constructor and move assignment operator
+    Connection(Connection&&) noexcept = default;
+    Connection& operator=(Connection&&) noexcept = default;
 #if ENABLE_UAMQP
     /** @brief Construct a new AMQP Connection.
      *
@@ -418,7 +426,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * the connection, BEFORE destroying it.
      *
      */
-    void Open(Azure::Core::Context const& context = {});
+    void Open(Azure::Core::Context const& context);
 
 #if ENABLE_UAMQP
     /** @brief Starts listening for incoming connections.
@@ -443,7 +451,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * @remarks If you have NOT called Open() or Listen(), then calling this is an error.
      *
      */
-    void Close(Azure::Core::Context const& context = {});
+    void Close(Azure::Core::Context const& context);
 
     /** @brief Closes the current connection.
      *
@@ -463,7 +471,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
         std::string const& condition,
         std::string const& description,
         Models::AmqpValue info,
-        Azure::Core::Context const& context = {});
+        Azure::Core::Context const& context);
 
 #if ENABLE_RUST_AMQP
   private:

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/endpoint.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/endpoint.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#if ENABLE_UAMQP
+
 #include "azure/core/amqp/models/amqp_value.hpp"
 #include "common/async_operation_queue.hpp"
 #include "connection_string_credential.hpp"
@@ -58,7 +60,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     {
       that.m_endpoint = nullptr;
     }
-    ~LinkEndpoint(){};
+    ~LinkEndpoint() {};
 
     LINK_ENDPOINT_INSTANCE_TAG* Get() const { return m_endpoint; }
     std::uint32_t GetHandle() const;
@@ -93,6 +95,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       return endpoint.Release();
     }
   };
+
   class LinkEndpointFactory final {
   public:
     static _internal::LinkEndpoint CreateLinkEndpoint(LINK_ENDPOINT_INSTANCE_TAG* endpoint);
@@ -101,5 +104,5 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       return linkEndpoint.Release();
     }
   };
-
 }}}} // namespace Azure::Core::Amqp::_detail
+#endif

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/endpoint.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/endpoint.hpp
@@ -60,7 +60,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     {
       that.m_endpoint = nullptr;
     }
-    ~LinkEndpoint() {};
+    ~LinkEndpoint(){};
 
     LINK_ENDPOINT_INSTANCE_TAG* Get() const { return m_endpoint; }
     std::uint32_t GetHandle() const;

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/management.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/management.hpp
@@ -85,6 +85,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     bool EnableTrace{false};
   };
 
+#if ENABLE_RUST_AMQP
   /**
    * @brief Callback event handler for management events such as error.
    */
@@ -100,6 +101,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      */
     virtual void OnError(Models::_internal::AmqpError const& error) = 0;
   };
+#endif
 
   /**
    * @brief Result of a management operation.

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/management.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/management.hpp
@@ -85,7 +85,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     bool EnableTrace{false};
   };
 
-#if ENABLE_RUST_AMQP
+#if ENABLE_UAMQP
   /**
    * @brief Callback event handler for management events such as error.
    */

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/message_receiver.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/message_receiver.hpp
@@ -91,6 +91,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     bool AuthenticationRequired{true};
   };
 
+#if ENABLE_UAMQP
   class MessageReceiverEvents {
   protected:
     ~MessageReceiverEvents() = default;
@@ -110,6 +111,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
         Models::_internal::AmqpError const& error)
         = 0;
   };
+#endif
 
   /** @brief MessageReceiver
    *

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/session.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/session.hpp
@@ -208,12 +208,20 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     /** @brief Begins operations on the session.
      *
      */
-    void Begin();
+    void Begin(Azure::Core::Context const& context = {});
 
     /** @brief Ends operations on the session.
      *
      */
-    void End(std::string const& condition_value = {}, std::string const& description = {});
+    void End(Azure::Core::Context const& context = {});
+
+    /** @brief Ends operations on the session.
+     *
+     */
+    void End(
+        std::string const& condition_value,
+        std::string const& description,
+        Azure::Core::Context const& context = {});
 
   private:
     /** @brief Returns the current value of the incoming window.

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/session.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/session.hpp
@@ -54,13 +54,15 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
   enum class SessionRole;
   class MessageSender;
   struct MessageSenderOptions;
-  class MessageSenderEvents;
   class MessageReceiver;
   struct MessageReceiverOptions;
-  class MessageReceiverEvents;
   class ManagementClient;
   struct ManagementClientOptions;
+#if ENABLE_UAMQP
+  class MessageSenderEvents;
+  class MessageReceiverEvents;
   class ManagementClientEvents;
+#endif
 
   enum class ExpiryPolicy
   {
@@ -188,6 +190,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
         MessageSenderOptions const& options) const;
 #endif
 
+#if ENABLE_UAMQP
     /** @brief Creates a MessageReceiver
      *
      * @param receiverSource - The source from which to receive messages.
@@ -206,7 +209,23 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
         std::string const& managementInstancePath,
         ManagementClientOptions const& options,
         ManagementClientEvents* managementEvents = nullptr) const;
+#elif ENABLE_RUST_AMQP
+    /** @brief Creates a MessageReceiver
+     *
+     * @param receiverSource - The source from which to receive messages.
+     * @param options - Options to configure the MessageReceiver.
+     *
+     * @returns A MessageSender object.
+     *
+     */
+    MessageReceiver CreateMessageReceiver(
+        Models::_internal::MessageSource const& receiverSource,
+        MessageReceiverOptions const& options) const;
 
+    ManagementClient CreateManagementClient(
+        std::string const& managementInstancePath,
+        ManagementClientOptions const& options) const;
+#endif
     /** @brief Begins operations on the session.
      *
      */

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/session.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/session.hpp
@@ -7,7 +7,9 @@
 #include "azure/core/amqp/models/amqp_value.hpp"
 #include "common/async_operation_queue.hpp"
 #include "connection_string_credential.hpp"
+#if ENABLE_UAMQP
 #include "endpoint.hpp"
+#endif
 #include "models/message_source.hpp"
 #include "models/message_target.hpp"
 
@@ -208,12 +210,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     /** @brief Begins operations on the session.
      *
      */
-    void Begin(Azure::Core::Context const& context = {});
+    void Begin(Azure::Core::Context const& context);
 
     /** @brief Ends operations on the session.
      *
      */
-    void End(Azure::Core::Context const& context = {});
+    void End(Azure::Core::Context const& context);
 
     /** @brief Ends operations on the session.
      *
@@ -221,7 +223,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     void End(
         std::string const& condition_value,
         std::string const& description,
-        Azure::Core::Context const& context = {});
+        Azure::Core::Context const& context);
 
   private:
     /** @brief Returns the current value of the incoming window.
@@ -241,6 +243,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      */
     uint32_t GetHandleMax() const;
 
+#if ENABLE_UAMQP
     /** @brief Sends a detach message on the specified link endpoint.
      *
      * @param linkEndpoint - Link endpoint to detach.
@@ -269,13 +272,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
      * use by AMQP listeners.
      *
      */
-#if ENABLE_UAMQP
     MessageSender CreateMessageSender(
         LinkEndpoint& endpoint,
         Models::_internal::MessageTarget const& target,
         MessageSenderOptions const& options,
         MessageSenderEvents* events = nullptr) const;
-#endif
 
     /** @brief Creates a MessageReceiver for use in a message listener.
      *
@@ -291,6 +292,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
         Models::_internal::MessageSource const& receiverSource,
         MessageReceiverOptions const& options,
         MessageReceiverEvents* receiverEvents = nullptr) const;
+#endif
 
     friend class _detail::SessionFactory;
 

--- a/sdk/core/azure-core-amqp/samples/internal/local_server_sample/local_server_sample.cpp
+++ b/sdk/core/azure-core-amqp/samples/internal/local_server_sample/local_server_sample.cpp
@@ -89,7 +89,7 @@ private:
     auto newSession = connection.CreateSession(endpoint, sessionOptions, this);
 
     // The new session *must* call `Begin` before returning from the OnNewEndpoint callback.
-    newSession.Begin();
+    newSession.Begin({});
     m_sessionQueue.CompleteOperation(std::move(newSession));
     return true;
   }

--- a/sdk/core/azure-core-amqp/src/amqp/connection.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/connection.cpp
@@ -99,13 +99,15 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
   void Connection::Listen() { m_impl->Listen(); }
 #endif // ENABLE_UAMQP
 
-  void Connection::Open() { m_impl->Open(); }
+  void Connection::Open(Azure::Core::Context const& context) { m_impl->Open(context); }
+  void Connection::Close(Azure::Core::Context const& context) { m_impl->Close(context); }
   void Connection::Close(
       std::string const& condition,
       std::string const& description,
-      Models::AmqpValue value)
+      Models::AmqpValue value,
+      Azure::Core::Context const& context)
   {
-    m_impl->Close(condition, description, value);
+    m_impl->Close(condition, description, value, context);
   }
   uint32_t Connection::GetMaxFrameSize() const { return m_impl->GetMaxFrameSize(); }
 #if ENABLE_UAMQP

--- a/sdk/core/azure-core-amqp/src/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/session.cpp
@@ -38,10 +38,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
   uint32_t Session::GetOutgoingWindow() const { return m_impl->GetOutgoingWindow(); }
   uint32_t Session::GetHandleMax() const { return m_impl->GetHandleMax(); }
 
-  void Session::Begin() { m_impl->Begin(); }
-  void Session::End(std::string const& condition_value, std::string const& description)
+  void Session::Begin(Azure::Core::Context const& context) { m_impl->Begin(context); }
+  void Session::End(Azure::Core::Context const& context) { m_impl->End(context); }
+  void Session::End(
+      std::string const& condition_value,
+      std::string const& description,
+      Azure::Core::Context const& context)
   {
-    m_impl->End(condition_value, description);
+    m_impl->End(condition_value, description, context);
   }
   void Session::SendDetach(
       _internal::LinkEndpoint const& linkEndpoint,

--- a/sdk/core/azure-core-amqp/src/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/session.cpp
@@ -22,15 +22,15 @@ using namespace Azure::Core::Diagnostics::_internal;
 using namespace Azure::Core::Diagnostics;
 
 namespace Azure { namespace Core { namespace Amqp { namespace _internal {
+#if ENABLE_UAMP
   Endpoint::~Endpoint()
   {
-#if ENABLE_UAMQP
     if (m_endpoint)
     {
       connection_destroy_endpoint(m_endpoint);
     }
-#endif
   }
+#endif
 
   Session::~Session() noexcept {}
 
@@ -47,6 +47,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
   {
     m_impl->End(condition_value, description, context);
   }
+
+#if ENABLE_UAMQP
   void Session::SendDetach(
       _internal::LinkEndpoint const& linkEndpoint,
       bool closeLink,
@@ -55,7 +57,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     m_impl->SendDetach(linkEndpoint, closeLink, error);
   }
 
-#if ENABLE_UAMQP
   MessageSender Session::CreateMessageSender(
       Models::_internal::MessageTarget const& target,
       MessageSenderOptions const& options,
@@ -95,6 +96,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
         std::make_shared<_detail::MessageReceiverImpl>(m_impl, receiverSource, options, events));
   }
 
+#if ENABLE_UAMQP
   MessageReceiver Session::CreateMessageReceiver(
       LinkEndpoint& endpoint,
       Models::_internal::MessageSource const& receiverSource,
@@ -105,6 +107,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
         std::make_shared<_detail::MessageReceiverImpl>(
             m_impl, endpoint, receiverSource, options, events));
   }
+#endif
 
   ManagementClient Session::CreateManagementClient(
       std::string const& entityPath,

--- a/sdk/core/azure-core-amqp/src/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/session.cpp
@@ -22,7 +22,7 @@ using namespace Azure::Core::Diagnostics::_internal;
 using namespace Azure::Core::Diagnostics;
 
 namespace Azure { namespace Core { namespace Amqp { namespace _internal {
-#if ENABLE_UAMP
+#if ENABLE_UAMQP
   Endpoint::~Endpoint()
   {
     if (m_endpoint)
@@ -87,6 +87,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
   }
 #endif
 
+#if ENABLE_UAMQP
   MessageReceiver Session::CreateMessageReceiver(
       Models::_internal::MessageSource const& receiverSource,
       MessageReceiverOptions const& options,
@@ -96,7 +97,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
         std::make_shared<_detail::MessageReceiverImpl>(m_impl, receiverSource, options, events));
   }
 
-#if ENABLE_UAMQP
   MessageReceiver Session::CreateMessageReceiver(
       LinkEndpoint& endpoint,
       Models::_internal::MessageSource const& receiverSource,
@@ -107,8 +107,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
         std::make_shared<_detail::MessageReceiverImpl>(
             m_impl, endpoint, receiverSource, options, events));
   }
-#endif
-
   ManagementClient Session::CreateManagementClient(
       std::string const& entityPath,
       ManagementClientOptions const& options,
@@ -117,5 +115,24 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     return _detail::ManagementClientFactory::CreateFromInternal(
         std::make_shared<_detail::ManagementClientImpl>(m_impl, entityPath, options, events));
   }
+
+#elif ENABLE_RUST_AMQP
+  MessageReceiver Session::CreateMessageReceiver(
+      Models::_internal::MessageSource const& receiverSource,
+      MessageReceiverOptions const& options) const
+  {
+    return _detail::MessageReceiverFactory::CreateFromInternal(
+        std::make_shared<_detail::MessageReceiverImpl>(m_impl, receiverSource, options));
+  }
+
+  ManagementClient Session::CreateManagementClient(
+      std::string const& entityPath,
+      ManagementClientOptions const& options) const
+  {
+    return _detail::ManagementClientFactory::CreateFromInternal(
+        std::make_shared<_detail::ManagementClientImpl>(m_impl, entityPath, options));
+  }
+
+#endif
 
 }}}} // namespace Azure::Core::Amqp::_internal

--- a/sdk/core/azure-core-amqp/src/common/global_state.cpp
+++ b/sdk/core/azure-core-amqp/src/common/global_state.cpp
@@ -218,5 +218,18 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     Azure::Core::Amqp::_detail::RustInterop::runtime_context_delete(obj);
   }
+
+  void UniqueHandleHelper<Azure::Core::Amqp::_detail::RustCallContext>::FreeCallContext(
+      RustCallContext* obj)
+  {
+    Azure::Core::Amqp::_detail::RustInterop::call_context_delete(obj);
+  }
+
+  void UniqueHandleHelper<Azure::Core::Amqp::_detail::RustAmqpError>::FreeRustError(
+      RustAmqpError* obj)
+  {
+    Azure::Core::Amqp::_detail::RustInterop::rust_error_delete(obj);
+  }
+
 }}}} // namespace Azure::Core::Amqp::_detail
 #endif

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/claim_based_security.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/claim_based_security.cpp
@@ -88,10 +88,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     return os;
   }
-
+#if ENABLE_UAMQP
   void ClaimsBasedSecurityImpl::OnError(Models::_internal::AmqpError const& error)
   {
     Log::Stream(Logger::Level::Warning) << "AMQP Error processing ClaimsBasedSecurity: " << error;
   }
+#endif
 
 }}}} // namespace Azure::Core::Amqp::_detail

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/claim_based_security.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/claim_based_security.cpp
@@ -24,35 +24,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
   CbsOpenResult ClaimsBasedSecurityImpl::Open(Context const& context)
   {
-    if (!m_management)
-    {
-      ManagementClientOptions managementOptions;
-      managementOptions.EnableTrace = m_session->GetConnection()->IsTraceEnabled();
-      managementOptions.ExpectedStatusCodeKeyName = "status-code";
-      managementOptions.ExpectedStatusDescriptionKeyName = "status-description";
-      managementOptions.ManagementNodeName = "$cbs";
-      m_management
-          = std::make_shared<ManagementClientImpl>(m_session, "$cbs", managementOptions, this);
-
-      auto rv{m_management->Open(context)};
-      switch (rv)
-      {
-        case ManagementOpenStatus::Invalid:
-          return CbsOpenResult::Invalid;
-        case ManagementOpenStatus::Ok:
-          return CbsOpenResult::Ok;
-        case ManagementOpenStatus::Error:
-          return CbsOpenResult::Error;
-        case ManagementOpenStatus::Cancelled:
-          return CbsOpenResult::Cancelled;
-        default:
-          throw std::runtime_error("Unknown return value from Management::Open()");
-      }
-    }
-    else
-    {
-      return CbsOpenResult::Error;
-    }
+    throw std::runtime_error("Not yet implemented.");
+    (void)context;
   }
 
   void ClaimsBasedSecurityImpl::Close(Context const& context) { m_management->Close(context); }
@@ -63,53 +36,13 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       std::string const& token,
       Context const& context)
   {
-    Models::AmqpMessage message;
-    message.SetBody(static_cast<Models::AmqpValue>(token));
-
-    message.ApplicationProperties["name"] = static_cast<Models::AmqpValue>(audience);
-
-    auto result = m_management->ExecuteOperation(
-        "put-token",
-        (tokenType == CbsTokenType::Jwt ? "jwt" : "servicebus.windows.net:sastoken"),
-        {},
-        message,
-        context);
-    if (result.Status != ManagementOperationStatus::Ok)
-    {
-      CbsOperationResult cbsResult;
-      switch (result.Status)
-      {
-        case ManagementOperationStatus::Invalid:
-          cbsResult = CbsOperationResult::Invalid;
-          break;
-        case ManagementOperationStatus::Ok:
-          cbsResult = CbsOperationResult::Ok;
-          break;
-        case ManagementOperationStatus::Error:
-          cbsResult = CbsOperationResult::Error;
-          break;
-        case ManagementOperationStatus::FailedBadStatus:
-          cbsResult = CbsOperationResult::Failed;
-          break;
-        case ManagementOperationStatus::InstanceClosed:
-          cbsResult = CbsOperationResult::InstanceClosed;
-          break;
-        case ManagementOperationStatus::Cancelled:
-          cbsResult = CbsOperationResult::Cancelled;
-          break;
-        default:
-          throw std::runtime_error("Unknown management operation status.");
-      }
-      Log::Stream(Logger::Level::Informational)
-          << "CBS PutToken result: " << cbsResult << " status code: " << result.StatusCode
-          << " Error: " << result.Error << ".";
-      return std::make_tuple(cbsResult, result.StatusCode, result.Error.Description);
-    }
-    else
-    {
-      return std::make_tuple(CbsOperationResult::Ok, result.StatusCode, result.Error.Description);
-    }
+    throw std::runtime_error("Not yet implemented.");
+    (void)tokenType;
+    (void)audience;
+    (void)token;
+    (void)context;
   }
+
   std::ostream& operator<<(std::ostream& os, CbsOperationResult operationResult)
   {
     switch (operationResult)

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/connection.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/connection.cpp
@@ -135,10 +135,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     if (!m_options.IncomingLocales.empty())
     {
-      std::vector<char*> locales;
+      std::vector<const char*> locales;
       for (auto& locale : m_options.IncomingLocales)
       {
-        locales.push_back(const_cast<char*>(locale.c_str()));
+        locales.push_back(locale.c_str());
       }
 
       if (amqpconnectionoptionsbuilder_set_incoming_locales(
@@ -149,10 +149,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     if (!m_options.OutgoingLocales.empty())
     {
-      std::vector<char*> locales;
-      for (auto& locale : m_options.OutgoingLocales)
+      std::vector<const char*> locales;
+      for (auto const& locale : m_options.OutgoingLocales)
       {
-        locales.push_back(const_cast<char*>(locale.c_str()));
+        locales.push_back(locale.c_str());
       }
 
       if (amqpconnectionoptionsbuilder_set_outgoing_locales(

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/management.cpp
@@ -23,15 +23,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   ManagementClientImpl::ManagementClientImpl(
       std::shared_ptr<SessionImpl> session,
       std::string const& managementEntityPath,
-      Azure::Core::Amqp::_internal::ManagementClientOptions const& options,
-      Azure::Core::Amqp::_internal::ManagementClientEvents* managementEvents)
-      : m_options{options}, m_session{session}, m_eventHandler{managementEvents},
-        m_managementEntityPath{managementEntityPath}
+      Azure::Core::Amqp::_internal::ManagementClientOptions const& options)
+      : m_options{options}, m_session{session}, m_managementEntityPath{managementEntityPath}
   {
   }
   ManagementClientImpl::~ManagementClientImpl() noexcept
   {
-    m_eventHandler = nullptr;
     if (m_isOpen)
     {
       AZURE_ASSERT_MSG(!m_isOpen, "Management being destroyed while open.");
@@ -215,11 +212,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     Log::Stream(Logger::Level::Warning)
         << "Indicate Management Error: " << condition << " - " << description;
-    if (m_eventHandler)
-    {
-      // Let external callers know that the error was triggered.
-      m_eventHandler->OnError(error);
-    }
     if (!correlationId.empty())
     {
       // Ensure nobody else is messing with the message queues right now.

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/claims_based_security_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/claims_based_security_impl.hpp
@@ -24,7 +24,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #if ENABLE_UAMQP
   using UniqueAmqpCbsHandle = UniqueHandle<CBS_INSTANCE_TAG>;
 #endif // ENABLE_UAMQP
-  class ClaimsBasedSecurityImpl final : public _internal::ManagementClientEvents {
+  class ClaimsBasedSecurityImpl final
+#if ENABLE_UAMQP
+      : public _internal::ManagementClientEvents
+#endif
+  {
 
   public:
     ClaimsBasedSecurityImpl(std::shared_ptr<_detail::SessionImpl> session);
@@ -47,7 +51,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   private:
     std::shared_ptr<_detail::SessionImpl> m_session;
     std::shared_ptr<_detail::ManagementClientImpl> m_management;
+#if ENABLE_UAMQP
     // Inherited via ManagementClientEvents
     void OnError(Models::_internal::AmqpError const& error) override;
+#endif
   };
 }}}} // namespace Azure::Core::Amqp::_detail

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
@@ -107,12 +107,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
      */
     void FinishConstruction();
 
-    void Open();
+    void Open(Azure::Core::Context const& context);
 
+    void Close(Azure::Core::Context const& context);
     void Close(
-        std::string const& condition = {},
-        std::string const& description = {},
-        Models::AmqpValue info = {});
+        std::string const& condition,
+        std::string const& description,
+        Models::AmqpValue info,
+        Azure::Core::Context const& context);
 
     std::string GetHost() const { return m_hostUrl.GetHost(); }
     uint16_t GetPort() const { return m_hostUrl.GetPort(); }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
@@ -164,8 +164,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     std::shared_ptr<Credentials::TokenCredential> m_credential{};
     std::map<std::string, Credentials::AccessToken> m_tokenStore;
 
+#if ENABLE_UAMQP
     ConnectionImpl(
         _internal::ConnectionEvents* eventHandler,
         _internal::ConnectionOptions const& options);
+#endif
   };
 }}}} // namespace Azure::Core::Amqp::_detail

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/management_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/management_impl.hpp
@@ -3,24 +3,15 @@
 
 #pragma once
 
-#include "azure/core/amqp/internal/connection.hpp"
 #include "azure/core/amqp/internal/management.hpp"
-#include "azure/core/amqp/internal/session.hpp"
-#include "connection_impl.hpp"
 #include "message_receiver_impl.hpp"
 #include "message_sender_impl.hpp"
 #include "session_impl.hpp"
 
 #include <azure/core/credentials/credentials.hpp>
 
-#if ENABLE_UAMQP
-#include <azure_uamqp_c/amqp_management.h>
-#endif
-
 #include <memory>
 #include <mutex>
-#include <queue>
-#include <vector>
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
@@ -44,8 +35,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     ManagementClientImpl(
         std::shared_ptr<SessionImpl> session,
         std::string const& managementEntityName,
-        _internal::ManagementClientOptions const& options,
-        _internal::ManagementClientEvents* managementEvents);
+        _internal::ManagementClientOptions const& options);
 
     ~ManagementClientImpl() noexcept;
 
@@ -101,7 +91,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     _internal::ManagementClientOptions m_options;
     std::string m_source;
     std::shared_ptr<SessionImpl> m_session;
-    _internal::ManagementClientEvents* m_eventHandler{};
     std::string m_managementEntityPath;
     Azure::Core::Credentials::AccessToken m_accessToken;
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/message_receiver_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/message_receiver_impl.hpp
@@ -37,6 +37,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
   class MessageReceiverImpl final : public std::enable_shared_from_this<MessageReceiverImpl> {
   public:
+#if ENABLE_UAMQP
     MessageReceiverImpl(
         std::shared_ptr<_detail::SessionImpl> session,
         Models::_internal::MessageSource const& receiverSource,
@@ -48,6 +49,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         Models::_internal::MessageSource const& receiverSource,
         _internal::MessageReceiverOptions const& options,
         _internal::MessageReceiverEvents* receiverEvents = nullptr);
+#elif ENABLE_RUST_AMQP
+    MessageReceiverImpl(
+        std::shared_ptr<_detail::SessionImpl> session,
+        Models::_internal::MessageSource const& receiverSource,
+        _internal::MessageReceiverOptions const& options);
+#endif
     ~MessageReceiverImpl() noexcept;
 
     MessageReceiverImpl(MessageReceiverImpl const&) = delete;
@@ -88,9 +95,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     // the close operation until the link is fully closed.
     Azure::Core::Amqp::Common::_internal::AsyncOperationQueue<Models::_internal::AmqpError>
         m_closeQueue;
-
+#if ENABLE_UAMQP
     _internal::MessageReceiverEvents* m_eventHandler{};
-
+#endif
     void CreateLink();
     void CreateLink(_internal::LinkEndpoint& endpoint);
     void PopulateLinkProperties();

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/session_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/session_impl.hpp
@@ -83,12 +83,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         std::string const& condition_value,
         std::string const& description,
         Azure::Core::Context const& context);
-
+#if ENABLE_UAMQP
     void SendDetach(
         _internal::LinkEndpoint const& linkEndpoint,
         bool closeLink,
         Models::_internal::AmqpError const& error) const;
-
+#endif
   private:
     SessionImpl();
     bool m_isBegun{false};

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/session_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/session_impl.hpp
@@ -77,8 +77,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t GetOutgoingWindow();
     uint32_t GetHandleMax();
 
-    void Begin();
-    void End(std::string const& condition_value, std::string const& description);
+    void Begin(Azure::Core::Context const& context);
+    void End(Azure::Core::Context const& context);
+    void End(
+        std::string const& condition_value,
+        std::string const& description,
+        Azure::Core::Context const& context);
 
     void SendDetach(
         _internal::LinkEndpoint const& linkEndpoint,

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
@@ -182,16 +182,4 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     (void)description;
   }
 
-  void SessionImpl::SendDetach(
-      _internal::LinkEndpoint const& linkEndpoint,
-      bool closeLink,
-      Models::_internal::AmqpError const& error) const
-  {
-    Models::_internal::Performatives::AmqpDetach detach;
-
-    detach.Closed = closeLink;
-    detach.Error = error;
-    (void)linkEndpoint;
-  }
-
 }}}} // namespace Azure::Core::Amqp::_detail

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
@@ -72,7 +72,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     else
     {
-      return std::numeric_limits<std::uint32_t>::max();
+      return 1;
     }
   }
 
@@ -102,6 +102,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
   void SessionImpl::Begin()
   {
+    Azure::Core::Amqp::Common::_detail::CallContext callContext{
+        Azure::Core::Amqp::Common::_detail::GlobalStateHolder::GlobalStateInstance()
+            ->GetRuntimeContext()};
+
     UniqueAmqpSessionOptionsBuilder optionsBuilder{amqpsessionoptionsbuilder_create()};
 
     if (m_options.MaximumLinkCount.HasValue())
@@ -124,26 +128,29 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
     UniqueAmqpSessionOptions sessionOptions{amqpsessionoptionsbuilder_build(optionsBuilder.get())};
     if (amqpsession_begin(
+            callContext.GetCallContext(),
             m_session.get(),
             m_connection->GetConnection(),
-            sessionOptions.get(),
-            Common::_detail::GlobalStateHolder::GlobalStateInstance()->GetRuntimeContext()))
+            sessionOptions.get()))
     {
-      throw std::runtime_error("Failed to begin session.");
+      throw std::runtime_error("Failed to begin session." + callContext.GetError());
     }
     m_isBegun = true;
   }
   void SessionImpl::End(const std::string& condition, const std::string& description)
   {
+    Azure::Core::Amqp::Common::_detail::CallContext callContext{
+        Azure::Core::Amqp::Common::_detail::GlobalStateHolder::GlobalStateInstance()
+            ->GetRuntimeContext()};
+
     if (!m_isBegun)
     {
       throw std::runtime_error("Session End without corresponding Begin.");
     }
-    if (amqpsession_end(
-            m_session.get(),
-            Common::_detail::GlobalStateHolder::GlobalStateInstance()->GetRuntimeContext()))
+
+    if (amqpsession_end(callContext.GetCallContext(), m_session.get()))
     {
-      throw std::runtime_error("Failed to end session.");
+      throw std::runtime_error("Failed to end session." + callContext.GetError());
     }
     m_isBegun = false;
     (void)condition;

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/cbs.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/cbs.rs
@@ -74,9 +74,9 @@ impl AmqpClaimsBasedSecurityApis for AmqpClaimsBasedSecurity {
 }
 
 impl AmqpClaimsBasedSecurity {
-    pub fn new(session: AmqpSession) -> Self {
-        Self {
-            implementation: CbsImplementation::new(session),
-        }
+    pub fn new(session: AmqpSession) -> Result<Self> {
+        Ok(Self {
+            implementation: CbsImplementation::new(session)?,
+        })
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/cbs.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/cbs.rs
@@ -1,4 +1,4 @@
- // Copyright (c) Microsoft Corporation. All Rights reserved
+// Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
 // cspell: words amqp sasl
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/cbs.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/cbs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All Rights reserved
+ // Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
 // cspell: words amqp sasl
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/cbs.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/cbs.rs
@@ -22,11 +22,11 @@ pub(crate) struct Fe2o3ClaimsBasedSecurity {
 }
 
 impl Fe2o3ClaimsBasedSecurity {
-    pub fn new(session: AmqpSession) -> Self {
-        Self {
+    pub fn new(session: AmqpSession) -> Result<Self> {
+        Ok(Self {
             cbs: OnceLock::new(),
-            session: session.implementation.get(),
-        }
+            session: session.implementation.get()?,
+        })
     }
 }
 
@@ -46,7 +46,12 @@ impl AmqpClaimsBasedSecurityApis for Fe2o3ClaimsBasedSecurity {
             .attach(session.borrow_mut())
             .await
             .map_err(AmqpManagementAttach::from)?;
-        self.cbs.set(Mutex::new(cbs_client)).unwrap();
+        self.cbs.set(Mutex::new(cbs_client)).map_err(|_| {
+            azure_core::Error::message(
+                azure_core::error::ErrorKind::Other,
+                "Claims Based Security is already set.",
+            )
+        })?;
         Ok(())
     }
 
@@ -69,12 +74,22 @@ impl AmqpClaimsBasedSecurityApis for Fe2o3ClaimsBasedSecurity {
                     .to_offset(time::UtcOffset::UTC)
                     .unix_timestamp()
                     .checked_mul(1_000)
-                    .unwrap(),
+                    .ok_or_else(|| {
+                        azure_core::Error::message(
+                            azure_core::error::ErrorKind::Other,
+                            "Unable to convert time to unix timestamp.",
+                        )
+                    })?,
             )),
         );
         self.cbs
             .get()
-            .unwrap()
+            .ok_or_else(|| {
+                azure_core::Error::message(
+                    azure_core::error::ErrorKind::Other,
+                    "Claims Based Security was not set.",
+                )
+            })?
             .lock()
             .await
             .borrow_mut()

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     messaging::{AmqpMessage, AmqpMessageBody},
     value::AmqpValue,
 };
+use azure_core::{error::ErrorKind, Error};
 use fe2o3_amqp_types::messaging::{message::EmptyBody, IntoBody};
 use serde_amqp::{extensions::TransparentVec, Value};
 use tracing::info;
@@ -47,12 +48,31 @@ impl TryInto<AmqpValue> for Vec<Vec<serde_amqp::Value>> {
     }
 }
 
+/*
+ * Convert a fe2o3 message into an AMQP message.
+ *
+ * Note that this API can be used for four different scenarios:
+ * 1) Body is empty
+ * 2) Body is an array of binary blobs
+ * 3) Body is an AMQP value
+ * 4) Body is a sequence of AMQP values.
+ *
+ * In order to satisfy all four of these, the method is specialized on the type of body element.
+ * Since the actual body is either <nothing>, a Vec<Vec<u8>> or AmqpValue or Vec<AmqpValue>
+ * the T specialization is declared as being TryInto<AmqpValue>. That way, when processing the
+ * empty body or the binary body, we won't call Into<AmqpValue> on the body, and when it is
+ * a Vec<AmqpValue> or an AmqpValue, we will.
+ *
+ * TryInto<T> has a specialization where Into<T> exists, which returns an immutable error
+ * and in this case there is an fe2o3 Value Into AmqpValue specialization, which means that the call to convert
+ * the T value into an AmqpValue will always succeed.
+ */
 fn amqp_message_from_fe2o3_message<T>(
     message: fe2o3_amqp_types::messaging::Message<fe2o3_amqp_types::messaging::Body<T>>,
-) -> AmqpMessage
+) -> azure_core::Result<AmqpMessage>
 where
     T: std::fmt::Debug + Clone + TryInto<AmqpValue>,
-    <T as TryInto<AmqpValue>>::Error: std::fmt::Debug,
+    <T as TryInto<AmqpValue>>::Error: std::error::Error,
 {
     let mut amqp_message_builder = AmqpMessage::builder();
 
@@ -65,22 +85,41 @@ where
         let body = AmqpMessageBody::Empty;
         amqp_message_builder.with_body(body);
     } else if body.is_data() {
-        let data = body.try_into_data().unwrap();
+        let data = body.try_into_data().map_err(|_| {
+            Error::message(
+                ErrorKind::DataConversion,
+                "Could not convert AMQP Message Body to data.",
+            )
+        })?;
         let body = AmqpMessageBody::Binary(data.map(|x| x.to_vec()).collect());
         amqp_message_builder.with_body(body);
     } else if body.is_value() {
-        let value = body.try_into_value().unwrap();
+        let value = body.try_into_value().map_err(|_| {
+            Error::message(
+                ErrorKind::DataConversion,
+                "Could not convert AMQP Message Body to value.",
+            )
+        })?;
+        // Because a conversion exists between fe2o3 values and AmqpValue types,
+        // this try_into will always succeed.
         let value = value.try_into().unwrap();
         amqp_message_builder.with_body(AmqpMessageBody::Value(value));
     } else if body.is_sequence() {
-        let sequence = body.try_into_sequence().unwrap();
+        let sequence = body.try_into_sequence().map_err(|_| {
+            Error::message(
+                ErrorKind::DataConversion,
+                "Could not convert AMQP Message Body to sequence.",
+            )
+        })?;
+
         let body = AmqpMessageBody::Sequence(
             sequence
                 .map(|x| {
-                    x.iter()
+                    x.into_iter()
                         .map(|v| {
-                            let v: AmqpValue = v.clone().try_into().unwrap();
-                            Into::<AmqpValue>::into(v)
+                            // Because a conversion exists between fe2o3 values and AmqpValue types,
+                            // this try_into will always succeed.
+                            TryInto::<AmqpValue>::try_into(v).unwrap()
                         })
                         .collect()
                 })
@@ -109,7 +148,7 @@ where
         amqp_message_builder.with_footer(footer.0.into());
     }
 
-    amqp_message_builder.build()
+    Ok(amqp_message_builder.build())
 }
 
 impl From<fe2o3_amqp_types::messaging::Message<fe2o3_amqp_types::messaging::Body<Value>>>
@@ -118,7 +157,7 @@ impl From<fe2o3_amqp_types::messaging::Message<fe2o3_amqp_types::messaging::Body
     fn from(
         message: fe2o3_amqp_types::messaging::Message<fe2o3_amqp_types::messaging::Body<Value>>,
     ) -> Self {
-        amqp_message_from_fe2o3_message(message)
+        amqp_message_from_fe2o3_message(message).unwrap()
     }
 }
 
@@ -134,7 +173,7 @@ impl
             fe2o3_amqp_types::messaging::Body<TransparentVec<fe2o3_amqp_types::messaging::Data>>,
         >,
     ) -> Self {
-        amqp_message_from_fe2o3_message(message)
+        amqp_message_from_fe2o3_message(message).unwrap()
     }
 }
 
@@ -154,7 +193,7 @@ impl
             >,
         >,
     ) -> Self {
-        amqp_message_from_fe2o3_message(message)
+        amqp_message_from_fe2o3_message(message).unwrap()
     }
 }
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -694,7 +694,7 @@ mod tests {
             >::new(
                 seq.into_iter()
                     .map(|x| {
-                        let iter = x.into_iter().map(|y| y.into());
+                        let iter = x.into_iter().map(Into::into);
                         iter.collect::<fe2o3_amqp_types::primitives::List<fe2o3_amqp_types::primitives::Value>>().into()
                     })
                     .collect::<Vec<
@@ -717,7 +717,7 @@ mod tests {
         //     AmqpMessageBody::Sequence(
         //         test_body
         //             .into_iter()
-        //             .map(|x| x.into_iter().map(|y| y.into()).collect())
+        //             .map(|x| x.into_iter().map(Into::into).collect())
         //             .collect()
         //     )
         // );

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/receiver.rs
@@ -55,20 +55,48 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             .auto_accept(auto_accept)
             .properties(properties.into())
             .name(name)
-            .attach(session.implementation.get().lock().await.borrow_mut())
+            .attach(session.implementation.get()?.lock().await.borrow_mut())
             .await
             .map_err(AmqpReceiverAttach::from)?;
-        self.receiver.set(Arc::new(Mutex::new(receiver))).unwrap();
+        self.receiver
+            .set(Arc::new(Mutex::new(receiver)))
+            .map_err(|_| {
+                azure_core::Error::message(
+                    azure_core::error::ErrorKind::Other,
+                    "Could not set message receiver.",
+                )
+            })?;
         Ok(())
     }
 
-    async fn max_message_size(&self) -> Option<u64> {
-        self.receiver.get().unwrap().lock().await.max_message_size()
+    async fn max_message_size(&self) -> Result<Option<u64>> {
+        Ok(self
+            .receiver
+            .get()
+            .ok_or_else(|| {
+                azure_core::Error::message(
+                    azure_core::error::ErrorKind::Other,
+                    "Message receiver is not set",
+                )
+            })?
+            .lock()
+            .await
+            .max_message_size())
     }
 
     #[tracing::instrument]
     async fn receive(&self) -> Result<AmqpMessage> {
-        let mut receiver = self.receiver.get().unwrap().lock().await;
+        let mut receiver = self
+            .receiver
+            .get()
+            .ok_or_else(|| {
+                azure_core::Error::message(
+                    azure_core::error::ErrorKind::Other,
+                    "Message receiver is not set.",
+                )
+            })?
+            .lock()
+            .await;
 
         let delivery: fe2o3_amqp::link::delivery::Delivery<
             fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/sender.rs
@@ -6,7 +6,7 @@ use crate::messaging::{AmqpMessage, AmqpTarget};
 use crate::sender::{AmqpSendOptions, AmqpSenderApis, AmqpSenderOptions};
 use crate::session::AmqpSession;
 use async_std::sync::Mutex;
-use azure_core::error::Result;
+use azure_core::Result;
 use std::borrow::BorrowMut;
 use std::sync::{Arc, OnceLock};
 
@@ -64,15 +64,31 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
         let sender = session_builder
             .name(name.into())
             .target(target.into())
-            .attach(session.implementation.get().lock().await.borrow_mut())
+            .attach(session.implementation.get()?.lock().await.borrow_mut())
             .await
             .map_err(AmqpSenderAttach::from)?;
-        self.sender.set(Arc::new(Mutex::new(sender))).unwrap();
+        self.sender.set(Arc::new(Mutex::new(sender))).map_err(|_| {
+            azure_core::Error::message(
+                azure_core::error::ErrorKind::Other,
+                "Could not set message sender.",
+            )
+        })?;
         Ok(())
     }
 
-    async fn max_message_size(&self) -> Option<u64> {
-        self.sender.get().unwrap().lock().await.max_message_size()
+    async fn max_message_size(&self) -> azure_core::Result<Option<u64>> {
+        Ok(self
+            .sender
+            .get()
+            .ok_or_else(|| {
+                azure_core::Error::message(
+                    azure_core::error::ErrorKind::Other,
+                    "Message Sender not set.",
+                )
+            })?
+            .lock()
+            .await
+            .max_message_size())
     }
 
     #[tracing::instrument]
@@ -100,7 +116,12 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
         let outcome = self
             .sender
             .get()
-            .unwrap()
+            .ok_or_else(|| {
+                azure_core::Error::message(
+                    azure_core::error::ErrorKind::Other,
+                    "Message Sender not set.",
+                )
+            })?
             .lock()
             .await
             .send(sendable)

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/session.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/session.rs
@@ -9,7 +9,7 @@ use crate::{
     session::{AmqpSessionApis, AmqpSessionOptions},
 };
 use async_std::sync::Mutex;
-use azure_core::Result;
+use azure_core::{error::ErrorKind, Error, Result};
 use std::{
     borrow::BorrowMut,
     sync::{Arc, OnceLock},
@@ -35,8 +35,17 @@ impl Fe2o3AmqpSession {
     }
 
     /// Returns a reference to the session handle
-    pub fn get(&self) -> Arc<Mutex<fe2o3_amqp::session::SessionHandle<()>>> {
-        self.session.get().unwrap().clone()
+    pub fn get(&self) -> Result<Arc<Mutex<fe2o3_amqp::session::SessionHandle<()>>>> {
+        Ok(self
+            .session
+            .get()
+            .ok_or_else(|| {
+                azure_core::Error::message(
+                    azure_core::error::ErrorKind::Other,
+                    "Session Handle was not set",
+                )
+            })?
+            .clone())
     }
 }
 
@@ -46,12 +55,22 @@ impl AmqpSessionApis for Fe2o3AmqpSession {
         connection: &AmqpConnection,
         options: Option<AmqpSessionOptions>,
     ) -> Result<()> {
-        let mut connection = connection.implementation.get().get().unwrap().lock().await;
+        let mut connection = connection
+            .implementation
+            .get()
+            .get()
+            .ok_or_else(|| {
+                azure_core::Error::new(
+                    azure_core::error::ErrorKind::Other,
+                    "Connection already set.",
+                )
+            })?
+            .lock()
+            .await;
 
         let mut session_builder = fe2o3_amqp::session::Session::builder();
-        if options.is_some() {
-            let options = options.unwrap();
 
+        if let Some(options) = options {
             if let Some(incoming_window) = options.incoming_window() {
                 session_builder = session_builder.incoming_window(incoming_window);
             }
@@ -78,12 +97,10 @@ impl AmqpSessionApis for Fe2o3AmqpSession {
             if let Some(properties) = options.properties() {
                 let mut fields = fe2o3_amqp::types::definitions::Fields::new();
                 for property in properties.iter() {
-                    debug!("Property: {:?}, Value: {:?}", property.0, property.1);
-                    let k: fe2o3_amqp_types::primitives::Symbol = property.0.into();
-                    let v: fe2o3_amqp_types::primitives::Value = property.1.into();
-                    debug!("Property: {:?}, Value: {:?}", k, v);
-
-                    fields.insert(k, v);
+                    fields.insert(
+                        fe2o3_amqp_types::primitives::Symbol::from(property.0),
+                        fe2o3_amqp_types::primitives::Value::from(property.1),
+                    );
                 }
                 session_builder = session_builder.properties(fields);
             }
@@ -95,14 +112,16 @@ impl AmqpSessionApis for Fe2o3AmqpSession {
             .begin(connection.borrow_mut())
             .await
             .map_err(AmqpBegin::from)?;
-        self.session.set(Arc::new(Mutex::new(session))).unwrap();
+        self.session
+            .set(Arc::new(Mutex::new(session)))
+            .map_err(|_| Error::message(ErrorKind::Other, "Could not set session instance."))?;
         Ok(())
     }
 
     async fn end(&self) -> Result<()> {
         self.session
             .get()
-            .unwrap()
+            .ok_or_else(|| Error::message(ErrorKind::Other, "Session Handle was not set"))?
             .lock()
             .await
             .end()

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/value.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/value.rs
@@ -47,7 +47,11 @@ impl From<fe2o3_amqp_types::primitives::Timestamp> for AmqpTimestamp {
 
 impl From<AmqpTimestamp> for fe2o3_amqp_types::primitives::Timestamp {
     fn from(timestamp: AmqpTimestamp) -> Self {
-        let t = timestamp.0.duration_since(UNIX_EPOCH).unwrap().as_millis();
+        let t = timestamp
+            .0
+            .duration_since(UNIX_EPOCH)
+            .expect("Could not convert timestamp to time since unix epoch")
+            .as_millis();
         fe2o3_amqp_types::primitives::Timestamp::from_milliseconds(t as i64)
     }
 }
@@ -325,7 +329,10 @@ impl PartialEq<AmqpValue> for fe2o3_amqp_types::primitives::Value {
             }
             AmqpValue::Char(c) => self == &fe2o3_amqp_types::primitives::Value::Char(*c),
             AmqpValue::TimeStamp(t) => {
-                let t: u64 = t.0.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+                let t: u64 =
+                    t.0.duration_since(UNIX_EPOCH)
+                        .expect("Could not convert timestamp into unix epoch")
+                        .as_millis() as u64;
                 self == &fe2o3_amqp_types::primitives::Value::Timestamp(
                     Timestamp::from_milliseconds(t as i64),
                 )

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/lib.rs
@@ -49,7 +49,7 @@ pub enum ReceiverSettleMode {
 pub trait Serializable {
     fn serialize(&self, buffer: &mut [u8]) -> azure_core::Result<()>;
 
-    fn encoded_size(&self) -> usize;
+    fn encoded_size(&self) -> azure_core::Result<usize>;
 }
 
 #[cfg(feature = "cplusplus")]

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/management.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/management.rs
@@ -51,9 +51,9 @@ impl AmqpManagement {
         session: AmqpSession,
         client_node_name: impl Into<String>,
         access_token: AccessToken,
-    ) -> Self {
-        Self {
-            implementation: ManagementImplementation::new(session, client_node_name, access_token),
-        }
+    ) -> Result<Self> {
+        Ok(Self {
+            implementation: ManagementImplementation::new(session, client_node_name, access_token)?,
+        })
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
@@ -894,6 +894,7 @@ impl From<AmqpMessageProperties> for AmqpList {
     }
 }
 
+#[allow(clippy::vec_init_then_push)]
 #[test]
 fn test_size_of_serialized_timestamp() {
     let timestamp = fe2o3_amqp_types::primitives::Timestamp::from_milliseconds(12345);
@@ -1546,13 +1547,13 @@ mod tests {
             .with_delivery_count(3)
             .build();
 
-        assert_eq!(header.durable, true);
+        assert!(header.durable);
         assert_eq!(header.priority, 5);
         assert_eq!(
             header.time_to_live,
             Some(std::time::Duration::from_millis(1000))
         );
-        assert_eq!(header.first_acquirer, false);
+        assert!(!header.first_acquirer);
         assert_eq!(header.delivery_count, 3);
     }
 
@@ -1561,7 +1562,7 @@ mod tests {
         {
             let c_serialized = vec![0x00, 0x53, 0x70, 0xc0, 0x04, 0x02, 0x40, 0x50, 0x05];
             let deserialized_from_c: fe2o3_amqp_types::messaging::Header =
-                serde_amqp::de::from_slice(&c_serialized.as_slice()).unwrap();
+                serde_amqp::de::from_slice(c_serialized.as_slice()).unwrap();
 
             let header = fe2o3_amqp_types::messaging::Header::builder()
                 .priority(Priority::from(5))
@@ -1570,7 +1571,7 @@ mod tests {
 
             assert_eq!(c_serialized, serialized);
             let deserialized: fe2o3_amqp_types::messaging::Header =
-                serde_amqp::de::from_slice(&serialized.as_slice()).unwrap();
+                serde_amqp::de::from_slice(serialized.as_slice()).unwrap();
 
             assert_eq!(c_serialized, serialized);
             assert_eq!(header, deserialized);

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
@@ -212,7 +212,9 @@ impl AmqpTarget {
 
 impl From<AmqpTarget> for String {
     fn from(target: AmqpTarget) -> String {
-        target.address.unwrap()
+        target
+            .address
+            .expect("Target does not have an address set.")
     }
 }
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/noop.rs
@@ -13,7 +13,7 @@ use super::{
     session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions},
     value::{AmqpOrderedMap, AmqpSymbol, AmqpValue},
 };
-use azure_core::{auth::AccessToken, error::Result};
+use azure_core::{credentials::AccessToken, error::Result};
 
 #[derive(Debug, Default)]
 pub(crate) struct NoopAmqpConnection {}
@@ -56,7 +56,7 @@ impl AmqpConnectionApis for NoopAmqpConnection {
         condition: impl Into<AmqpSymbol>,
         description: Option<String>,
         info: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-    ) -> impl Result<()> {
+    ) -> Result<()> {
         unimplemented!()
     }
 }
@@ -82,8 +82,8 @@ impl AmqpSessionApis for NoopAmqpSession {
 }
 
 impl NoopAmqpClaimsBasedSecurity {
-    pub fn new(session: AmqpSession) -> Self {
-        Self {}
+    pub fn new(session: AmqpSession) -> Result<Self> {
+        Ok(Self {})
     }
 }
 
@@ -102,8 +102,12 @@ impl AmqpClaimsBasedSecurityApis for NoopAmqpClaimsBasedSecurity {
 }
 
 impl NoopAmqpManagement {
-    pub fn new(session: AmqpSession, name: impl Into<String>, access_token: AccessToken) -> Self {
-        Self {}
+    pub fn new(
+        session: AmqpSession,
+        name: impl Into<String>,
+        access_token: AccessToken,
+    ) -> Result<Self> {
+        Ok(Self {})
     }
 }
 impl AmqpManagementApis for NoopAmqpManagement {
@@ -137,7 +141,7 @@ impl AmqpSenderApis for NoopAmqpSender {
         unimplemented!();
     }
 
-    async fn max_message_size(&self) -> Option<u64> {
+    async fn max_message_size(&self) -> Result<Option<u64>> {
         unimplemented!();
     }
 
@@ -166,7 +170,7 @@ impl AmqpReceiverApis for NoopAmqpReceiver {
         unimplemented!();
     }
 
-    async fn max_message_size(&self) -> Option<u64> {
+    async fn max_message_size(&self) -> Result<Option<u64>> {
         unimplemented!();
     }
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/receiver.rs
@@ -83,7 +83,7 @@ pub trait AmqpReceiverApis {
         source: impl Into<AmqpSource>,
         options: Option<AmqpReceiverOptions>,
     ) -> impl std::future::Future<Output = Result<()>>;
-    fn max_message_size(&self) -> impl std::future::Future<Output = Option<u64>>;
+    fn max_message_size(&self) -> impl std::future::Future<Output = Result<Option<u64>>>;
     fn receive(&self) -> impl std::future::Future<Output = Result<AmqpMessage>>;
 }
 
@@ -101,7 +101,7 @@ impl AmqpReceiverApis for AmqpReceiver {
     ) -> Result<()> {
         self.implementation.attach(session, source, options).await
     }
-    async fn max_message_size(&self) -> Option<u64> {
+    async fn max_message_size(&self) -> Result<Option<u64>> {
         self.implementation.max_message_size().await
     }
     async fn receive(&self) -> Result<AmqpMessage> {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/receiver.rs
@@ -257,7 +257,7 @@ mod tests {
             .with_auto_accept(true)
             .build();
 
-        assert_eq!(receiver_options.auto_accept, true);
+        assert!(receiver_options.auto_accept);
     }
 
     #[test]
@@ -297,6 +297,6 @@ mod tests {
             receiver_options.credit_mode.unwrap(),
             ReceiverCreditMode::Manual
         );
-        assert_eq!(receiver_options.auto_accept, false);
+        assert!(!receiver_options.auto_accept);
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/sender.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/sender.rs
@@ -40,7 +40,7 @@ pub trait AmqpSenderApis {
         target: impl Into<AmqpTarget>,
         options: Option<AmqpSenderOptions>,
     ) -> impl std::future::Future<Output = Result<()>>;
-    fn max_message_size(&self) -> impl std::future::Future<Output = Option<u64>>;
+    fn max_message_size(&self) -> impl std::future::Future<Output = Result<Option<u64>>>;
     fn send(
         &self,
         message: impl Into<AmqpMessage> + std::fmt::Debug,
@@ -65,7 +65,7 @@ impl AmqpSenderApis for AmqpSender {
             .attach(session, name, target, options)
             .await
     }
-    async fn max_message_size(&self) -> Option<u64> {
+    async fn max_message_size(&self) -> Result<Option<u64>> {
         self.implementation.max_message_size().await
     }
     async fn send(

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/value.rs
@@ -601,8 +601,7 @@ mod tests {
             let v: AmqpValue = AmqpValue::Null;
             assert_eq!(v, AmqpValue::Null);
             assert_eq!(AmqpValue::Null, v);
-            let b: () = v.into();
-            assert_eq!(b, ());
+            let _: () = v.into();
         }
 
         {
@@ -611,6 +610,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::approx_constant)]
     #[test]
     fn test_amqp_ordered_map() {
         let mut map = AmqpOrderedMap::new();
@@ -628,21 +628,21 @@ mod tests {
         assert_eq!(map.get("key1"), None);
     }
 
+    #[allow(clippy::approx_constant)]
     #[test]
     fn test_amqp_value() {
         // Test AmqpValue::Null
         let null_value: AmqpValue = AmqpValue::Null;
         assert_eq!(null_value, AmqpValue::Null);
         assert_eq!(AmqpValue::Null, null_value);
-        let null_unit: () = null_value.into();
-        assert_eq!(null_unit, ());
+        let _: () = null_value.into();
 
         // Test AmqpValue::Boolean
         let bool_value: AmqpValue = AmqpValue::Boolean(true);
         assert_eq!(bool_value, AmqpValue::Boolean(true));
         assert_eq!(AmqpValue::Boolean(true), bool_value);
         let bool_val: bool = bool_value.into();
-        assert_eq!(bool_val, true);
+        assert!(bool_val);
 
         // Test AmqpValue::UByte
         let ubyte_value: AmqpValue = AmqpValue::UByte(255);

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/value.rs
@@ -3,6 +3,13 @@
 // cspell: words amqp
 
 use crate::Uuid;
+
+#[cfg(all(
+    feature = "cplusplus",
+    feature = "fe2o3-amqp",
+    not(target_arch = "wasm32")
+))]
+use crate::fe2o3::error::AmqpSerialization;
 #[cfg(feature = "cplusplus")]
 use crate::{Deserializable, Serializable};
 #[cfg(feature = "cplusplus")]
@@ -186,11 +193,11 @@ pub enum AmqpValue {
 
 #[cfg(feature = "cplusplus")]
 impl Serializable for AmqpValue {
-    fn encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> Result<usize> {
         #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]
         {
             let fe2o3_value = fe2o3_amqp_types::primitives::Value::from(self.clone());
-            serde_amqp::serialized_size(&fe2o3_value).unwrap()
+            Ok(serde_amqp::serialized_size(&fe2o3_value).map_err(AmqpSerialization::from)?)
         }
         #[cfg(any(not(feature = "fe2o3-amqp"), target_arch = "wasm32"))]
         {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/build.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/build.rs
@@ -19,7 +19,7 @@ fn main() {
     config.structure = struct_config;
     config.language = Language::Cxx;
     config.namespaces = Some(
-        vec!["Azure", "Core", "Amqp", "_detail", "RustInterop"]
+        ["Azure", "Core", "Amqp", "_detail", "RustInterop"]
             .iter()
             .map(|x| x.to_string())
             .collect(),

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/connection.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/connection.rs
@@ -6,7 +6,7 @@ use core::panic;
 use std::{
     ffi::{c_char, CStr},
     mem,
-    ptr::{self, null},
+    ptr::{self},
 };
 use time::Duration;
 
@@ -54,15 +54,23 @@ pub extern "C" fn amqpconnection_create() -> *mut RustAmqpConnection {
     }))
 }
 
+/// # Safety
+/// This function is unsafe because it dereferences the `connection` pointer.
+/// The caller must guarantee that the pointer is valid.
+///
 #[no_mangle]
-pub extern "C" fn amqpconnection_destroy(connection: *mut RustAmqpConnection) {
+pub unsafe extern "C" fn amqpconnection_destroy(connection: *mut RustAmqpConnection) {
     unsafe {
         mem::drop(Box::from_raw(connection));
     }
 }
 
+/// # Safety
+/// This function is unsafe because it dereferences the `connection` pointer.
+/// The caller must guarantee that the pointer is valid.
+///
 #[no_mangle]
-pub extern "C" fn amqpconnection_open(
+pub unsafe extern "C" fn amqpconnection_open(
     ctx: *mut RustCallContext,
     connection: *const RustAmqpConnection,
     url: *const c_char,
@@ -77,7 +85,7 @@ pub extern "C" fn amqpconnection_open(
     let default_options: RustAmqpConnectionOptions = RustAmqpConnectionOptions {
         inner: Default::default(),
     };
-    let options = if options != null() {
+    let options = if options.is_null() {
         unsafe { &*options }
     } else {
         &default_options
@@ -117,8 +125,12 @@ pub extern "C" fn amqpconnection_open(
     }
 }
 
+/// # Safety
+/// This function is unsafe because it dereferences the `connection` pointer.
+/// The caller must guarantee that the pointer is valid.
+///
 #[no_mangle]
-pub extern "C" fn amqpconnection_close(
+pub unsafe extern "C" fn amqpconnection_close(
     ctx: *mut RustCallContext,
     connection: *const RustAmqpConnection,
 ) -> u32 {
@@ -138,8 +150,10 @@ pub extern "C" fn amqpconnection_close(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnection_close_with_error(
+pub unsafe extern "C" fn amqpconnection_close_with_error(
     ctx: *mut RustCallContext,
     connection: *const RustAmqpConnection,
     condition: *const c_char,
@@ -187,8 +201,10 @@ pub extern "C" fn amqpconnection_close_with_error(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptions_get_idle_timeout(
+pub unsafe extern "C" fn amqpconnectionoptions_get_idle_timeout(
     options: *const RustAmqpConnectionOptions,
 ) -> u32 {
     let options = unsafe { &*options };
@@ -198,8 +214,10 @@ pub extern "C" fn amqpconnectionoptions_get_idle_timeout(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptions_get_max_frame_size(
+pub unsafe extern "C" fn amqpconnectionoptions_get_max_frame_size(
     options: *const RustAmqpConnectionOptions,
 ) -> u32 {
     let options = unsafe { &*options };
@@ -209,8 +227,10 @@ pub extern "C" fn amqpconnectionoptions_get_max_frame_size(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptions_get_channel_max(
+pub unsafe extern "C" fn amqpconnectionoptions_get_channel_max(
     options: *const RustAmqpConnectionOptions,
 ) -> u16 {
     let options = unsafe { &*options };
@@ -220,8 +240,10 @@ pub extern "C" fn amqpconnectionoptions_get_channel_max(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptions_get_properties(
+pub unsafe extern "C" fn amqpconnectionoptions_get_properties(
     options: *const RustAmqpConnectionOptions,
 ) -> *mut RustAmqpValue {
     let options = unsafe { &*options };
@@ -239,16 +261,21 @@ pub extern "C" fn amqpconnectionoptions_get_properties(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_create() -> *mut RustAmqpConnectionOptionsBuilder {
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_create(
+) -> *mut RustAmqpConnectionOptionsBuilder {
     let builder = AmqpConnectionOptions::builder();
     Box::into_raw(Box::new(RustAmqpConnectionOptionsBuilder {
         inner: builder,
     }))
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_destroy(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_destroy(
     builder: *mut RustAmqpConnectionOptionsBuilder,
 ) {
     unsafe {
@@ -256,24 +283,29 @@ pub extern "C" fn amqpconnectionoptionsbuilder_destroy(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_build(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_build(
     builder: *mut RustAmqpConnectionOptionsBuilder,
 ) -> *mut RustAmqpConnectionOptions {
     let builder = unsafe { &mut *builder };
     let options = builder.inner.build();
     Box::into_raw(Box::new(RustAmqpConnectionOptions { inner: options }))
 }
-
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptions_destroy(options: *mut RustAmqpConnectionOptions) {
+pub unsafe extern "C" fn amqpconnectionoptions_destroy(options: *mut RustAmqpConnectionOptions) {
     unsafe {
         mem::drop(Box::from_raw(options));
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_set_idle_timeout(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_idle_timeout(
     builder: *mut RustAmqpConnectionOptionsBuilder,
     idle_timeout: u32,
 ) -> u32 {
@@ -284,8 +316,10 @@ pub extern "C" fn amqpconnectionoptionsbuilder_set_idle_timeout(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_set_max_frame_size(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_max_frame_size(
     builder: *mut RustAmqpConnectionOptionsBuilder,
     max_frame_size: u32,
 ) -> u32 {
@@ -294,8 +328,10 @@ pub extern "C" fn amqpconnectionoptionsbuilder_set_max_frame_size(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_set_channel_max(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_channel_max(
     builder: *mut RustAmqpConnectionOptionsBuilder,
     channel_max: u16,
 ) -> u32 {
@@ -304,8 +340,10 @@ pub extern "C" fn amqpconnectionoptionsbuilder_set_channel_max(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_set_outgoing_locales(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_outgoing_locales(
     builder: *mut RustAmqpConnectionOptionsBuilder,
     locales: *const *const c_char,
     count: usize,
@@ -322,8 +360,10 @@ pub extern "C" fn amqpconnectionoptionsbuilder_set_outgoing_locales(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_set_incoming_locales(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_incoming_locales(
     builder: *mut RustAmqpConnectionOptionsBuilder,
     locales: *const *const c_char,
     count: usize,
@@ -340,8 +380,10 @@ pub extern "C" fn amqpconnectionoptionsbuilder_set_incoming_locales(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_set_offered_capabilities(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_offered_capabilities(
     builder: *mut RustAmqpConnectionOptionsBuilder,
     capabilities: *const *const c_char,
     count: usize,
@@ -358,8 +400,10 @@ pub extern "C" fn amqpconnectionoptionsbuilder_set_offered_capabilities(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_set_desired_capabilities(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_desired_capabilities(
     builder: *mut RustAmqpConnectionOptionsBuilder,
     capabilities: *const *const c_char,
     count: usize,
@@ -376,8 +420,10 @@ pub extern "C" fn amqpconnectionoptionsbuilder_set_desired_capabilities(
     0
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_set_properties(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_properties(
     builder: *mut RustAmqpConnectionOptionsBuilder,
     properties: *const RustAmqpValue,
 ) -> u32 {
@@ -405,8 +451,10 @@ pub extern "C" fn amqpconnectionoptionsbuilder_set_properties(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpconnectionoptionsbuilder_set_buffer_size(
+pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_buffer_size(
     builder: *mut RustAmqpConnectionOptionsBuilder,
     buffer_size: usize,
 ) -> u32 {
@@ -435,7 +483,9 @@ mod tests {
     fn test_amqpconnection_create_and_destroy() {
         let connection = amqpconnection_create();
         assert!(!connection.is_null());
-        amqpconnection_destroy(connection);
+        unsafe {
+            amqpconnection_destroy(connection);
+        }
     }
 
     #[test]
@@ -447,127 +497,149 @@ mod tests {
         let container_id = CString::new("test_container").unwrap();
         let options = ptr::null();
 
-        let open_result = amqpconnection_open(
-            ctx,
-            connection,
-            url.as_ptr(),
-            container_id.as_ptr(),
-            options,
-        );
+        let open_result = unsafe {
+            amqpconnection_open(
+                ctx,
+                connection,
+                url.as_ptr(),
+                container_id.as_ptr(),
+                options,
+            )
+        };
         assert_eq!(open_result, 0);
 
-        let close_result = amqpconnection_close(ctx, connection);
+        let close_result = unsafe { amqpconnection_close(ctx, connection) };
         assert_eq!(close_result, 0);
 
-        amqpconnection_destroy(connection);
+        unsafe {
+            amqpconnection_destroy(connection);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_create_and_destroy() {
-        let builder = amqpconnectionoptionsbuilder_create();
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
         assert!(!builder.is_null());
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe {
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_idle_timeout() {
-        let builder = amqpconnectionoptionsbuilder_create();
-        let result = amqpconnectionoptionsbuilder_set_idle_timeout(builder, 30);
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
+        let result = unsafe { amqpconnectionoptionsbuilder_set_idle_timeout(builder, 30) };
         assert_eq!(result, 0);
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe {
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_max_frame_size() {
-        let builder = amqpconnectionoptionsbuilder_create();
-        let result = amqpconnectionoptionsbuilder_set_max_frame_size(builder, 65536);
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
+        let result = unsafe { amqpconnectionoptionsbuilder_set_max_frame_size(builder, 65536) };
         assert_eq!(result, 0);
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe {
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_channel_max() {
-        let builder = amqpconnectionoptionsbuilder_create();
-        let result = amqpconnectionoptionsbuilder_set_channel_max(builder, 256);
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
+        let result = unsafe { amqpconnectionoptionsbuilder_set_channel_max(builder, 256) };
         assert_eq!(result, 0);
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe {
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_outgoing_locales() {
-        let builder = amqpconnectionoptionsbuilder_create();
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
         let locales = vec![
             CString::new("en-US").unwrap(),
             CString::new("fr-FR").unwrap(),
         ];
         let locale_ptrs: Vec<*const c_char> =
             locales.iter().map(|locale| locale.as_ptr()).collect();
-        let result = amqpconnectionoptionsbuilder_set_outgoing_locales(
-            builder,
-            locale_ptrs.as_ptr(),
-            locale_ptrs.len(),
-        );
+        let result = unsafe {
+            amqpconnectionoptionsbuilder_set_outgoing_locales(
+                builder,
+                locale_ptrs.as_ptr(),
+                locale_ptrs.len(),
+            )
+        };
         assert_eq!(result, 0);
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe {
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_incoming_locales() {
-        let builder = amqpconnectionoptionsbuilder_create();
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
         let locales = vec![
             CString::new("en-US").unwrap(),
             CString::new("fr-FR").unwrap(),
         ];
         let locale_ptrs: Vec<*const c_char> =
             locales.iter().map(|locale| locale.as_ptr()).collect();
-        let result = amqpconnectionoptionsbuilder_set_incoming_locales(
-            builder,
-            locale_ptrs.as_ptr(),
-            locale_ptrs.len(),
-        );
+        let result = unsafe {
+            amqpconnectionoptionsbuilder_set_incoming_locales(
+                builder,
+                locale_ptrs.as_ptr(),
+                locale_ptrs.len(),
+            )
+        };
         assert_eq!(result, 0);
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_offered_capabilities() {
-        let builder = amqpconnectionoptionsbuilder_create();
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
         let capabilities = vec![
             CString::new("capability1").unwrap(),
             CString::new("capability2").unwrap(),
         ];
         let capability_ptrs: Vec<*const c_char> =
             capabilities.iter().map(|cap| cap.as_ptr()).collect();
-        let result = amqpconnectionoptionsbuilder_set_offered_capabilities(
-            builder,
-            capability_ptrs.as_ptr(),
-            capability_ptrs.len(),
-        );
+        let result = unsafe {
+            amqpconnectionoptionsbuilder_set_offered_capabilities(
+                builder,
+                capability_ptrs.as_ptr(),
+                capability_ptrs.len(),
+            )
+        };
         assert_eq!(result, 0);
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_desired_capabilities() {
-        let builder = amqpconnectionoptionsbuilder_create();
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
         let capabilities = vec![
             CString::new("capability1").unwrap(),
             CString::new("capability2").unwrap(),
         ];
         let capability_ptrs: Vec<*const c_char> =
             capabilities.iter().map(|cap| cap.as_ptr()).collect();
-        let result = amqpconnectionoptionsbuilder_set_desired_capabilities(
-            builder,
-            capability_ptrs.as_ptr(),
-            capability_ptrs.len(),
-        );
+        let result = unsafe {
+            amqpconnectionoptionsbuilder_set_desired_capabilities(
+                builder,
+                capability_ptrs.as_ptr(),
+                capability_ptrs.len(),
+            )
+        };
         assert_eq!(result, 0);
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_properties() {
-        let builder = amqpconnectionoptionsbuilder_create();
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
         let mut map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = AmqpOrderedMap::new();
         map.insert(AmqpSymbol::from("key1"), AmqpValue::from("value1"));
         map.insert(AmqpSymbol::from("key2"), AmqpValue::from("value2"));
@@ -576,19 +648,21 @@ mod tests {
             inner: AmqpValue::Map(map.into_iter().map(|f| (f.0.into(), f.1)).collect()),
         };
 
-        let result = amqpconnectionoptionsbuilder_set_properties(
-            builder,
-            &rust_value as *const RustAmqpValue,
-        );
+        let result = unsafe {
+            amqpconnectionoptionsbuilder_set_properties(
+                builder,
+                &rust_value as *const RustAmqpValue,
+            )
+        };
         assert_eq!(result, 0);
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_buffer_size() {
-        let builder = amqpconnectionoptionsbuilder_create();
-        let result = amqpconnectionoptionsbuilder_set_buffer_size(builder, 1024);
+        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
+        let result = unsafe { amqpconnectionoptionsbuilder_set_buffer_size(builder, 1024) };
         assert_eq!(result, 0);
-        amqpconnectionoptionsbuilder_destroy(builder);
+        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/session.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/session.rs
@@ -28,22 +28,28 @@ pub struct RustAmqpSessionOptions {
     inner: AmqpSessionOptions,
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsession_create() -> *mut RustAmqpSession {
+pub unsafe extern "C" fn amqpsession_create() -> *mut RustAmqpSession {
     Box::into_raw(Box::new(RustAmqpSession {
         inner: AmqpSession::new(),
     }))
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsession_destroy(session: *mut RustAmqpSession) {
+pub unsafe extern "C" fn amqpsession_destroy(session: *mut RustAmqpSession) {
     unsafe {
         mem::drop(Box::from_raw(session));
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsession_begin(
+pub unsafe extern "C" fn amqpsession_begin(
     call_context: *mut RustCallContext,
     session: *mut RustAmqpSession,
     connection: *mut RustAmqpConnection,
@@ -86,8 +92,10 @@ pub extern "C" fn amqpsession_begin(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsession_end(
+pub unsafe extern "C" fn amqpsession_end(
     call_context: *mut RustCallContext,
     session: *mut RustAmqpSession,
 ) -> u32 {
@@ -107,22 +115,28 @@ pub extern "C" fn amqpsession_end(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptions_destroy(session_options: *mut RustAmqpSessionOptions) {
+pub unsafe extern "C" fn amqpsessionoptions_destroy(session_options: *mut RustAmqpSessionOptions) {
     unsafe {
         mem::drop(Box::from_raw(session_options));
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_create() -> *mut RustAmqpSessionOptionsBuilder {
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_create() -> *mut RustAmqpSessionOptionsBuilder {
     Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
         inner: AmqpSessionOptions::builder(),
     }))
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_destroy(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_destroy(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
 ) {
     unsafe {
@@ -130,8 +144,10 @@ pub extern "C" fn amqpsessionoptionsbuilder_destroy(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_set_outgoing_window(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_outgoing_window(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     outgoing_window: u32,
 ) {
@@ -141,8 +157,10 @@ pub extern "C" fn amqpsessionoptionsbuilder_set_outgoing_window(
         .with_outgoing_window(outgoing_window);
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_set_incoming_window(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_incoming_window(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     incoming_window: u32,
 ) {
@@ -152,8 +170,10 @@ pub extern "C" fn amqpsessionoptionsbuilder_set_incoming_window(
         .with_incoming_window(incoming_window);
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_set_next_outgoing_id(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_next_outgoing_id(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     next_outgoing_id: u32,
 ) {
@@ -163,16 +183,21 @@ pub extern "C" fn amqpsessionoptionsbuilder_set_next_outgoing_id(
         .with_next_outgoing_id(next_outgoing_id);
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_set_handle_max(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_handle_max(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     handle_max: u32,
 ) {
     let session_options_builder = unsafe { &mut *session_options_builder };
     session_options_builder.inner.with_handle_max(handle_max);
 }
+
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_set_offered_capabilities(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_offered_capabilities(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     offered_capabilities: *mut RustAmqpValue,
 ) {
@@ -188,8 +213,11 @@ pub extern "C" fn amqpsessionoptionsbuilder_set_offered_capabilities(
             .with_offered_capabilities(offered_capabilities);
     }
 }
+
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_set_desired_capabilities(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_desired_capabilities(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     desired_capabilities: *mut RustAmqpValue,
 ) {
@@ -206,8 +234,10 @@ pub extern "C" fn amqpsessionoptionsbuilder_set_desired_capabilities(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_set_properties(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_properties(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     properties: *mut RustAmqpValue,
 ) {
@@ -216,7 +246,7 @@ pub extern "C" fn amqpsessionoptionsbuilder_set_properties(
     if let AmqpValue::Map(properties) = &properties.inner {
         let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
             .iter()
-            .map(|(k, v)| (AmqpSymbol::from(k), AmqpValue::from(v)))
+            .map(|(k, v)| (AmqpSymbol::from(k), v))
             .collect();
         session_options_builder
             .inner
@@ -224,8 +254,10 @@ pub extern "C" fn amqpsessionoptionsbuilder_set_properties(
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_set_buffer_size(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_buffer_size(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     buffer_size: usize,
 ) {
@@ -233,8 +265,10 @@ pub extern "C" fn amqpsessionoptionsbuilder_set_buffer_size(
     session_options_builder.inner.with_buffer_size(buffer_size);
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn amqpsessionoptionsbuilder_build(
+pub unsafe extern "C" fn amqpsessionoptionsbuilder_build(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
 ) -> *mut RustAmqpSessionOptions {
     let session_options_builder = unsafe { &mut *session_options_builder };
@@ -255,77 +289,81 @@ mod tests {
 
     #[test]
     fn test_amqpsession_create() {
-        let session = amqpsession_create();
+        let session = unsafe { amqpsession_create() };
         assert_ne!(session, std::ptr::null_mut());
-        amqpsession_destroy(session);
+        unsafe { amqpsession_destroy(session) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_create() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
         assert_ne!(session_options_builder, std::ptr::null_mut());
-        amqpsessionoptionsbuilder_destroy(session_options_builder);
+        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_outgoing_window() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
-        amqpsessionoptionsbuilder_set_outgoing_window(session_options_builder, 10);
-        amqpsessionoptionsbuilder_destroy(session_options_builder);
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
+        unsafe { amqpsessionoptionsbuilder_set_outgoing_window(session_options_builder, 10) };
+        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_incoming_window() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
-        amqpsessionoptionsbuilder_set_incoming_window(session_options_builder, 10);
-        amqpsessionoptionsbuilder_destroy(session_options_builder);
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
+        unsafe { amqpsessionoptionsbuilder_set_incoming_window(session_options_builder, 10) };
+        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_next_outgoing_id() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
-        amqpsessionoptionsbuilder_set_next_outgoing_id(session_options_builder, 10);
-        amqpsessionoptionsbuilder_destroy(session_options_builder);
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
+        unsafe { amqpsessionoptionsbuilder_set_next_outgoing_id(session_options_builder, 10) };
+        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_handle_max() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
-        amqpsessionoptionsbuilder_set_handle_max(session_options_builder, 10);
-        amqpsessionoptionsbuilder_destroy(session_options_builder);
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
+        unsafe { amqpsessionoptionsbuilder_set_handle_max(session_options_builder, 10) };
+        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_offered_capabilities() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
         let offered_capabilities = RustAmqpValue {
             inner: AmqpValue::List(AmqpList::from(vec![AmqpValue::Symbol(AmqpSymbol::from(
                 "test",
             ))])),
         };
-        amqpsessionoptionsbuilder_set_offered_capabilities(
-            session_options_builder,
-            &offered_capabilities as *const RustAmqpValue as *mut RustAmqpValue,
-        );
-        amqpsessionoptionsbuilder_destroy(session_options_builder);
+        unsafe {
+            amqpsessionoptionsbuilder_set_offered_capabilities(
+                session_options_builder,
+                &offered_capabilities as *const RustAmqpValue as *mut RustAmqpValue,
+            )
+        };
+        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_desired_capabilities() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
         let desired_capabilities = RustAmqpValue {
             inner: AmqpValue::List(vec![AmqpValue::Symbol(AmqpSymbol::from("test"))].into()),
         };
-        amqpsessionoptionsbuilder_set_desired_capabilities(
-            session_options_builder,
-            &desired_capabilities as *const RustAmqpValue as *mut RustAmqpValue,
-        );
-        amqpsessionoptionsbuilder_destroy(session_options_builder);
+        unsafe {
+            amqpsessionoptionsbuilder_set_desired_capabilities(
+                session_options_builder,
+                &desired_capabilities as *const RustAmqpValue as *mut RustAmqpValue,
+            )
+        };
+        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_properties() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
         let properties = RustAmqpValue {
             inner: AmqpValue::Map(
                 vec![(
@@ -336,33 +374,35 @@ mod tests {
                 .collect(),
             ),
         };
-        amqpsessionoptionsbuilder_set_properties(
-            session_options_builder,
-            &properties as *const RustAmqpValue as *mut RustAmqpValue,
-        );
-        amqpsessionoptionsbuilder_destroy(session_options_builder);
+        unsafe {
+            amqpsessionoptionsbuilder_set_properties(
+                session_options_builder,
+                &properties as *const RustAmqpValue as *mut RustAmqpValue,
+            )
+        };
+        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_buffer_size() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
-        amqpsessionoptionsbuilder_set_buffer_size(session_options_builder, 1024);
-        amqpsessionoptionsbuilder_destroy(session_options_builder);
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
+        unsafe { amqpsessionoptionsbuilder_set_buffer_size(session_options_builder, 1024) };
+        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_build() {
-        let session_options_builder = amqpsessionoptionsbuilder_create();
-        let session_options = amqpsessionoptionsbuilder_build(session_options_builder);
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
+        let session_options = unsafe { amqpsessionoptionsbuilder_build(session_options_builder) };
         assert_ne!(session_options, std::ptr::null_mut());
-        amqpsessionoptions_destroy(session_options);
+        unsafe { amqpsessionoptions_destroy(session_options) };
     }
 
     #[test]
     fn test_amqpsession_begin() {
         let runtime_context = Box::into_raw(Box::new(RuntimeContext::new().unwrap()));
         let call_context = Box::into_raw(Box::new(RustCallContext::new(runtime_context)));
-        let session = amqpsession_create();
+        let session = unsafe { amqpsession_create() };
         let connection = AmqpConnection::new();
 
         call_context_from_ptr_mut(call_context)
@@ -376,7 +416,8 @@ mod tests {
             .unwrap();
 
         let connection = Box::into_raw(Box::new(RustAmqpConnection::new(connection)));
-        let result = amqpsession_begin(call_context, session, connection, std::ptr::null_mut());
+        let result =
+            unsafe { amqpsession_begin(call_context, session, connection, std::ptr::null_mut()) };
         assert_eq!(result, 0);
         unsafe {
             drop(Box::from_raw(connection));
@@ -389,7 +430,7 @@ mod tests {
     fn test_amqpsession_begin_with_options() {
         let runtime_context = Box::into_raw(Box::new(RuntimeContext::new().unwrap()));
         let call_context = Box::into_raw(Box::new(RustCallContext::new(runtime_context)));
-        let session = amqpsession_create();
+        let session = unsafe { amqpsession_create() };
         let connection = AmqpConnection::new();
 
         call_context_from_ptr_mut(call_context)
@@ -404,15 +445,16 @@ mod tests {
 
         let connection = Box::into_raw(Box::new(RustAmqpConnection::new(connection)));
 
-        let session_options_builder = amqpsessionoptionsbuilder_create();
-        let session_options = amqpsessionoptionsbuilder_build(session_options_builder);
-        let result = amqpsession_begin(call_context, session, connection, session_options);
+        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
+        let session_options = unsafe { amqpsessionoptionsbuilder_build(session_options_builder) };
+        let result =
+            unsafe { amqpsession_begin(call_context, session, connection, session_options) };
         assert_eq!(result, 0);
-        amqpsession_destroy(session);
+        unsafe { amqpsession_destroy(session) };
         unsafe {
             drop(Box::from_raw(connection));
             drop(Box::from_raw(runtime_context));
         }
-        amqpsessionoptions_destroy(session_options);
+        unsafe { amqpsessionoptions_destroy(session_options) };
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/call_context.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/call_context.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corp. All Rights Reserved
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// cspell: words reqwest repr tokio
+
+use crate::{runtime_context::RuntimeContext, rust_error::RustError};
+
+pub struct RustCallContext {
+    runtime_context: *mut RuntimeContext,
+    error: Option<RustError>,
+}
+
+impl RustCallContext {
+    pub fn new(runtime_context: *mut RuntimeContext) -> Self {
+        Self {
+            runtime_context,
+            error: None,
+        }
+    }
+
+    pub fn runtime_context(&self) -> &RuntimeContext {
+        unsafe { &*self.runtime_context }
+    }
+
+    pub fn set_error(&mut self, error: Box<dyn std::error::Error + Send + Sync>) {
+        self.error = Some(RustError::new(error));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call_context_new(runtime_context: *mut RuntimeContext) -> *mut RustCallContext {
+    Box::into_raw(Box::new(RustCallContext::new(runtime_context)))
+}
+
+#[no_mangle]
+pub extern "C" fn call_context_delete(ctx: *mut RustCallContext) {
+    unsafe {
+        drop(Box::from_raw(ctx));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call_context_get_error(ctx: *const RustCallContext) -> *mut RustError {
+    let ctx = unsafe { &*ctx };
+    match &ctx.error {
+        Some(err) => Box::into_raw(Box::new(err)).cast(),
+        None => std::ptr::null::<RustError>().cast_mut(),
+    }
+}
+
+pub(crate) fn call_context_from_ptr_mut<'a>(ctx: *mut RustCallContext) -> &'a mut RustCallContext {
+    unsafe { &mut *ctx }
+}
+
+#[test]
+fn test_call_context_get_error() {
+    let runtime_context = Box::into_raw(Box::new(RuntimeContext::new().unwrap()));
+    assert_ne!(runtime_context, std::ptr::null_mut());
+    let call_context = Box::into_raw(Box::new(RustCallContext::new(runtime_context)));
+    let error = call_context_get_error(call_context);
+    assert_eq!(error, std::ptr::null_mut());
+    unsafe {
+        drop(Box::from_raw(call_context));
+        drop(Box::from_raw(runtime_context));
+    }
+}
+
+#[test]
+fn test_call_context_set_error() {
+    let ctx = Box::into_raw(Box::new(RuntimeContext::new().unwrap()));
+    let mut call_context = RustCallContext::new(ctx);
+    call_context.set_error(Box::new(azure_core::Error::new(
+        azure_core::error::ErrorKind::Other,
+        "test",
+    )));
+    let error = call_context_get_error(&call_context);
+    assert_ne!(error, std::ptr::null_mut());
+}

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/call_context.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/call_context.rs
@@ -32,15 +32,19 @@ pub extern "C" fn call_context_new(runtime_context: *mut RuntimeContext) -> *mut
     Box::into_raw(Box::new(RustCallContext::new(runtime_context)))
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn call_context_delete(ctx: *mut RustCallContext) {
+pub unsafe extern "C" fn call_context_delete(ctx: *mut RustCallContext) {
     unsafe {
         drop(Box::from_raw(ctx));
     }
 }
 
+/// # Safety
+///
 #[no_mangle]
-pub extern "C" fn call_context_get_error(ctx: *const RustCallContext) -> *mut RustError {
+pub unsafe extern "C" fn call_context_get_error(ctx: *const RustCallContext) -> *mut RustError {
     let ctx = unsafe { &*ctx };
     match &ctx.error {
         Some(err) => Box::into_raw(Box::new(err)).cast(),
@@ -57,7 +61,7 @@ fn test_call_context_get_error() {
     let runtime_context = Box::into_raw(Box::new(RuntimeContext::new().unwrap()));
     assert_ne!(runtime_context, std::ptr::null_mut());
     let call_context = Box::into_raw(Box::new(RustCallContext::new(runtime_context)));
-    let error = call_context_get_error(call_context);
+    let error = unsafe { call_context_get_error(call_context) };
     assert_eq!(error, std::ptr::null_mut());
     unsafe {
         drop(Box::from_raw(call_context));
@@ -73,6 +77,6 @@ fn test_call_context_set_error() {
         azure_core::error::ErrorKind::Other,
         "test",
     )));
-    let error = call_context_get_error(&call_context);
+    let error = unsafe { call_context_get_error(&call_context) };
     assert_ne!(error, std::ptr::null_mut());
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/lib.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 pub mod amqp;
+pub mod call_context;
 pub mod model;
 pub mod runtime_context;
 pub mod rust_error;

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/header.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/header.rs
@@ -216,11 +216,14 @@ mod tests {
 
         let mut size: usize = 0;
         assert_eq!(
-            amqpvalue_get_encoded_size(value.clone(), &mut size as *mut usize),
+            unsafe { amqpvalue_get_encoded_size(value.clone(), &mut size as *mut usize) },
             0
         );
         let mut buffer: Vec<u8> = vec![0; size];
-        assert_eq!(amqpvalue_encode(value, buffer.as_mut_ptr(), size), 0);
+        assert_eq!(
+            unsafe { amqpvalue_encode(value, buffer.as_mut_ptr(), size) },
+            0
+        );
 
         let deserialized = <AmqpValue as Deserializable<AmqpValue>>::decode(buffer.as_slice());
         assert!(deserialized.is_ok());

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/message.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/message.rs
@@ -212,7 +212,7 @@ extern "C" fn message_set_delivery_annotations(
             .iter()
             .map(|f| match f.0 {
                 AmqpValue::Symbol(s) => (AmqpAnnotationKey::Symbol(s.clone()), f.1.clone()),
-                AmqpValue::ULong(u) => (AmqpAnnotationKey::Ulong(u.clone()), f.1.clone()),
+                AmqpValue::ULong(u) => (AmqpAnnotationKey::Ulong(u), f.1.clone()),
                 _ => panic!("Invalid message annotation key type"),
             })
             .collect();
@@ -236,7 +236,7 @@ extern "C" fn message_set_message_annotations(
             .iter()
             .map(|f| match f.0 {
                 AmqpValue::Symbol(s) => (AmqpAnnotationKey::Symbol(s.clone()), f.1.clone()),
-                AmqpValue::ULong(u) => (AmqpAnnotationKey::Ulong(u.clone()), f.1.clone()),
+                AmqpValue::ULong(u) => (AmqpAnnotationKey::Ulong(u), f.1.clone()),
                 _ => panic!("Invalid message annotation key type"),
             })
             .collect();
@@ -288,7 +288,7 @@ extern "C" fn message_set_footer(
             .iter()
             .map(|f| match f.0 {
                 AmqpValue::Symbol(s) => (AmqpAnnotationKey::Symbol(s.clone()), f.1.clone()),
-                AmqpValue::ULong(u) => (AmqpAnnotationKey::Ulong(u.clone()), f.1.clone()),
+                AmqpValue::ULong(u) => (AmqpAnnotationKey::Ulong(u), f.1.clone()),
                 _ => panic!("Invalid message annotation key type"),
             })
             .collect();

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/properties.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/properties.rs
@@ -268,7 +268,7 @@ extern "C" fn properties_set_message_id(
     builder.inner.with_message_id(match &message_id.inner {
         AmqpValue::Binary(id) => AmqpMessageId::Binary(id.clone()),
         AmqpValue::String(id) => AmqpMessageId::String(id.clone()),
-        AmqpValue::Uuid(id) => AmqpMessageId::Uuid(id.clone()),
+        AmqpValue::Uuid(id) => AmqpMessageId::Uuid(*id),
         AmqpValue::ULong(id) => AmqpMessageId::Ulong(*id),
         _ => return -1,
     });
@@ -287,7 +287,7 @@ extern "C" fn properties_set_correlation_id(
         .with_correlation_id(match &correlation_id.inner {
             AmqpValue::Binary(id) => AmqpMessageId::Binary(id.clone()),
             AmqpValue::String(id) => AmqpMessageId::String(id.clone()),
-            AmqpValue::Uuid(id) => AmqpMessageId::Uuid(id.clone()),
+            AmqpValue::Uuid(id) => AmqpMessageId::Uuid(*id),
             AmqpValue::ULong(id) => AmqpMessageId::Ulong(*id),
             _ => return -1,
         });

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/source.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/source.rs
@@ -263,7 +263,7 @@ extern "C" fn source_get_outcomes(
         let list: Vec<AmqpValue> = source_outcomes
             .clone()
             .into_iter()
-            .map(|f| AmqpValue::from(f))
+            .map(AmqpValue::from)
             .collect();
         *outcomes = Box::into_raw(Box::new(RustAmqpValue {
             inner: AmqpValue::Array(list),
@@ -285,7 +285,7 @@ extern "C" fn source_get_capabilities(
         let list: Vec<AmqpValue> = source_capabilities
             .clone()
             .into_iter()
-            .map(|f| AmqpValue::from(f))
+            .map(AmqpValue::from)
             .collect();
         *capabilities = Box::into_raw(Box::new(RustAmqpValue {
             inner: AmqpValue::Array(list),

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/target.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/target.rs
@@ -183,7 +183,7 @@ extern "C" fn target_get_dynamic(target: *const RustAmqpTarget, dynamic: *mut bo
     let target = unsafe { &*target };
     if let Some(dynamic_val) = target.inner.dynamic() {
         unsafe { *dynamic = *dynamic_val };
-        return 0;
+        0
     } else {
         unsafe { *dynamic = false };
         0
@@ -267,11 +267,11 @@ extern "C" fn target_set_address(
     match &address.inner {
         AmqpValue::String(value) => {
             builder.inner.with_address(value.clone());
-            return 0;
+            0
         }
         _ => {
             warn!("Expected string value for address");
-            return 1;
+            1
         }
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/value.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/value.rs
@@ -50,8 +50,9 @@ pub enum RustAmqpValueType {
     AmqpValueUnknown,
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_type(value: *const RustAmqpValue) -> RustAmqpValueType {
+pub unsafe extern "C" fn amqpvalue_get_type(value: *const RustAmqpValue) -> RustAmqpValueType {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::Null => RustAmqpValueType::AmqpValueNull,
@@ -81,8 +82,9 @@ pub extern "C" fn amqpvalue_get_type(value: *const RustAmqpValue) -> RustAmqpVal
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_clone(value: *const RustAmqpValue) -> *mut RustAmqpValue {
+pub unsafe extern "C" fn amqpvalue_clone(value: *const RustAmqpValue) -> *mut RustAmqpValue {
     let value = unsafe { &*value };
     let amqp_value = RustAmqpValue {
         inner: value.inner.clone(),
@@ -90,13 +92,15 @@ pub extern "C" fn amqpvalue_clone(value: *const RustAmqpValue) -> *mut RustAmqpV
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn amqpvalue_destroy(value: *mut RustAmqpValue) {
     mem::drop(Box::from(value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_are_equal(
+pub unsafe extern "C" fn amqpvalue_are_equal(
     value1: *const RustAmqpValue,
     value2: *const RustAmqpValue,
 ) -> bool {
@@ -105,8 +109,9 @@ pub extern "C" fn amqpvalue_are_equal(
     value1.inner == value2.inner
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_to_string(value: *const RustAmqpValue) -> *mut c_char {
+pub unsafe extern "C" fn amqpvalue_to_string(value: *const RustAmqpValue) -> *mut c_char {
     let value = unsafe { &*value };
     let s = format!("{:?}", value.inner);
     let c_str = CString::new(s).unwrap();
@@ -129,8 +134,12 @@ pub extern "C" fn amqpvalue_create_boolean(bool_value: bool) -> *mut RustAmqpVal
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_boolean(value: *const RustAmqpValue, bool_value: *mut bool) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_boolean(
+    value: *const RustAmqpValue,
+    bool_value: *mut bool,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::Boolean(b) => {
@@ -149,8 +158,12 @@ pub extern "C" fn amqpvalue_create_ubyte(ubyte_value: u8) -> *mut RustAmqpValue 
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_ubyte(value: *const RustAmqpValue, ubyte_value: *mut u8) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_ubyte(
+    value: *const RustAmqpValue,
+    ubyte_value: *mut u8,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::UByte(b) => {
@@ -169,8 +182,12 @@ pub extern "C" fn amqpvalue_create_byte(byte_value: i8) -> *mut RustAmqpValue {
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_byte(value: *const RustAmqpValue, byte_value: *mut i8) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_byte(
+    value: *const RustAmqpValue,
+    byte_value: *mut i8,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::Byte(b) => {
@@ -189,8 +206,12 @@ pub extern "C" fn amqpvalue_create_ushort(ushort_value: u16) -> *mut RustAmqpVal
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_ushort(value: *const RustAmqpValue, ushort_value: *mut u16) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_ushort(
+    value: *const RustAmqpValue,
+    ushort_value: *mut u16,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::UShort(b) => {
@@ -209,8 +230,12 @@ pub extern "C" fn amqpvalue_create_short(short_value: i16) -> *mut RustAmqpValue
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_short(value: *const RustAmqpValue, short_value: *mut i16) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_short(
+    value: *const RustAmqpValue,
+    short_value: *mut i16,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::Short(b) => {
@@ -222,15 +247,19 @@ pub extern "C" fn amqpvalue_get_short(value: *const RustAmqpValue, short_value: 
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_uint(uint_value: u32) -> *mut RustAmqpValue {
+pub extern "C" fn amqpvalue_create_uint(uint_value: u32) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::UInt(uint_value),
     };
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_uint(value: *const RustAmqpValue, uint_value: *mut u32) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_uint(
+    value: *const RustAmqpValue,
+    uint_value: *mut u32,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::UInt(b) => {
@@ -242,15 +271,19 @@ extern "C" fn amqpvalue_get_uint(value: *const RustAmqpValue, uint_value: *mut u
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_int(int_value: i32) -> *mut RustAmqpValue {
+pub extern "C" fn amqpvalue_create_int(int_value: i32) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::Int(int_value),
     };
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_int(value: *const RustAmqpValue, int_value: *mut i32) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_int(
+    value: *const RustAmqpValue,
+    int_value: *mut i32,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::Int(b) => {
@@ -262,15 +295,19 @@ extern "C" fn amqpvalue_get_int(value: *const RustAmqpValue, int_value: *mut i32
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_ulong(ulong_value: u64) -> *mut RustAmqpValue {
+pub extern "C" fn amqpvalue_create_ulong(ulong_value: u64) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::ULong(ulong_value),
     };
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_ulong(value: *const RustAmqpValue, ulong_value: *mut u64) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_ulong(
+    value: *const RustAmqpValue,
+    ulong_value: *mut u64,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::ULong(b) => {
@@ -282,15 +319,19 @@ extern "C" fn amqpvalue_get_ulong(value: *const RustAmqpValue, ulong_value: *mut
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_long(long_value: i64) -> *mut RustAmqpValue {
+pub extern "C" fn amqpvalue_create_long(long_value: i64) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::Long(long_value),
     };
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_long(value: *const RustAmqpValue, long_value: *mut i64) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_long(
+    value: *const RustAmqpValue,
+    long_value: *mut i64,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::Long(b) => {
@@ -302,15 +343,19 @@ extern "C" fn amqpvalue_get_long(value: *const RustAmqpValue, long_value: *mut i
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_float(float_value: f32) -> *mut RustAmqpValue {
+pub extern "C" fn amqpvalue_create_float(float_value: f32) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::Float(float_value),
     };
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_float(value: *const RustAmqpValue, float_value: *mut f32) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_float(
+    value: *const RustAmqpValue,
+    float_value: *mut f32,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::Float(b) => {
@@ -322,15 +367,19 @@ extern "C" fn amqpvalue_get_float(value: *const RustAmqpValue, float_value: *mut
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_double(double_value: f64) -> *mut RustAmqpValue {
+pub extern "C" fn amqpvalue_create_double(double_value: f64) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::Double(double_value),
     };
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_double(value: *const RustAmqpValue, double_value: *mut f64) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_double(
+    value: *const RustAmqpValue,
+    double_value: *mut f64,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::Double(b) => {
@@ -342,15 +391,19 @@ extern "C" fn amqpvalue_get_double(value: *const RustAmqpValue, double_value: *m
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_char(char_value: u32) -> *mut RustAmqpValue {
+pub extern "C" fn amqpvalue_create_char(char_value: u32) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::Char(char::from_u32(char_value).unwrap()),
     };
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_char(value: *const RustAmqpValue, char_value: *mut u32) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_char(
+    value: *const RustAmqpValue,
+    char_value: *mut u32,
+) -> i32 {
     let value = unsafe { &*value };
     match value.inner {
         AmqpValue::Char(b) => {
@@ -361,8 +414,9 @@ extern "C" fn amqpvalue_get_char(value: *const RustAmqpValue, char_value: *mut u
     }
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_create_timestamp(timestamp_value: u64) -> *mut RustAmqpValue {
+pub extern "C" fn amqpvalue_create_timestamp(timestamp_value: u64) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::TimeStamp(AmqpTimestamp(
             std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(timestamp_value),
@@ -371,8 +425,9 @@ extern "C" fn amqpvalue_create_timestamp(timestamp_value: u64) -> *mut RustAmqpV
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_timestamp(
+pub unsafe extern "C" fn amqpvalue_get_timestamp(
     value: *const RustAmqpValue,
     timestamp_value: *mut i64,
 ) -> i32 {
@@ -391,16 +446,21 @@ extern "C" fn amqpvalue_get_timestamp(
     }
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_create_uuid(uuid_value: *const [u8; 16]) -> *mut RustAmqpValue {
+pub unsafe extern "C" fn amqpvalue_create_uuid(uuid_value: *const [u8; 16]) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: unsafe { AmqpValue::Uuid(uuid::Uuid::from_bytes(*uuid_value)) },
     };
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_uuid(value: *const RustAmqpValue, uuid_value: *mut [u8; 16]) -> i32 {
+pub unsafe extern "C" fn amqpvalue_get_uuid(
+    value: *const RustAmqpValue,
+    uuid_value: *mut [u8; 16],
+) -> i32 {
     let value = unsafe { &*value };
     match &value.inner {
         AmqpValue::Uuid(b) => {
@@ -411,8 +471,11 @@ extern "C" fn amqpvalue_get_uuid(value: *const RustAmqpValue, uuid_value: *mut [
     }
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_create_string(string_value: *const c_char) -> *mut RustAmqpValue {
+pub unsafe extern "C" fn amqpvalue_create_string(
+    string_value: *const c_char,
+) -> *mut RustAmqpValue {
     let string_value = unsafe { std::ffi::CStr::from_ptr(string_value).to_str().unwrap() };
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::String(string_value.to_string()),
@@ -420,8 +483,9 @@ extern "C" fn amqpvalue_create_string(string_value: *const c_char) -> *mut RustA
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_string(
+pub unsafe extern "C" fn amqpvalue_get_string(
     value: *const RustAmqpValue,
     string_value: *mut *const std::os::raw::c_char,
 ) -> i32 {
@@ -435,8 +499,11 @@ extern "C" fn amqpvalue_get_string(
     }
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_create_symbol(symbol_value: *const c_char) -> *mut RustAmqpValue {
+pub unsafe extern "C" fn amqpvalue_create_symbol(
+    symbol_value: *const c_char,
+) -> *mut RustAmqpValue {
     let symbol_value = unsafe { std::ffi::CStr::from_ptr(symbol_value).to_str().unwrap() };
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::Symbol(AmqpSymbol::from(symbol_value.to_string())),
@@ -444,8 +511,9 @@ extern "C" fn amqpvalue_create_symbol(symbol_value: *const c_char) -> *mut RustA
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-extern "C" fn amqpvalue_get_symbol(
+pub unsafe extern "C" fn amqpvalue_get_symbol(
     value: *const RustAmqpValue,
     symbol_value: *mut *const std::os::raw::c_char,
 ) -> i32 {
@@ -459,8 +527,9 @@ extern "C" fn amqpvalue_get_symbol(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_create_binary(
+pub unsafe extern "C" fn amqpvalue_create_binary(
     binary_value: *const u8,
     size: u32,
 ) -> *mut RustAmqpValue {
@@ -468,18 +537,16 @@ pub extern "C" fn amqpvalue_create_binary(
         inner: AmqpValue::Binary(Vec::new()),
     };
     for i in 0..size {
-        match &mut amqp_value.inner {
-            AmqpValue::Binary(v) => {
-                v.push(unsafe { *binary_value.wrapping_add(i as usize) });
-            }
-            _ => {}
+        if let AmqpValue::Binary(v) = &mut amqp_value.inner {
+            v.push(*binary_value.wrapping_add(i as usize));
         }
     }
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_binary(
+pub unsafe extern "C" fn amqpvalue_get_binary(
     value: *const RustAmqpValue,
     binary_value: *mut *const u8,
     size: *mut u32,
@@ -487,7 +554,7 @@ pub extern "C" fn amqpvalue_get_binary(
     let value = unsafe { &*value };
     match &value.inner {
         AmqpValue::Binary(b) => {
-            if b.len() != 0 {
+            if !b.is_empty() {
                 unsafe {
                     *binary_value = b.as_ptr();
                     *size = b.len() as u32
@@ -512,8 +579,9 @@ pub extern "C" fn amqpvalue_create_array() -> *mut RustAmqpValue {
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_add_array_item(
+pub unsafe extern "C" fn amqpvalue_add_array_item(
     value: *mut RustAmqpValue,
     array_item_value: *mut RustAmqpValue,
 ) -> i32 {
@@ -528,8 +596,9 @@ pub extern "C" fn amqpvalue_add_array_item(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_array_item(
+pub unsafe extern "C" fn amqpvalue_get_array_item(
     value: *const RustAmqpValue,
     index: u32,
 ) -> *mut RustAmqpValue {
@@ -545,8 +614,9 @@ pub extern "C" fn amqpvalue_get_array_item(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_array_item_count(
+pub unsafe extern "C" fn amqpvalue_get_array_item_count(
     value: *const RustAmqpValue,
     count: *mut u32,
 ) -> i32 {
@@ -568,8 +638,9 @@ pub extern "C" fn amqpvalue_create_list() -> *mut RustAmqpValue {
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_add_list_item(
+pub unsafe extern "C" fn amqpvalue_add_list_item(
     value: *mut RustAmqpValue,
     list_item_value: *mut RustAmqpValue,
 ) -> i32 {
@@ -584,8 +655,9 @@ pub extern "C" fn amqpvalue_add_list_item(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_list_item(
+pub unsafe extern "C" fn amqpvalue_get_list_item(
     value: *const RustAmqpValue,
     index: u32,
 ) -> *mut RustAmqpValue {
@@ -601,8 +673,9 @@ pub extern "C" fn amqpvalue_get_list_item(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_list_item_count(
+pub unsafe extern "C" fn amqpvalue_get_list_item_count(
     value: *const RustAmqpValue,
     count: *mut u32,
 ) -> i32 {
@@ -616,8 +689,12 @@ pub extern "C" fn amqpvalue_get_list_item_count(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_set_list_item_count(value: *mut RustAmqpValue, count: u32) -> i32 {
+pub unsafe extern "C" fn amqpvalue_set_list_item_count(
+    value: *mut RustAmqpValue,
+    count: u32,
+) -> i32 {
     let value = unsafe { &mut *value };
     match &mut value.inner {
         AmqpValue::List(v) => {
@@ -628,8 +705,9 @@ pub extern "C" fn amqpvalue_set_list_item_count(value: *mut RustAmqpValue, count
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_set_list_item(
+pub unsafe extern "C" fn amqpvalue_set_list_item(
     value: *mut RustAmqpValue,
     index: u32,
     list_item_value: *mut RustAmqpValue,
@@ -645,16 +723,18 @@ pub extern "C" fn amqpvalue_set_list_item(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_create_map() -> *mut RustAmqpValue {
+pub unsafe extern "C" fn amqpvalue_create_map() -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::Map(AmqpOrderedMap::new()),
     };
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_add_map_item(
+pub unsafe extern "C" fn amqpvalue_add_map_item(
     value: *mut RustAmqpValue,
     key: *mut RustAmqpValue,
     map_item_value: *mut RustAmqpValue,
@@ -671,8 +751,9 @@ pub extern "C" fn amqpvalue_add_map_item(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_set_map_value(
+pub unsafe extern "C" fn amqpvalue_set_map_value(
     value: *mut RustAmqpValue,
     key: *mut RustAmqpValue,
     map_item_value: *mut RustAmqpValue,
@@ -689,8 +770,9 @@ pub extern "C" fn amqpvalue_set_map_value(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_map_item(
+pub unsafe extern "C" fn amqpvalue_get_map_item(
     value: *const RustAmqpValue,
     key: *mut RustAmqpValue,
 ) -> *mut RustAmqpValue {
@@ -707,8 +789,9 @@ pub extern "C" fn amqpvalue_get_map_item(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_map_key_value_pair(
+pub unsafe extern "C" fn amqpvalue_get_map_key_value_pair(
     value: *const RustAmqpValue,
     index: u32,
     key: *mut *mut RustAmqpValue,
@@ -730,8 +813,9 @@ pub extern "C" fn amqpvalue_get_map_key_value_pair(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_map_pair_count(
+pub unsafe extern "C" fn amqpvalue_get_map_pair_count(
     value: *const RustAmqpValue,
     count: *mut u32,
 ) -> i32 {
@@ -745,8 +829,9 @@ pub extern "C" fn amqpvalue_get_map_pair_count(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_create_described(
+pub unsafe extern "C" fn amqpvalue_create_described(
     descriptor: *const RustAmqpValue,
     value: *const RustAmqpValue,
 ) -> *mut RustAmqpValue {
@@ -767,8 +852,9 @@ pub extern "C" fn amqpvalue_create_described(
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_inplace_descriptor(
+pub unsafe extern "C" fn amqpvalue_get_inplace_descriptor(
     value: *const RustAmqpValue,
     descriptor: *mut *mut RustAmqpValue,
 ) -> i32 {
@@ -802,8 +888,9 @@ pub extern "C" fn amqpvalue_get_inplace_descriptor(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_inplace_described_value(
+pub unsafe extern "C" fn amqpvalue_get_inplace_described_value(
     value: *const RustAmqpValue,
     described_value: *mut *mut RustAmqpValue,
 ) -> i32 {
@@ -822,8 +909,9 @@ pub extern "C" fn amqpvalue_get_inplace_described_value(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_create_composite(
+pub unsafe extern "C" fn amqpvalue_create_composite(
     descriptor: *const RustAmqpValue,
     size: usize,
 ) -> *mut RustAmqpValue {
@@ -847,8 +935,9 @@ pub extern "C" fn amqpvalue_create_composite(
     Box::into_raw(Box::new(amqp_value))
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_set_composite_item(
+pub unsafe extern "C" fn amqpvalue_set_composite_item(
     value: *mut RustAmqpValue,
     index: u32,
     composite_item: *mut RustAmqpValue,
@@ -878,8 +967,9 @@ pub extern "C" fn amqpvalue_set_composite_item(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_composite_item_count(
+pub unsafe extern "C" fn amqpvalue_get_composite_item_count(
     value: *const RustAmqpValue,
     count: *mut u32,
 ) -> i32 {
@@ -893,8 +983,9 @@ pub extern "C" fn amqpvalue_get_composite_item_count(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_composite_item_in_place(
+pub unsafe extern "C" fn amqpvalue_get_composite_item_in_place(
     value: *const RustAmqpValue,
     index: u32,
     composite_item: *mut *mut RustAmqpValue,
@@ -914,8 +1005,12 @@ pub extern "C" fn amqpvalue_get_composite_item_in_place(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_get_encoded_size(value: *const RustAmqpValue, size: *mut usize) -> u32 {
+pub unsafe extern "C" fn amqpvalue_get_encoded_size(
+    value: *const RustAmqpValue,
+    size: *mut usize,
+) -> u32 {
     let value = unsafe { &*value };
     let encoded_size = Serializable::encoded_size(&value.inner);
     if encoded_size.is_ok() {
@@ -924,13 +1019,17 @@ pub extern "C" fn amqpvalue_get_encoded_size(value: *const RustAmqpValue, size: 
         }
         0
     } else {
-        error!("Unable to compute encoded size: {:?}", encoded_size.err().unwrap());
+        error!(
+            "Unable to compute encoded size: {:?}",
+            encoded_size.err().unwrap()
+        );
         1
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_encode(
+pub unsafe extern "C" fn amqpvalue_encode(
     value: *const RustAmqpValue,
     buffer: *mut u8,
     size: usize,
@@ -943,8 +1042,9 @@ pub extern "C" fn amqpvalue_encode(
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn amqpvalue_decode_bytes(
+pub unsafe extern "C" fn amqpvalue_decode_bytes(
     buffer: *const u8,
     size: usize,
     value: *mut *mut RustAmqpValue,

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/runtime_context.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/runtime_context.rs
@@ -3,14 +3,12 @@
 
 // cspell: words reqwest repr tokio
 
-use crate::rust_error::RustError;
 use azure_core::{error::ErrorKind, Error, Result};
 use std::mem;
 
 #[derive(Debug)]
 pub struct RuntimeContext {
     runtime: tokio::runtime::Runtime,
-    error: Option<Error>,
 }
 
 impl RuntimeContext {
@@ -25,14 +23,8 @@ impl RuntimeContext {
                 Ok(it) => it,
                 Err(err) => return Err(err),
             },
-            error: None,
         })
     }
-
-    pub fn set_error(&mut self, error: Error) {
-        self.error = Some(error);
-    }
-
     pub fn runtime(&self) -> &tokio::runtime::Runtime {
         &self.runtime
     }
@@ -47,49 +39,22 @@ pub extern "C" fn runtime_context_new() -> *mut RuntimeContext {
 }
 
 #[no_mangle]
-pub extern "C" fn runtime_context_get_error(ctx: *const RuntimeContext) -> *mut RustError {
-    let ctx = unsafe { &*ctx };
-    match &ctx.error {
-        Some(err) => {
-            let msg = format!("{:?}", err);
-            Box::into_raw(Box::new(RustError::new(Error::message(
-                err.kind().clone(),
-                msg,
-            ))))
-            .cast()
-        }
-        None => std::ptr::null::<RustError>().cast_mut(),
-    }
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn runtime_context_delete(ctx: *mut RuntimeContext) {
     mem::drop(Box::from_raw(ctx))
 }
 
-pub fn runtime_context_from_ptr<'a>(ctx: *const RuntimeContext) -> &'a RuntimeContext {
-    unsafe { &*ctx }
-}
+//pub fn runtime_context_from_ptr<'a>(ctx: *const RuntimeContext) -> &'a RuntimeContext {
+//    unsafe { &*ctx }
+//}
 
-pub(crate) fn runtime_context_from_ptr_mut<'a>(ctx: *mut RuntimeContext) -> &'a mut RuntimeContext {
-    unsafe { &mut *ctx }
-}
+//pub(crate) fn runtime_context_from_ptr_mut<'a>(ctx: *mut RuntimeContext) -> &'a mut RuntimeContext {
+//    unsafe { &mut *ctx }
+//}
 
 #[test]
 fn test_runtime_context_new() {
     let ctx = runtime_context_new();
     assert_ne!(ctx, std::ptr::null_mut());
-    unsafe {
-        runtime_context_delete(ctx);
-    }
-}
-
-#[test]
-fn test_runtime_context_get_error() {
-    let ctx = runtime_context_new();
-    assert_ne!(ctx, std::ptr::null_mut());
-    let error = runtime_context_get_error(ctx);
-    assert_eq!(error, std::ptr::null_mut());
     unsafe {
         runtime_context_delete(ctx);
     }
@@ -102,32 +67,4 @@ fn test_runtime_context_delete() {
     unsafe {
         runtime_context_delete(ctx);
     }
-}
-
-#[test]
-fn test_runtime_context_from_ptr() {
-    let ctx = runtime_context_new();
-    assert_ne!(ctx, std::ptr::null_mut());
-    let _ctx_from_ptr = runtime_context_from_ptr(ctx);
-    unsafe {
-        runtime_context_delete(ctx as *mut RuntimeContext);
-    }
-}
-
-#[test]
-fn test_runtime_context_from_ptr_mut() {
-    let ctx = runtime_context_new();
-    assert_ne!(ctx, std::ptr::null_mut());
-    let _ctx_from_ptr = runtime_context_from_ptr_mut(ctx);
-    unsafe {
-        runtime_context_delete(ctx);
-    }
-}
-
-#[test]
-fn test_runtime_context_set_error() {
-    let mut ctx = RuntimeContext::new().unwrap();
-    ctx.set_error(Error::new(ErrorKind::Other, "test"));
-    let error = runtime_context_get_error(&ctx);
-    assert_ne!(error, std::ptr::null_mut());
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/runtime_context.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/runtime_context.rs
@@ -38,6 +38,7 @@ pub extern "C" fn runtime_context_new() -> *mut RuntimeContext {
     }
 }
 
+/// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn runtime_context_delete(ctx: *mut RuntimeContext) {
     mem::drop(Box::from_raw(ctx))

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/runtime_context.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/runtime_context.rs
@@ -43,14 +43,6 @@ pub unsafe extern "C" fn runtime_context_delete(ctx: *mut RuntimeContext) {
     mem::drop(Box::from_raw(ctx))
 }
 
-//pub fn runtime_context_from_ptr<'a>(ctx: *const RuntimeContext) -> &'a RuntimeContext {
-//    unsafe { &*ctx }
-//}
-
-//pub(crate) fn runtime_context_from_ptr_mut<'a>(ctx: *mut RuntimeContext) -> &'a mut RuntimeContext {
-//    unsafe { &mut *ctx }
-//}
-
 #[test]
 fn test_runtime_context_new() {
     let ctx = runtime_context_new();

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/rust_error.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/rust_error.rs
@@ -7,10 +7,11 @@ cspell: words reqwest repr staticlib dylib brotli gzip
 
 use std::ffi::c_char;
 
-pub struct RustError(azure_core::Error);
+#[derive(Debug)]
+pub struct RustError(Box<dyn std::error::Error + Send + Sync>);
 
 impl RustError {
-    pub fn new(error: azure_core::Error) -> Self {
+    pub fn new(error: Box<dyn std::error::Error + Send + Sync>) -> Self {
         RustError(error)
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/rust_error.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/rust_error.rs
@@ -16,16 +16,18 @@ impl RustError {
     }
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn rust_error_get_message(error: *const RustError) -> *mut c_char {
+pub unsafe extern "C" fn rust_error_get_message(error: *const RustError) -> *mut c_char {
     let error = unsafe { error.as_ref().unwrap() };
     let message = error.0.to_string();
     let c_message = std::ffi::CString::new(message).unwrap();
     c_message.into_raw()
 }
 
+/// # Safety
 #[no_mangle]
-pub extern "C" fn rust_error_delete(error: *mut RustError) {
+pub unsafe extern "C" fn rust_error_delete(error: *mut RustError) {
     unsafe {
         let _ = Box::from_raw(error);
     }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/rust_error.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/rust_error.rs
@@ -8,10 +8,10 @@ cspell: words reqwest repr staticlib dylib brotli gzip
 use std::ffi::c_char;
 
 #[derive(Debug)]
-pub struct RustError(Box<dyn std::error::Error + Send + Sync>);
+pub struct RustError(Box<dyn std::error::Error>);
 
 impl RustError {
-    pub fn new(error: Box<dyn std::error::Error + Send + Sync>) -> Self {
+    pub fn new(error: Box<dyn std::error::Error>) -> Self {
         RustError(error)
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/connection_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/connection_impl.hpp
@@ -96,13 +96,15 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     void FinishConstruction();
     operator CONNECTION_HANDLE() const { return m_connection.get(); }
 
-    void Open();
+    void Open(Azure::Core::Context const&);
     void Listen();
 
+    void Close(Azure::Core::Context const&);
     void Close(
-        std::string const& condition = {},
-        std::string const& description = {},
-        Models::AmqpValue info = {});
+        std::string const& condition,
+        std::string const& description,
+        Models::AmqpValue info,
+        Azure::Core::Context const&);
 
     void Poll() override;
     std::string GetHost() const { return m_hostName; }

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/session_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/session_impl.hpp
@@ -65,8 +65,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     uint32_t GetOutgoingWindow();
     uint32_t GetHandleMax();
 
-    void Begin();
-    void End(std::string const& condition_value, std::string const& description);
+    void Begin(Azure::Core::Context const&);
+    void End(Azure::Core::Context const&);
+    void End(std::string const& condition_value, std::string const& description, Azure::Core::Context const&);
 
     void SendDetach(
         _internal::LinkEndpoint const& linkEndpoint,

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/session_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/session_impl.hpp
@@ -67,7 +67,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     void Begin(Azure::Core::Context const&);
     void End(Azure::Core::Context const&);
-    void End(std::string const& condition_value, std::string const& description, Azure::Core::Context const&);
+    void End(
+        std::string const& condition_value,
+        std::string const& description,
+        Azure::Core::Context const&);
 
     void SendDetach(
         _internal::LinkEndpoint const& linkEndpoint,

--- a/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
@@ -190,9 +190,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     Azure::Core::Amqp::_internal::Connection connection("localhost", nullptr, connectionOptions);
 
     // Open the connection
-    connection.Open();
+    connection.Open({});
 
-    connection.Close("", "", {});
+    connection.Close({});
 
 #endif
   }

--- a/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
@@ -172,7 +172,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       Azure::Core::Amqp::_internal::Connection connection("localhost", nullptr, connectionOptions);
 
       // Open the connection
-      connection.Open();
+      connection.Open({});
 
       // Ensure that we got an OnComplete callback within 5 seconds.
       auto transport = listenerEvents.WaitForResult(
@@ -180,7 +180,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
           Azure::Core::Context{std::chrono::system_clock::now() + std::chrono::seconds(5)});
 
       // Now we can close the connection.
-      connection.Close("xxx", "yyy", {});
+      connection.Close("xxx", "yyy", {}, {});
       listener.Stop();
     }
 #else

--- a/sdk/core/azure-core-amqp/test/ut/link_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/link_tests.cpp
@@ -165,7 +165,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       sessionOptions.InitialIncomingWindowSize = 10000;
       auto listeningSession = std::make_unique<Azure::Core::Amqp::_internal::Session>(
           connection.CreateSession(endpoint, sessionOptions, this));
-      listeningSession->Begin();
+      listeningSession->Begin({});
       m_session = std::move(listeningSession);
 
       m_listeningSessionQueue.CompleteOperation(true);
@@ -239,12 +239,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       }
       if (m_session)
       {
-        m_session->End();
+        m_session->End({});
         m_session.reset();
       }
       if (m_connection)
       {
-        m_connection->Close();
+        m_connection->Close({});
         m_connection.reset();
       }
     }

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -49,11 +49,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     Session session{connection.CreateSession()};
 
     {
-      MessageReceiver receiver(session.CreateMessageReceiver("MySource", {}, nullptr));
+      MessageReceiver receiver(session.CreateMessageReceiver("MySource", {}));
     }
     {
-      MessageReceiver receiver1(session.CreateMessageReceiver("MySource", {}, nullptr));
-      MessageReceiver receiver2(session.CreateMessageReceiver("MySource", {}, nullptr));
+      MessageReceiver receiver1(session.CreateMessageReceiver("MySource", {}));
+      MessageReceiver receiver2(session.CreateMessageReceiver("MySource", {}));
     }
 
     GTEST_LOG_(INFO) << _internal::MessageReceiverState::Invalid

--- a/sdk/core/azure-core-amqp/test/ut/mock_amqp_server.hpp
+++ b/sdk/core/azure-core-amqp/test/ut/mock_amqp_server.hpp
@@ -643,7 +643,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
         {
           for (const auto& session : m_sessions)
           {
-            session->End();
+            session->End({});
           }
           // Note: clearing the sessions list destroys the session and calls session_end always, so
           // it does not need to be called here.
@@ -651,7 +651,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
         }
         for (const auto& connection : m_connections)
         {
-          connection->Close();
+          connection->Close({});
         }
         m_listening = false;
       }
@@ -714,7 +714,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
         auto newSession = std::make_shared<Azure::Core::Amqp::_internal::Session>(
             connection.CreateSession(endpoint, options, this));
         m_sessions.push_back(newSession);
-        newSession->Begin();
+        newSession->Begin({});
         return true;
       }
       virtual void OnIOError(Azure::Core::Amqp::_internal::Connection const&) override

--- a/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
@@ -53,7 +53,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     Azure::Core::Amqp::_internal::Connection connection("localhost", nullptr, options);
 
 #if ENABLE_RUST_AMQP
-    connection.Open();
+    connection.Open({});
 #endif
     {
       // Create a session
@@ -65,7 +65,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       Session session1{connection.CreateSession({})};
       Session session2{connection.CreateSession({})};
 
-      EXPECT_ANY_THROW(session1.End());
+      EXPECT_ANY_THROW(session1.End({}));
     }
   }
 
@@ -217,28 +217,28 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
 #if ENABLE_RUST_AMQP
     // Open the connection
     GTEST_LOG_(INFO) << "Open connection.";
-    connection.Open();
+    connection.Open({});
 #endif
 
     {
       Session session{connection.CreateSession()};
 
-      session.Begin();
-      session.End();
+      session.Begin({});
+      session.End({});
     }
 
     {
       Session session{connection.CreateSession()};
 
-      session.Begin();
-      session.End("", "");
+      session.Begin({});
+      session.End("", "",{});
     }
 
     {
       Session session{connection.CreateSession()};
 
-      session.Begin();
-      session.End("amqp:link:detach-forced", "Forced detach.");
+      session.Begin({});
+      session.End("amqp:link:detach-forced", "Forced detach.", {});
     }
 #if ENABLE_UAMQP
     listener.Stop();
@@ -288,7 +288,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     connectionOptions.Port = 25672;
     Azure::Core::Amqp::_internal::Connection connection("localhost", nullptr, connectionOptions);
 
-    connection.Open();
+    connection.Open({});
 
 #endif
 
@@ -299,7 +299,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       for (size_t i = 0; i < sessionCount; i += 1)
       {
         sessions.push_back(connection.CreateSession());
-        sessions.back().Begin();
+        sessions.back().Begin({});
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
 
@@ -308,11 +308,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       GTEST_LOG_(INFO) << "Closing " << sessionCount << " sessions.";
       for (auto& session : sessions)
       {
-        session.End();
+        session.End({});
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
     }
-    connection.Close();
+    connection.Close({});
 #if ENABLE_UAMQP
     mockServer.StopListening();
 #endif

--- a/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
@@ -231,7 +231,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       Session session{connection.CreateSession()};
 
       session.Begin({});
-      session.End("", "",{});
+      session.End("", "", {});
     }
 
     {

--- a/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
@@ -282,15 +282,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     Azure::Core::Amqp::_internal::Connection connection(
         "localhost", nullptr, connectionOptions, &connectionEvents);
 
-    connection.Open();
 #elif ENABLE_RUST_AMQP
     Azure::Core::Amqp::_internal::ConnectionOptions connectionOptions;
     connectionOptions.Port = 25672;
     Azure::Core::Amqp::_internal::Connection connection("localhost", nullptr, connectionOptions);
-
-    connection.Open({});
-
 #endif
+    connection.Open({});
 
     {
       constexpr const size_t sessionCount = 30;

--- a/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
@@ -65,7 +65,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       Session session1{connection.CreateSession({})};
       Session session2{connection.CreateSession({})};
 
-      EXPECT_ANY_THROW(session1.End("", ""));
+      EXPECT_ANY_THROW(session1.End());
     }
   }
 
@@ -232,6 +232,13 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
 
       session.Begin();
       session.End("", "");
+    }
+
+    {
+      Session session{connection.CreateSession()};
+
+      session.Begin();
+      session.End("amqp:link:detach-forced", "Forced detach.");
     }
 #if ENABLE_UAMQP
     listener.Stop();

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/partition_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/partition_client.cpp
@@ -104,7 +104,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
         return returnValue;
       }
     }
-
+#if ENABLE_UAMQP
     // Helper function to create a message receiver.
     Azure::Core::Amqp::_internal::MessageReceiver CreateMessageReceiver(
         Azure::Core::Amqp::_internal::Session const& session,
@@ -139,6 +139,42 @@ namespace Azure { namespace Messaging { namespace EventHubs {
       }
       return session.CreateMessageReceiver(messageSource, receiverOptions, events);
     }
+#elif ENABLE_RUST_AMQP
+    // Helper function to create a message receiver.
+    Azure::Core::Amqp::_internal::MessageReceiver CreateMessageReceiver(
+        Azure::Core::Amqp::_internal::Session const& session,
+        std::string const& partitionUrl,
+        std::string const& receiverName,
+        PartitionClientOptions const& options)
+    {
+      Azure::Core::Amqp::Models::_internal::MessageSourceOptions sourceOptions;
+      sourceOptions.Address = static_cast<Azure::Core::Amqp::Models::AmqpValue>(partitionUrl);
+      AddFilterElementToSourceOptions(
+          sourceOptions,
+          SelectorFilter,
+          static_cast<Azure::Core::Amqp::Models::AmqpValue>(
+              GetStartExpression(options.StartPosition)));
+
+      Azure::Core::Amqp::Models::_internal::MessageSource messageSource(sourceOptions);
+      Azure::Core::Amqp::_internal::MessageReceiverOptions receiverOptions;
+
+      receiverOptions.EnableTrace = _detail::EnableAmqpTrace;
+      // Set the link credit to the prefetch count. If the user has not set a prefetch count, then
+      // we will use the default value.
+      if (options.Prefetch >= 0)
+      {
+        receiverOptions.MaxLinkCredit = options.Prefetch;
+      }
+      receiverOptions.Name = receiverName;
+      receiverOptions.Properties.emplace("com.microsoft:receiver-name", receiverName);
+      if (options.OwnerLevel.HasValue())
+      {
+        receiverOptions.Properties.emplace("com.microsoft:epoch", options.OwnerLevel.Value());
+      }
+      return session.CreateMessageReceiver(messageSource, receiverOptions);
+    }
+#endif
+
   } // namespace
 
   PartitionClient _detail::PartitionClientFactory::CreatePartitionClient(


### PR DESCRIPTION
# Added per-call context to Rust AMQP API calls to facilitate better error propagation.

Fixes #6035 

The PR summary below is pretty good at explaining the change - basically this switches from passing in a pointer to the Rust runtime to passing in a new per-call context object. That per-call context object handles error propagation from Rust to C++ so C++ will get robust error information about the particular calls which failed.

## Copilot PR summary.

This pull request introduces several changes to the `azure-core-amqp` library, primarily focusing on adding context management and improving error handling. The most important changes include the addition of `Azure::Core::Context` parameters to various methods, the introduction of new helper structures for managing Rust contexts and errors, and modifications to the internal Rust implementation to support these changes.

### Context Management Enhancements:
* Added `Azure::Core::Context` parameters to methods in `Connection`, `Session`, and their respective implementations to manage operation contexts. (`sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection.hpp`, `sdk/core/azure-core-amqp/src/amqp/connection.cpp`, `sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/session.hpp`, `sdk/core/azure-core-amqp/src/amqp/session.cpp`) [[1]](diffhunk://#diff-a8eb83634fb258cf64006ee25b8441a7c46ef918c40a53562ce86c8fd9125272L420-R420) [[2]](diffhunk://#diff-b7b5a15e23b479dc092741989f4198442b844714af752cc89671342fa2a0932cL211-R224) [[3]](diffhunk://#diff-fc3a6e5b11f1254c4fd344bcd1846c83ad4ca8e2a8a23b7db0657c2846f43937L102-R110) [[4]](diffhunk://#diff-609231a5af5856a139687058bbcf6cbe97aa029462b1df146097137a23f74033L41-R48)

### Error Handling Improvements:
* Introduced `CallContext` and `RustAmqpError` structures to encapsulate Rust call contexts and errors, enhancing error management and reporting. (`sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp`, `sdk/core/azure-core-amqp/src/common/global_state.cpp`) [[1]](diffhunk://#diff-d16a32915896ba45423c57cecc739c2ca2a295a6c28fe44db35f0bf4e5c382beL9-R49) [[2]](diffhunk://#diff-b8cfc24898d8a356422e5660979d84bcdb46a5559f03a8c9438d16e2bcdfb1ccR221-R233)

### Internal Rust Implementation Updates:
* Updated Rust functions to use `RustCallContext` instead of `RuntimeContext`, aligning with the new context management approach. (`sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/connection.rs`) [[1]](diffhunk://#diff-a6d53a167f7ae33ba5c77fd8eae308e0b2670fb4dff2f4b6797cb477f4c0d9b1R14-L15) [[2]](diffhunk://#diff-a6d53a167f7ae33ba5c77fd8eae308e0b2670fb4dff2f4b6797cb477f4c0d9b1L68-R72)

### Method Signature Changes:
* Modified method signatures in `ConnectionImpl` and `SessionImpl` to include `Azure::Core::Context` parameters, ensuring consistent context propagation. (`sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/connection.cpp`, `sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp`) [[1]](diffhunk://#diff-42b9c4271988dc7b8b42fc437d17579f405d1f519a0ebe496b137c4a38dffaf0L212-R275) [[2]](diffhunk://#diff-7c735f86f5bf02f6e4a8a1cdb149943acf8dcfff8f525a5a3d95a3d300acc0bfL103-R109)

### Additional Helper Methods:
* Added helper methods to manage the lifecycle of `RustCallContext` and `RustAmqpError` objects, ensuring proper resource management. (`sdk/core/azure-core-amqp/src/common/global_state.cpp`)

These changes improve the robustness and flexibility of the `azure-core-amqp` library by introducing better context management and error handling mechanisms.

## Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
