### PR TITLE
Set VERSION property against all libraries to write versioned SONAME

### DIFF
--- a/sdk/attestation/azure-security-attestation/CMakeLists.txt
+++ b/sdk/attestation/azure-security-attestation/CMakeLists.txt
@@ -86,6 +86,7 @@ create_code_coverage(attestation azure-security-attestation azure-security-attes
 
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-security-attestation PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-security-attestation ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/core/azure-core-amqp/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/CMakeLists.txt
@@ -177,6 +177,7 @@ target_link_libraries(azure-core-amqp PRIVATE
     PUBLIC Azure::azure-core)
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-core-amqp PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-core-amqp ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/core/azure-core-tracing-opentelemetry/CMakeLists.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/CMakeLists.txt
@@ -83,6 +83,8 @@ get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
 generate_documentation(azure-core-tracing-opentelemetry ${AZ_LIBRARY_VERSION})
 
 if(BUILD_AZURE_CORE_TRACING_OPENTELEMETRY)
+  set_target_properties(azure-core-tracing-opentelemetry PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
+
   az_vcpkg_export(
     azure-core-tracing-opentelemetry
     CORE_TRACING_OPENTELEMETRY

--- a/sdk/core/azure-core/CMakeLists.txt
+++ b/sdk/core/azure-core/CMakeLists.txt
@@ -192,6 +192,7 @@ if(BUILD_TRANSPORT_WINHTTP)
 endif()
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-core PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-core ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/CMakeLists.txt
@@ -91,6 +91,7 @@ target_link_libraries(azure-messaging-eventhubs-checkpointstore-blob
 create_code_coverage(eventhubs azure-messaging-eventhubs-checkpointstore-blob azure-messaging-eventhubs-blobcheckpointstore-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-messaging-eventhubs-checkpointstore-blob PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 #generate_documentation(azure-messaging-eventhubs-checkpointstore-blob ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-messaging-eventhubs-checkpointstore-blob ${AZ_LIBRARY_VERSION})
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CMakeLists.txt
@@ -116,6 +116,7 @@ target_compile_definitions(azure-messaging-eventhubs PRIVATE _azure_BUILDING_SDK
 create_code_coverage(eventhubs azure-messaging-eventhubs azure-messaging-eventhubs-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-messaging-eventhubs PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-messaging-eventhubs ${AZ_LIBRARY_VERSION})
 
 add_subdirectory(test)

--- a/sdk/identity/azure-identity/CMakeLists.txt
+++ b/sdk/identity/azure-identity/CMakeLists.txt
@@ -117,6 +117,7 @@ else()
 endif()
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-identity PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-identity ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/keyvault/azure-security-keyvault-administration/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-administration/CMakeLists.txt
@@ -95,6 +95,7 @@ target_compile_definitions(azure-security-keyvault-administration PRIVATE _azure
 create_code_coverage(keyvault azure-security-keyvault-administration azure-security-keyvault-administration-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-security-keyvault-administration PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-security-keyvault-administration ${AZ_LIBRARY_VERSION})
 if(BUILD_TESTING)
 

--- a/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-certificates/CMakeLists.txt
@@ -100,6 +100,7 @@ target_compile_definitions(azure-security-keyvault-certificates PRIVATE _azure_B
 create_code_coverage(keyvault azure-security-keyvault-certificates azure-security-keyvault-certificates-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-security-keyvault-certificates PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-security-keyvault-certificates ${AZ_LIBRARY_VERSION})
 
 if(BUILD_TESTING)

--- a/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-keys/CMakeLists.txt
@@ -138,6 +138,7 @@ target_compile_definitions(azure-security-keyvault-keys PRIVATE _azure_BUILDING_
 create_code_coverage(keyvault azure-security-keyvault-keys azure-security-keyvault-keys-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-security-keyvault-keys PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-security-keyvault-keys ${AZ_LIBRARY_VERSION})
 
 if(BUILD_TESTING)

--- a/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
+++ b/sdk/keyvault/azure-security-keyvault-secrets/CMakeLists.txt
@@ -115,6 +115,7 @@ target_compile_definitions(azure-security-keyvault-secrets PRIVATE _azure_BUILDI
 create_code_coverage(keyvault azure-security-keyvault-secrets azure-security-keyvault-secrets-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-security-keyvault-secrets PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-security-keyvault-secrets ${AZ_LIBRARY_VERSION})
 if(BUILD_TESTING)
 

--- a/sdk/storage/azure-storage-blobs/CMakeLists.txt
+++ b/sdk/storage/azure-storage-blobs/CMakeLists.txt
@@ -96,6 +96,7 @@ target_link_libraries(azure-storage-blobs PUBLIC Azure::azure-storage-common)
 target_compile_definitions(azure-storage-blobs PRIVATE _azure_BUILDING_SDK)
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-storage-blobs PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-storage-blobs ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/storage/azure-storage-common/CMakeLists.txt
+++ b/sdk/storage/azure-storage-common/CMakeLists.txt
@@ -107,6 +107,7 @@ else()
 endif()
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-storage-common PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-storage-common ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-datalake/CMakeLists.txt
@@ -92,6 +92,7 @@ target_include_directories(
 target_link_libraries(azure-storage-files-datalake PUBLIC Azure::azure-storage-blobs)
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-storage-files-datalake PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-storage-files-datalake ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/storage/azure-storage-files-shares/CMakeLists.txt
+++ b/sdk/storage/azure-storage-files-shares/CMakeLists.txt
@@ -88,6 +88,7 @@ target_include_directories(
 target_link_libraries(azure-storage-files-shares PUBLIC Azure::azure-storage-common)
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-storage-files-shares PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-storage-files-shares ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/storage/azure-storage-queues/CMakeLists.txt
+++ b/sdk/storage/azure-storage-queues/CMakeLists.txt
@@ -81,6 +81,7 @@ target_include_directories(
 target_link_libraries(azure-storage-queues PUBLIC Azure::azure-storage-common)
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-storage-queues PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-storage-queues ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/tables/azure-data-tables/CMakeLists.txt
+++ b/sdk/tables/azure-data-tables/CMakeLists.txt
@@ -106,6 +106,7 @@ target_include_directories(
 target_link_libraries(azure-data-tables PUBLIC Azure::azure-core)
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-data-tables PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-data-tables ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(

--- a/sdk/template/azure-template/CMakeLists.txt
+++ b/sdk/template/azure-template/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(Azure::azure-template ALIAS azure-template)
 create_code_coverage(template azure-template azure-template-test "tests?/*;samples?/*")
 
 get_az_version("${CMAKE_CURRENT_SOURCE_DIR}/src/private/package_version.hpp")
+set_target_properties(azure-template PROPERTIES VERSION ${AZ_LIBRARY_VERSION})
 generate_documentation(azure-template ${AZ_LIBRARY_VERSION})
 
 az_vcpkg_export(


### PR DESCRIPTION
The SONAME currently written to shared libraries is unversioned, e.g. libazure-core.so. The SDK's ABI is unstable, so replacing these .so files with newer versions will immediately break any consumers.

Setting the VERSION property results in libazure-core.so being a symlink that is used at build time to point to the versioned library, e.g. libazure-core.so.1.14.0. Consumers point directly to the versioned library and continue to work against the older version when the library is upgraded. Once rebuilt, they then point to the newer version instead.

It is more common to use an ABI version that is separate to the library version, but it makes sense to use the latter when the ABI is unstable. The Boost libraries do exactly this.

This change has no effect on static libraries, which is the more common use case. See the CMake documentation for its wider effects.

https://cmake.org/cmake/help/latest/prop_tgt/VERSION.html

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html) -- **N/A**
- [ ] Doxygen docs -- **N/A**
- [ ] Unit tests -- **N/A**
- [X] No unwanted commits/changes
- [X] Descriptive title/description
  - [X] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [X] No typos
- [ ] Update changelog -- **N/A**
- [X] Not work-in-progress
- [X] External references or docs updated
- [X] Self review of PR done
- [ ] Any breaking changes?
