### PR TITLE
Investigate if we see build errors for unused functions in CI

### DIFF
--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -308,13 +308,6 @@ Azure::Core::Http::CurlTransportOptions CurlTransportOptionsFromTransportOptions
   curlOptions.SslOptions.EnableCertificateRevocationListCheck
       = transportOptions.EnableCertificateRevocationListCheck;
 
-#if LIBCURL_VERSION_NUM >= 0x074D00 // 7.77.0
-  if (!transportOptions.ExpectedTlsRootCertificate.empty())
-  {
-    curlOptions.SslOptions.PemEncodedExpectedRootCertificates
-        = PemEncodeFromBase64(transportOptions.ExpectedTlsRootCertificate, "CERTIFICATE");
-  }
-#endif
   curlOptions.SslVerifyPeer = !transportOptions.DisableTlsCertificateValidation;
   return curlOptions;
 }


### PR DESCRIPTION
Testing CI outcomes (related to https://github.com/Azure/azure-sdk-for-cpp/pull/6073), not intended to be merged.