### PR TITLE
Disable treating warnings as errors when the SDK is being consumed via FolderList

### DIFF
--- a/cmake-modules/FolderList.cmake
+++ b/cmake-modules/FolderList.cmake
@@ -66,6 +66,8 @@ macro(SetCompileOptions project)
     message ("setting up compile options for ${project}")
     # Compile Options
     SetGlobalOptions()
+    # When the SDK is being consumed via FolderList, an consumption mechanism alternative to vcpkg, do disable treating warnings as errors.
+    SET(WARNINGS_AS_ERRORS OFF)
 endmacro()
 
 macro(DownloadDepVersion DEP_FOLDER DEP_NAME DEP_VERSION)


### PR DESCRIPTION
When we build SDK, and it produces a warning, our CI will still fail (#6065).
When customers consume our SDK via FolderList, when they build it, and if it produces a warning, build will not fail.