### PR TITLE
Get TSP files from remote git location with sparse checkout

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -165,7 +165,6 @@
     "MAKELANGID",
     "mbedtls",
     "mchelnokov",
-    "mccoyp",
     "mbps",
     "MHSM",
     "mmdc",

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -165,6 +165,7 @@
     "MAKELANGID",
     "mbedtls",
     "mchelnokov",
+    "mccoyp",
     "mbps",
     "MHSM",
     "mmdc",

--- a/cmake-modules/TSPCompile.cmake
+++ b/cmake-modules/TSPCompile.cmake
@@ -3,8 +3,8 @@
 
 find_package(Git)
 
-macro(DownloadTSPFiles TSP_REPO TSP_BRANCH TSP_REPO_PATH TSP_DESTINATION)
-    message ("Downloading TSP files using the following params  TSP_REPO=${TSP_REPO} TSP_BRANCH=${TSP_BRANCH} TSP_REPO_PATH=${TSP_REPO_PATH}  TSP_DESTINATION=${TSP_DESTINATION}")
+macro(DownloadTSPFiles TSP_REPO TSP_SHA TSP_REPO_PATH TSP_DESTINATION)
+    message ("Downloading TSP files using the following params  TSP_REPO=${TSP_REPO} TSP_SHA=${TSP_SHA} TSP_REPO_PATH=${TSP_REPO_PATH}  TSP_DESTINATION=${TSP_DESTINATION}")
 
     if(Git_FOUND)
         message("Git found: ${GIT_EXECUTABLE}")
@@ -33,7 +33,7 @@ macro(DownloadTSPFiles TSP_REPO TSP_BRANCH TSP_REPO_PATH TSP_DESTINATION)
     execute_process(COMMAND ${GIT_EXECUTABLE} fetch
          WORKING_DIRECTORY ${DOWNLOAD_FOLDER})
     #switch branch
-    execute_process(COMMAND ${GIT_EXECUTABLE} checkout ${TSP_BRANCH}
+    execute_process(COMMAND ${GIT_EXECUTABLE} checkout ${TSP_SHA}
           WORKING_DIRECTORY ${DOWNLOAD_FOLDER})
  
     if (NOT ${STATUS_CODE} EQUAL 0)

--- a/cmake-modules/TSPCompile.cmake
+++ b/cmake-modules/TSPCompile.cmake
@@ -1,0 +1,39 @@
+find_package(Git)
+
+macro(DownloadTSPFiles TSP_REPO TSP_BRANCH TSP_REPO_PATH TSP_DESTINATION)
+    message ("Downloading TSP files from ${TSP_REPO} branch ${TSP_BRANCH} path ${TSP_REPO_PATH} to ${TSP_DESTINATION}")
+
+    if(Git_FOUND)
+        message("Git found: ${GIT_EXECUTABLE}")
+    else()
+        message(FATAL_ERROR "Git not found")
+    endif()
+    
+    set(DOWNLOAD_FOLDER ${CMAKE_SOURCE_DIR}/build/${TSP_DESTINATION})
+    #cleanup folder
+    file(REMOVE_RECURSE ${DOWNLOAD_FOLDER})
+    make_directory(${DOWNLOAD_FOLDER})
+
+    #init git in folder
+    execute_process(COMMAND ${GIT_EXECUTABLE} init
+        WORKING_DIRECTORY ${DOWNLOAD_FOLDER})
+    #add remote
+    execute_process(COMMAND ${GIT_EXECUTABLE} remote add origin ${TSP_REPO}
+         WORKING_DIRECTORY ${DOWNLOAD_FOLDER})
+    #set sparse-checkout
+    execute_process(COMMAND ${GIT_EXECUTABLE} sparse-checkout init --cone
+         WORKING_DIRECTORY ${DOWNLOAD_FOLDER})
+    #set sparse-checkout folder
+    execute_process(COMMAND ${GIT_EXECUTABLE} sparse-checkout set ${TSP_REPO_PATH}
+         WORKING_DIRECTORY ${DOWNLOAD_FOLDER})
+    #fetch
+    execute_process(COMMAND ${GIT_EXECUTABLE} fetch
+         WORKING_DIRECTORY ${DOWNLOAD_FOLDER})
+    #switch branch
+    execute_process(COMMAND ${GIT_EXECUTABLE} checkout ${TSP_BRANCH}
+          WORKING_DIRECTORY ${DOWNLOAD_FOLDER})
+ 
+    if (NOT ${STATUS_CODE} EQUAL 0)
+        message(FATAL_ERROR "TSP download failed (Link: ${TSP_FULL_PATH}).")
+    endif()
+endmacro()

--- a/cmake-modules/TSPCompile.cmake
+++ b/cmake-modules/TSPCompile.cmake
@@ -1,7 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 find_package(Git)
 
 macro(DownloadTSPFiles TSP_REPO TSP_BRANCH TSP_REPO_PATH TSP_DESTINATION)
-    message ("Downloading TSP files from ${TSP_REPO} branch ${TSP_BRANCH} path ${TSP_REPO_PATH} to ${TSP_DESTINATION}")
+    message ("Downloading TSP files using the following params  TSP_REPO=${TSP_REPO} TSP_BRANCH=${TSP_BRANCH} TSP_REPO_PATH=${TSP_REPO_PATH}  TSP_DESTINATION=${TSP_DESTINATION}")
 
     if(Git_FOUND)
         message("Git found: ${GIT_EXECUTABLE}")

--- a/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
@@ -38,10 +38,10 @@ if(TSP_GEN)
 
     set(TSP_DESTINATION "keyvault_secrets")
     set(TSP_REPO "https://github.com/Azure/azure-rest-api-specs.git")
-    set(TSP_BRANCH "mccoyp/kv-secrets-tsp")
+    set(TSP_SHA "1da5a85c4dc4f4f1caa47fff691e85960ef4bf20")
     set(TSP_REPO_PATH "specification/keyvault/data-plane/Security.KeyVault.Secrets/")
 
-    DownloadTSPFiles(${TSP_REPO} ${TSP_BRANCH} ${TSP_REPO_PATH}  ${TSP_DESTINATION})
+    DownloadTSPFiles(${TSP_REPO} ${TSP_SHA} ${TSP_REPO_PATH}  ${TSP_DESTINATION})
 endif()
 
 if(FETCH_SOURCE_DEPS)

--- a/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
@@ -31,6 +31,18 @@ include(AzureConfigRTTI)
 include(AzureBuildTargetForCI)
 # Add create_map_file function
 include(CreateMapFile)
+option(TSP_GEN "Generate from TypeSpec" OFF)
+
+if(TSP_GEN)
+    include(TSPCompile) 
+
+    set(TSP_DESTINATION "keyvault_secrets")
+    set(TSP_REPO "https://github.com/Azure/azure-rest-api-specs.git")
+    set(TSP_BRANCH "mccoyp/kv-secrets-tsp")
+    set(TSP_REPO_PATH "specification/keyvault/data-plane/Security.KeyVault.Secrets/")
+
+    DownloadTSPFiles(${TSP_REPO} ${TSP_BRANCH} ${TSP_REPO_PATH}  ${TSP_DESTINATION})
+endif()
 
 if(FETCH_SOURCE_DEPS)
     GetFolderList(SECRETS)


### PR DESCRIPTION
Step 1 in KV generation from TSP. 
download the specs localy from azure specs using git sparse checkout, thus only the folder we need vs the whole repo.
# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
