### PR TITLE
Fixed warning for an unused function in curl.cpp when building the SDK using a version of libcurl older than 7.77.0

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed warning for an unused function in curl.cpp when building the SDK using a version of libcurl older than 7.77.0.
+
 ### Other Changes
 
 ## 1.14.0 (2024-10-03)

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -275,6 +275,9 @@ static void CleanupThread()
   }
 }
 
+// This function is only used when ExpectedTlsRootCertificate transport options is set to non empty.
+// And that capability only impacts the curl transport behavior in versions of libcurl >= 7.77.0.
+#if LIBCURL_VERSION_NUM >= 0x074D00 // 7.77.0
 std::string PemEncodeFromBase64(std::string const& base64, std::string const& pemType)
 {
   std::stringstream rv;
@@ -293,6 +296,7 @@ std::string PemEncodeFromBase64(std::string const& base64, std::string const& pe
   rv << encodedValue << std::endl << "-----END " << pemType << "-----" << std::endl;
   return rv.str();
 }
+#endif
 
 Azure::Core::Http::CurlTransportOptions CurlTransportOptionsFromTransportOptions(
     Azure::Core::Http::Policies::TransportOptions const& transportOptions)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/6070

cc @jasperrxzhu