### PR TITLE
Update vcpkg SHA

### DIFF
--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -18,7 +18,7 @@ macro(az_vcpkg_integrate)
       message("AZURE_SDK_DISABLE_AUTO_VCPKG is not defined. Fetch a local copy of vcpkg.")
       # GET VCPKG FROM SOURCE
       #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
-      set(VCPKG_COMMIT_STRING 5312e9f976e89b256954f571433e34f783dd2d12) # default SDK tested commit
+      set(VCPKG_COMMIT_STRING f0f811770e0538fcb295a1750c0a5e0de5131d29) # default SDK tested commit
       if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
         message("AZURE_SDK_VCPKG_COMMIT is defined. Using that instead of the default.")
         set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-sdk-for-cpp",
   "version": "1.5.0",
-  "builtin-baseline": "5312e9f976e89b256954f571433e34f783dd2d12",
+  "builtin-baseline": "f0f811770e0538fcb295a1750c0a5e0de5131d29",
   "dependencies": [
     {
       "name": "curl"


### PR DESCRIPTION
Nothing urgent, it is just to update from the July SHA, we should do it periodically.
I want to merge this before the Core release, so that the change gets auto-pushed to the Betas registry with the release.