### PR TITLE
Converted builders to be compliant with Rust guidelines.

### DIFF
--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
@@ -12,8 +12,8 @@
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
-  using RustRuntimeContext = RustInterop::RuntimeContext;
-  using RustCallContext = RustInterop::RustCallContext;
+  using RustRuntimeContext = Azure::Core::Amqp::RustInterop::_detail::RuntimeContext;
+  using RustCallContext = Azure::Core::Amqp::RustInterop::_detail::RustCallContext;
 
   template <> struct UniqueHandleHelper<RustRuntimeContext>
   {
@@ -48,7 +48,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
 
   public:
     RustRuntimeContext()
-        : m_runtimeContext{Azure::Core::Amqp::_detail::RustInterop::runtime_context_new()}
+        : m_runtimeContext{Azure::Core::Amqp::RustInterop::_detail::runtime_context_new()}
     {
     }
 
@@ -72,15 +72,15 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
      */
 
     CallContext(
-        Azure::Core::Amqp::_detail::RustInterop::RuntimeContext* runtimeContext,
+        Azure::Core::Amqp::RustInterop::_detail::RuntimeContext* runtimeContext,
         Azure::Core::Context const& context)
-        : m_callContext{Azure::Core::Amqp::_detail::RustInterop::call_context_new(runtimeContext)},
+        : m_callContext{Azure::Core::Amqp::RustInterop::_detail::call_context_new(runtimeContext)},
           m_context(context)
     {
     }
 
     CallContext()
-        : m_callContext{Azure::Core::Amqp::_detail::RustInterop::call_context_new(nullptr)}
+        : m_callContext{Azure::Core::Amqp::RustInterop::_detail::call_context_new(nullptr)}
     {
     }
 
@@ -96,7 +96,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
       {
         //        auto err{rust_error_get_message(error.get())};
         std::string errorString{err};
-        Azure::Core::Amqp::_detail::RustInterop::rust_string_delete(err);
+        Azure::Core::Amqp::RustInterop::_detail::rust_string_delete(err);
         return errorString;
       }
       else

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
@@ -123,7 +123,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
    *
    */
   template <typename Api, typename T, typename... Args>
-  void invoke_builder_api(Api& api, T& builder, Args&&... args)
+  void InvokeBuilderApi(Api& api, T& builder, Args&&... args)
   {
     CallContext callContext;
     auto raw = api(callContext.GetCallContext(), builder.release(), std::forward<Args>(args)...);

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
@@ -110,6 +110,18 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
     Azure::Core::Context m_context;
   };
 
+  /**
+   * Invoke a Rust AMQP builder API, checking for error.
+   *
+   * @param api - Flat C API to invoke. The first parameter MUST be a RustCallContext object, the
+   * second parameter must be a Rust client object.
+   * @param builder - Unique Pointer to a Rust builder object.
+   * @param args - remaining arguments to the flat C API.
+   *
+   * This function will check the return from the API, and if it is null, will throw an exception
+   * with error information from the callContext.
+   *
+   */
   template <typename Api, typename T, typename... Args>
   void invoke_builder_api(Api& api, T& builder, Args&&... args)
   {

--- a/sdk/core/azure-core-amqp/src/common/global_state.cpp
+++ b/sdk/core/azure-core-amqp/src/common/global_state.cpp
@@ -213,14 +213,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
 
 #if ENABLE_RUST_AMQP
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
-  void UniqueHandleHelper<RustRuntimeContext>::FreeRuntimeContext(
-      RustRuntimeContext* obj)
+  void UniqueHandleHelper<RustRuntimeContext>::FreeRuntimeContext(RustRuntimeContext* obj)
   {
     Azure::Core::Amqp::RustInterop::_detail::runtime_context_delete(obj);
   }
 
-  void UniqueHandleHelper<RustCallContext>::FreeCallContext(
-      RustCallContext* obj)
+  void UniqueHandleHelper<RustCallContext>::FreeCallContext(RustCallContext* obj)
   {
     Azure::Core::Amqp::RustInterop::_detail::call_context_delete(obj);
   }

--- a/sdk/core/azure-core-amqp/src/common/global_state.cpp
+++ b/sdk/core/azure-core-amqp/src/common/global_state.cpp
@@ -213,16 +213,16 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
 
 #if ENABLE_RUST_AMQP
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
-  void UniqueHandleHelper<Azure::Core::Amqp::_detail::RustRuntimeContext>::FreeRuntimeContext(
+  void UniqueHandleHelper<RustRuntimeContext>::FreeRuntimeContext(
       RustRuntimeContext* obj)
   {
-    Azure::Core::Amqp::_detail::RustInterop::runtime_context_delete(obj);
+    Azure::Core::Amqp::RustInterop::_detail::runtime_context_delete(obj);
   }
 
-  void UniqueHandleHelper<Azure::Core::Amqp::_detail::RustCallContext>::FreeCallContext(
+  void UniqueHandleHelper<RustCallContext>::FreeCallContext(
       RustCallContext* obj)
   {
-    Azure::Core::Amqp::_detail::RustInterop::call_context_delete(obj);
+    Azure::Core::Amqp::RustInterop::_detail::call_context_delete(obj);
   }
 
   //  void UniqueHandleHelper<Azure::Core::Amqp::_detail::RustAmqpError>::FreeRustError(

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/claim_based_security.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/claim_based_security.cpp
@@ -9,7 +9,7 @@
 
 using namespace Azure::Core::Diagnostics::_internal;
 using namespace Azure::Core::Diagnostics;
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using namespace Azure::Core::Amqp::_internal;
@@ -30,7 +30,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     Common::_detail::CallContext callContext(
         Common::_detail::GlobalStateHolder::GlobalStateInstance()->GetRuntimeContext(), {});
-    RustInterop::RustAmqpClaimsBasedSecurity* cbs;
+    RustAmqpClaimsBasedSecurity* cbs;
     if (amqpclaimsbasedsecurity_create(
             callContext.GetCallContext(), session->GetAmqpSession().get(), &cbs))
     {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/connection.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/connection.cpp
@@ -7,18 +7,15 @@
 
 #include "../../../models/private/value_impl.hpp"
 #include "azure/core/amqp/internal/common/global_state.hpp"
-#include "azure/core/amqp/internal/network/socket_transport.hpp"
-#include "azure/core/amqp/internal/network/tls_transport.hpp"
 #include "azure/core/amqp/models/amqp_value.hpp"
 #include "private/claims_based_security_impl.hpp"
 #include "private/connection_impl.hpp"
-#include "private/session_impl.hpp"
 
 #include <azure/core/diagnostics/logger.hpp>
 #include <azure/core/internal/diagnostics/log.hpp>
 #include <azure/core/uuid.hpp>
 
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 
 #include <memory>
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/management.cpp
@@ -22,10 +22,10 @@
 
 using namespace Azure::Core::Diagnostics::_internal;
 using namespace Azure::Core::Diagnostics;
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
-  using namespace RustInterop;
 
   void UniqueHandleHelper<RustAmqpManagement>::FreeManagement(RustAmqpManagement* value)
   {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/management.cpp
@@ -26,7 +26,6 @@ using namespace Azure::Core::Amqp::RustInterop::_detail;
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
-
   void UniqueHandleHelper<RustAmqpManagement>::FreeManagement(RustAmqpManagement* value)
   {
     amqpmanagement_destroy(value);

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
@@ -28,7 +28,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   void UniqueHandleHelper<RustAmqpMessageSender>::FreeMessageSender(RustAmqpMessageSender* value)
   {
     amqpmessagesender_destroy(value);
-  }
+  } 
 
   template <> struct UniqueHandleHelper<RustInterop::RustAmqpSenderOptions>
   {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
@@ -37,8 +37,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       amqpmessagesenderoptions_destroy(value);
     }
 
-    using type
-        = Core::_internal::BasicUniqueHandle<RustAmqpSenderOptions, FreeSenderOptions>;
+    using type = Core::_internal::BasicUniqueHandle<RustAmqpSenderOptions, FreeSenderOptions>;
   };
   template <> struct UniqueHandleHelper<RustAmqpSenderOptionsBuilder>
   {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
@@ -28,7 +28,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   void UniqueHandleHelper<RustAmqpMessageSender>::FreeMessageSender(RustAmqpMessageSender* value)
   {
     amqpmessagesender_destroy(value);
-  } 
+  }
 
   template <> struct UniqueHandleHelper<RustInterop::RustAmqpSenderOptions>
   {
@@ -61,8 +61,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       std::shared_ptr<_detail::SessionImpl> session,
       Models::_internal::MessageTarget const& target,
       _internal::MessageSenderOptions const& options)
-      : m_session{session}, m_target{target}, m_options{options}, m_messageSender{
-                                                                      amqpmessagesender_create()}
+      : m_session{session}, m_target{target}, m_options{options},
+        m_messageSender{amqpmessagesender_create()}
   {
   }
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
@@ -61,8 +61,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       std::shared_ptr<_detail::SessionImpl> session,
       Models::_internal::MessageTarget const& target,
       _internal::MessageSenderOptions const& options)
-      : m_session{session}, m_target{target}, m_options{options},
-        m_messageSender{amqpmessagesender_create()}
+      : m_session{session}, m_target{target}, m_options{options}, m_messageSender{
+                                                                      amqpmessagesender_create()}
   {
   }
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
@@ -17,7 +17,7 @@
 #include <azure/core/diagnostics/logger.hpp>
 #include <azure/core/internal/diagnostics/log.hpp>
 
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 
 #include <memory>
 
@@ -30,32 +30,32 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     amqpmessagesender_destroy(value);
   }
 
-  template <> struct UniqueHandleHelper<RustInterop::RustAmqpSenderOptions>
+  template <> struct UniqueHandleHelper<RustAmqpSenderOptions>
   {
-    static void FreeSenderOptions(RustInterop::RustAmqpSenderOptions* value)
+    static void FreeSenderOptions(RustAmqpSenderOptions* value)
     {
       amqpmessagesenderoptions_destroy(value);
     }
 
     using type
-        = Core::_internal::BasicUniqueHandle<RustInterop::RustAmqpSenderOptions, FreeSenderOptions>;
+        = Core::_internal::BasicUniqueHandle<RustAmqpSenderOptions, FreeSenderOptions>;
   };
-  template <> struct UniqueHandleHelper<RustInterop::RustAmqpSenderOptionsBuilder>
+  template <> struct UniqueHandleHelper<RustAmqpSenderOptionsBuilder>
   {
-    static void FreeSenderOptionsBuilder(RustInterop::RustAmqpSenderOptionsBuilder* value)
+    static void FreeSenderOptionsBuilder(RustAmqpSenderOptionsBuilder* value)
     {
       amqpmessagesenderoptions_builder_destroy(value);
     }
 
     using type = Core::_internal::
-        BasicUniqueHandle<RustInterop::RustAmqpSenderOptionsBuilder, FreeSenderOptionsBuilder>;
+        BasicUniqueHandle<RustAmqpSenderOptionsBuilder, FreeSenderOptionsBuilder>;
   };
 
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
-  using UniqueSenderOptions = UniqueHandle<RustInterop::RustAmqpSenderOptions>;
-  using UniqueSenderOptionsBuilder = UniqueHandle<RustInterop::RustAmqpSenderOptionsBuilder>;
+  using UniqueSenderOptions = UniqueHandle<RustAmqpSenderOptions>;
+  using UniqueSenderOptionsBuilder = UniqueHandle<RustAmqpSenderOptionsBuilder>;
 
   MessageSenderImpl::MessageSenderImpl(
       std::shared_ptr<_detail::SessionImpl> session,

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/claims_based_security_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/claims_based_security_impl.hpp
@@ -10,20 +10,20 @@
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   template <>
-  struct UniqueHandleHelper<Azure::Core::Amqp::_detail::RustInterop::RustAmqpClaimsBasedSecurity>
+  struct UniqueHandleHelper<Azure::Core::Amqp::RustInterop::_detail::RustAmqpClaimsBasedSecurity>
   {
     static void FreeAmqpCbs(
-        Azure::Core::Amqp::_detail::RustInterop::RustAmqpClaimsBasedSecurity* obj);
+        Azure::Core::Amqp::RustInterop::_detail::RustAmqpClaimsBasedSecurity* obj);
 
     using type = Core::_internal::BasicUniqueHandle<
-        Azure::Core::Amqp::_detail::RustInterop::RustAmqpClaimsBasedSecurity,
+        Azure::Core::Amqp::RustInterop::_detail::RustAmqpClaimsBasedSecurity,
         FreeAmqpCbs>;
   };
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using UniqueAmqpCbsHandle
-      = UniqueHandle<Azure::Core::Amqp::_detail::RustInterop::RustAmqpClaimsBasedSecurity>;
+      = UniqueHandle<Azure::Core::Amqp::RustInterop::_detail::RustAmqpClaimsBasedSecurity>;
 
   class ClaimsBasedSecurityImpl final {
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
@@ -25,8 +25,10 @@
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
   using AmqpConnectionImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnection;
-  using AmqpConnectionOptionsImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnectionOptions;
-  using AmqpConnectionOptionsBuilderImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnectionOptionsBuilder;
+  using AmqpConnectionOptionsImplementation
+      = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnectionOptions;
+  using AmqpConnectionOptionsBuilderImplementation
+      = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnectionOptionsBuilder;
 
   template <> struct UniqueHandleHelper<AmqpConnectionImplementation>
   {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
@@ -24,9 +24,9 @@
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
-  using AmqpConnectionImplementation = RustInterop::RustAmqpConnection;
-  using AmqpConnectionOptionsImplementation = RustInterop::RustAmqpConnectionOptions;
-  using AmqpConnectionOptionsBuilderImplementation = RustInterop::RustAmqpConnectionOptionsBuilder;
+  using AmqpConnectionImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnection;
+  using AmqpConnectionOptionsImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnectionOptions;
+  using AmqpConnectionOptionsBuilderImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnectionOptionsBuilder;
 
   template <> struct UniqueHandleHelper<AmqpConnectionImplementation>
   {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/management_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/management_impl.hpp
@@ -14,15 +14,17 @@
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
-  template <> struct UniqueHandleHelper<RustInterop::RustAmqpManagement>
+  template <> struct UniqueHandleHelper<Azure::Core::Amqp::RustInterop::_detail::RustAmqpManagement>
   {
-    static void FreeManagement(RustInterop::RustAmqpManagement* value);
+    static void FreeManagement(Azure::Core::Amqp::RustInterop::_detail::RustAmqpManagement* value);
 
-    using type
-        = Core::_internal::BasicUniqueHandle<RustInterop::RustAmqpManagement, FreeManagement>;
+    using type = Core::_internal::BasicUniqueHandle<
+        Azure::Core::Amqp::RustInterop::_detail::RustAmqpManagement,
+        FreeManagement>;
   };
 
-  using UniqueAmqpManagement = UniqueHandle<RustInterop::RustAmqpManagement>;
+  using UniqueAmqpManagement
+      = UniqueHandle<Azure::Core::Amqp::RustInterop::_detail::RustAmqpManagement>;
 
   class ManagementClientFactory final {
   public:

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/message_sender_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/message_sender_impl.hpp
@@ -8,17 +8,20 @@
 #include "unique_handle.hpp"
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
-  template <> struct UniqueHandleHelper<RustInterop::RustAmqpMessageSender>
+  template <>
+  struct UniqueHandleHelper<Azure::Core::Amqp::RustInterop::_detail::RustAmqpMessageSender>
   {
-    static void FreeMessageSender(RustInterop::RustAmqpMessageSender* value);
+    static void FreeMessageSender(
+        Azure::Core::Amqp::RustInterop::_detail::RustAmqpMessageSender* value);
 
-    using type
-        = Core::_internal::BasicUniqueHandle<RustInterop::RustAmqpMessageSender, FreeMessageSender>;
+    using type = Core::_internal::BasicUniqueHandle<
+        Azure::Core::Amqp::RustInterop::_detail::RustAmqpMessageSender,
+        FreeMessageSender>;
   };
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
-  using UniqueMessageSender = UniqueHandle<_detail::RustInterop::RustAmqpMessageSender>;
+  using UniqueMessageSender = UniqueHandle<Azure::Core::Amqp::RustInterop::_detail::RustAmqpMessageSender>;
 
   class MessageSenderFactory final {
   public:

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/message_sender_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/message_sender_impl.hpp
@@ -21,7 +21,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
-  using UniqueMessageSender = UniqueHandle<Azure::Core::Amqp::RustInterop::_detail::RustAmqpMessageSender>;
+  using UniqueMessageSender
+      = UniqueHandle<Azure::Core::Amqp::RustInterop::_detail::RustAmqpMessageSender>;
 
   class MessageSenderFactory final {
   public:

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/session_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/session_impl.hpp
@@ -13,10 +13,10 @@
 #include <string>
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
-  using AmqpSessionImplementation = Azure::Core::Amqp::_detail::RustInterop::RustAmqpSession;
-  using AmqpSessionOptions = Azure::Core::Amqp::_detail::RustInterop::RustAmqpSessionOptions;
+  using AmqpSessionImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpSession;
+  using AmqpSessionOptions = Azure::Core::Amqp::RustInterop::_detail::RustAmqpSessionOptions;
   using AmqpSessionOptionsBuilder
-      = Azure::Core::Amqp::_detail::RustInterop::RustAmqpSessionOptionsBuilder;
+      = Azure::Core::Amqp::RustInterop::_detail::RustAmqpSessionOptionsBuilder;
 
   template <> struct UniqueHandleHelper<AmqpSessionImplementation>
   {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
@@ -102,23 +102,24 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     if (m_options.MaximumLinkCount.HasValue())
     {
-      amqpsessionoptionsbuilder_set_handle_max(
-          optionsBuilder.get(), m_options.MaximumLinkCount.Value());
+      optionsBuilder.reset(amqpsessionoptionsbuilder_set_handle_max(
+          optionsBuilder.release(), m_options.MaximumLinkCount.Value()));
     }
     if (m_options.InitialIncomingWindowSize.HasValue())
     {
-      amqpsessionoptionsbuilder_set_incoming_window(
-          optionsBuilder.get(), m_options.InitialIncomingWindowSize.Value());
+      optionsBuilder.reset(amqpsessionoptionsbuilder_set_incoming_window(
+          optionsBuilder.release(), m_options.InitialIncomingWindowSize.Value()));
     }
     if (m_options.InitialOutgoingWindowSize.HasValue())
     {
-      amqpsessionoptionsbuilder_set_outgoing_window(
-          optionsBuilder.get(), m_options.InitialOutgoingWindowSize.Value());
+      optionsBuilder.reset(amqpsessionoptionsbuilder_set_outgoing_window(
+          optionsBuilder.release(), m_options.InitialOutgoingWindowSize.Value()));
     }
     if (!m_options.DesiredCapabilities.empty())
     {
     }
-    UniqueAmqpSessionOptions sessionOptions{amqpsessionoptionsbuilder_build(optionsBuilder.get())};
+    UniqueAmqpSessionOptions sessionOptions{
+        amqpsessionoptionsbuilder_build(optionsBuilder.release())};
     if (amqpsession_begin(
             callContext.GetCallContext(),
             m_session.get(),

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
@@ -5,12 +5,13 @@
 
 #include "azure/core/amqp/internal/session.hpp"
 
+#include "azure/core/amqp/internal/common/runtime_context.hpp"
 #include "private/connection_impl.hpp"
 #include "private/session_impl.hpp"
-
 using namespace Azure::Core::Diagnostics::_internal;
 using namespace Azure::Core::Diagnostics;
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+using namespace Azure::Core::Amqp::RustInterop::_detail;
+using namespace Azure::Core::Amqp::Common::_detail;
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   void UniqueHandleHelper<AmqpSessionImplementation>::FreeAmqpSession(
@@ -102,18 +103,24 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     if (m_options.MaximumLinkCount.HasValue())
     {
-      optionsBuilder.reset(amqpsessionoptionsbuilder_set_handle_max(
-          optionsBuilder.release(), m_options.MaximumLinkCount.Value()));
+      invoke_builder_api(
+          amqpsessionoptionsbuilder_set_handle_max,
+          optionsBuilder,
+          m_options.MaximumLinkCount.Value());
     }
     if (m_options.InitialIncomingWindowSize.HasValue())
     {
-      optionsBuilder.reset(amqpsessionoptionsbuilder_set_incoming_window(
-          optionsBuilder.release(), m_options.InitialIncomingWindowSize.Value()));
+      invoke_builder_api(
+          amqpsessionoptionsbuilder_set_incoming_window,
+          optionsBuilder,
+          m_options.InitialIncomingWindowSize.Value());
     }
     if (m_options.InitialOutgoingWindowSize.HasValue())
     {
-      optionsBuilder.reset(amqpsessionoptionsbuilder_set_outgoing_window(
-          optionsBuilder.release(), m_options.InitialOutgoingWindowSize.Value()));
+      invoke_builder_api(
+          amqpsessionoptionsbuilder_set_outgoing_window,
+          optionsBuilder,
+          m_options.InitialOutgoingWindowSize.Value());
     }
     if (!m_options.DesiredCapabilities.empty())
     {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
@@ -103,21 +103,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     if (m_options.MaximumLinkCount.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           amqpsessionoptionsbuilder_set_handle_max,
           optionsBuilder,
           m_options.MaximumLinkCount.Value());
     }
     if (m_options.InitialIncomingWindowSize.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           amqpsessionoptionsbuilder_set_incoming_window,
           optionsBuilder,
           m_options.InitialIncomingWindowSize.Value());
     }
     if (m_options.InitialOutgoingWindowSize.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           amqpsessionoptionsbuilder_set_outgoing_window,
           optionsBuilder,
           m_options.InitialOutgoingWindowSize.Value());

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/connection.rs
@@ -30,7 +30,6 @@ impl AmqpConnectionOptions {
     pub fn builder() -> builders::AmqpConnectionOptionsBuilder {
         builders::AmqpConnectionOptionsBuilder::new()
     }
-
     pub fn max_frame_size(&self) -> Option<u32> {
         self.max_frame_size
     }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/connection.rs
@@ -139,7 +139,7 @@ pub mod builders {
             self.options.idle_timeout = Some(idle_timeout);
             self
         }
-        pub fn with_outgoing_locales(mut self, outgoing_locales: Vec<String>) ->  Self {
+        pub fn with_outgoing_locales(mut self, outgoing_locales: Vec<String>) -> Self {
             self.options.outgoing_locales = Some(outgoing_locales);
             self
         }
@@ -147,24 +147,15 @@ pub mod builders {
             self.options.incoming_locales = Some(incoming_locales);
             self
         }
-        pub fn with_offered_capabilities(
-            mut self,
-            offered_capabilities: Vec<AmqpSymbol>,
-        ) ->  Self {
+        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
             self.options.offered_capabilities = Some(offered_capabilities);
             self
         }
-        pub fn with_desired_capabilities(
-            mut self,
-            desired_capabilities: Vec<AmqpSymbol>,
-        ) -> Self {
+        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
             self.options.desired_capabilities = Some(desired_capabilities);
             self
         }
-        pub fn with_properties<K, V>(
-            mut self,
-            properties: impl Into<AmqpOrderedMap<K, V>>,
-        ) -> Self
+        pub fn with_properties<K, V>(mut self, properties: impl Into<AmqpOrderedMap<K, V>>) -> Self
         where
             K: Into<AmqpSymbol> + Debug + Default + PartialEq,
             V: Into<AmqpValue> + Debug + Default,

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/management.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/management.rs
@@ -11,7 +11,11 @@ use crate::{
 };
 
 use async_std::sync::Mutex;
-use azure_core::{auth::AccessToken, error::{ErrorKind, Result}, Error};
+use azure_core::{
+    auth::AccessToken,
+    error::{ErrorKind, Result},
+    Error,
+};
 use fe2o3_amqp_management::operations::ReadResponse;
 use fe2o3_amqp_types::{messaging::ApplicationProperties, primitives::SimpleValue};
 use std::sync::{Arc, OnceLock};

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
@@ -340,43 +340,54 @@ impl From<fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
         let mut amqp_message_properties_builder = AmqpMessageProperties::builder();
 
         if let Some(message_id) = properties.message_id {
-            amqp_message_properties_builder.with_message_id(message_id);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_message_id(message_id);
         }
         if let Some(user_id) = properties.user_id {
-            amqp_message_properties_builder.with_user_id(user_id.to_vec());
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_user_id(user_id.to_vec());
         }
         if let Some(to) = properties.to {
-            amqp_message_properties_builder.with_to(to);
+            amqp_message_properties_builder = amqp_message_properties_builder.with_to(to);
         }
         if let Some(subject) = properties.subject {
-            amqp_message_properties_builder.with_subject(subject);
+            amqp_message_properties_builder = amqp_message_properties_builder.with_subject(subject);
         }
         if let Some(reply_to) = properties.reply_to {
-            amqp_message_properties_builder.with_reply_to(reply_to);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_reply_to(reply_to);
         }
         if let Some(correlation_id) = properties.correlation_id {
-            amqp_message_properties_builder.with_correlation_id(correlation_id);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_correlation_id(correlation_id);
         }
         if let Some(content_type) = properties.content_type {
-            amqp_message_properties_builder.with_content_type(content_type);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_content_type(content_type);
         }
         if let Some(content_encoding) = properties.content_encoding {
-            amqp_message_properties_builder.with_content_encoding(content_encoding);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_content_encoding(content_encoding);
         }
         if let Some(absolute_expiry_time) = properties.absolute_expiry_time {
-            amqp_message_properties_builder.with_absolute_expiry_time(absolute_expiry_time);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_absolute_expiry_time(absolute_expiry_time);
         }
         if let Some(creation_time) = properties.creation_time {
-            amqp_message_properties_builder.with_creation_time(creation_time);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_creation_time(creation_time);
         }
         if let Some(group_id) = properties.group_id {
-            amqp_message_properties_builder.with_group_id(group_id);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_group_id(group_id);
         }
         if let Some(group_sequence) = properties.group_sequence {
-            amqp_message_properties_builder.with_group_sequence(group_sequence);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_group_sequence(group_sequence);
         }
         if let Some(reply_to_group_id) = properties.reply_to_group_id {
-            amqp_message_properties_builder.with_reply_to_group_id(reply_to_group_id);
+            amqp_message_properties_builder =
+                amqp_message_properties_builder.with_reply_to_group_id(reply_to_group_id);
         }
         amqp_message_properties_builder.build()
     }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_source.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_source.rs
@@ -77,9 +77,9 @@ impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
         let mut amqp_source_builder = AmqpSource::builder();
 
         if let Some(address) = source.address {
-            amqp_source_builder.with_address(address);
+            amqp_source_builder = amqp_source_builder.with_address(address);
         }
-        amqp_source_builder
+       amqp_source_builder= amqp_source_builder
             .with_durable(source.durable.into())
             .with_expiry_policy(source.expiry_policy.into())
             .with_timeout(source.timeout)
@@ -92,26 +92,26 @@ impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
                     .map(|(k, v)| (k.into(), v.into()))
                     .collect();
 
-            amqp_source_builder.with_dynamic_node_properties(dynamic_node_properties);
+                amqp_source_builder = amqp_source_builder.with_dynamic_node_properties(dynamic_node_properties);
         }
         if let Some(distribution_mode) = source.distribution_mode {
-            amqp_source_builder.with_distribution_mode(distribution_mode.into());
+            amqp_source_builder = amqp_source_builder.with_distribution_mode(distribution_mode.into());
         }
         if let Some(filter) = source.filter {
             let filter: AmqpOrderedMap<AmqpSymbol, AmqpValue> = filter
                 .into_iter()
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect();
-            amqp_source_builder.with_filter(filter);
+            amqp_source_builder = amqp_source_builder.with_filter(filter);
         }
         if let Some(default_outcome) = source.default_outcome {
-            amqp_source_builder.with_default_outcome(default_outcome.into());
+            amqp_source_builder = amqp_source_builder.with_default_outcome(default_outcome.into());
         }
         if let Some(outcomes) = source.outcomes {
-            amqp_source_builder.with_outcomes(outcomes.into_iter().map(|o| o.into()).collect());
+            amqp_source_builder = amqp_source_builder.with_outcomes(outcomes.into_iter().map(|o| o.into()).collect());
         }
         if let Some(capabilities) = source.capabilities {
-            amqp_source_builder
+            amqp_source_builder = amqp_source_builder
                 .with_capabilities(capabilities.into_iter().map(|c| c.into()).collect());
         }
         amqp_source_builder.build()

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_source.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_source.rs
@@ -79,7 +79,7 @@ impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
         if let Some(address) = source.address {
             amqp_source_builder = amqp_source_builder.with_address(address);
         }
-       amqp_source_builder= amqp_source_builder
+        amqp_source_builder = amqp_source_builder
             .with_durable(source.durable.into())
             .with_expiry_policy(source.expiry_policy.into())
             .with_timeout(source.timeout)
@@ -92,10 +92,12 @@ impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
                     .map(|(k, v)| (k.into(), v.into()))
                     .collect();
 
-                amqp_source_builder = amqp_source_builder.with_dynamic_node_properties(dynamic_node_properties);
+            amqp_source_builder =
+                amqp_source_builder.with_dynamic_node_properties(dynamic_node_properties);
         }
         if let Some(distribution_mode) = source.distribution_mode {
-            amqp_source_builder = amqp_source_builder.with_distribution_mode(distribution_mode.into());
+            amqp_source_builder =
+                amqp_source_builder.with_distribution_mode(distribution_mode.into());
         }
         if let Some(filter) = source.filter {
             let filter: AmqpOrderedMap<AmqpSymbol, AmqpValue> = filter
@@ -108,7 +110,8 @@ impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
             amqp_source_builder = amqp_source_builder.with_default_outcome(default_outcome.into());
         }
         if let Some(outcomes) = source.outcomes {
-            amqp_source_builder = amqp_source_builder.with_outcomes(outcomes.into_iter().map(|o| o.into()).collect());
+            amqp_source_builder =
+                amqp_source_builder.with_outcomes(outcomes.into_iter().map(|o| o.into()).collect());
         }
         if let Some(capabilities) = source.capabilities {
             amqp_source_builder = amqp_source_builder

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -217,7 +217,8 @@ impl
         amqp_message_builder = amqp_message_builder.with_body(AmqpMessageBody::Empty);
 
         if let Some(application_properties) = message.application_properties {
-            amqp_message_builder = amqp_message_builder.with_application_properties(application_properties.into());
+            amqp_message_builder =
+                amqp_message_builder.with_application_properties(application_properties.into());
         }
 
         if let Some(header) = message.header {
@@ -230,11 +231,13 @@ impl
         }
 
         if let Some(delivery_annotations) = message.delivery_annotations {
-            amqp_message_builder = amqp_message_builder.with_delivery_annotations(delivery_annotations.0.into());
+            amqp_message_builder =
+                amqp_message_builder.with_delivery_annotations(delivery_annotations.0.into());
         }
 
         if let Some(message_annotations) = message.message_annotations {
-            amqp_message_builder = amqp_message_builder.with_message_annotations(message_annotations.0.into());
+            amqp_message_builder =
+                amqp_message_builder.with_message_annotations(message_annotations.0.into());
         }
 
         if let Some(footer) = message.footer {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
@@ -239,20 +239,20 @@ impl From<AmqpList> for AmqpTarget {
         let field_count = list.len();
         if field_count >= 1 {
             if let Some(AmqpValue::String(address)) = list.0.first() {
-                builder.with_address(address.clone());
+                builder = builder.with_address(address.clone());
             }
         }
         if field_count >= 2 {
             if let Some(AmqpValue::UByte(durable)) = list.0.get(1) {
                 match *durable {
                     0 => {
-                        builder.with_durable(TerminusDurability::None);
+                        builder = builder.with_durable(TerminusDurability::None);
                     }
                     1 => {
-                        builder.with_durable(TerminusDurability::Configuration);
+                        builder = builder.with_durable(TerminusDurability::Configuration);
                     }
                     2 => {
-                        builder.with_durable(TerminusDurability::UnsettledState);
+                        builder = builder.with_durable(TerminusDurability::UnsettledState);
                     }
                     _ => {
                         panic!("Invalid durable value");
@@ -262,17 +262,17 @@ impl From<AmqpList> for AmqpTarget {
         }
         if field_count >= 3 {
             if let Some(AmqpValue::Symbol(expiry_policy)) = list.0.get(2) {
-                builder.with_expiry_policy(expiry_policy.clone().into());
+                builder = builder.with_expiry_policy(expiry_policy.clone().into());
             }
         }
         if field_count >= 4 {
             if let Some(AmqpValue::UInt(timeout)) = list.0.get(3) {
-                builder.with_timeout(*timeout);
+                builder = builder.with_timeout(*timeout);
             }
         }
         if field_count >= 5 {
             if let Some(AmqpValue::Boolean(dynamic)) = list.0.get(4) {
-                builder.with_dynamic(*dynamic);
+                builder = builder.with_dynamic(*dynamic);
             }
         }
         if field_count >= 6 {
@@ -282,12 +282,12 @@ impl From<AmqpList> for AmqpTarget {
                         .iter()
                         .map(|(k, v)| (k.clone().into(), v.clone()))
                         .collect();
-                builder.with_dynamic_node_properties(dynamic_node_properties);
+                builder = builder.with_dynamic_node_properties(dynamic_node_properties);
             }
         }
         if field_count >= 7 {
             if let Some(AmqpValue::Array(capabilities)) = list.0.get(6) {
-                builder.with_capabilities(capabilities.to_vec());
+                builder = builder.with_capabilities(capabilities.to_vec());
             }
         }
         builder.build()
@@ -385,20 +385,20 @@ impl From<AmqpList> for AmqpSource {
         let field_count = list.len();
         if field_count >= 1 {
             if let Some(AmqpValue::String(address)) = list.0.first() {
-                builder.with_address(address.clone());
+                builder = builder.with_address(address.clone());
             }
         }
         if field_count >= 2 {
             if let Some(AmqpValue::UByte(durable)) = list.0.get(1) {
                 match *durable {
                     0 => {
-                        builder.with_durable(TerminusDurability::None);
+                        builder = builder.with_durable(TerminusDurability::None);
                     }
                     1 => {
-                        builder.with_durable(TerminusDurability::Configuration);
+                        builder = builder.with_durable(TerminusDurability::Configuration);
                     }
                     2 => {
-                        builder.with_durable(TerminusDurability::UnsettledState);
+                        builder = builder.with_durable(TerminusDurability::UnsettledState);
                     }
                     _ => {
                         panic!("Invalid durable value");
@@ -408,17 +408,17 @@ impl From<AmqpList> for AmqpSource {
         }
         if field_count >= 3 {
             if let Some(AmqpValue::Symbol(expiry_policy)) = list.0.get(2) {
-                builder.with_expiry_policy(expiry_policy.clone().into());
+                builder = builder.with_expiry_policy(expiry_policy.clone().into());
             }
         }
         if field_count >= 4 {
             if let Some(AmqpValue::UInt(timeout)) = list.0.get(3) {
-                builder.with_timeout(*timeout);
+                builder = builder.with_timeout(*timeout);
             }
         }
         if field_count >= 5 {
             if let Some(AmqpValue::Boolean(dynamic)) = list.0.get(4) {
-                builder.with_dynamic(*dynamic);
+                builder = builder.with_dynamic(*dynamic);
             }
         }
         if field_count >= 6 {
@@ -428,12 +428,12 @@ impl From<AmqpList> for AmqpSource {
                         .iter()
                         .map(|(k, v)| (k.clone().into(), v.clone()))
                         .collect();
-                builder.with_dynamic_node_properties(dynamic_node_properties);
+                builder = builder.with_dynamic_node_properties(dynamic_node_properties);
             }
         }
         if field_count >= 7 {
             if let Some(AmqpValue::Symbol(distribution_mode)) = list.0.get(6) {
-                builder.with_distribution_mode(distribution_mode.clone().into());
+                builder = builder.with_distribution_mode(distribution_mode.clone().into());
             }
         }
         if field_count >= 8 {
@@ -442,22 +442,24 @@ impl From<AmqpList> for AmqpSource {
                     .iter()
                     .map(|(k, v)| (k.clone().into(), v.clone()))
                     .collect();
-                builder.with_filter(filter);
+                builder = builder.with_filter(filter);
             }
         }
         if field_count >= 9 {
             if let Some(AmqpValue::Symbol(default_outcome)) = list.0.get(8) {
-                builder.with_default_outcome(default_outcome.clone().into());
+                builder = builder.with_default_outcome(default_outcome.clone().into());
             }
         }
         if field_count >= 10 {
             if let Some(AmqpValue::Array(outcomes)) = list.0.get(9) {
-                builder.with_outcomes(outcomes.iter().map(|v| v.clone().into()).collect());
+                builder =
+                    builder.with_outcomes(outcomes.iter().map(|v| v.clone().into()).collect());
             }
         }
         if field_count >= 11 {
             if let Some(AmqpValue::Array(capabilities)) = list.0.get(10) {
-                builder.with_capabilities(capabilities.iter().map(|v| v.clone().into()).collect());
+                builder = builder
+                    .with_capabilities(capabilities.iter().map(|v| v.clone().into()).collect());
             }
         }
         builder.build()
@@ -581,29 +583,29 @@ impl From<AmqpList> for AmqpMessageHeader {
         let field_count = list.len();
         if field_count >= 1 {
             if let Some(AmqpValue::Boolean(durable)) = list.0.first() {
-                builder.with_durable(*durable);
+                builder = builder.with_durable(*durable);
             }
         }
         if field_count >= 2 {
             if let Some(AmqpValue::UByte(priority)) = list.0.get(1) {
-                builder.with_priority(*priority);
+                builder = builder.with_priority(*priority);
             }
         }
         if field_count >= 3 {
             if let Some(AmqpValue::UInt(time_to_live)) = list.0.get(2) {
-                builder.with_time_to_live(Some(std::time::Duration::from_millis(
+                builder = builder.with_time_to_live(Some(std::time::Duration::from_millis(
                     *time_to_live as u64,
                 )));
             }
         }
         if field_count >= 4 {
             if let Some(AmqpValue::Boolean(first_acquirer)) = list.0.get(3) {
-                builder.with_first_acquirer(*first_acquirer);
+                builder = builder.with_first_acquirer(*first_acquirer);
             }
         }
         if field_count >= 5 {
             if let Some(AmqpValue::UInt(delivery_count)) = list.0.get(4) {
-                builder.with_delivery_count(*delivery_count);
+                builder = builder.with_delivery_count(*delivery_count);
             }
         }
         builder.build()
@@ -741,90 +743,92 @@ impl From<AmqpList> for AmqpMessageProperties {
         if field_count >= 1 {
             match &list.0[0] {
                 AmqpValue::ULong(message_id) => {
-                    builder.with_message_id(AmqpMessageId::Ulong(*message_id));
+                    builder = builder.with_message_id(AmqpMessageId::Ulong(*message_id));
                 }
                 AmqpValue::Uuid(message_id) => {
-                    builder.with_message_id(AmqpMessageId::Uuid(*message_id));
+                    builder = builder.with_message_id(AmqpMessageId::Uuid(*message_id));
                 }
                 AmqpValue::Binary(message_id) => {
-                    builder.with_message_id(AmqpMessageId::Binary(message_id.clone()));
+                    builder = builder.with_message_id(AmqpMessageId::Binary(message_id.clone()));
                 }
                 AmqpValue::String(message_id) => {
-                    builder.with_message_id(AmqpMessageId::String(message_id.clone()));
+                    builder = builder.with_message_id(AmqpMessageId::String(message_id.clone()));
                 }
                 _ => {}
             }
         }
         if field_count >= 2 {
             if let AmqpValue::Binary(user_id) = &list.0[1] {
-                builder.with_user_id(user_id.clone());
+                builder = builder.with_user_id(user_id.clone());
             }
         }
         if field_count >= 3 {
             if let AmqpValue::String(to) = &list.0[2] {
-                builder.with_to(to.clone());
+                builder = builder.with_to(to.clone());
             }
         }
         if field_count >= 4 {
             if let AmqpValue::String(subject) = &list.0[3] {
-                builder.with_subject(subject.clone());
+                builder = builder.with_subject(subject.clone());
             }
         }
         if field_count >= 5 {
             if let AmqpValue::String(reply_to) = &list.0[4] {
-                builder.with_reply_to(reply_to.clone());
+                builder = builder.with_reply_to(reply_to.clone());
             }
         }
         if field_count >= 6 {
             match &list.0[5] {
                 AmqpValue::ULong(correlation_id) => {
-                    builder.with_correlation_id(AmqpMessageId::Ulong(*correlation_id));
+                    builder = builder.with_correlation_id(AmqpMessageId::Ulong(*correlation_id));
                 }
                 AmqpValue::Uuid(correlation_id) => {
-                    builder.with_correlation_id(AmqpMessageId::Uuid(*correlation_id));
+                    builder = builder.with_correlation_id(AmqpMessageId::Uuid(*correlation_id));
                 }
                 AmqpValue::Binary(correlation_id) => {
-                    builder.with_correlation_id(AmqpMessageId::Binary(correlation_id.clone()));
+                    builder =
+                        builder.with_correlation_id(AmqpMessageId::Binary(correlation_id.clone()));
                 }
                 AmqpValue::String(correlation_id) => {
-                    builder.with_correlation_id(AmqpMessageId::String(correlation_id.clone()));
+                    builder =
+                        builder.with_correlation_id(AmqpMessageId::String(correlation_id.clone()));
                 }
                 _ => {}
             }
         }
         if field_count >= 7 {
             if let AmqpValue::Symbol(content_type) = &list.0[6] {
-                builder.with_content_type(content_type.clone());
+                builder = builder.with_content_type(content_type.clone());
             }
         }
         if field_count >= 8 {
             if let AmqpValue::Symbol(content_encoding) = &list.0[7] {
-                builder.with_content_encoding(content_encoding.clone());
+                builder = builder.with_content_encoding(content_encoding.clone());
             }
         }
         if field_count >= 9 {
             if let AmqpValue::TimeStamp(absolute_expiry_time) = &list.0[8] {
-                builder.with_absolute_expiry_time(absolute_expiry_time.clone());
+                builder = builder.with_absolute_expiry_time(absolute_expiry_time.clone());
             }
         }
         if field_count >= 10 {
             if let AmqpValue::TimeStamp(creation_time) = &list.0[9] {
-                builder.with_creation_time(creation_time.clone());
+                builder = builder.with_creation_time(creation_time.clone());
             }
         }
         if field_count >= 11 {
             if let AmqpValue::String(group_id) = &list.0[10] {
-                builder.with_group_id(group_id.clone());
+                builder = builder.with_group_id(group_id.clone());
             }
         }
         if field_count >= 12 {
             if let AmqpValue::UInt(group_sequence) = &list.0[11] {
-                builder.with_group_sequence(*group_sequence);
+                builder = builder.with_group_sequence(*group_sequence);
             }
         }
         if field_count >= 13 {
             if let AmqpValue::String(reply_to_group_id) = &list.0[12] {
-                builder.with_reply_to_group_id(reply_to_group_id.clone());
+                builder = builder.with_reply_to_group_id(reply_to_group_id.clone());
             }
         }
 
@@ -1075,74 +1079,71 @@ impl AmqpMessage {
         self.footer.as_ref()
     }
 
-    pub fn set_header(&mut self, header: AmqpMessageHeader) {
-        self.header = Some(header);
-    }
+    // pub fn set_header(&mut self, header: AmqpMessageHeader) {
+    //     self.header = Some(header);
+    // }
 
-    pub fn set_properties(&mut self, properties: AmqpMessageProperties) {
-        self.properties = Some(properties);
-    }
+    // pub fn set_properties(&mut self, properties: AmqpMessageProperties) {
+    //     self.properties = Some(properties);
+    // }
 
-    pub fn set_message_annotations(&mut self, message_annotations: impl Into<AmqpAnnotations>) {
-        self.message_annotations = Some(message_annotations.into());
-    }
+    // pub fn set_message_annotations(&mut self, message_annotations: impl Into<AmqpAnnotations>) {
+    //     self.message_annotations = Some(message_annotations.into());
+    // }
 
-    pub fn set_message_body(&mut self, body: impl Into<AmqpMessageBody>) {
-        self.body = body.into();
-    }
+    // pub fn set_message_body(&mut self, body: impl Into<AmqpMessageBody>) {
+    //     self.body = body.into();
+    // }
 
-    pub fn set_application_properties(
-        &mut self,
-        application_properties: impl Into<AmqpApplicationProperties>,
-    ) {
-        self.application_properties = Some(application_properties.into());
-    }
+    // pub fn set_application_properties(
+    //     &mut self,
+    //     application_properties: impl Into<AmqpApplicationProperties>,
+    // ) {
+    //     self.application_properties = Some(application_properties.into());
+    // }
 
-    pub fn set_delivery_annotations(&mut self, delivery_annotations: impl Into<AmqpAnnotations>) {
-        self.delivery_annotations = Some(delivery_annotations.into());
-    }
+    // pub fn set_delivery_annotations(&mut self, delivery_annotations: impl Into<AmqpAnnotations>) {
+    //     self.delivery_annotations = Some(delivery_annotations.into());
+    // }
 
-    pub fn set_footer(&mut self, footer: impl Into<AmqpAnnotations>) {
-        self.footer = Some(footer.into());
-    }
+    // pub fn set_footer(&mut self, footer: impl Into<AmqpAnnotations>) {
+    //     self.footer = Some(footer.into());
+    // }
 
-    pub fn add_message_body_binary(&mut self, body: &[u8]) {
-        match &mut self.body {
-            AmqpMessageBody::Binary(bodies) => {
-                bodies.push(body.to_owned());
-            }
-            AmqpMessageBody::Empty => {
-                self.body = AmqpMessageBody::Binary(vec![body.to_owned()]);
-            }
-            _ => {
-                panic!("Cannot add binary body to non-binary body");
-            }
-        }
-    }
+    // pub fn add_message_body_binary(&mut self, body: &[u8]) {
+    //     match &mut self.body {
+    //         AmqpMessageBody::Binary(bodies) => {
+    //             bodies.push(body.to_owned());
+    //         }
+    //         AmqpMessageBody::Empty => {
+    //             self.body = AmqpMessageBody::Binary(vec![body.to_owned()]);
+    //         }
+    //         _ => {
+    //             panic!("Cannot add binary body to non-binary body");
+    //         }
+    //     }
+    // }
 
-    pub fn add_message_body_sequence(&mut self, body: AmqpList) {
-        match &mut self.body {
-            AmqpMessageBody::Sequence(bodies) => {
-                bodies.push(body);
-            }
-            AmqpMessageBody::Empty => {
-                self.body = AmqpMessageBody::Sequence(vec![body]);
-            }
-            _ => {
-                panic!("Cannot add sequence body to non-sequence body");
-            }
-        }
-    }
+    // pub fn add_message_body_sequence(&mut self, body: AmqpList) {
+    //     match &mut self.body {
+    //         AmqpMessageBody::Sequence(bodies) => {
+    //             bodies.push(body);
+    //         }
+    //         AmqpMessageBody::Empty => {
+    //             self.body = AmqpMessageBody::Sequence(vec![body]);
+    //         }
+    //         _ => {
+    //             panic!("Cannot add sequence body to non-sequence body");
+    //         }
+    //     }
+    // }
 
-    #[allow(unused_variables)]
-    pub fn serialize(message: AmqpMessage) -> Result<Vec<u8>> {
+    pub fn serialize(message: &AmqpMessage) -> Result<Vec<u8>> {
         #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]
         {
-            let amqp_message = Into::<
-                fe2o3_amqp_types::messaging::Message<
-                    fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
-                >,
-            >::into(message);
+            let amqp_message: fe2o3_amqp_types::messaging::Message<
+                fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
+            > = message.into();
             let res = serde_amqp::ser::to_vec(
                 &fe2o3_amqp_types::messaging::message::__private::Serializable(amqp_message),
             )
@@ -1228,49 +1229,49 @@ pub mod builders {
                 source: Default::default(),
             }
         }
-        pub fn with_address(&mut self, address: impl Into<String>) -> &mut Self {
+        pub fn with_address(mut self, address: impl Into<String>) -> Self {
             self.source.address = Some(address.into());
             self
         }
-        pub fn with_durable(&mut self, durable: TerminusDurability) -> &mut Self {
+        pub fn with_durable(mut self, durable: TerminusDurability) -> Self {
             self.source.durable = Some(durable);
             self
         }
-        pub fn with_expiry_policy(&mut self, expiry_policy: TerminusExpiryPolicy) -> &mut Self {
+        pub fn with_expiry_policy(mut self, expiry_policy: TerminusExpiryPolicy) -> Self {
             self.source.expiry_policy = Some(expiry_policy);
             self
         }
-        pub fn with_timeout(&mut self, timeout: u32) -> &mut Self {
+        pub fn with_timeout(mut self, timeout: u32) -> Self {
             self.source.timeout = Some(timeout);
             self
         }
-        pub fn with_dynamic(&mut self, dynamic: bool) -> &mut Self {
+        pub fn with_dynamic(mut self, dynamic: bool) -> Self {
             self.source.dynamic = Some(dynamic);
             self
         }
         pub fn with_dynamic_node_properties(
-            &mut self,
+            mut self,
             dynamic_node_properties: impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-        ) -> &mut Self {
+        ) -> Self {
             self.source.dynamic_node_properties = Some(dynamic_node_properties.into());
             self
         }
-        pub fn with_distribution_mode(&mut self, distribution_mode: DistributionMode) -> &mut Self {
+        pub fn with_distribution_mode(mut self, distribution_mode: DistributionMode) -> Self {
             self.source.distribution_mode = Some(distribution_mode);
             self
         }
         pub fn with_filter(
-            &mut self,
+            mut self,
             filter: impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-        ) -> &mut Self {
+        ) -> Self {
             self.source.filter = Some(filter.into());
             self
         }
         pub fn add_to_filter(
-            &mut self,
+            mut self,
             key: impl Into<AmqpSymbol>,
             value: impl Into<AmqpValue>,
-        ) -> &mut Self {
+        ) -> Self {
             if let Some(filter) = &mut self.source.filter {
                 filter.insert(key.into(), value.into());
             } else {
@@ -1280,19 +1281,19 @@ pub mod builders {
             }
             self
         }
-        pub fn with_default_outcome(&mut self, default_outcome: AmqpOutcome) -> &mut Self {
+        pub fn with_default_outcome(mut self, default_outcome: AmqpOutcome) -> Self {
             self.source.default_outcome = Some(default_outcome);
             self
         }
-        pub fn with_outcomes(&mut self, outcomes: Vec<AmqpSymbol>) -> &mut Self {
+        pub fn with_outcomes(mut self, outcomes: Vec<AmqpSymbol>) -> Self {
             self.source.outcomes = Some(outcomes);
             self
         }
-        pub fn with_capabilities(&mut self, capabilities: Vec<AmqpSymbol>) -> &mut Self {
+        pub fn with_capabilities(mut self, capabilities: Vec<AmqpSymbol>) -> Self {
             self.source.capabilities = Some(capabilities);
             self
         }
-        pub fn build(&mut self) -> AmqpSource {
+        pub fn build(&self) -> AmqpSource {
             self.source.clone()
         }
     }
@@ -1302,7 +1303,7 @@ pub mod builders {
     }
 
     impl AmqpTargetBuilder {
-        pub fn build(&mut self) -> AmqpTarget {
+        pub fn build(&self) -> AmqpTarget {
             self.target.clone()
         }
         pub(super) fn new() -> AmqpTargetBuilder {
@@ -1310,34 +1311,34 @@ pub mod builders {
                 target: Default::default(),
             }
         }
-        pub fn with_address(&mut self, address: impl Into<String>) -> &mut Self {
+        pub fn with_address(mut self, address: impl Into<String>) -> Self {
             self.target.address = Some(address.into());
             self
         }
-        pub fn with_durable(&mut self, durable: TerminusDurability) -> &mut Self {
+        pub fn with_durable(mut self, durable: TerminusDurability) -> Self {
             self.target.durable = Some(durable);
             self
         }
-        pub fn with_expiry_policy(&mut self, expiry_policy: TerminusExpiryPolicy) -> &mut Self {
+        pub fn with_expiry_policy(mut self, expiry_policy: TerminusExpiryPolicy) -> Self {
             self.target.expiry_policy = Some(expiry_policy);
             self
         }
-        pub fn with_timeout(&mut self, timeout: u32) -> &mut Self {
+        pub fn with_timeout(mut self, timeout: u32) -> Self {
             self.target.timeout = Some(timeout);
             self
         }
-        pub fn with_dynamic(&mut self, dynamic: bool) -> &mut Self {
+        pub fn with_dynamic(mut self, dynamic: bool) -> Self {
             self.target.dynamic = Some(dynamic);
             self
         }
         pub fn with_dynamic_node_properties(
-            &mut self,
+            mut self,
             dynamic_node_properties: impl Into<AmqpOrderedMap<String, AmqpValue>>,
-        ) -> &mut Self {
+        ) -> Self {
             self.target.dynamic_node_properties = Some(dynamic_node_properties.into());
             self
         }
-        pub fn with_capabilities(&mut self, capabilities: Vec<AmqpValue>) -> &mut Self {
+        pub fn with_capabilities(mut self, capabilities: Vec<AmqpValue>) -> Self {
             self.target.capabilities = Some(capabilities);
             self
         }
@@ -1356,26 +1357,23 @@ pub mod builders {
                 header: Default::default(),
             }
         }
-        pub fn with_durable(&mut self, durable: bool) -> &mut Self {
+        pub fn with_durable(mut self, durable: bool) -> Self {
             self.header.durable = durable;
             self
         }
-        pub fn with_priority(&mut self, priority: u8) -> &mut Self {
+        pub fn with_priority(mut self, priority: u8) -> Self {
             self.header.priority = priority;
             self
         }
-        pub fn with_time_to_live(
-            &mut self,
-            time_to_live: Option<std::time::Duration>,
-        ) -> &mut Self {
+        pub fn with_time_to_live(mut self, time_to_live: Option<std::time::Duration>) -> Self {
             self.header.time_to_live = time_to_live;
             self
         }
-        pub fn with_first_acquirer(&mut self, first_acquirer: bool) -> &mut Self {
+        pub fn with_first_acquirer(mut self, first_acquirer: bool) -> Self {
             self.header.first_acquirer = first_acquirer;
             self
         }
-        pub fn with_delivery_count(&mut self, delivery_count: u32) -> &mut Self {
+        pub fn with_delivery_count(mut self, delivery_count: u32) -> Self {
             self.header.delivery_count = delivery_count;
             self
         }
@@ -1386,7 +1384,7 @@ pub mod builders {
     }
 
     impl AmqpMessagePropertiesBuilder {
-        pub fn build(&mut self) -> AmqpMessageProperties {
+        pub fn build(&self) -> AmqpMessageProperties {
             self.properties.clone()
         }
         pub(super) fn new() -> AmqpMessagePropertiesBuilder {
@@ -1394,67 +1392,58 @@ pub mod builders {
                 properties: Default::default(),
             }
         }
-        pub fn with_message_id(&mut self, message_id: impl Into<AmqpMessageId>) -> &mut Self {
+        pub fn with_message_id(mut self, message_id: impl Into<AmqpMessageId>) -> Self {
             self.properties.message_id = Some(message_id.into());
             self
         }
-        pub fn with_user_id(&mut self, user_id: impl Into<Vec<u8>>) -> &mut Self {
+        pub fn with_user_id(mut self, user_id: impl Into<Vec<u8>>) -> Self {
             self.properties.user_id = Some(user_id.into());
             self
         }
-        pub fn with_to(&mut self, to: impl Into<String>) -> &mut Self {
+        pub fn with_to(mut self, to: impl Into<String>) -> Self {
             self.properties.to = Some(to.into());
             self
         }
-        pub fn with_subject(&mut self, subject: impl Into<String>) -> &mut Self {
+        pub fn with_subject(mut self, subject: impl Into<String>) -> Self {
             self.properties.subject = Some(subject.into());
             self
         }
-        pub fn with_reply_to(&mut self, reply_to: impl Into<String>) -> &mut Self {
+        pub fn with_reply_to(mut self, reply_to: impl Into<String>) -> Self {
             self.properties.reply_to = Some(reply_to.into());
             self
         }
-        pub fn with_correlation_id(
-            &mut self,
-            correlation_id: impl Into<AmqpMessageId>,
-        ) -> &mut Self {
+        pub fn with_correlation_id(mut self, correlation_id: impl Into<AmqpMessageId>) -> Self {
             self.properties.correlation_id = Some(correlation_id.into());
             self
         }
-        pub fn with_content_type(&mut self, content_type: impl Into<AmqpSymbol>) -> &mut Self {
+        pub fn with_content_type(mut self, content_type: impl Into<AmqpSymbol>) -> Self {
             self.properties.content_type = Some(content_type.into());
             self
         }
-        pub fn with_content_encoding(
-            &mut self,
-            content_encoding: impl Into<AmqpSymbol>,
-        ) -> &mut Self {
+        pub fn with_content_encoding(mut self, content_encoding: impl Into<AmqpSymbol>) -> Self {
             self.properties.content_encoding = Some(content_encoding.into());
             self
         }
         pub fn with_absolute_expiry_time(
-            &mut self,
+            mut self,
             absolute_expiry_time: impl Into<AmqpTimestamp>,
-        ) -> &mut Self {
+        ) -> Self {
             self.properties.absolute_expiry_time = Some(absolute_expiry_time.into());
             self
         }
-        pub fn with_creation_time(&mut self, creation_time: impl Into<AmqpTimestamp>) -> &mut Self {
+        pub fn with_creation_time(mut self, creation_time: impl Into<AmqpTimestamp>) -> Self {
             self.properties.creation_time = Some(creation_time.into());
             self
         }
-        pub fn with_group_id(&mut self, group_id: impl Into<String>) -> &mut Self {
+        pub fn with_group_id(mut self, group_id: impl Into<String>) -> Self {
             self.properties.group_id = Some(group_id.into());
             self
         }
-        pub fn with_group_sequence(&mut self, group_sequence: u32) -> &mut Self {
+        pub fn with_group_sequence(mut self, group_sequence: u32) -> Self {
             self.properties.group_sequence = Some(group_sequence);
             self
         }
-        pub fn with_reply_to_group_id(
-            &mut self,
-            reply_to_group_id: impl Into<String>,
-        ) -> &mut Self {
+        pub fn with_reply_to_group_id(mut self, reply_to_group_id: impl Into<String>) -> Self {
             self.properties.reply_to_group_id = Some(reply_to_group_id.into());
             self
         }
@@ -1465,7 +1454,7 @@ pub mod builders {
     }
 
     impl AmqpMessageBuilder {
-        pub fn build(&mut self) -> AmqpMessage {
+        pub fn build(&self) -> AmqpMessage {
             self.message.clone()
         }
         pub(super) fn new() -> AmqpMessageBuilder {
@@ -1473,26 +1462,54 @@ pub mod builders {
                 message: Default::default(),
             }
         }
-        pub fn with_body(&mut self, body: impl Into<AmqpMessageBody>) -> &mut Self {
+        pub fn with_body(mut self, body: impl Into<AmqpMessageBody>) -> Self {
             self.message.body = body.into();
             self
         }
-        pub fn with_header(&mut self, header: AmqpMessageHeader) -> &mut Self {
+        pub fn add_message_body_binary(mut self, body: Vec<u8>) -> Self {
+            match &mut self.message.body {
+                AmqpMessageBody::Binary(bodies) => {
+                    bodies.push(body);
+                }
+                AmqpMessageBody::Empty => {
+                    self.message.body = AmqpMessageBody::Binary(vec![body]);
+                }
+                _ => {
+                    panic!("Cannot add binary body to non-binary body");
+                }
+            }
+            self
+        }
+        pub fn add_message_body_sequence(mut self, body: AmqpList) -> Self {
+            match &mut self.message.body {
+                AmqpMessageBody::Sequence(bodies) => {
+                    bodies.push(body);
+                }
+                AmqpMessageBody::Empty => {
+                    self.message.body = AmqpMessageBody::Sequence(vec![body]);
+                }
+                _ => {
+                    panic!("Cannot add sequence body to non-sequence body");
+                }
+            }
+            self
+        }
+        pub fn with_header(mut self, header: AmqpMessageHeader) -> Self {
             self.message.header = Some(header);
             self
         }
         pub fn with_application_properties(
-            &mut self,
+            mut self,
             application_properties: AmqpApplicationProperties,
-        ) -> &mut Self {
+        ) -> Self {
             self.message.application_properties = Some(application_properties);
             self
         }
         pub fn add_application_property(
-            &mut self,
+            mut self,
             key: impl Into<String>,
             value: impl Into<AmqpValue>,
-        ) -> &mut Self {
+        ) -> Self {
             if let Some(application_properties) = &mut self.message.application_properties {
                 application_properties.0.insert(key.into(), value.into());
             } else {
@@ -1503,28 +1520,22 @@ pub mod builders {
             }
             self
         }
-        pub fn with_message_annotations(
-            &mut self,
-            message_annotations: AmqpAnnotations,
-        ) -> &mut Self {
+        pub fn with_message_annotations(mut self, message_annotations: AmqpAnnotations) -> Self {
             self.message.message_annotations = Some(message_annotations);
             self
         }
-        pub fn with_delivery_annotations(
-            &mut self,
-            delivery_annotations: AmqpAnnotations,
-        ) -> &mut Self {
+        pub fn with_delivery_annotations(mut self, delivery_annotations: AmqpAnnotations) -> Self {
             self.message.delivery_annotations = Some(delivery_annotations);
             self
         }
-        pub fn with_properties<T>(&mut self, properties: T) -> &mut Self
+        pub fn with_properties<T>(mut self, properties: T) -> Self
         where
             T: Into<AmqpMessageProperties>,
         {
             self.message.properties = Some(properties.into());
             self
         }
-        pub fn with_footer(&mut self, footer: AmqpAnnotations) -> &mut Self {
+        pub fn with_footer(mut self, footer: AmqpAnnotations) -> Self {
             self.message.footer = Some(footer);
             self
         }
@@ -1775,7 +1786,7 @@ mod tests {
     fn test_empty_message_serialization() {
         {
             let message = AmqpMessage::builder().build();
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
             assert_eq!(serialized, vec![0, 0x53, 0x77, 0x40]);
             #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]
             {
@@ -1801,7 +1812,7 @@ mod tests {
                         .build(),
                 )
                 .build();
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
 
             // The serialized body should contain:
             // - 0x0 DESCRIPTOR
@@ -1832,7 +1843,7 @@ mod tests {
             let message = AmqpMessage::builder()
                 .with_body(AmqpValue::from(123))
                 .build();
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
             // The serialized body should contain:
             // - 0x00: 0 DESCRIPTOR
             // - 0x53: SMALLULONG
@@ -1845,7 +1856,7 @@ mod tests {
             let message = AmqpMessage::builder()
                 .with_body(AmqpValue::from("hello"))
                 .build();
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
             // The serialized body should contain:
             // - 0x00: 0 DESCRIPTOR
             // - 0x53: SMALLULONG
@@ -1866,7 +1877,7 @@ mod tests {
             let message = AmqpMessage::builder()
                 .with_body(AmqpMessageBody::Binary(vec![vec![1, 2, 3]]))
                 .build();
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
             // The serialized body should contain:
             // - 0x00: 0 DESCRIPTOR
             // - 0x53: SMALLULONG
@@ -1879,7 +1890,7 @@ mod tests {
             let message = AmqpMessage::builder()
                 .with_body(AmqpMessageBody::Binary(vec![vec![1, 2, 3], vec![4, 5, 6]]))
                 .build();
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
             // The serialized body should contain:
             // - 0x00: 0 DESCRIPTOR
             // - 0x53: SMALLULONG
@@ -1896,7 +1907,7 @@ mod tests {
             let message = AmqpMessage::builder()
                 .with_body(vec![vec![1, 2, 3]])
                 .build();
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
             // The serialized body should contain:
             // - 0x00: 0 DESCRIPTOR
             // - 0x53: SMALLULONG
@@ -1908,7 +1919,7 @@ mod tests {
 
         {
             let message = AmqpMessage::builder().with_body(vec![1, 2, 3]).build();
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
             // The serialized body should contain:
             // - 0x00: 0 DESCRIPTOR
             // - 0x53: SMALLULONG
@@ -1926,7 +1937,7 @@ mod tests {
                 .with_body(AmqpMessageBody::Sequence(vec![AmqpList::new()]))
                 .build();
 
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
 
             // The serialized body should contain:
             // - 0x00: 0 DESCRIPTOR
@@ -1944,7 +1955,7 @@ mod tests {
                 .with_body(AmqpMessageBody::Sequence(vec![body]))
                 .build();
 
-            let serialized = AmqpMessage::serialize(message).unwrap();
+            let serialized = AmqpMessage::serialize(&message).unwrap();
 
             // The serialized body should contain:
             // - 0x00: 0 DESCRIPTOR
@@ -1980,7 +1991,7 @@ mod tests {
             )
             .build();
 
-        let serialized = AmqpMessage::serialize(message.clone()).unwrap();
+        let serialized = AmqpMessage::serialize(&message).unwrap();
         assert_eq!(
             serialized,
             vec![

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
@@ -993,6 +993,15 @@ impl From<AmqpValue> for AmqpAnnotationKey {
     }
 }
 
+impl From<AmqpAnnotationKey> for AmqpValue {
+    fn from(key: AmqpAnnotationKey) -> Self {
+        match key {
+            AmqpAnnotationKey::Symbol(symbol) => AmqpValue::Symbol(symbol),
+            AmqpAnnotationKey::Ulong(ulong) => AmqpValue::ULong(ulong),
+        }
+    }
+}
+
 impl From<AmqpSymbol> for AmqpAnnotationKey {
     fn from(symbol: AmqpSymbol) -> Self {
         AmqpAnnotationKey::Symbol(symbol)

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
@@ -1161,6 +1161,7 @@ impl AmqpMessage {
         self.body = body.into();
     }
 
+    #[allow(unused_variables)]
     pub fn serialize(message: &AmqpMessage) -> Result<Vec<u8>> {
         #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]
         {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
@@ -1113,7 +1113,7 @@ impl AmqpMessage {
     ///
     /// * `message_id` - The message ID to set on the message.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// use azure_core_amqp::messaging::AmqpMessage;
@@ -1137,12 +1137,14 @@ impl AmqpMessage {
     }
 
     /// Adds a message annotation for the message.
+    ///
     /// If the message annotations already exist, the annotation will be added to the existing annotations.
     /// If the message annotations do not exist, a new message annotations map will be created with the annotation.
     /// # Arguments
     /// * `name` - The name of the annotation to add.
     /// * `value` - The value of the annotation to add.
-    /// # Example
+    ///
+    /// # Examples
     /// ```
     /// use azure_core_amqp::messaging::AmqpMessage;
     /// let mut message = AmqpMessage::default();
@@ -1172,7 +1174,7 @@ impl AmqpMessage {
     ///
     /// * `body` - The new message body to set on the message.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// use azure_core_amqp::messaging::AmqpMessage;

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
@@ -976,6 +976,23 @@ impl Default for AmqpAnnotationKey {
     }
 }
 
+// Implementing From for AmqpValue to AmqpAnnotationKey
+// Note that this is a lossy conversion as AmqpValue can contain other types.
+// See also: https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-annotations
+//
+impl From<AmqpValue> for AmqpAnnotationKey {
+    fn from(value: AmqpValue) -> Self {
+        match value {
+            AmqpValue::Symbol(symbol) => AmqpAnnotationKey::Symbol(symbol),
+            AmqpValue::ULong(ulong) => AmqpAnnotationKey::Ulong(ulong),
+            _ => panic!(
+                "Annotation Keys can only be Symbol or ULong values, found: {:?}",
+                value
+            ),
+        }
+    }
+}
+
 impl From<AmqpSymbol> for AmqpAnnotationKey {
     fn from(symbol: AmqpSymbol) -> Self {
         AmqpAnnotationKey::Symbol(symbol)

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/noop.rs
@@ -123,6 +123,10 @@ impl AmqpManagementApis for NoopAmqpManagement {
         unimplemented!();
     }
 
+    async fn detach(self) -> Result<()> {
+        unimplemented!();
+    }
+
     async fn call(
         &self,
         operation_type: impl Into<String>,

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/session.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/session.rs
@@ -115,43 +115,34 @@ pub mod builders {
                 options: Default::default(),
             }
         }
-        pub fn build(&mut self) -> AmqpSessionOptions {
+        pub fn build(&self) -> AmqpSessionOptions {
             self.options.clone()
         }
-        pub fn with_next_outgoing_id(&mut self, next_outgoing_id: u32) -> &mut Self {
+        pub fn with_next_outgoing_id(mut self, next_outgoing_id: u32) -> Self {
             self.options.next_outgoing_id = Some(next_outgoing_id);
             self
         }
-        pub fn with_incoming_window(&mut self, incoming_window: u32) -> &mut Self {
+        pub fn with_incoming_window(mut self, incoming_window: u32) -> Self {
             self.options.incoming_window = Some(incoming_window);
             self
         }
-        pub fn with_outgoing_window(&mut self, outgoing_window: u32) -> &mut Self {
+        pub fn with_outgoing_window(mut self, outgoing_window: u32) -> Self {
             self.options.outgoing_window = Some(outgoing_window);
             self
         }
-        pub fn with_handle_max(&mut self, handle_max: u32) -> &mut Self {
+        pub fn with_handle_max(mut self, handle_max: u32) -> Self {
             self.options.handle_max = Some(handle_max);
             self
         }
-        pub fn with_offered_capabilities(
-            &mut self,
-            offered_capabilities: Vec<AmqpSymbol>,
-        ) -> &mut Self {
+        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
             self.options.offered_capabilities = Some(offered_capabilities);
             self
         }
-        pub fn with_desired_capabilities(
-            &mut self,
-            desired_capabilities: Vec<AmqpSymbol>,
-        ) -> &mut Self {
+        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
             self.options.desired_capabilities = Some(desired_capabilities);
             self
         }
-        pub fn with_properties<K, V>(
-            &mut self,
-            properties: impl Into<AmqpOrderedMap<K, V>>,
-        ) -> &mut Self
+        pub fn with_properties<K, V>(mut self, properties: impl Into<AmqpOrderedMap<K, V>>) -> Self
         where
             K: Into<AmqpSymbol> + PartialEq + Default + Debug,
             V: Into<AmqpValue> + Default,
@@ -164,7 +155,7 @@ pub mod builders {
             self.options.properties = Some(properties_map);
             self
         }
-        pub fn with_buffer_size(&mut self, buffer_size: usize) -> &mut Self {
+        pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
             self.options.buffer_size = Some(buffer_size);
             self
         }
@@ -176,8 +167,7 @@ mod tests {
 
     #[test]
     fn test_amqp_session_options_builder() {
-        let mut builder = AmqpSessionOptions::builder();
-        builder
+        let session_options = AmqpSessionOptions::builder()
             .with_next_outgoing_id(1)
             .with_incoming_window(1)
             .with_outgoing_window(1)
@@ -185,9 +175,9 @@ mod tests {
             .with_offered_capabilities(vec!["capability".into()])
             .with_desired_capabilities(vec!["capability".into()])
             .with_properties(vec![("key", "value")])
-            .with_buffer_size(1024);
+            .with_buffer_size(1024)
+            .build();
 
-        let session_options = builder.build();
         assert_eq!(session_options.next_outgoing_id, Some(1));
         assert_eq!(session_options.incoming_window, Some(1));
         assert_eq!(session_options.outgoing_window, Some(1));

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/build.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/build.rs
@@ -19,7 +19,7 @@ fn main() {
     config.structure = struct_config;
     config.language = Language::Cxx;
     config.namespaces = Some(
-        ["Azure", "Core", "Amqp", "_detail", "RustInterop"]
+        ["Azure", "Core", "Amqp", "RustInterop", "_detail"]
             .iter()
             .map(|x| x.to_string())
             .collect(),

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/cbs.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/cbs.rs
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn amqpclaimsbasedsecurity_create(
     claims_based_security: *mut *mut RustAmqpClaimsBasedSecurity,
 ) -> i32 {
     let call_context = call_context_from_ptr_mut(call_context);
-    let session = unsafe { (*session).get_session() };
+    let session = (*session).get_session();
     let cbs = AmqpClaimsBasedSecurity::new(session);
     match cbs {
         Ok(cbs) => {
@@ -47,10 +47,8 @@ pub unsafe extern "C" fn amqpclaimsbasedsecurity_create(
 ///
 #[no_mangle]
 pub unsafe extern "C" fn amqpclaimsbasedsecurity_destroy(cbs: *mut RustAmqpClaimsBasedSecurity) {
-    unsafe {
-        trace!("Destroying CBS");
-        mem::drop(Box::from_raw(cbs));
-    }
+    trace!("Destroying CBS");
+    mem::drop(Box::from_raw(cbs));
 }
 
 #[no_mangle]
@@ -128,8 +126,8 @@ pub unsafe extern "C" fn amqpclaimsbasedsecurity_authorize_path(
 ) -> i32 {
     let call_context = call_context_from_ptr_mut(call_context);
     let cbs = &mut (*cbs).inner;
-    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
-    let secret = unsafe { std::ffi::CStr::from_ptr(secret).to_str().unwrap() };
+    let path = std::ffi::CStr::from_ptr(path).to_str().unwrap();
+    let secret = std::ffi::CStr::from_ptr(secret).to_str().unwrap();
     let expires_on = UNIX_EPOCH + Duration::from_secs(expires_on);
     let expires_on = time::OffsetDateTime::from(expires_on);
 
@@ -181,7 +179,7 @@ mod tests {
             assert_eq!(result, 0);
 
             let claims_based_security = Box::into_raw(Box::new(RustAmqpClaimsBasedSecurity {
-                inner: AmqpClaimsBasedSecurity::new(&(*session).get_session()).unwrap(),
+                inner: AmqpClaimsBasedSecurity::new((*session).get_session()).unwrap(),
             }));
 
             let result = amqpclaimsbasedsecurity_attach(call_context, claims_based_security);

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/connection.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/connection.rs
@@ -58,9 +58,7 @@ pub extern "C" fn amqpconnection_create() -> *mut RustAmqpConnection {
 ///
 #[no_mangle]
 pub unsafe extern "C" fn amqpconnection_destroy(connection: *mut RustAmqpConnection) {
-    unsafe {
-        mem::drop(Box::from_raw(connection));
-    }
+    mem::drop(Box::from_raw(connection));
 }
 
 /// # Safety
@@ -76,15 +74,15 @@ pub unsafe extern "C" fn amqpconnection_open(
     options: *const RustAmqpConnectionOptions,
 ) -> i32 {
     let call_context = call_context_from_ptr_mut(ctx);
-    let connection = unsafe { &*connection };
-    let url = unsafe { CStr::from_ptr(url) };
+    let connection = &*connection;
+    let url = CStr::from_ptr(url);
     let url = url.to_str();
-    let container_id = unsafe { CStr::from_ptr(container_id) };
+    let container_id = CStr::from_ptr(container_id);
     let default_options: RustAmqpConnectionOptions = RustAmqpConnectionOptions {
         inner: Default::default(),
     };
     let options = if !options.is_null() {
-        unsafe { &*options }
+        &*options
     } else {
         &default_options
     };
@@ -132,7 +130,7 @@ pub unsafe extern "C" fn amqpconnection_close(
     ctx: *mut RustCallContext,
     connection: *const RustAmqpConnection,
 ) -> i32 {
-    let connection = unsafe { &*connection };
+    let connection = &*connection;
     let runtime_context = call_context_from_ptr_mut(ctx);
     let result = runtime_context
         .runtime_context()
@@ -158,11 +156,11 @@ pub unsafe extern "C" fn amqpconnection_close_with_error(
     description: *const c_char,
     info: *const RustAmqpValue,
 ) -> i32 {
-    let connection = unsafe { &*connection };
+    let connection = &*connection;
     let call_context = call_context_from_ptr_mut(ctx);
-    let condition = unsafe { CStr::from_ptr(condition) };
-    let description = unsafe { CStr::from_ptr(description) };
-    let info = unsafe { &*info };
+    let condition = CStr::from_ptr(condition);
+    let description = CStr::from_ptr(description);
+    let info = &*info;
     if let AmqpValue::Map(info) = &info.inner {
         let info: AmqpOrderedMap<AmqpSymbol, AmqpValue> = info
             .clone()
@@ -205,7 +203,7 @@ pub unsafe extern "C" fn amqpconnection_close_with_error(
 pub unsafe extern "C" fn amqpconnectionoptions_get_idle_timeout(
     options: *const RustAmqpConnectionOptions,
 ) -> u32 {
-    let options = unsafe { &*options };
+    let options = &*options;
     if let Some(timeout) = options.inner.idle_timeout() {
         return timeout.whole_milliseconds() as u32;
     }
@@ -218,7 +216,7 @@ pub unsafe extern "C" fn amqpconnectionoptions_get_idle_timeout(
 pub unsafe extern "C" fn amqpconnectionoptions_get_max_frame_size(
     options: *const RustAmqpConnectionOptions,
 ) -> u32 {
-    let options = unsafe { &*options };
+    let options = &*options;
     if let Some(max_frame_size) = options.inner.max_frame_size() {
         return max_frame_size;
     }
@@ -231,7 +229,7 @@ pub unsafe extern "C" fn amqpconnectionoptions_get_max_frame_size(
 pub unsafe extern "C" fn amqpconnectionoptions_get_channel_max(
     options: *const RustAmqpConnectionOptions,
 ) -> u16 {
-    let options = unsafe { &*options };
+    let options = &*options;
     if let Some(channel_max) = options.inner.channel_max() {
         return channel_max;
     }
@@ -244,7 +242,7 @@ pub unsafe extern "C" fn amqpconnectionoptions_get_channel_max(
 pub unsafe extern "C" fn amqpconnectionoptions_get_properties(
     options: *const RustAmqpConnectionOptions,
 ) -> *mut RustAmqpValue {
-    let options = unsafe { &*options };
+    let options = &*options;
     let properties = options.inner.properties();
     if let Some(properties) = properties {
         let properties: AmqpOrderedMap<AmqpValue, AmqpValue> = properties
@@ -276,9 +274,7 @@ pub unsafe extern "C" fn amqpconnectionoptionsbuilder_create(
 pub unsafe extern "C" fn amqpconnectionoptionsbuilder_destroy(
     builder: *mut RustAmqpConnectionOptionsBuilder,
 ) {
-    unsafe {
-        mem::drop(Box::from_raw(builder));
-    }
+    mem::drop(Box::from_raw(builder));
 }
 
 /// # Safety
@@ -295,9 +291,7 @@ pub unsafe extern "C" fn amqpconnectionoptionsbuilder_build(
 ///
 #[no_mangle]
 pub unsafe extern "C" fn amqpconnectionoptions_destroy(options: *mut RustAmqpConnectionOptions) {
-    unsafe {
-        mem::drop(Box::from_raw(options));
-    }
+    mem::drop(Box::from_raw(options));
 }
 
 /// # Safety
@@ -350,10 +344,10 @@ pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_outgoing_locales(
     count: usize,
 ) -> *mut RustAmqpConnectionOptionsBuilder {
     let builder = Box::from_raw(builder);
-    let locales = unsafe { std::slice::from_raw_parts(locales, count) };
+    let locales = std::slice::from_raw_parts(locales, count);
     let locales = locales
         .iter()
-        .map(|locale| unsafe { CStr::from_ptr(*locale).to_str().unwrap() })
+        .map(|locale| CStr::from_ptr(*locale).to_str().unwrap())
         .collect::<Vec<&str>>();
     Box::into_raw(Box::new(RustAmqpConnectionOptionsBuilder {
         inner: builder
@@ -371,10 +365,10 @@ pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_incoming_locales(
     count: usize,
 ) -> *mut RustAmqpConnectionOptionsBuilder {
     let builder = Box::from_raw(builder);
-    let locales = unsafe { std::slice::from_raw_parts(locales, count) };
+    let locales = std::slice::from_raw_parts(locales, count);
     let locales = locales
         .iter()
-        .map(|locale| unsafe { CStr::from_ptr(*locale).to_str().unwrap() })
+        .map(|locale| CStr::from_ptr(*locale).to_str().unwrap())
         .collect::<Vec<&str>>();
     Box::into_raw(Box::new(RustAmqpConnectionOptionsBuilder {
         inner: builder
@@ -392,10 +386,10 @@ pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_offered_capabilities(
     count: usize,
 ) -> *mut RustAmqpConnectionOptionsBuilder {
     let builder = Box::from_raw(builder);
-    let capabilities = unsafe { std::slice::from_raw_parts(capabilities, count) };
+    let capabilities = std::slice::from_raw_parts(capabilities, count);
     let capabilities = capabilities
         .iter()
-        .map(|capability| unsafe { CStr::from_ptr(*capability).to_str().unwrap() })
+        .map(|capability| CStr::from_ptr(*capability).to_str().unwrap())
         .collect::<Vec<&str>>();
     Box::into_raw(Box::new(RustAmqpConnectionOptionsBuilder {
         inner: builder
@@ -413,10 +407,10 @@ pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_desired_capabilities(
     count: usize,
 ) -> *mut RustAmqpConnectionOptionsBuilder {
     let builder = Box::from_raw(builder);
-    let capabilities = unsafe { std::slice::from_raw_parts(capabilities, count) };
+    let capabilities = std::slice::from_raw_parts(capabilities, count);
     let capabilities = capabilities
         .iter()
-        .map(|capability| unsafe { CStr::from_ptr(*capability).to_str().unwrap() })
+        .map(|capability| CStr::from_ptr(*capability).to_str().unwrap())
         .collect::<Vec<&str>>();
     Box::into_raw(Box::new(RustAmqpConnectionOptionsBuilder {
         inner: builder
@@ -433,7 +427,7 @@ pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_properties(
     properties: *const RustAmqpValue,
 ) -> *mut RustAmqpConnectionOptionsBuilder {
     let builder = Box::from_raw(builder);
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     match &properties.inner {
         AmqpValue::Map(properties) => {
             let properties: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
@@ -497,179 +491,184 @@ mod tests {
 
     #[test]
     fn test_amqpconnection_open_and_close() {
-        let ctx = create_runtime_context();
-        let ctx = create_call_context(ctx);
-        let connection = amqpconnection_create();
-        let url = CString::new("amqp://localhost:25672").unwrap();
-        let container_id = CString::new("test_container").unwrap();
-        let options = ptr::null();
+        unsafe {
+            let ctx = create_runtime_context();
+            let ctx = create_call_context(ctx);
+            let connection = amqpconnection_create();
+            let url = CString::new("amqp://localhost:25672").unwrap();
+            let container_id = CString::new("test_container").unwrap();
+            let options = ptr::null();
 
-        let open_result = unsafe {
-            amqpconnection_open(
+            let open_result = amqpconnection_open(
                 ctx,
                 connection,
                 url.as_ptr(),
                 container_id.as_ptr(),
                 options,
-            )
-        };
-        assert_eq!(open_result, 0);
+            );
+            assert_eq!(open_result, 0);
 
-        let close_result = unsafe { amqpconnection_close(ctx, connection) };
-        assert_eq!(close_result, 0);
+            let close_result = amqpconnection_close(ctx, connection);
+            assert_eq!(close_result, 0);
 
-        unsafe {
             amqpconnection_destroy(connection);
         }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_create_and_destroy() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        assert!(!builder.is_null());
         unsafe {
+            let builder = amqpconnectionoptionsbuilder_create();
+            assert!(!builder.is_null());
             amqpconnectionoptionsbuilder_destroy(builder);
         }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_idle_timeout() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        let result = unsafe { amqpconnectionoptionsbuilder_set_idle_timeout(builder, 30) };
-        assert_ne!(result, ptr::null_mut());
         unsafe {
+            let builder = amqpconnectionoptionsbuilder_create();
+            let result = amqpconnectionoptionsbuilder_set_idle_timeout(builder, 30);
+            assert_ne!(result, ptr::null_mut());
             amqpconnectionoptionsbuilder_destroy(builder);
         }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_max_frame_size() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        let result = unsafe { amqpconnectionoptionsbuilder_set_max_frame_size(builder, 65536) };
-        assert_ne!(result, ptr::null_mut());
         unsafe {
+            let builder = { amqpconnectionoptionsbuilder_create() };
+            let result = { amqpconnectionoptionsbuilder_set_max_frame_size(builder, 65536) };
+            assert_ne!(result, ptr::null_mut());
             amqpconnectionoptionsbuilder_destroy(builder);
         }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_channel_max() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        let result = unsafe { amqpconnectionoptionsbuilder_set_channel_max(builder, 256) };
-        assert_ne!(result, ptr::null_mut());
         unsafe {
+            let builder = { amqpconnectionoptionsbuilder_create() };
+            let result = { amqpconnectionoptionsbuilder_set_channel_max(builder, 256) };
+            assert_ne!(result, ptr::null_mut());
             amqpconnectionoptionsbuilder_destroy(builder);
         }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_outgoing_locales() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        let locales = vec![
-            CString::new("en-US").unwrap(),
-            CString::new("fr-FR").unwrap(),
-        ];
-        let locale_ptrs: Vec<*const c_char> =
-            locales.iter().map(|locale| locale.as_ptr()).collect();
-        let result = unsafe {
-            amqpconnectionoptionsbuilder_set_outgoing_locales(
-                builder,
-                locale_ptrs.as_ptr(),
-                locale_ptrs.len(),
-            )
-        };
-        assert_ne!(result, ptr::null_mut());
         unsafe {
+            let builder = { amqpconnectionoptionsbuilder_create() };
+            let locales = [
+                CString::new("en-US").unwrap(),
+                CString::new("fr-FR").unwrap(),
+            ];
+            let locale_ptrs: Vec<*const c_char> =
+                locales.iter().map(|locale| locale.as_ptr()).collect();
+            let result = {
+                amqpconnectionoptionsbuilder_set_outgoing_locales(
+                    builder,
+                    locale_ptrs.as_ptr(),
+                    locale_ptrs.len(),
+                )
+            };
+            assert_ne!(result, ptr::null_mut());
             amqpconnectionoptionsbuilder_destroy(builder);
         }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_incoming_locales() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        let locales = vec![
-            CString::new("en-US").unwrap(),
-            CString::new("fr-FR").unwrap(),
-        ];
-        let locale_ptrs: Vec<*const c_char> =
-            locales.iter().map(|locale| locale.as_ptr()).collect();
-        let result = unsafe {
-            amqpconnectionoptionsbuilder_set_incoming_locales(
-                builder,
-                locale_ptrs.as_ptr(),
-                locale_ptrs.len(),
-            )
-        };
-        assert_ne!(result, ptr::null_mut());
-        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
+        unsafe {
+            let builder = { amqpconnectionoptionsbuilder_create() };
+            let locales = [
+                CString::new("en-US").unwrap(),
+                CString::new("fr-FR").unwrap(),
+            ];
+            let locale_ptrs: Vec<*const c_char> =
+                locales.iter().map(|locale| locale.as_ptr()).collect();
+            let result = {
+                amqpconnectionoptionsbuilder_set_incoming_locales(
+                    builder,
+                    locale_ptrs.as_ptr(),
+                    locale_ptrs.len(),
+                )
+            };
+            assert_ne!(result, ptr::null_mut());
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_offered_capabilities() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        let capabilities = vec![
-            CString::new("capability1").unwrap(),
-            CString::new("capability2").unwrap(),
-        ];
-        let capability_ptrs: Vec<*const c_char> =
-            capabilities.iter().map(|cap| cap.as_ptr()).collect();
-        let result = unsafe {
-            amqpconnectionoptionsbuilder_set_offered_capabilities(
-                builder,
-                capability_ptrs.as_ptr(),
-                capability_ptrs.len(),
-            )
-        };
-        assert_ne!(result, ptr::null_mut());
-        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
+        unsafe {
+            let builder = { amqpconnectionoptionsbuilder_create() };
+            let capabilities = [
+                CString::new("capability1").unwrap(),
+                CString::new("capability2").unwrap(),
+            ];
+            let capability_ptrs: Vec<*const c_char> =
+                capabilities.iter().map(|cap| cap.as_ptr()).collect();
+            let result = {
+                amqpconnectionoptionsbuilder_set_offered_capabilities(
+                    builder,
+                    capability_ptrs.as_ptr(),
+                    capability_ptrs.len(),
+                )
+            };
+            assert_ne!(result, ptr::null_mut());
+
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_desired_capabilities() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        let capabilities = vec![
-            CString::new("capability1").unwrap(),
-            CString::new("capability2").unwrap(),
-        ];
-        let capability_ptrs: Vec<*const c_char> =
-            capabilities.iter().map(|cap| cap.as_ptr()).collect();
-        let result = unsafe {
-            amqpconnectionoptionsbuilder_set_desired_capabilities(
+        unsafe {
+            let builder = { amqpconnectionoptionsbuilder_create() };
+            let capabilities = [
+                CString::new("capability1").unwrap(),
+                CString::new("capability2").unwrap(),
+            ];
+            let capability_ptrs: Vec<*const c_char> =
+                capabilities.iter().map(|cap| cap.as_ptr()).collect();
+            let result = amqpconnectionoptionsbuilder_set_desired_capabilities(
                 builder,
                 capability_ptrs.as_ptr(),
                 capability_ptrs.len(),
-            )
-        };
-        assert_ne!(result, ptr::null_mut());
-        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
+            );
+            assert_ne!(result, ptr::null_mut());
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_properties() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        let mut map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = AmqpOrderedMap::new();
-        map.insert(AmqpSymbol::from("key1"), AmqpValue::from("value1"));
-        map.insert(AmqpSymbol::from("key2"), AmqpValue::from("value2"));
+        unsafe {
+            let builder = amqpconnectionoptionsbuilder_create();
+            let mut map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = AmqpOrderedMap::new();
+            map.insert(AmqpSymbol::from("key1"), AmqpValue::from("value1"));
+            map.insert(AmqpSymbol::from("key2"), AmqpValue::from("value2"));
 
-        let rust_value = RustAmqpValue {
-            inner: AmqpValue::Map(map.into_iter().map(|f| (f.0.into(), f.1)).collect()),
-        };
+            let rust_value = RustAmqpValue {
+                inner: AmqpValue::Map(map.into_iter().map(|f| (f.0.into(), f.1)).collect()),
+            };
 
-        let result = unsafe {
-            amqpconnectionoptionsbuilder_set_properties(
+            let result = amqpconnectionoptionsbuilder_set_properties(
                 builder,
                 &rust_value as *const RustAmqpValue,
-            )
-        };
-        assert_ne!(result, ptr::null_mut());
-        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
+            );
+            assert_ne!(result, ptr::null_mut());
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 
     #[test]
     fn test_amqpconnectionoptionsbuilder_set_buffer_size() {
-        let builder = unsafe { amqpconnectionoptionsbuilder_create() };
-        let result = unsafe { amqpconnectionoptionsbuilder_set_buffer_size(builder, 1024) };
-        assert_ne!(result, ptr::null_mut());
-        unsafe { amqpconnectionoptionsbuilder_destroy(builder) };
+        unsafe {
+            let builder = amqpconnectionoptionsbuilder_create();
+            let result = amqpconnectionoptionsbuilder_set_buffer_size(builder, 1024);
+            assert_ne!(result, ptr::null_mut());
+            amqpconnectionoptionsbuilder_destroy(builder);
+        }
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/connection.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/connection.rs
@@ -449,9 +449,9 @@ pub unsafe extern "C" fn amqpconnectionoptionsbuilder_set_properties(
                     )
                 })
                 .collect();
-            return Box::into_raw(Box::new(RustAmqpConnectionOptionsBuilder {
+            Box::into_raw(Box::new(RustAmqpConnectionOptionsBuilder {
                 inner: builder.inner.with_properties(properties),
-            }));
+            }))
         }
         _ => panic!("Expected map for value, found: {:?}", properties.inner),
     }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/management.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/management.rs
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn amqpmanagement_create(
     access_token: *const RustAccessToken,
 ) -> *mut RustAmqpManagement {
     let call_context = call_context_from_ptr_mut(call_context);
-    let session = unsafe { (*session).get_session() };
+    let session = (*session).get_session();
     let name = std::ffi::CStr::from_ptr(name).to_str().unwrap();
     let rust_access_token: &RustAccessToken = &*access_token;
     let access_token: AccessToken = AccessToken::new(

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/management.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/management.rs
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn amqpmanagement_call(
             .iter()
             .map(|(key, value)| {
                 let key = String::from(key);
-                let value = value.into();
+                let value = value;
                 (key, value)
             })
             .collect();
@@ -202,6 +202,6 @@ pub unsafe extern "C" fn amqpmanagement_call(
             "Application properties must be a map, found: {:?}",
             application_properties
         );
-        return ptr::null_mut();
+        ptr::null_mut()
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/session.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/session.rs
@@ -13,7 +13,7 @@ use azure_core_amqp::{
     },
     value::{AmqpOrderedMap, AmqpSymbol, AmqpValue},
 };
-use std::mem;
+use std::{mem, ptr};
 use tracing::error;
 
 pub struct RustAmqpSession {
@@ -156,11 +156,13 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_destroy(
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_outgoing_window(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     outgoing_window: u32,
-) {
-    let session_options_builder = unsafe { &mut *session_options_builder };
-    session_options_builder
-        .inner
-        .with_outgoing_window(outgoing_window);
+) -> *mut RustAmqpSessionOptionsBuilder {
+    let session_options_builder = Box::from_raw(session_options_builder);
+    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
+        inner: session_options_builder
+            .inner
+            .with_outgoing_window(outgoing_window),
+    }))
 }
 
 /// # Safety
@@ -169,11 +171,13 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_outgoing_window(
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_incoming_window(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     incoming_window: u32,
-) {
-    let session_options_builder = unsafe { &mut *session_options_builder };
-    session_options_builder
-        .inner
-        .with_incoming_window(incoming_window);
+) -> *mut RustAmqpSessionOptionsBuilder {
+    let session_options_builder = Box::from_raw(session_options_builder);
+    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
+        inner: session_options_builder
+            .inner
+            .with_incoming_window(incoming_window),
+    }))
 }
 
 /// # Safety
@@ -182,11 +186,13 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_incoming_window(
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_next_outgoing_id(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     next_outgoing_id: u32,
-) {
-    let session_options_builder = unsafe { &mut *session_options_builder };
-    session_options_builder
-        .inner
-        .with_next_outgoing_id(next_outgoing_id);
+) -> *mut RustAmqpSessionOptionsBuilder {
+    let session_options_builder = Box::from_raw(session_options_builder);
+    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
+        inner: session_options_builder
+            .inner
+            .with_next_outgoing_id(next_outgoing_id),
+    }))
 }
 
 /// # Safety
@@ -195,9 +201,11 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_next_outgoing_id(
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_handle_max(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     handle_max: u32,
-) {
-    let session_options_builder = unsafe { &mut *session_options_builder };
-    session_options_builder.inner.with_handle_max(handle_max);
+) -> *mut RustAmqpSessionOptionsBuilder {
+    let session_options_builder = Box::from_raw(session_options_builder);
+    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
+        inner: session_options_builder.inner.with_handle_max(handle_max),
+    }))
 }
 
 /// # Safety
@@ -206,17 +214,21 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_handle_max(
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_offered_capabilities(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     offered_capabilities: *mut RustAmqpValue,
-) {
-    let session_options_builder = unsafe { &mut *session_options_builder };
+) -> *mut RustAmqpSessionOptionsBuilder {
+    let session_options_builder = Box::from_raw(session_options_builder);
     let offered_capabilities = unsafe { &*offered_capabilities };
     if let AmqpValue::List(offered_capabilities) = &offered_capabilities.inner {
         let offered_capabilities: Vec<AmqpSymbol> = offered_capabilities
             .iter()
             .map(|v| AmqpSymbol::from(v.clone()))
             .collect();
-        session_options_builder
-            .inner
-            .with_offered_capabilities(offered_capabilities);
+        Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
+            inner: session_options_builder
+                .inner
+                .with_offered_capabilities(offered_capabilities),
+        }))
+    } else {
+        ptr::null_mut()
     }
 }
 
@@ -226,17 +238,21 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_offered_capabilities(
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_desired_capabilities(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     desired_capabilities: *mut RustAmqpValue,
-) {
-    let session_options_builder = unsafe { &mut *session_options_builder };
+) -> *mut RustAmqpSessionOptionsBuilder {
+    let session_options_builder = Box::from_raw(session_options_builder);
     let desired_capabilities = unsafe { &*desired_capabilities };
     if let AmqpValue::List(desired_capabilities) = &desired_capabilities.inner {
         let desired_capabilities: Vec<AmqpSymbol> = desired_capabilities
             .iter()
             .map(|v| AmqpSymbol::from(v.clone()))
             .collect();
-        session_options_builder
-            .inner
-            .with_desired_capabilities(desired_capabilities);
+        Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
+            inner: session_options_builder
+                .inner
+                .with_desired_capabilities(desired_capabilities),
+        }))
+    } else {
+        ptr::null_mut()
     }
 }
 
@@ -246,17 +262,21 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_desired_capabilities(
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_properties(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     properties: *mut RustAmqpValue,
-) {
-    let session_options_builder = unsafe { &mut *session_options_builder };
+) -> *mut RustAmqpSessionOptionsBuilder {
+    let session_options_builder = Box::from_raw(session_options_builder);
     let properties = unsafe { &*properties };
     if let AmqpValue::Map(properties) = &properties.inner {
         let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
             .iter()
             .map(|(k, v)| (AmqpSymbol::from(k), v))
             .collect();
-        session_options_builder
-            .inner
-            .with_properties(properties_map);
+        Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
+            inner: session_options_builder
+                .inner
+                .with_properties(properties_map),
+        }))
+    } else {
+        ptr::null_mut()
     }
 }
 
@@ -266,9 +286,11 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_properties(
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_buffer_size(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
     buffer_size: usize,
-) {
-    let session_options_builder = unsafe { &mut *session_options_builder };
-    session_options_builder.inner.with_buffer_size(buffer_size);
+) -> *mut RustAmqpSessionOptionsBuilder {
+    let session_options_builder = Box::from_raw(session_options_builder);
+    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
+        inner: session_options_builder.inner.with_buffer_size(buffer_size),
+    }))
 }
 
 /// # Safety

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/session.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/session.rs
@@ -47,9 +47,7 @@ pub unsafe extern "C" fn amqpsession_create() -> *mut RustAmqpSession {
 ///
 #[no_mangle]
 pub unsafe extern "C" fn amqpsession_destroy(session: *mut RustAmqpSession) {
-    unsafe {
-        mem::drop(Box::from_raw(session));
-    }
+    mem::drop(Box::from_raw(session));
 }
 
 /// # Safety
@@ -61,8 +59,8 @@ pub unsafe extern "C" fn amqpsession_begin(
     connection: *mut RustAmqpConnection,
     session_options: *mut RustAmqpSessionOptions,
 ) -> i32 {
-    let session = unsafe { &mut *session };
-    let connection = unsafe { &mut *connection };
+    let session = &mut *session;
+    let connection = &mut *connection;
     let call_context = call_context_from_ptr_mut(call_context);
 
     if session_options.is_null() {
@@ -79,7 +77,7 @@ pub unsafe extern "C" fn amqpsession_begin(
             }
         }
     } else {
-        let session_options = unsafe { &*session_options };
+        let session_options = &*session_options;
         let result = call_context
             .runtime_context()
             .runtime()
@@ -105,7 +103,7 @@ pub unsafe extern "C" fn amqpsession_end(
     call_context: *mut RustCallContext,
     session: *mut RustAmqpSession,
 ) -> i32 {
-    let session = unsafe { &*session };
+    let session = &*session;
     let call_context = call_context_from_ptr_mut(call_context);
     let result = call_context
         .runtime_context()
@@ -125,9 +123,7 @@ pub unsafe extern "C" fn amqpsession_end(
 ///
 #[no_mangle]
 pub unsafe extern "C" fn amqpsessionoptions_destroy(session_options: *mut RustAmqpSessionOptions) {
-    unsafe {
-        mem::drop(Box::from_raw(session_options));
-    }
+    mem::drop(Box::from_raw(session_options));
 }
 
 /// # Safety
@@ -145,9 +141,7 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_create() -> *mut RustAmqpSess
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_destroy(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
 ) {
-    unsafe {
-        mem::drop(Box::from_raw(session_options_builder));
-    }
+    mem::drop(Box::from_raw(session_options_builder));
 }
 
 /// # Safety
@@ -216,7 +210,7 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_offered_capabilities(
     offered_capabilities: *mut RustAmqpValue,
 ) -> *mut RustAmqpSessionOptionsBuilder {
     let session_options_builder = Box::from_raw(session_options_builder);
-    let offered_capabilities = unsafe { &*offered_capabilities };
+    let offered_capabilities = &*offered_capabilities;
     if let AmqpValue::List(offered_capabilities) = &offered_capabilities.inner {
         let offered_capabilities: Vec<AmqpSymbol> = offered_capabilities
             .iter()
@@ -240,7 +234,7 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_desired_capabilities(
     desired_capabilities: *mut RustAmqpValue,
 ) -> *mut RustAmqpSessionOptionsBuilder {
     let session_options_builder = Box::from_raw(session_options_builder);
-    let desired_capabilities = unsafe { &*desired_capabilities };
+    let desired_capabilities = &*desired_capabilities;
     if let AmqpValue::List(desired_capabilities) = &desired_capabilities.inner {
         let desired_capabilities: Vec<AmqpSymbol> = desired_capabilities
             .iter()
@@ -264,7 +258,7 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_properties(
     properties: *mut RustAmqpValue,
 ) -> *mut RustAmqpSessionOptionsBuilder {
     let session_options_builder = Box::from_raw(session_options_builder);
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     if let AmqpValue::Map(properties) = &properties.inner {
         let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
             .iter()
@@ -299,7 +293,7 @@ pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_buffer_size(
 pub unsafe extern "C" fn amqpsessionoptionsbuilder_build(
     session_options_builder: *mut RustAmqpSessionOptionsBuilder,
 ) -> *mut RustAmqpSessionOptions {
-    let session_options_builder = unsafe { &mut *session_options_builder };
+    let session_options_builder = &mut *session_options_builder;
     Box::into_raw(Box::new(RustAmqpSessionOptions {
         inner: session_options_builder.inner.build(),
     }))
@@ -317,137 +311,169 @@ mod tests {
 
     #[test]
     fn test_amqpsession_create() {
-        let session = unsafe { amqpsession_create() };
-        assert_ne!(session, std::ptr::null_mut());
-        unsafe { amqpsession_destroy(session) };
+        unsafe {
+            let session = { amqpsession_create() };
+            assert_ne!(session, std::ptr::null_mut());
+
+            amqpsession_destroy(session);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_create() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        assert_ne!(session_options_builder, std::ptr::null_mut());
-        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
+        unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            assert_ne!(session_options_builder, std::ptr::null_mut());
+
+            amqpsessionoptionsbuilder_destroy(session_options_builder);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_outgoing_window() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        unsafe { amqpsessionoptionsbuilder_set_outgoing_window(session_options_builder, 10) };
-        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
+        unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+
+            amqpsessionoptionsbuilder_set_outgoing_window(session_options_builder, 10);
+
+            amqpsessionoptionsbuilder_destroy(session_options_builder);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_incoming_window() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        unsafe { amqpsessionoptionsbuilder_set_incoming_window(session_options_builder, 10) };
-        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
+        unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+
+            amqpsessionoptionsbuilder_set_incoming_window(session_options_builder, 10);
+
+            amqpsessionoptionsbuilder_destroy(session_options_builder);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_next_outgoing_id() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        unsafe { amqpsessionoptionsbuilder_set_next_outgoing_id(session_options_builder, 10) };
-        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
+        unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+
+            amqpsessionoptionsbuilder_set_next_outgoing_id(session_options_builder, 10);
+
+            amqpsessionoptionsbuilder_destroy(session_options_builder);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_handle_max() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        unsafe { amqpsessionoptionsbuilder_set_handle_max(session_options_builder, 10) };
-        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
+        unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+
+            amqpsessionoptionsbuilder_set_handle_max(session_options_builder, 10);
+
+            amqpsessionoptionsbuilder_destroy(session_options_builder);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_offered_capabilities() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        let offered_capabilities = RustAmqpValue {
-            inner: AmqpValue::List(AmqpList::from(vec![AmqpValue::Symbol(AmqpSymbol::from(
-                "test",
-            ))])),
-        };
         unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let offered_capabilities = RustAmqpValue {
+                inner: AmqpValue::List(AmqpList::from(vec![AmqpValue::Symbol(AmqpSymbol::from(
+                    "test",
+                ))])),
+            };
+
             amqpsessionoptionsbuilder_set_offered_capabilities(
                 session_options_builder,
                 &offered_capabilities as *const RustAmqpValue as *mut RustAmqpValue,
-            )
-        };
-        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
+            );
+
+            amqpsessionoptionsbuilder_destroy(session_options_builder);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_desired_capabilities() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        let desired_capabilities = RustAmqpValue {
-            inner: AmqpValue::List(vec![AmqpValue::Symbol(AmqpSymbol::from("test"))].into()),
-        };
         unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let desired_capabilities = RustAmqpValue {
+                inner: AmqpValue::List(vec![AmqpValue::Symbol(AmqpSymbol::from("test"))].into()),
+            };
+
             amqpsessionoptionsbuilder_set_desired_capabilities(
                 session_options_builder,
                 &desired_capabilities as *const RustAmqpValue as *mut RustAmqpValue,
-            )
-        };
-        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
+            );
+
+            amqpsessionoptionsbuilder_destroy(session_options_builder);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_properties() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        let properties = RustAmqpValue {
-            inner: AmqpValue::Map(
-                vec![(
-                    AmqpValue::Symbol("key".into()),
-                    AmqpValue::Symbol("value".into()),
-                )]
-                .into_iter()
-                .collect(),
-            ),
-        };
         unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let properties = RustAmqpValue {
+                inner: AmqpValue::Map(
+                    vec![(
+                        AmqpValue::Symbol("key".into()),
+                        AmqpValue::Symbol("value".into()),
+                    )]
+                    .into_iter()
+                    .collect(),
+                ),
+            };
+
             amqpsessionoptionsbuilder_set_properties(
                 session_options_builder,
                 &properties as *const RustAmqpValue as *mut RustAmqpValue,
-            )
-        };
-        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
+            );
+
+            amqpsessionoptionsbuilder_destroy(session_options_builder);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_set_buffer_size() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        unsafe { amqpsessionoptionsbuilder_set_buffer_size(session_options_builder, 1024) };
-        unsafe { amqpsessionoptionsbuilder_destroy(session_options_builder) };
+        unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            amqpsessionoptionsbuilder_set_buffer_size(session_options_builder, 1024);
+
+            amqpsessionoptionsbuilder_destroy(session_options_builder);
+        }
     }
 
     #[test]
     fn test_amqpsessionoptionsbuilder_build() {
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        let session_options = unsafe { amqpsessionoptionsbuilder_build(session_options_builder) };
-        assert_ne!(session_options, std::ptr::null_mut());
-        unsafe { amqpsessionoptions_destroy(session_options) };
+        unsafe {
+            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let session_options = { amqpsessionoptionsbuilder_build(session_options_builder) };
+            assert_ne!(session_options, std::ptr::null_mut());
+            amqpsessionoptions_destroy(session_options);
+        }
     }
 
     #[test]
     fn test_amqpsession_begin() {
-        let runtime_context = Box::into_raw(Box::new(RuntimeContext::new().unwrap()));
-        let call_context = Box::into_raw(Box::new(RustCallContext::new(runtime_context)));
-        let session = unsafe { amqpsession_create() };
-        let connection = AmqpConnection::new();
-
-        call_context_from_ptr_mut(call_context)
-            .runtime_context()
-            .runtime()
-            .block_on(connection.open(
-                "testConnection",
-                url::Url::parse("amqp://localhost:25672").unwrap(),
-                None,
-            ))
-            .unwrap();
-
-        let connection = Box::into_raw(Box::new(RustAmqpConnection::new(connection)));
-        let result =
-            unsafe { amqpsession_begin(call_context, session, connection, std::ptr::null_mut()) };
-        assert_eq!(result, 0);
         unsafe {
+            let runtime_context = Box::into_raw(Box::new(RuntimeContext::new().unwrap()));
+            let call_context = Box::into_raw(Box::new(RustCallContext::new(runtime_context)));
+            let session = amqpsession_create();
+            let connection = AmqpConnection::new();
+
+            call_context_from_ptr_mut(call_context)
+                .runtime_context()
+                .runtime()
+                .block_on(connection.open(
+                    "testConnection",
+                    url::Url::parse("amqp://localhost:25672").unwrap(),
+                    None,
+                ))
+                .unwrap();
+
+            let connection = Box::into_raw(Box::new(RustAmqpConnection::new(connection)));
+            let result = amqpsession_begin(call_context, session, connection, std::ptr::null_mut());
+            assert_eq!(result, 0);
             drop(Box::from_raw(connection));
             amqpsession_destroy(session);
             drop(Box::from_raw(runtime_context));
@@ -456,33 +482,32 @@ mod tests {
 
     #[test]
     fn test_amqpsession_begin_with_options() {
-        let runtime_context = Box::into_raw(Box::new(RuntimeContext::new().unwrap()));
-        let call_context = Box::into_raw(Box::new(RustCallContext::new(runtime_context)));
-        let session = unsafe { amqpsession_create() };
-        let connection = AmqpConnection::new();
-
-        call_context_from_ptr_mut(call_context)
-            .runtime_context()
-            .runtime()
-            .block_on(connection.open(
-                "testConnection",
-                url::Url::parse("amqp://localhost:25672").unwrap(),
-                None,
-            ))
-            .unwrap();
-
-        let connection = Box::into_raw(Box::new(RustAmqpConnection::new(connection)));
-
-        let session_options_builder = unsafe { amqpsessionoptionsbuilder_create() };
-        let session_options = unsafe { amqpsessionoptionsbuilder_build(session_options_builder) };
-        let result =
-            unsafe { amqpsession_begin(call_context, session, connection, session_options) };
-        assert_eq!(result, 0);
-        unsafe { amqpsession_destroy(session) };
         unsafe {
+            let runtime_context = Box::into_raw(Box::new(RuntimeContext::new().unwrap()));
+            let call_context = Box::into_raw(Box::new(RustCallContext::new(runtime_context)));
+            let session = amqpsession_create();
+            let connection = AmqpConnection::new();
+
+            call_context_from_ptr_mut(call_context)
+                .runtime_context()
+                .runtime()
+                .block_on(connection.open(
+                    "testConnection",
+                    url::Url::parse("amqp://localhost:25672").unwrap(),
+                    None,
+                ))
+                .unwrap();
+
+            let connection = Box::into_raw(Box::new(RustAmqpConnection::new(connection)));
+
+            let session_options_builder = amqpsessionoptionsbuilder_create();
+            let session_options = amqpsessionoptionsbuilder_build(session_options_builder);
+            let result = amqpsession_begin(call_context, session, connection, session_options);
+            assert_eq!(result, 0);
+            amqpsession_destroy(session);
             drop(Box::from_raw(connection));
             drop(Box::from_raw(runtime_context));
+            amqpsessionoptions_destroy(session_options);
         }
-        unsafe { amqpsessionoptions_destroy(session_options) };
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/call_context.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/call_context.rs
@@ -19,8 +19,9 @@ impl RustCallContext {
         }
     }
 
-    pub fn runtime_context(&self) -> &RuntimeContext {
-        unsafe { &*self.runtime_context }
+    /// # Safety
+    pub unsafe fn runtime_context(&self) -> &RuntimeContext {
+        &*self.runtime_context
     }
 
     pub fn set_error(&mut self, error: Box<dyn std::error::Error + Send + Sync>) {
@@ -37,9 +38,7 @@ pub extern "C" fn call_context_new(runtime_context: *mut RuntimeContext) -> *mut
 ///
 #[no_mangle]
 pub unsafe extern "C" fn call_context_delete(ctx: *mut RustCallContext) {
-    unsafe {
-        drop(Box::from_raw(ctx));
-    }
+    drop(Box::from_raw(ctx));
 }
 
 /// # Safety

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/lib.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/lib.rs
@@ -22,3 +22,10 @@ pub extern "C" fn rust_string_delete(rust_string: *const c_char) {
         mem::drop(CString::from_raw(rust_string as *mut c_char));
     }
 }
+
+pub(crate) fn error_from_str(msg: &'static str) -> Box<dyn std::error::Error + Send + Sync> {
+    Box::new(azure_core::error::Error::message(
+        azure_core::error::ErrorKind::Other,
+        msg,
+    ))
+}

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/header.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/header.rs
@@ -98,68 +98,80 @@ extern "C" fn header_builder_destroy(builder: *mut RustMessageHeaderBuilder) {
 }
 
 #[no_mangle]
-extern "C" fn header_set_durable(builder: *mut RustMessageHeaderBuilder, durable: bool) -> i32 {
-    let builder = unsafe { &mut *builder };
-    builder.inner.with_durable(durable);
-    0
+unsafe extern "C" fn header_set_durable(
+    builder: *mut RustMessageHeaderBuilder,
+    durable: bool,
+) -> *mut RustMessageHeaderBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustMessageHeaderBuilder {
+        inner: builder.inner.with_durable(durable),
+    }))
 }
 
 #[no_mangle]
-extern "C" fn header_set_priority(builder: *mut RustMessageHeaderBuilder, priority: u8) -> i32 {
-    let builder = unsafe { &mut *builder };
-    builder.inner.with_priority(priority);
-    0
+unsafe extern "C" fn header_set_priority(
+    builder: *mut RustMessageHeaderBuilder,
+    priority: u8,
+) -> *mut RustMessageHeaderBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustMessageHeaderBuilder {
+        inner: builder.inner.with_priority(priority),
+    }))
 }
 
 #[no_mangle]
-extern "C" fn header_set_ttl(builder: *mut RustMessageHeaderBuilder, time_to_live: u64) -> i32 {
-    let builder = unsafe { &mut *builder };
-    builder
-        .inner
-        .with_time_to_live(Some(std::time::Duration::from_millis(time_to_live)));
-    0
+unsafe extern "C" fn header_set_ttl(
+    builder: *mut RustMessageHeaderBuilder,
+    time_to_live: u64,
+) -> *mut RustMessageHeaderBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustMessageHeaderBuilder {
+        inner: builder
+            .inner
+            .with_time_to_live(Some(std::time::Duration::from_millis(time_to_live))),
+    }))
 }
 
 #[no_mangle]
-extern "C" fn header_set_first_acquirer(
+unsafe extern "C" fn header_set_first_acquirer(
     builder: *mut RustMessageHeaderBuilder,
     first_acquirer: bool,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
-    builder.inner.with_first_acquirer(first_acquirer);
-    0
+) -> *mut RustMessageHeaderBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustMessageHeaderBuilder {
+        inner: builder.inner.with_first_acquirer(first_acquirer),
+    }))
 }
 
 #[no_mangle]
-extern "C" fn header_set_delivery_count(
+unsafe extern "C" fn header_set_delivery_count(
     builder: *mut RustMessageHeaderBuilder,
     delivery_count: u32,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
-    builder.inner.with_delivery_count(delivery_count);
-    0
+) -> *mut RustMessageHeaderBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustMessageHeaderBuilder {
+        inner: builder.inner.with_delivery_count(delivery_count),
+    }))
 }
 
 #[no_mangle]
-extern "C" fn header_build(
+unsafe extern "C" fn header_build(
     builder: *mut RustMessageHeaderBuilder,
     header: *mut *mut RustMessageHeader,
 ) -> i32 {
-    let builder = unsafe { &mut *builder };
-    unsafe {
-        *header = Box::into_raw(Box::new(RustMessageHeader {
-            inner: builder.inner.build(),
-        }))
-    };
+    let builder = Box::from_raw(builder);
+    *header = Box::into_raw(Box::new(RustMessageHeader {
+        inner: builder.inner.build(),
+    }));
     0
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_get_header(
+unsafe extern "C" fn amqpvalue_get_header(
     value: *const RustAmqpValue,
     header: &mut *mut RustMessageHeader,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Described(value) => match value.descriptor() {
             AmqpDescriptor::Code(0x70) => {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/header.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/header.rs
@@ -8,7 +8,7 @@ use azure_core_amqp::{
     value::{AmqpComposite, AmqpDescriptor, AmqpValue},
 };
 use std::mem;
-
+use crate::call_context::{RustCallContext, call_context_from_ptr_mut};
 use super::value::RustAmqpValue;
 
 pub struct RustMessageHeader {
@@ -99,9 +99,11 @@ extern "C" fn header_builder_destroy(builder: *mut RustMessageHeaderBuilder) {
 
 #[no_mangle]
 unsafe extern "C" fn header_set_durable(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessageHeaderBuilder,
     durable: bool,
 ) -> *mut RustMessageHeaderBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustMessageHeaderBuilder {
         inner: builder.inner.with_durable(durable),
@@ -110,9 +112,11 @@ unsafe extern "C" fn header_set_durable(
 
 #[no_mangle]
 unsafe extern "C" fn header_set_priority(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessageHeaderBuilder,
     priority: u8,
 ) -> *mut RustMessageHeaderBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustMessageHeaderBuilder {
         inner: builder.inner.with_priority(priority),
@@ -121,9 +125,11 @@ unsafe extern "C" fn header_set_priority(
 
 #[no_mangle]
 unsafe extern "C" fn header_set_ttl(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessageHeaderBuilder,
     time_to_live: u64,
 ) -> *mut RustMessageHeaderBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustMessageHeaderBuilder {
         inner: builder
@@ -134,9 +140,11 @@ unsafe extern "C" fn header_set_ttl(
 
 #[no_mangle]
 unsafe extern "C" fn header_set_first_acquirer(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessageHeaderBuilder,
     first_acquirer: bool,
 ) -> *mut RustMessageHeaderBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustMessageHeaderBuilder {
         inner: builder.inner.with_first_acquirer(first_acquirer),
@@ -145,9 +153,11 @@ unsafe extern "C" fn header_set_first_acquirer(
 
 #[no_mangle]
 unsafe extern "C" fn header_set_delivery_count(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessageHeaderBuilder,
     delivery_count: u32,
 ) -> *mut RustMessageHeaderBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustMessageHeaderBuilder {
         inner: builder.inner.with_delivery_count(delivery_count),

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/header.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/header.rs
@@ -230,6 +230,7 @@ mod tests {
 
     #[test]
     fn test_amqpvalue_create_header() {
+        unsafe {
         let header = RustMessageHeader {
             inner: AmqpMessageHeader::builder().with_priority(3).build(),
         };
@@ -238,12 +239,12 @@ mod tests {
 
         let mut size: usize = 0;
         assert_eq!(
-            unsafe { amqpvalue_get_encoded_size(value.clone(), &mut size as *mut usize) },
+             { amqpvalue_get_encoded_size(value, &mut size as *mut usize) },
             0
         );
         let mut buffer: Vec<u8> = vec![0; size];
         assert_eq!(
-            unsafe { amqpvalue_encode(value, buffer.as_mut_ptr(), size) },
+             { amqpvalue_encode(value, buffer.as_mut_ptr(), size) },
             0
         );
 
@@ -262,5 +263,6 @@ mod tests {
         //     ),
         //     0
         // );
+    }
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/message.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/message.rs
@@ -331,7 +331,7 @@ unsafe extern "C" fn messagebuilder_set_delivery_annotations(
 ) -> *mut RustAmqpMessageBuilder {
     let call_context = call_context_from_ptr_mut(call_context);
     let message_builder = Box::from_raw(message_builder);
-    let delivery_annotations = unsafe { &*delivery_annotations };
+    let delivery_annotations =  &*delivery_annotations ;
     if let AmqpValue::Map(map) = &delivery_annotations.inner {
         let amqp_map: AmqpOrderedMap<AmqpAnnotationKey, AmqpValue> =
             map.iter().map(|f| (f.0.into(), f.1)).collect();
@@ -354,7 +354,7 @@ unsafe extern "C" fn messagebuilder_set_message_annotations(
 ) -> *mut RustAmqpMessageBuilder {
     let call_context = call_context_from_ptr_mut(call_context);
     let message_builder = Box::from_raw(message_builder);
-    let message_annotations = unsafe { &*message_annotations };
+    let message_annotations =  &*message_annotations ;
     if let AmqpValue::Map(map) = &message_annotations.inner {
         let amqp_map: AmqpOrderedMap<AmqpAnnotationKey, AmqpValue> =
             map.iter().map(|f| (f.0.into(), f.1)).collect();
@@ -377,7 +377,7 @@ unsafe extern "C" fn messagebuilder_set_application_properties(
 ) -> *mut RustAmqpMessageBuilder {
     let call_context = call_context_from_ptr_mut(call_context);
     let message_builder = Box::from_raw(message_builder);
-    let application_properties = unsafe { &*application_properties };
+    let application_properties =  &*application_properties ;
     if let AmqpValue::Map(map) = &application_properties.inner {
         let amqp_map: AmqpOrderedMap<String, AmqpValue> = map
             .iter()
@@ -410,7 +410,7 @@ unsafe extern "C" fn messagebuilder_set_footer(
 ) -> *mut RustAmqpMessageBuilder {
     let call_context = call_context_from_ptr_mut(call_context);
     let message_builder = Box::from_raw(message_builder);
-    let footer = unsafe { &*footer };
+    let footer =  &*footer ;
     if let AmqpValue::Map(map) = &footer.inner {
         let amqp_map: AmqpOrderedMap<AmqpAnnotationKey, AmqpValue> =
             map.iter().map(|f| (f.0.into(), f.1)).collect();

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/message_fields.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/message_fields.rs
@@ -7,10 +7,10 @@ use crate::model::value::RustAmqpValue;
 use azure_core_amqp::value::{AmqpDescribed, AmqpValue};
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_delivery_annotations(
+unsafe extern "C" fn amqpvalue_create_delivery_annotations(
     value: *const RustAmqpValue,
 ) -> *mut RustAmqpValue {
-    let value = unsafe { &*value };
+    let value = { &*value };
     let annotations = match &value.inner {
         AmqpValue::Map(map) => map,
         _ => return std::ptr::null_mut(),
@@ -23,10 +23,10 @@ extern "C" fn amqpvalue_create_delivery_annotations(
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_message_annotations(
+unsafe extern "C" fn amqpvalue_create_message_annotations(
     value: *const RustAmqpValue,
 ) -> *mut RustAmqpValue {
-    let value = unsafe { &*value };
+    let value = { &*value };
     let annotations = match &value.inner {
         AmqpValue::Map(map) => map,
         _ => return std::ptr::null_mut(),
@@ -39,8 +39,8 @@ extern "C" fn amqpvalue_create_message_annotations(
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_footer(value: *const RustAmqpValue) -> *mut RustAmqpValue {
-    let value = unsafe { &*value };
+unsafe extern "C" fn amqpvalue_create_footer(value: *const RustAmqpValue) -> *mut RustAmqpValue {
+    let value = { &*value };
     let annotations = match &value.inner {
         AmqpValue::Map(map) => map,
         _ => return std::ptr::null_mut(),
@@ -53,10 +53,10 @@ extern "C" fn amqpvalue_create_footer(value: *const RustAmqpValue) -> *mut RustA
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_application_properties(
+unsafe extern "C" fn amqpvalue_create_application_properties(
     value: *const RustAmqpValue,
 ) -> *mut RustAmqpValue {
-    let value = unsafe { &*value };
+    let value = { &*value };
     let properties = match &value.inner {
         AmqpValue::Map(map) => map,
         _ => return std::ptr::null_mut(),
@@ -66,4 +66,118 @@ extern "C" fn amqpvalue_create_application_properties(
     Box::into_raw(Box::new(RustAmqpValue {
         inner: AmqpValue::Described(Box::new(application_properties)),
     }))
+}
+#[cfg(test)]
+mod tests {
+    use azure_core_amqp::value::AmqpDescriptor;
+
+    use super::*;
+
+    #[test]
+    fn test_amqpvalue_create_delivery_annotations() {
+        unsafe {
+            let map = AmqpValue::Map(
+                vec![("key".into(), AmqpValue::String("value".into()))]
+                    .into_iter()
+                    .collect(),
+            );
+            let rust_amqp_value = RustAmqpValue { inner: map };
+            let result = { amqpvalue_create_delivery_annotations(&rust_amqp_value) };
+            assert!(!result.is_null());
+            let result_value = { &*result };
+            match &result_value.inner {
+                AmqpValue::Described(described) => {
+                    assert_eq!(described.descriptor, AmqpDescriptor::Code(0x71));
+                    match &described.value {
+                        AmqpValue::Map(map) => {
+                            assert_eq!(map.get("key").unwrap(), &AmqpValue::String("value".into()));
+                        }
+                        _ => panic!("Expected AmqpValue::Map"),
+                    }
+                }
+                _ => panic!("Expected AmqpValue::Described"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_amqpvalue_create_message_annotations() {
+        unsafe {
+            let map = AmqpValue::Map(
+                vec![("key".into(), AmqpValue::String("value".into()))]
+                    .into_iter()
+                    .collect(),
+            );
+            let rust_amqp_value = RustAmqpValue { inner: map };
+            let result = { amqpvalue_create_message_annotations(&rust_amqp_value) };
+            assert!(!result.is_null());
+            let result_value = { &*result };
+            match &result_value.inner {
+                AmqpValue::Described(described) => {
+                    assert_eq!(described.descriptor, AmqpDescriptor::Code(0x72));
+                    match &described.value {
+                        AmqpValue::Map(map) => {
+                            assert_eq!(map.get("key").unwrap(), &AmqpValue::String("value".into()));
+                        }
+                        _ => panic!("Expected AmqpValue::Map"),
+                    }
+                }
+                _ => panic!("Expected AmqpValue::Described"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_amqpvalue_create_footer() {
+        unsafe {
+            let map = AmqpValue::Map(
+                vec![("key".into(), AmqpValue::String("value".into()))]
+                    .into_iter()
+                    .collect(),
+            );
+            let rust_amqp_value = RustAmqpValue { inner: map };
+            let result = { amqpvalue_create_footer(&rust_amqp_value) };
+            assert!(!result.is_null());
+            let result_value = { &*result };
+            match &result_value.inner {
+                AmqpValue::Described(described) => {
+                    assert_eq!(described.descriptor, AmqpDescriptor::Code(0x78));
+                    match &described.value {
+                        AmqpValue::Map(map) => {
+                            assert_eq!(map.get("key").unwrap(), &AmqpValue::String("value".into()));
+                        }
+                        _ => panic!("Expected AmqpValue::Map"),
+                    }
+                }
+                _ => panic!("Expected AmqpValue::Described"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_amqpvalue_create_application_properties() {
+        unsafe {
+            let map = AmqpValue::Map(
+                vec![("key".into(), AmqpValue::String("value".into()))]
+                    .into_iter()
+                    .collect(),
+            );
+            let rust_amqp_value = RustAmqpValue { inner: map };
+            let result = { amqpvalue_create_application_properties(&rust_amqp_value) };
+            assert!(!result.is_null());
+            let result_value = { &*result };
+            match &result_value.inner {
+                AmqpValue::Described(described) => {
+                    assert_eq!(described.descriptor, AmqpDescriptor::Code(0x74));
+                    match &described.value {
+                        AmqpValue::Map(map) => {
+                            assert_eq!(map.get("key").unwrap(), &AmqpValue::String("value".into()));
+                        }
+                        _ => panic!("Expected AmqpValue::Map"),
+                    }
+                }
+                _ => panic!("Expected AmqpValue::Described"),
+            }
+        }
+    }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/properties.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/properties.rs
@@ -25,10 +25,8 @@ pub struct RustMessageProperties {
 }
 
 #[no_mangle]
-extern "C" fn properties_destroy(properties: *mut RustMessageProperties) {
-    unsafe {
-        mem::drop(Box::from_raw(properties));
-    }
+unsafe extern "C" fn properties_destroy(properties: *mut RustMessageProperties) {
+    mem::drop(Box::from_raw(properties));
 }
 
 fn value_from_message_id(message_id: AmqpMessageId) -> AmqpValue {
@@ -41,11 +39,11 @@ fn value_from_message_id(message_id: AmqpMessageId) -> AmqpValue {
 }
 
 #[no_mangle]
-extern "C" fn properties_get_message_id(
+unsafe extern "C" fn properties_get_message_id(
     properties: *const RustMessageProperties,
     message_id: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     if let Some(id) = properties.inner.message_id() {
         *message_id = Box::into_raw(Box::new(RustAmqpValue {
             inner: value_from_message_id(id.clone()),
@@ -57,11 +55,11 @@ extern "C" fn properties_get_message_id(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_correlation_id(
+unsafe extern "C" fn properties_get_correlation_id(
     properties: *const RustMessageProperties,
     correlation_id: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     if let Some(id) = properties.inner.correlation_id() {
         *correlation_id = Box::into_raw(Box::new(RustAmqpValue {
             inner: value_from_message_id(id.clone()),
@@ -73,12 +71,12 @@ extern "C" fn properties_get_correlation_id(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_user_id(
+unsafe extern "C" fn properties_get_user_id(
     properties: *const RustMessageProperties,
     value: &mut *const u8,
     size: &mut u32,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     if let Some(id) = properties.inner.user_id() {
         *value = id.as_ptr();
         *size = id.len() as u32;
@@ -89,17 +87,15 @@ extern "C" fn properties_get_user_id(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_to(
+unsafe extern "C" fn properties_get_to(
     properties: *const RustMessageProperties,
     value: *mut *mut RustAmqpValue,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     if let Some(to) = properties.inner.to() {
-        unsafe {
-            *value = Box::into_raw(Box::new(RustAmqpValue {
-                inner: AmqpValue::String(to.clone()),
-            }))
-        };
+        *value = Box::into_raw(Box::new(RustAmqpValue {
+            inner: AmqpValue::String(to.clone()),
+        }));
     } else {
         return -1;
     }
@@ -107,13 +103,13 @@ extern "C" fn properties_get_to(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_subject(
+unsafe extern "C" fn properties_get_subject(
     properties: *const RustMessageProperties,
     string_value: *mut *const std::os::raw::c_char,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     if let Some(subject) = properties.inner.subject() {
-        unsafe { *string_value = std::ffi::CString::new(subject.clone()).unwrap().into_raw() };
+        *string_value = std::ffi::CString::new(subject.clone()).unwrap().into_raw();
     } else {
         return -1;
     }
@@ -121,17 +117,15 @@ extern "C" fn properties_get_subject(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_reply_to(
+unsafe extern "C" fn properties_get_reply_to(
     properties: *const RustMessageProperties,
     value: *mut *mut RustAmqpValue,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     if let Some(reply_to) = properties.inner.reply_to() {
-        unsafe {
-            *value = Box::into_raw(Box::new(RustAmqpValue {
-                inner: AmqpValue::String(reply_to.clone()),
-            }))
-        };
+        *value = Box::into_raw(Box::new(RustAmqpValue {
+            inner: AmqpValue::String(reply_to.clone()),
+        }));
     } else {
         return -1;
     }
@@ -139,17 +133,15 @@ extern "C" fn properties_get_reply_to(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_content_type(
+unsafe extern "C" fn properties_get_content_type(
     properties: *const RustMessageProperties,
     string_value: *mut *const std::os::raw::c_char,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = { &*properties };
     if let Some(content_type) = properties.inner.content_type() {
-        unsafe {
-            *string_value = std::ffi::CString::new(content_type.clone().0)
-                .unwrap()
-                .into_raw()
-        };
+        *string_value = std::ffi::CString::new(content_type.clone().0)
+            .unwrap()
+            .into_raw();
     } else {
         return -1;
     }
@@ -157,17 +149,15 @@ extern "C" fn properties_get_content_type(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_content_encoding(
+unsafe extern "C" fn properties_get_content_encoding(
     properties: *const RustMessageProperties,
     string_value: *mut *const std::os::raw::c_char,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = { &*properties };
     if let Some(content_encoding) = properties.inner.content_encoding() {
-        unsafe {
-            *string_value = std::ffi::CString::new(content_encoding.clone().0)
-                .unwrap()
-                .into_raw()
-        };
+        *string_value = std::ffi::CString::new(content_encoding.clone().0)
+            .unwrap()
+            .into_raw();
     } else {
         return -1;
     }
@@ -175,11 +165,11 @@ extern "C" fn properties_get_content_encoding(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_absolute_expiry_time(
+unsafe extern "C" fn properties_get_absolute_expiry_time(
     properties: *const RustMessageProperties,
     expiry_time: &mut u64,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = { &*properties };
     if let Some(expiry) = properties.inner.absolute_expiry_time() {
         *expiry_time = expiry.0.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
     } else {
@@ -189,11 +179,11 @@ extern "C" fn properties_get_absolute_expiry_time(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_creation_time(
+unsafe extern "C" fn properties_get_creation_time(
     properties: *const RustMessageProperties,
     creation_time: &mut u64,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = { &*properties };
     if let Some(creation) = properties.inner.creation_time() {
         *creation_time = creation.0.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
     } else {
@@ -203,13 +193,13 @@ extern "C" fn properties_get_creation_time(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_group_id(
+unsafe extern "C" fn properties_get_group_id(
     properties: *const RustMessageProperties,
     string_value: *mut *const std::os::raw::c_char,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = { &*properties };
     if let Some(group_id) = properties.inner.group_id() {
-        unsafe { *string_value = std::ffi::CString::new(group_id.clone()).unwrap().into_raw() };
+        *string_value = std::ffi::CString::new(group_id.clone()).unwrap().into_raw();
     } else {
         return -1;
     }
@@ -217,11 +207,11 @@ extern "C" fn properties_get_group_id(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_group_sequence(
+unsafe extern "C" fn properties_get_group_sequence(
     properties: *const RustMessageProperties,
     group_sequence: &mut u32,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = { &*properties };
     if let Some(sequence) = properties.inner.group_sequence() {
         *group_sequence = *sequence;
     } else {
@@ -231,17 +221,15 @@ extern "C" fn properties_get_group_sequence(
 }
 
 #[no_mangle]
-extern "C" fn properties_get_reply_to_group_id(
+unsafe extern "C" fn properties_get_reply_to_group_id(
     properties: *const RustMessageProperties,
     string_value: *mut *const std::os::raw::c_char,
 ) -> i32 {
-    let properties = unsafe { &*properties };
+    let properties = { &*properties };
     if let Some(reply_to_group_id) = properties.inner.reply_to_group_id() {
-        unsafe {
-            *string_value = std::ffi::CString::new(reply_to_group_id.clone())
-                .unwrap()
-                .into_raw()
-        };
+        *string_value = std::ffi::CString::new(reply_to_group_id.clone())
+            .unwrap()
+            .into_raw();
     } else {
         return -1;
     }
@@ -260,10 +248,8 @@ extern "C" fn properties_builder_create() -> *mut RustMessagePropertiesBuilder {
 }
 
 #[no_mangle]
-extern "C" fn properties_builder_destroy(properties: *mut RustMessagePropertiesBuilder) {
-    unsafe {
-        mem::drop(Box::from_raw(properties));
-    }
+unsafe extern "C" fn properties_builder_destroy(properties: *mut RustMessagePropertiesBuilder) {
+    mem::drop(Box::from_raw(properties));
 }
 
 #[no_mangle]
@@ -274,7 +260,7 @@ unsafe extern "C" fn properties_set_message_id(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let message_id = unsafe { &*message_id };
+    let message_id = &*message_id;
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
         inner: builder.inner.with_message_id(match &message_id.inner {
             AmqpValue::Binary(id) => AmqpMessageId::Binary(id.clone()),
@@ -294,7 +280,7 @@ unsafe extern "C" fn properties_set_correlation_id(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let correlation_id = unsafe { &*correlation_id };
+    let correlation_id = &*correlation_id;
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
         inner: builder
             .inner
@@ -317,7 +303,7 @@ unsafe extern "C" fn properties_set_user_id(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let value = unsafe { std::slice::from_raw_parts(value, size as usize) };
+    let value = std::slice::from_raw_parts(value, size as usize);
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
         inner: builder.inner.with_user_id(value.to_vec()),
     }))
@@ -331,7 +317,7 @@ unsafe extern "C" fn properties_set_to(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let value = unsafe { CStr::from_ptr(value) };
+    let value = { CStr::from_ptr(value) };
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
         inner: builder.inner.with_to(value.to_str().unwrap()),
     }))
@@ -345,7 +331,7 @@ unsafe extern "C" fn properties_set_subject(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let subject = unsafe {
+    let subject = {
         std::ffi::CStr::from_ptr(string_value)
             .to_string_lossy()
             .to_string()
@@ -363,7 +349,7 @@ unsafe extern "C" fn properties_set_reply_to(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let value = unsafe { &*value };
+    let value = { &*value };
     if let AmqpValue::String(reply_to) = &value.inner {
         Box::into_raw(Box::new(RustMessagePropertiesBuilder {
             inner: builder.inner.with_reply_to(reply_to.clone()),
@@ -381,7 +367,7 @@ unsafe extern "C" fn properties_set_content_type(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let content_type = unsafe {
+    let content_type = {
         std::ffi::CStr::from_ptr(string_value)
             .to_string_lossy()
             .to_string()
@@ -399,7 +385,7 @@ unsafe extern "C" fn properties_set_content_encoding(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let content_encoding = unsafe {
+    let content_encoding = {
         std::ffi::CStr::from_ptr(string_value)
             .to_string_lossy()
             .to_string()
@@ -447,7 +433,7 @@ unsafe extern "C" fn properties_set_group_id(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let group_id = unsafe {
+    let group_id = {
         std::ffi::CStr::from_ptr(string_value)
             .to_string_lossy()
             .to_string()
@@ -478,7 +464,7 @@ unsafe extern "C" fn properties_set_reply_to_group_id(
 ) -> *mut RustMessagePropertiesBuilder {
     let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let reply_to_group_id = unsafe {
+    let reply_to_group_id = {
         std::ffi::CStr::from_ptr(string_value)
             .to_string_lossy()
             .to_string()
@@ -502,13 +488,13 @@ unsafe extern "C" fn properties_build(
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_get_properties(
+unsafe extern "C" fn amqpvalue_get_properties(
     call_context: *mut RustCallContext,
     value: *const RustAmqpValue,
     header: &mut *mut RustMessageProperties,
 ) -> i32 {
     let call_context = call_context_from_ptr_mut(call_context);
-    let value = unsafe { &*value };
+    let value = { &*value };
     match &value.inner {
         AmqpValue::Described(value) => match value.descriptor() {
             AmqpDescriptor::Code(0x73) => {
@@ -545,10 +531,10 @@ extern "C" fn amqpvalue_get_properties(
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_properties(
+unsafe extern "C" fn amqpvalue_create_properties(
     properties: *const RustMessageProperties,
 ) -> *mut RustAmqpValue {
-    let properties = unsafe { &*properties };
+    let properties = { &*properties };
     let value = AmqpValue::Composite(Box::new(AmqpComposite::new(
         AmqpDescriptor::Code(0x73),
         properties.inner.clone(),
@@ -587,185 +573,212 @@ mod tests {
 
     #[test]
     fn test_properties_get_message_id() {
-        let properties = create_test_properties();
-        let mut message_id: *mut RustAmqpValue = ptr::null_mut();
-        let result = properties_get_message_id(properties, &mut message_id);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut message_id: *mut RustAmqpValue = ptr::null_mut();
+            let result = properties_get_message_id(properties, &mut message_id);
+            assert_eq!(result, 0);
+
             assert_eq!(
                 (*message_id).inner,
                 AmqpValue::String("test_message_id".to_string())
             );
             drop(Box::from_raw(message_id));
-        }
-        unsafe {
+
             drop(Box::from_raw(properties));
         }
     }
 
     #[test]
     fn test_properties_get_correlation_id() {
-        let properties = create_test_properties();
-        let mut correlation_id: *mut RustAmqpValue = ptr::null_mut();
-        let result = properties_get_correlation_id(properties, &mut correlation_id);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut correlation_id: *mut RustAmqpValue = ptr::null_mut();
+            let result = properties_get_correlation_id(properties, &mut correlation_id);
+            assert_eq!(result, 0);
+
             assert_eq!(
                 (*correlation_id).inner,
                 AmqpValue::String("test_correlation_id".to_string())
             );
             drop(Box::from_raw(correlation_id));
+
+            drop(Box::from_raw(properties));
         }
-        unsafe { drop(Box::from_raw(properties)) };
     }
 
     #[test]
     fn test_properties_get_user_id() {
-        let properties = create_test_properties();
-        let mut value: *const u8 = ptr::null();
-        let mut size: u32 = 0;
-        let result = properties_get_user_id(properties, &mut value, &mut size);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut value: *const u8 = ptr::null();
+            let mut size: u32 = 0;
+            let result = properties_get_user_id(properties, &mut value, &mut size);
+            assert_eq!(result, 0);
+
             assert_eq!(
                 std::slice::from_raw_parts(value, size as usize),
                 &[1, 2, 3, 4]
             );
+
+            drop(Box::from_raw(properties));
         }
-        unsafe { drop(Box::from_raw(properties)) };
     }
 
     #[test]
     fn test_properties_get_to() {
-        let properties = create_test_properties();
-        let mut value: *mut RustAmqpValue = ptr::null_mut();
-        let result = properties_get_to(properties, &mut value);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut value: *mut RustAmqpValue = ptr::null_mut();
+            let result = properties_get_to(properties, &mut value);
+            assert_eq!(result, 0);
+
             assert_eq!((*value).inner, AmqpValue::String("test_to".to_string()));
             drop(Box::from_raw(value));
+
+            drop(Box::from_raw(properties));
         }
-        unsafe { drop(Box::from_raw(properties)) };
     }
 
     #[test]
     fn test_properties_get_subject() {
-        let properties = create_test_properties();
-        let mut string_value: *const std::os::raw::c_char = ptr::null();
-        let result = properties_get_subject(properties, &mut string_value);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut string_value: *const std::os::raw::c_char = ptr::null();
+            let result = properties_get_subject(properties, &mut string_value);
+            assert_eq!(result, 0);
+
             assert_eq!(
                 CString::from_raw(string_value as *mut _).to_str().unwrap(),
                 "test_subject"
             );
+
+            drop(Box::from_raw(properties));
         }
-        unsafe { drop(Box::from_raw(properties)) };
     }
 
     #[test]
     fn test_properties_get_reply_to() {
-        let properties = create_test_properties();
-        let mut value: *mut RustAmqpValue = ptr::null_mut();
-        let result = properties_get_reply_to(properties, &mut value);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut value: *mut RustAmqpValue = ptr::null_mut();
+            let result = properties_get_reply_to(properties, &mut value);
+            assert_eq!(result, 0);
+
             assert_eq!(
                 (*value).inner,
                 AmqpValue::String("test_reply_to".to_string())
             );
             drop(Box::from_raw(value));
+
+            drop(Box::from_raw(properties));
         }
-        unsafe { drop(Box::from_raw(properties)) };
     }
 
     #[test]
     fn test_properties_get_content_type() {
-        let properties = create_test_properties();
-        let mut string_value: *const std::os::raw::c_char = ptr::null();
-        let result = properties_get_content_type(properties, &mut string_value);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut string_value: *const std::os::raw::c_char = ptr::null();
+            let result = properties_get_content_type(properties, &mut string_value);
+            assert_eq!(result, 0);
+
             assert_eq!(
                 CString::from_raw(string_value as *mut _).to_str().unwrap(),
                 "test_content_type"
             );
+
+            drop(Box::from_raw(properties));
         }
-        unsafe { drop(Box::from_raw(properties)) };
     }
 
     #[test]
     fn test_properties_get_content_encoding() {
-        let properties = create_test_properties();
-        let mut string_value: *const std::os::raw::c_char = ptr::null();
-        let result = properties_get_content_encoding(properties, &mut string_value);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut string_value: *const std::os::raw::c_char = ptr::null();
+            let result = properties_get_content_encoding(properties, &mut string_value);
+            assert_eq!(result, 0);
+
             assert_eq!(
                 CString::from_raw(string_value as *mut _).to_str().unwrap(),
                 "test_content_encoding"
             );
+
+            drop(Box::from_raw(properties));
         }
-        unsafe { drop(Box::from_raw(properties)) };
     }
 
     #[test]
     fn test_properties_get_absolute_expiry_time() {
-        let properties = create_test_properties();
-        let mut expiry_time: u64 = 0;
-        let result = properties_get_absolute_expiry_time(properties, &mut expiry_time);
-        assert_eq!(result, 0);
-        assert_eq!(expiry_time, 1000 * 1000);
-        unsafe { drop(Box::from_raw(properties)) };
+        unsafe {
+            let properties = create_test_properties();
+            let mut expiry_time: u64 = 0;
+            let result = properties_get_absolute_expiry_time(properties, &mut expiry_time);
+            assert_eq!(result, 0);
+            assert_eq!(expiry_time, 1000 * 1000);
+
+            drop(Box::from_raw(properties));
+        }
     }
 
     #[test]
     fn test_properties_get_creation_time() {
-        let properties = create_test_properties();
-        let mut creation_time: u64 = 0;
-        let result = properties_get_creation_time(properties, &mut creation_time);
-        assert_eq!(result, 0);
-        assert_eq!(creation_time, 500 * 1000);
-        unsafe { drop(Box::from_raw(properties)) };
+        unsafe {
+            let properties = create_test_properties();
+            let mut creation_time: u64 = 0;
+            let result = properties_get_creation_time(properties, &mut creation_time);
+            assert_eq!(result, 0);
+            assert_eq!(creation_time, 500 * 1000);
+
+            drop(Box::from_raw(properties));
+        }
     }
 
     #[test]
     fn test_properties_get_group_id() {
-        let properties = create_test_properties();
-        let mut string_value: *const std::os::raw::c_char = ptr::null();
-        let result = properties_get_group_id(properties, &mut string_value);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut string_value: *const std::os::raw::c_char = ptr::null();
+            let result = properties_get_group_id(properties, &mut string_value);
+            assert_eq!(result, 0);
+
             assert_eq!(
                 CString::from_raw(string_value as *mut _).to_str().unwrap(),
                 "test_group_id"
             );
+
+            drop(Box::from_raw(properties));
         }
-        unsafe { drop(Box::from_raw(properties)) };
     }
 
     #[test]
     fn test_properties_get_group_sequence() {
-        let properties = create_test_properties();
-        let mut group_sequence: u32 = 0;
-        let result = properties_get_group_sequence(properties, &mut group_sequence);
-        assert_eq!(result, 0);
-        assert_eq!(group_sequence, 42);
-        unsafe { drop(Box::from_raw(properties)) };
+        unsafe {
+            let properties = create_test_properties();
+            let mut group_sequence: u32 = 0;
+            let result = properties_get_group_sequence(properties, &mut group_sequence);
+            assert_eq!(result, 0);
+            assert_eq!(group_sequence, 42);
+
+            drop(Box::from_raw(properties));
+        }
     }
 
     #[test]
     fn test_properties_get_reply_to_group_id() {
-        let properties = create_test_properties();
-        let mut string_value: *const std::os::raw::c_char = ptr::null();
-        let result = properties_get_reply_to_group_id(properties, &mut string_value);
-        assert_eq!(result, 0);
         unsafe {
+            let properties = create_test_properties();
+            let mut string_value: *const std::os::raw::c_char = ptr::null();
+            let result = properties_get_reply_to_group_id(properties, &mut string_value);
+            assert_eq!(result, 0);
+
             assert_eq!(
                 CString::from_raw(string_value as *mut _).to_str().unwrap(),
                 "test_reply_to_group_id"
             );
+
+            drop(Box::from_raw(properties));
         }
-        unsafe { drop(Box::from_raw(properties)) };
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/properties.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/properties.rs
@@ -3,7 +3,11 @@
 
 // cspell: words amqp amqpvalue repr
 
-use crate::model::value::RustAmqpValue;
+use crate::{
+    call_context::{call_context_from_ptr_mut, RustCallContext},
+    error_from_str,
+    model::value::RustAmqpValue,
+};
 use azure_core_amqp::{
     messaging::{builders::AmqpMessagePropertiesBuilder, AmqpMessageId, AmqpMessageProperties},
     value::{AmqpComposite, AmqpDescriptor, AmqpTimestamp, AmqpValue},
@@ -264,9 +268,11 @@ extern "C" fn properties_builder_destroy(properties: *mut RustMessagePropertiesB
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_message_id(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     message_id: *const RustAmqpValue,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let message_id = unsafe { &*message_id };
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
@@ -282,9 +288,11 @@ unsafe extern "C" fn properties_set_message_id(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_correlation_id(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     correlation_id: *const RustAmqpValue,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let correlation_id = unsafe { &*correlation_id };
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
@@ -302,10 +310,12 @@ unsafe extern "C" fn properties_set_correlation_id(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_user_id(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     value: *const u8,
     size: u32,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let value = unsafe { std::slice::from_raw_parts(value, size as usize) };
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
@@ -315,9 +325,11 @@ unsafe extern "C" fn properties_set_user_id(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_to(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     value: *const c_char,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let value = unsafe { CStr::from_ptr(value) };
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
@@ -327,9 +339,11 @@ unsafe extern "C" fn properties_set_to(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_subject(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     string_value: *const std::os::raw::c_char,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let subject = unsafe {
         std::ffi::CStr::from_ptr(string_value)
@@ -343,9 +357,11 @@ unsafe extern "C" fn properties_set_subject(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_reply_to(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     value: *const RustAmqpValue,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let value = unsafe { &*value };
     if let AmqpValue::String(reply_to) = &value.inner {
@@ -359,9 +375,11 @@ unsafe extern "C" fn properties_set_reply_to(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_content_type(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     string_value: *const std::os::raw::c_char,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let content_type = unsafe {
         std::ffi::CStr::from_ptr(string_value)
@@ -375,9 +393,11 @@ unsafe extern "C" fn properties_set_content_type(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_content_encoding(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     string_value: *const std::os::raw::c_char,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let content_encoding = unsafe {
         std::ffi::CStr::from_ptr(string_value)
@@ -391,9 +411,11 @@ unsafe extern "C" fn properties_set_content_encoding(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_absolute_expiry_time(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     expiry_time: u64,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
         inner: builder.inner.with_absolute_expiry_time(AmqpTimestamp(
@@ -404,9 +426,11 @@ unsafe extern "C" fn properties_set_absolute_expiry_time(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_creation_time(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     creation_time: u64,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
         inner: builder.inner.with_creation_time(AmqpTimestamp(
@@ -417,9 +441,11 @@ unsafe extern "C" fn properties_set_creation_time(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_group_id(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     string_value: *const std::os::raw::c_char,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let group_id = unsafe {
         std::ffi::CStr::from_ptr(string_value)
@@ -433,9 +459,11 @@ unsafe extern "C" fn properties_set_group_id(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_group_sequence(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     group_sequence: u32,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustMessagePropertiesBuilder {
         inner: builder.inner.with_group_sequence(group_sequence),
@@ -444,9 +472,11 @@ unsafe extern "C" fn properties_set_group_sequence(
 
 #[no_mangle]
 unsafe extern "C" fn properties_set_reply_to_group_id(
+    call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     string_value: *const std::os::raw::c_char,
 ) -> *mut RustMessagePropertiesBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     let reply_to_group_id = unsafe {
         std::ffi::CStr::from_ptr(string_value)
@@ -460,6 +490,7 @@ unsafe extern "C" fn properties_set_reply_to_group_id(
 
 #[no_mangle]
 unsafe extern "C" fn properties_build(
+    _call_context: *mut RustCallContext,
     builder: *mut RustMessagePropertiesBuilder,
     header: *mut *mut RustMessageProperties,
 ) -> i32 {
@@ -472,9 +503,11 @@ unsafe extern "C" fn properties_build(
 
 #[no_mangle]
 extern "C" fn amqpvalue_get_properties(
+    call_context: *mut RustCallContext,
     value: *const RustAmqpValue,
     header: &mut *mut RustMessageProperties,
 ) -> i32 {
+    let call_context = call_context_from_ptr_mut(call_context);
     let value = unsafe { &*value };
     match &value.inner {
         AmqpValue::Described(value) => match value.descriptor() {
@@ -489,6 +522,8 @@ extern "C" fn amqpvalue_get_properties(
                     }
                     _ => {
                         *header = std::ptr::null_mut();
+                        call_context
+                            .set_error(error_from_str("Properties value must be an AMQP list."));
                         println!("Unexpected properties value: {:?}", value);
                         1
                     }
@@ -496,11 +531,13 @@ extern "C" fn amqpvalue_get_properties(
             }
             _ => {
                 println!("Unexpected properties descriptor code: {:?}", value);
+                call_context.set_error(error_from_str("Unexpected AMQP descriptor code."));
                 *header = std::ptr::null_mut();
                 1
             }
         },
         _ => {
+            call_context.set_error(error_from_str("Properties must be a described type."));
             println!("Unexpected properties type: {:?}", value.inner);
             1
         }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/source.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/source.rs
@@ -19,9 +19,9 @@ impl RustAmqpSource {
         Self { inner: source }
     }
 
-        pub(crate) fn get(&self) -> &AmqpSource {
-            &self.inner
-        }
+    pub(crate) fn get(&self) -> &AmqpSource {
+        &self.inner
+    }
 }
 
 #[repr(C)]
@@ -391,124 +391,112 @@ extern "C" fn source_builder_build(
 }
 
 #[no_mangle]
-extern "C" fn source_set_address(
+unsafe extern "C" fn source_set_address(
     builder: *mut RustAmqpSourceBuilder,
     address: *const RustAmqpValue,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
     let address = unsafe { &*address };
     match &address.inner {
-        AmqpValue::String(address) => {
-            builder.inner.with_address(address.clone());
-            0
-        }
+        AmqpValue::String(address) => Box::into_raw(Box::new(RustAmqpSourceBuilder {
+            inner: builder.inner.with_address(address.clone()),
+        })),
         _ => {
             warn!("Invalid address type: {:?}", address.inner);
-            1
+            std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-extern "C" fn source_set_durable(
+unsafe extern "C" fn source_set_durable(
     builder: *mut RustAmqpSourceBuilder,
     durable: RustTerminusDurability,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
-    match durable {
-        RustTerminusDurability::None => {
-            builder
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustAmqpSourceBuilder {
+        inner: match durable {
+            RustTerminusDurability::None => builder
                 .inner
-                .with_durable(azure_core_amqp::messaging::TerminusDurability::None);
-            0
-        }
-        RustTerminusDurability::Configuration => {
-            builder
+                .with_durable(azure_core_amqp::messaging::TerminusDurability::None),
+            RustTerminusDurability::Configuration => builder
                 .inner
-                .with_durable(azure_core_amqp::messaging::TerminusDurability::Configuration);
-            0
-        }
-        RustTerminusDurability::UnsettledState => {
-            builder
+                .with_durable(azure_core_amqp::messaging::TerminusDurability::Configuration),
+            RustTerminusDurability::UnsettledState => builder
                 .inner
-                .with_durable(azure_core_amqp::messaging::TerminusDurability::UnsettledState);
-            0
-        }
-    }
+                .with_durable(azure_core_amqp::messaging::TerminusDurability::UnsettledState),
+        },
+    }))
 }
 
 #[no_mangle]
-extern "C" fn source_set_expiry_policy(
+unsafe extern "C" fn source_set_expiry_policy(
     builder: *mut RustAmqpSourceBuilder,
     expiry_policy: RustExpiryPolicy,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
-    match expiry_policy {
-        RustExpiryPolicy::LinkDetach => {
-            builder
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustAmqpSourceBuilder {
+        inner: match expiry_policy {
+            RustExpiryPolicy::LinkDetach => builder
                 .inner
-                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::LinkDetach);
-            0
-        }
-        RustExpiryPolicy::SessionEnd => {
-            builder
+                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::LinkDetach),
+            RustExpiryPolicy::SessionEnd => builder
                 .inner
-                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::SessionEnd);
-            0
-        }
-        RustExpiryPolicy::ConnectionClose => {
-            builder.inner.with_expiry_policy(
+                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::SessionEnd),
+            RustExpiryPolicy::ConnectionClose => builder.inner.with_expiry_policy(
                 azure_core_amqp::messaging::TerminusExpiryPolicy::ConnectionClose,
-            );
-            0
-        }
-        RustExpiryPolicy::Never => {
-            builder
+            ),
+            RustExpiryPolicy::Never => builder
                 .inner
-                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::Never);
-            0
-        }
-    }
+                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::Never),
+        },
+    }))
 }
 
 #[no_mangle]
-extern "C" fn source_set_timeout(builder: *mut RustAmqpSourceBuilder, timeout: u32) -> i32 {
-    let builder = unsafe { &mut *builder };
-    builder.inner.with_timeout(timeout);
-    0
+unsafe extern "C" fn source_set_timeout(
+    builder: *mut RustAmqpSourceBuilder,
+    timeout: u32,
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustAmqpSourceBuilder {
+        inner: builder.inner.with_timeout(timeout),
+    }))
 }
 
 #[no_mangle]
-extern "C" fn source_set_dynamic(builder: *mut RustAmqpSourceBuilder, dynamic: bool) -> i32 {
-    let builder = unsafe { &mut *builder };
-    builder.inner.with_dynamic(dynamic);
-    0
+unsafe extern "C" fn source_set_dynamic(
+    builder: *mut RustAmqpSourceBuilder,
+    dynamic: bool,
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustAmqpSourceBuilder {
+        inner: builder.inner.with_dynamic(dynamic),
+    }))
 }
 
 #[no_mangle]
-extern "C" fn source_set_distribution_mode(
+unsafe extern "C" fn source_set_distribution_mode(
     builder: *mut RustAmqpSourceBuilder,
     distribution_mode: *const RustAmqpValue,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
     let distribution_mode = unsafe { &*distribution_mode };
     match &distribution_mode.inner {
         AmqpValue::Symbol(s) => match s.0.as_str() {
-            "move" => {
-                builder
+            "move" => Box::into_raw(Box::new(RustAmqpSourceBuilder {
+                inner: builder
                     .inner
-                    .with_distribution_mode(azure_core_amqp::messaging::DistributionMode::Move);
-                0
-            }
-            "copy" => {
-                builder
+                    .with_distribution_mode(azure_core_amqp::messaging::DistributionMode::Move),
+            })),
+            "copy" => Box::into_raw(Box::new(RustAmqpSourceBuilder {
+                inner: builder
                     .inner
-                    .with_distribution_mode(azure_core_amqp::messaging::DistributionMode::Copy);
-                0
-            }
+                    .with_distribution_mode(azure_core_amqp::messaging::DistributionMode::Copy),
+            })),
             _ => {
                 warn!("Invalid distribution mode: {}", s.0);
-                1
+                std::ptr::null_mut()
             }
         },
         _ => {
@@ -516,17 +504,17 @@ extern "C" fn source_set_distribution_mode(
                 "Invalid distribution mode type: {:?}",
                 distribution_mode.inner
             );
-            1
+            std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-extern "C" fn source_set_filter(
+unsafe extern "C" fn source_set_filter(
     builder: *mut RustAmqpSourceBuilder,
     filter: *const RustAmqpValue,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
     let filter = unsafe { &*filter };
     match &filter.inner {
         AmqpValue::Map(filter) => {
@@ -535,56 +523,47 @@ extern "C" fn source_set_filter(
                 .into_iter()
                 .map(|f| (f.0.into(), f.1.clone()))
                 .collect();
-            builder.inner.with_filter(map);
-            0
+            Box::into_raw(Box::new(RustAmqpSourceBuilder {
+                inner: builder.inner.with_filter(map),
+            }))
         }
         _ => {
             warn!("Invalid filter type: {:?}", filter.inner);
-            1
+            std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-extern "C" fn source_set_default_outcome(
+unsafe extern "C" fn source_set_default_outcome(
     builder: *mut RustAmqpSourceBuilder,
     default_outcome: RustDeliveryOutcome,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
-    match default_outcome {
-        RustDeliveryOutcome::Accepted => {
-            builder
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustAmqpSourceBuilder {
+        inner: match default_outcome {
+            RustDeliveryOutcome::Accepted => builder
                 .inner
-                .with_default_outcome(azure_core_amqp::messaging::AmqpOutcome::Accepted);
-            0
-        }
-        RustDeliveryOutcome::Rejected => {
-            builder
+                .with_default_outcome(azure_core_amqp::messaging::AmqpOutcome::Accepted),
+            RustDeliveryOutcome::Rejected => builder
                 .inner
-                .with_default_outcome(azure_core_amqp::messaging::AmqpOutcome::Rejected);
-            0
-        }
-        RustDeliveryOutcome::Released => {
-            builder
+                .with_default_outcome(azure_core_amqp::messaging::AmqpOutcome::Rejected),
+            RustDeliveryOutcome::Released => builder
                 .inner
-                .with_default_outcome(azure_core_amqp::messaging::AmqpOutcome::Released);
-            0
-        }
-        RustDeliveryOutcome::Modified => {
-            builder
+                .with_default_outcome(azure_core_amqp::messaging::AmqpOutcome::Released),
+            RustDeliveryOutcome::Modified => builder
                 .inner
-                .with_default_outcome(azure_core_amqp::messaging::AmqpOutcome::Modified);
-            0
-        }
-    }
+                .with_default_outcome(azure_core_amqp::messaging::AmqpOutcome::Modified),
+        },
+    }))
 }
 
 #[no_mangle]
-extern "C" fn source_set_dynamic_node_properties(
+unsafe extern "C" fn source_set_dynamic_node_properties(
     builder: *mut RustAmqpSourceBuilder,
     properties: *const RustAmqpValue,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
     let properties = unsafe { &*properties };
     match &properties.inner {
         AmqpValue::Map(properties) => {
@@ -604,25 +583,26 @@ extern "C" fn source_set_dynamic_node_properties(
                     )
                 })
                 .collect();
-            builder.inner.with_dynamic_node_properties(map);
-            0
+            Box::into_raw(Box::new(RustAmqpSourceBuilder {
+                inner: builder.inner.with_dynamic_node_properties(map),
+            }))
         }
         _ => {
             warn!(
                 "Invalid dynamic node properties type: {:?}",
                 properties.inner
             );
-            1
+            std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-extern "C" fn source_set_outcomes(
+unsafe extern "C" fn source_set_outcomes(
     builder: *mut RustAmqpSourceBuilder,
     outcomes: *const RustAmqpValue,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
     let outcomes = unsafe { &*outcomes };
     match &outcomes.inner {
         AmqpValue::List(outcomes) => {
@@ -638,8 +618,9 @@ extern "C" fn source_set_outcomes(
                     }
                 })
                 .collect();
-            builder.inner.with_outcomes(list);
-            0
+            Box::into_raw(Box::new(RustAmqpSourceBuilder {
+                inner: builder.inner.with_outcomes(list),
+            }))
         }
         AmqpValue::Array(outcomes) => {
             let list: Vec<azure_core_amqp::value::AmqpSymbol> = outcomes
@@ -653,22 +634,23 @@ extern "C" fn source_set_outcomes(
                     }
                 })
                 .collect();
-            builder.inner.with_outcomes(list);
-            0
+            Box::into_raw(Box::new(RustAmqpSourceBuilder {
+                inner: builder.inner.with_outcomes(list),
+            }))
         }
         _ => {
             warn!("Invalid outcomes type: {:?}", outcomes.inner);
-            1
+            std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-extern "C" fn source_set_capabilities(
+unsafe extern "C" fn source_set_capabilities(
     builder: *mut RustAmqpSourceBuilder,
     capabilities: *const RustAmqpValue,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
+) -> *mut RustAmqpSourceBuilder {
+    let builder = Box::from_raw(builder);
     let capabilities = unsafe { &*capabilities };
     match &capabilities.inner {
         AmqpValue::Array(capabilities) => {
@@ -683,12 +665,13 @@ extern "C" fn source_set_capabilities(
                     }
                 })
                 .collect();
-            builder.inner.with_capabilities(list);
-            0
+            Box::into_raw(Box::new(RustAmqpSourceBuilder {
+                inner: builder.inner.with_capabilities(list),
+            }))
         }
         _ => {
             warn!("Invalid capabilities type: {:?}", capabilities.inner);
-            1
+            std::ptr::null_mut()
         }
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/source.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/source.rs
@@ -3,7 +3,13 @@
 
 // cspell: words amqp amqpvalue repr
 
-use crate::model::value::RustAmqpValue;
+use std::ffi::{c_char, CStr};
+
+use crate::{
+    call_context::{call_context_from_ptr_mut, RustCallContext},
+    error_from_str,
+    model::value::RustAmqpValue,
+};
 use azure_core_amqp::{
     messaging::{builders::AmqpSourceBuilder, AmqpSource},
     value::{AmqpComposite, AmqpDescriptor, AmqpOrderedMap, AmqpSymbol, AmqpValue},
@@ -48,24 +54,22 @@ pub enum RustDeliveryOutcome {
 }
 
 #[no_mangle]
-extern "C" fn source_destroy(source: *mut RustAmqpSource) {
-    unsafe {
-        std::mem::drop(Box::from_raw(source));
-    }
+unsafe extern "C" fn source_destroy(source: *mut RustAmqpSource) {
+    std::mem::drop(Box::from_raw(source));
 }
 
 #[no_mangle]
-extern "C" fn source_clone(source: *const RustAmqpSource) -> *mut RustAmqpSource {
-    let source = unsafe { &*source };
+unsafe extern "C" fn source_clone(source: *const RustAmqpSource) -> *mut RustAmqpSource {
+    let source = &*source;
     Box::into_raw(Box::new(RustAmqpSource::new(source.inner.clone())))
 }
 
 #[no_mangle]
-extern "C" fn source_get_address(
+unsafe extern "C" fn source_get_address(
     source: *const RustAmqpSource,
     address: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     if let Some(source_address) = &source.inner.address {
         *address = Box::into_raw(Box::new(RustAmqpValue {
             inner: AmqpValue::String(source_address.clone()),
@@ -78,11 +82,11 @@ extern "C" fn source_get_address(
 }
 
 #[no_mangle]
-extern "C" fn source_get_durable(
+unsafe extern "C" fn source_get_durable(
     source: *const RustAmqpSource,
     durable: &mut RustTerminusDurability,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     if let Some(durable_value) = &source.inner.durable {
         match durable_value {
             azure_core_amqp::messaging::TerminusDurability::None => {
@@ -103,11 +107,11 @@ extern "C" fn source_get_durable(
 }
 
 #[no_mangle]
-extern "C" fn source_get_expiry_policy(
+unsafe extern "C" fn source_get_expiry_policy(
     source: *const RustAmqpSource,
     expiry_policy: &mut RustExpiryPolicy,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     if let Some(expiry_policy_value) = &source.inner.expiry_policy {
         match expiry_policy_value {
             azure_core_amqp::messaging::TerminusExpiryPolicy::LinkDetach => {
@@ -131,8 +135,8 @@ extern "C" fn source_get_expiry_policy(
 }
 
 #[no_mangle]
-extern "C" fn source_get_timeout(source: *const RustAmqpSource, timeout: &mut u32) -> i32 {
-    let source = unsafe { &*source };
+unsafe extern "C" fn source_get_timeout(source: *const RustAmqpSource, timeout: &mut u32) -> i32 {
+    let source = &*source;
     if let Some(timeout_value) = source.inner.timeout {
         *timeout = timeout_value;
         0
@@ -143,8 +147,8 @@ extern "C" fn source_get_timeout(source: *const RustAmqpSource, timeout: &mut u3
 }
 
 #[no_mangle]
-extern "C" fn source_get_dynamic(source: *const RustAmqpSource, dynamic: &mut bool) -> i32 {
-    let source = unsafe { &*source };
+unsafe extern "C" fn source_get_dynamic(source: *const RustAmqpSource, dynamic: &mut bool) -> i32 {
+    let source = &*source;
     if let Some(dynamic_value) = source.inner.dynamic {
         *dynamic = dynamic_value;
         0
@@ -157,11 +161,11 @@ extern "C" fn source_get_dynamic(source: *const RustAmqpSource, dynamic: &mut bo
 // Returns 0 == DistributionMode::Move
 // Returns 1 == DistributionMode::Copy
 #[no_mangle]
-extern "C" fn source_get_distribution_mode(
+unsafe extern "C" fn source_get_distribution_mode(
     source: *const RustAmqpSource,
     distribution_mode: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     if let Some(distribution_mode_value) = &source.inner.distribution_mode {
         match distribution_mode_value {
             azure_core_amqp::messaging::DistributionMode::Move => {
@@ -183,11 +187,11 @@ extern "C" fn source_get_distribution_mode(
 }
 
 #[no_mangle]
-extern "C" fn source_get_filter(
+unsafe extern "C" fn source_get_filter(
     source: *const RustAmqpSource,
     filter: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     if let Some(source_filter) = &source.inner.filter {
         let map: AmqpOrderedMap<AmqpValue, AmqpValue> = source_filter
             .clone()
@@ -205,11 +209,11 @@ extern "C" fn source_get_filter(
 }
 
 #[no_mangle]
-extern "C" fn source_get_default_outcome(
+unsafe extern "C" fn source_get_default_outcome(
     source: *const RustAmqpSource,
     default_outcome: &mut RustDeliveryOutcome,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     if let Some(source_default_outcome) = &source.inner.default_outcome {
         match source_default_outcome {
             azure_core_amqp::messaging::AmqpOutcome::Accepted => {
@@ -232,11 +236,11 @@ extern "C" fn source_get_default_outcome(
 }
 
 #[no_mangle]
-extern "C" fn source_get_dynamic_node_properties(
+unsafe extern "C" fn source_get_dynamic_node_properties(
     source: *const RustAmqpSource,
     properties: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     if let Some(source_properties) = &source.inner.dynamic_node_properties {
         let map: AmqpOrderedMap<AmqpValue, AmqpValue> = source_properties
             .clone()
@@ -254,11 +258,11 @@ extern "C" fn source_get_dynamic_node_properties(
 }
 
 #[no_mangle]
-extern "C" fn source_get_outcomes(
+unsafe extern "C" fn source_get_outcomes(
     source: *const RustAmqpSource,
     outcomes: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     if let Some(source_outcomes) = &source.inner.outcomes {
         let list: Vec<AmqpValue> = source_outcomes
             .clone()
@@ -276,11 +280,11 @@ extern "C" fn source_get_outcomes(
 }
 
 #[no_mangle]
-extern "C" fn source_get_capabilities(
+unsafe extern "C" fn source_get_capabilities(
     source: *const RustAmqpSource,
     capabilities: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     if let Some(source_capabilities) = &source.inner.capabilities {
         let list: Vec<AmqpValue> = source_capabilities
             .clone()
@@ -298,25 +302,25 @@ extern "C" fn source_get_capabilities(
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_source(
+unsafe extern "C" fn amqpvalue_create_source(
     source: *const RustAmqpSource,
     value: *mut *mut RustAmqpValue,
 ) -> i32 {
-    let source = unsafe { &*source };
+    let source = &*source;
     let inner_value = AmqpValue::Composite(Box::new(AmqpComposite::new(
         AmqpDescriptor::Code(0x28),
         source.inner.clone(),
     )));
-    unsafe { *value = Box::into_raw(Box::new(RustAmqpValue { inner: inner_value })) };
+    *value = Box::into_raw(Box::new(RustAmqpValue { inner: inner_value }));
     0
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_get_source(
+unsafe extern "C" fn amqpvalue_get_source(
     value: *const RustAmqpValue,
     source: &mut *mut RustAmqpSource,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Described(value) => match value.descriptor() {
             AmqpDescriptor::Code(0x28) => {
@@ -374,45 +378,47 @@ extern "C" fn source_builder_create() -> *mut RustAmqpSourceBuilder {
 }
 
 #[no_mangle]
-extern "C" fn source_builder_destroy(builder: *mut RustAmqpSourceBuilder) {
-    unsafe {
-        std::mem::drop(Box::from_raw(builder));
-    }
+unsafe extern "C" fn source_builder_destroy(builder: *mut RustAmqpSourceBuilder) {
+    std::mem::drop(Box::from_raw(builder));
 }
 
 #[no_mangle]
-extern "C" fn source_builder_build(
+unsafe extern "C" fn source_builder_build(
     builder: *mut RustAmqpSourceBuilder,
     source: &mut *mut RustAmqpSource,
 ) -> i32 {
-    let builder = unsafe { &mut *builder };
+    let builder = &mut *builder;
     *source = Box::into_raw(Box::new(RustAmqpSource::new(builder.inner.build())));
     0
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_address(
+unsafe extern "C" fn source_builder_set_address(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
-    address: *const RustAmqpValue,
+    address: *const c_char,
 ) -> *mut RustAmqpSourceBuilder {
+    let call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let address = unsafe { &*address };
-    match &address.inner {
-        AmqpValue::String(address) => Box::into_raw(Box::new(RustAmqpSourceBuilder {
-            inner: builder.inner.with_address(address.clone()),
+    let address = CStr::from_ptr(address).to_str();
+    match address {
+        Ok(address) => Box::into_raw(Box::new(RustAmqpSourceBuilder {
+            inner: builder.inner.with_address(address),
         })),
-        _ => {
-            warn!("Invalid address type: {:?}", address.inner);
+        Err(err) => {
+            call_context.set_error(Box::new(err));
             std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_durable(
+unsafe extern "C" fn source_builder_set_durable(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     durable: RustTerminusDurability,
 ) -> *mut RustAmqpSourceBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustAmqpSourceBuilder {
         inner: match durable {
@@ -430,10 +436,12 @@ unsafe extern "C" fn source_set_durable(
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_expiry_policy(
+unsafe extern "C" fn source_builder_set_expiry_policy(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     expiry_policy: RustExpiryPolicy,
 ) -> *mut RustAmqpSourceBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustAmqpSourceBuilder {
         inner: match expiry_policy {
@@ -454,10 +462,12 @@ unsafe extern "C" fn source_set_expiry_policy(
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_timeout(
+unsafe extern "C" fn source_builder_set_timeout(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     timeout: u32,
 ) -> *mut RustAmqpSourceBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustAmqpSourceBuilder {
         inner: builder.inner.with_timeout(timeout),
@@ -465,10 +475,12 @@ unsafe extern "C" fn source_set_timeout(
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_dynamic(
+unsafe extern "C" fn source_builder_set_dynamic(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     dynamic: bool,
 ) -> *mut RustAmqpSourceBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustAmqpSourceBuilder {
         inner: builder.inner.with_dynamic(dynamic),
@@ -476,12 +488,14 @@ unsafe extern "C" fn source_set_dynamic(
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_distribution_mode(
+unsafe extern "C" fn source_builder_set_distribution_mode(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     distribution_mode: *const RustAmqpValue,
 ) -> *mut RustAmqpSourceBuilder {
+    let call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let distribution_mode = unsafe { &*distribution_mode };
+    let distribution_mode = &*distribution_mode;
     match &distribution_mode.inner {
         AmqpValue::Symbol(s) => match s.0.as_str() {
             "move" => Box::into_raw(Box::new(RustAmqpSourceBuilder {
@@ -496,6 +510,7 @@ unsafe extern "C" fn source_set_distribution_mode(
             })),
             _ => {
                 warn!("Invalid distribution mode: {}", s.0);
+                call_context.set_error(error_from_str("Invalid distribution mode"));
                 std::ptr::null_mut()
             }
         },
@@ -504,18 +519,21 @@ unsafe extern "C" fn source_set_distribution_mode(
                 "Invalid distribution mode type: {:?}",
                 distribution_mode.inner
             );
+            call_context.set_error(error_from_str("Distribution mode must be a symbol."));
             std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_filter(
+unsafe extern "C" fn source_builder_set_filter(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     filter: *const RustAmqpValue,
 ) -> *mut RustAmqpSourceBuilder {
+    let call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let filter = unsafe { &*filter };
+    let filter = &*filter;
     match &filter.inner {
         AmqpValue::Map(filter) => {
             let map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = filter
@@ -529,16 +547,19 @@ unsafe extern "C" fn source_set_filter(
         }
         _ => {
             warn!("Invalid filter type: {:?}", filter.inner);
+            call_context.set_error(error_from_str("Filter type must be a map."));
             std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_default_outcome(
+unsafe extern "C" fn source_builder_set_default_outcome(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     default_outcome: RustDeliveryOutcome,
 ) -> *mut RustAmqpSourceBuilder {
+    let _call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
     Box::into_raw(Box::new(RustAmqpSourceBuilder {
         inner: match default_outcome {
@@ -559,29 +580,20 @@ unsafe extern "C" fn source_set_default_outcome(
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_dynamic_node_properties(
+unsafe extern "C" fn source_builder_set_dynamic_node_properties(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     properties: *const RustAmqpValue,
 ) -> *mut RustAmqpSourceBuilder {
+    let call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     match &properties.inner {
         AmqpValue::Map(properties) => {
             let map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
                 .clone()
                 .into_iter()
-                .map(|f| {
-                    (
-                        match f.0 {
-                            AmqpValue::Symbol(f) => f,
-                            _ => {
-                                warn!("Invalid dynamic node properties key: {:?}", f.0);
-                                AmqpSymbol("invalid".to_string())
-                            }
-                        },
-                        f.1.clone(),
-                    )
-                })
+                .map(|f| (f.0.into(), f.1))
                 .collect();
             Box::into_raw(Box::new(RustAmqpSourceBuilder {
                 inner: builder.inner.with_dynamic_node_properties(map),
@@ -592,18 +604,21 @@ unsafe extern "C" fn source_set_dynamic_node_properties(
                 "Invalid dynamic node properties type: {:?}",
                 properties.inner
             );
+            call_context.set_error(error_from_str("Dynamic node properties must be a map."));
             std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_outcomes(
+unsafe extern "C" fn source_builder_set_outcomes(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     outcomes: *const RustAmqpValue,
 ) -> *mut RustAmqpSourceBuilder {
+    let call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let outcomes = unsafe { &*outcomes };
+    let outcomes = &*outcomes;
     match &outcomes.inner {
         AmqpValue::List(outcomes) => {
             let list: Vec<azure_core_amqp::value::AmqpSymbol> = outcomes
@@ -611,7 +626,7 @@ unsafe extern "C" fn source_set_outcomes(
                 .clone()
                 .into_iter()
                 .map(|f| match f {
-                    AmqpValue::Symbol(f) => f.clone(),
+                    AmqpValue::Symbol(f) => f,
                     _ => {
                         warn!("Invalid outcome type: {:?}", f);
                         AmqpSymbol("invalid".to_string())
@@ -627,7 +642,7 @@ unsafe extern "C" fn source_set_outcomes(
                 .clone()
                 .into_iter()
                 .map(|f| match f {
-                    AmqpValue::Symbol(f) => f.clone(),
+                    AmqpValue::Symbol(f) => f,
                     _ => {
                         warn!("Invalid outcome type: {:?}", f);
                         AmqpSymbol("invalid".to_string())
@@ -639,19 +654,21 @@ unsafe extern "C" fn source_set_outcomes(
             }))
         }
         _ => {
-            warn!("Invalid outcomes type: {:?}", outcomes.inner);
+            call_context.set_error(error_from_str("Outcomes must be an array or a list."));
             std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn source_set_capabilities(
+unsafe extern "C" fn source_builder_set_capabilities(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpSourceBuilder,
     capabilities: *const RustAmqpValue,
 ) -> *mut RustAmqpSourceBuilder {
+    let call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let capabilities = unsafe { &*capabilities };
+    let capabilities = &*capabilities;
     match &capabilities.inner {
         AmqpValue::Array(capabilities) => {
             let list: Vec<AmqpSymbol> = capabilities
@@ -671,6 +688,7 @@ unsafe extern "C" fn source_set_capabilities(
         }
         _ => {
             warn!("Invalid capabilities type: {:?}", capabilities.inner);
+            call_context.set_error(error_from_str("Capabilities must be an array."));
             std::ptr::null_mut()
         }
     }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/target.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/target.rs
@@ -23,9 +23,9 @@ impl RustAmqpTarget {
         Self { inner: target }
     }
 
-        pub(crate) fn get(&self) -> &AmqpTarget {
-            &self.inner
-        }
+    pub(crate) fn get(&self) -> &AmqpTarget {
+        &self.inner
+    }
 }
 
 #[no_mangle]
@@ -258,119 +258,114 @@ extern "C" fn target_builder_build(
 }
 
 #[no_mangle]
-extern "C" fn target_set_address(
+unsafe extern "C" fn target_set_address(
     builder: *mut RustAmqpTargetBuilder,
     address: *const RustAmqpValue,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
+) -> *mut RustAmqpTargetBuilder {
+    let builder = Box::from_raw(builder);
     let address = unsafe { &*address };
     match &address.inner {
-        AmqpValue::String(value) => {
-            builder.inner.with_address(value.clone());
-            0
-        }
+        AmqpValue::String(value) => Box::into_raw(Box::new(RustAmqpTargetBuilder {
+            inner: builder.inner.with_address(value.clone()),
+        })),
         _ => {
             warn!("Expected string value for address");
-            1
+            std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-extern "C" fn target_set_durable(
+unsafe extern "C" fn target_set_durable(
     builder: *mut RustAmqpTargetBuilder,
     durable: RustTerminusDurability,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
-    match durable {
-        RustTerminusDurability::None => {
-            builder
+) -> *mut RustAmqpTargetBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustAmqpTargetBuilder {
+        inner: match durable {
+            RustTerminusDurability::None => builder
                 .inner
-                .with_durable(azure_core_amqp::messaging::TerminusDurability::None);
-        }
-        RustTerminusDurability::Configuration => {
-            builder
+                .with_durable(azure_core_amqp::messaging::TerminusDurability::None),
+            RustTerminusDurability::Configuration => builder
                 .inner
-                .with_durable(azure_core_amqp::messaging::TerminusDurability::Configuration);
-        }
-        RustTerminusDurability::UnsettledState => {
-            builder
+                .with_durable(azure_core_amqp::messaging::TerminusDurability::Configuration),
+            RustTerminusDurability::UnsettledState => builder
                 .inner
-                .with_durable(azure_core_amqp::messaging::TerminusDurability::UnsettledState);
-        }
-    }
-    0
+                .with_durable(azure_core_amqp::messaging::TerminusDurability::UnsettledState),
+        },
+    }))
 }
 
 #[no_mangle]
-extern "C" fn target_set_expiry_policy(
+unsafe extern "C" fn target_set_expiry_policy(
     builder: *mut RustAmqpTargetBuilder,
     expiry_policy: RustExpiryPolicy,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
-    match expiry_policy {
-        RustExpiryPolicy::LinkDetach => {
-            builder
+) -> *mut RustAmqpTargetBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustAmqpTargetBuilder {
+        inner: match expiry_policy {
+            RustExpiryPolicy::LinkDetach => builder
                 .inner
-                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::LinkDetach);
-        }
-        RustExpiryPolicy::SessionEnd => {
-            builder
+                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::LinkDetach),
+            RustExpiryPolicy::SessionEnd => builder
                 .inner
-                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::SessionEnd);
-        }
-        RustExpiryPolicy::ConnectionClose => {
-            builder.inner.with_expiry_policy(
+                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::SessionEnd),
+            RustExpiryPolicy::ConnectionClose => builder.inner.with_expiry_policy(
                 azure_core_amqp::messaging::TerminusExpiryPolicy::ConnectionClose,
-            );
-        }
-        RustExpiryPolicy::Never => {
-            builder
+            ),
+            RustExpiryPolicy::Never => builder
                 .inner
-                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::Never);
-        }
-    }
-    0
+                .with_expiry_policy(azure_core_amqp::messaging::TerminusExpiryPolicy::Never),
+        },
+    }))
 }
 
 #[no_mangle]
-extern "C" fn target_set_timeout(builder: *mut RustAmqpTargetBuilder, timeout: u32) -> u32 {
-    let builder = unsafe { &mut *builder };
-    builder.inner.with_timeout(timeout);
-    0
+unsafe extern "C" fn target_set_timeout(
+    builder: *mut RustAmqpTargetBuilder,
+    timeout: u32,
+) -> *mut RustAmqpTargetBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustAmqpTargetBuilder {
+        inner: builder.inner.with_timeout(timeout),
+    }))
 }
 
 #[no_mangle]
-extern "C" fn target_set_dynamic(builder: *mut RustAmqpTargetBuilder, dynamic: bool) -> u32 {
-    let builder = unsafe { &mut *builder };
-    builder.inner.with_dynamic(dynamic);
-    0
+unsafe extern "C" fn target_set_dynamic(
+    builder: *mut RustAmqpTargetBuilder,
+    dynamic: bool,
+) -> *mut RustAmqpTargetBuilder {
+    let builder = Box::from_raw(builder);
+    Box::into_raw(Box::new(RustAmqpTargetBuilder {
+        inner: builder.inner.with_dynamic(dynamic),
+    }))
 }
 
 #[no_mangle]
-extern "C" fn target_set_capabilities(
+unsafe extern "C" fn target_set_capabilities(
     builder: *mut RustAmqpTargetBuilder,
     capabilities: *const RustAmqpValue,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
+) -> *mut RustAmqpTargetBuilder {
+    let builder = Box::from_raw(builder);
     let capabilities = unsafe { &*capabilities };
     match &capabilities.inner {
-        AmqpValue::Array(value) => {
-            builder.inner.with_capabilities(value.clone());
-        }
+        AmqpValue::Array(value) => Box::into_raw(Box::new(RustAmqpTargetBuilder {
+            inner: builder.inner.with_capabilities(value.clone()),
+        })),
         _ => {
-            return 1;
+            warn!("Expected array value for capabilities");
+            std::ptr::null_mut()
         }
     }
-    0
 }
 
 #[no_mangle]
-extern "C" fn target_set_dynamic_node_properties(
+unsafe extern "C" fn target_set_dynamic_node_properties(
     builder: *mut RustAmqpTargetBuilder,
     properties: *const RustAmqpValue,
-) -> i32 {
-    let builder = unsafe { &mut *builder };
+) -> *mut RustAmqpTargetBuilder {
+    let builder = Box::from_raw(builder);
     let properties = unsafe { &*properties };
     match &properties.inner {
         AmqpValue::Map(value) => {
@@ -387,11 +382,10 @@ extern "C" fn target_set_dynamic_node_properties(
                     )
                 })
                 .collect();
-            builder.inner.with_dynamic_node_properties(value.clone());
+            Box::into_raw(Box::new(RustAmqpTargetBuilder {
+                inner: builder.inner.with_dynamic_node_properties(value.clone()),
+            }))
         }
-        _ => {
-            return 1;
-        }
+        _ => std::ptr::null_mut(),
     }
-    0
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/target.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/target.rs
@@ -3,14 +3,20 @@
 
 // cspell: words amqp amqpvalue repr
 
+use std::ffi::c_char;
+
 use azure_core_amqp::{
     messaging::{builders::AmqpTargetBuilder, AmqpTarget},
     value::{AmqpDescribed, AmqpDescriptor, AmqpList, AmqpOrderedMap, AmqpValue},
 };
 
-use crate::model::{
-    source::{RustExpiryPolicy, RustTerminusDurability},
-    value::RustAmqpValue,
+use crate::{
+    call_context::{call_context_from_ptr_mut, RustCallContext},
+    error_from_str,
+    model::{
+        source::{RustExpiryPolicy, RustTerminusDurability},
+        value::RustAmqpValue,
+    },
 };
 use tracing::warn;
 
@@ -29,21 +35,19 @@ impl RustAmqpTarget {
 }
 
 #[no_mangle]
-extern "C" fn target_destroy(source: *mut RustAmqpTarget) {
-    unsafe {
-        std::mem::drop(Box::from_raw(source));
-    }
+unsafe extern "C" fn target_destroy(source: *mut RustAmqpTarget) {
+    std::mem::drop(Box::from_raw(source));
 }
 
 #[no_mangle]
-extern "C" fn target_clone(target: *const RustAmqpTarget) -> *mut RustAmqpTarget {
-    let target = unsafe { &*target };
+unsafe extern "C" fn target_clone(target: *const RustAmqpTarget) -> *mut RustAmqpTarget {
+    let target = &*target;
     Box::into_raw(Box::new(RustAmqpTarget::new(target.inner.clone())))
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_create_target(target: *const RustAmqpTarget) -> *mut RustAmqpValue {
-    let target = unsafe { &*target };
+unsafe extern "C" fn amqpvalue_create_target(target: *const RustAmqpTarget) -> *mut RustAmqpValue {
+    let target = &*target;
     Box::into_raw(Box::new(RustAmqpValue {
         inner: AmqpValue::Described(Box::new(AmqpDescribed::new(
             AmqpDescriptor::Code(0x29),
@@ -53,28 +57,24 @@ extern "C" fn amqpvalue_create_target(target: *const RustAmqpTarget) -> *mut Rus
 }
 
 #[no_mangle]
-extern "C" fn amqpvalue_get_target(
+unsafe extern "C" fn amqpvalue_get_target(
     value: *const RustAmqpValue,
     target: *mut *mut RustAmqpTarget,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Described(value) => match value.descriptor() {
             AmqpDescriptor::Code(0x29) => {
                 let h = value.value();
                 match h {
                     AmqpValue::List(c) => {
-                        unsafe {
-                            *target = Box::into_raw(Box::new(RustAmqpTarget {
-                                inner: AmqpTarget::from(c.clone()),
-                            }));
-                        }
+                        *target = Box::into_raw(Box::new(RustAmqpTarget {
+                            inner: AmqpTarget::from(c.clone()),
+                        }));
                         0
                     }
                     _ => {
-                        unsafe {
-                            *target = std::ptr::null_mut();
-                        }
+                        *target = std::ptr::null_mut();
                         println!("Unexpected target value: {:?}", value);
                         1
                     }
@@ -82,9 +82,7 @@ extern "C" fn amqpvalue_get_target(
             }
             _ => {
                 println!("Unexpected target descriptor code: {:?}", value);
-                unsafe {
-                    *target = std::ptr::null_mut();
-                }
+                *target = std::ptr::null_mut();
                 1
             }
         },
@@ -96,11 +94,11 @@ extern "C" fn amqpvalue_get_target(
 }
 
 #[no_mangle]
-extern "C" fn target_get_address(
+unsafe extern "C" fn target_get_address(
     target: *const RustAmqpTarget,
     address: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let target = unsafe { &*target };
+    let target = &*target;
     if let Some(s) = target.inner.address() {
         *address = Box::into_raw(Box::new(RustAmqpValue {
             inner: AmqpValue::String(s.clone()),
@@ -114,11 +112,11 @@ extern "C" fn target_get_address(
 }
 
 #[no_mangle]
-extern "C" fn target_get_durable(
+unsafe extern "C" fn target_get_durable(
     target: *const RustAmqpTarget,
     durable: &mut RustTerminusDurability,
 ) -> i32 {
-    let target = unsafe { &*target };
+    let target = &*target;
     if let Some(durability) = target.inner.durable() {
         match durability {
             azure_core_amqp::messaging::TerminusDurability::None => {
@@ -140,11 +138,11 @@ extern "C" fn target_get_durable(
 }
 
 #[no_mangle]
-extern "C" fn target_get_expiry_policy(
+unsafe extern "C" fn target_get_expiry_policy(
     target: *const RustAmqpTarget,
     expiry_policy: &mut RustExpiryPolicy,
 ) -> i32 {
-    let target = unsafe { &*target };
+    let target = &*target;
     if let Some(policy) = target.inner.expiry_policy() {
         match policy {
             azure_core_amqp::messaging::TerminusExpiryPolicy::LinkDetach => {
@@ -169,33 +167,33 @@ extern "C" fn target_get_expiry_policy(
 }
 
 #[no_mangle]
-extern "C" fn target_get_timeout(target: *const RustAmqpTarget, timeout: *mut u32) -> i32 {
-    let target = unsafe { &*target };
+unsafe extern "C" fn target_get_timeout(target: *const RustAmqpTarget, timeout: *mut u32) -> i32 {
+    let target = &*target;
     if let Some(timeout_val) = target.inner.timeout() {
-        unsafe { *timeout = *timeout_val };
+        *timeout = *timeout_val;
         return 0;
     }
     1
 }
 
 #[no_mangle]
-extern "C" fn target_get_dynamic(target: *const RustAmqpTarget, dynamic: *mut bool) -> i32 {
-    let target = unsafe { &*target };
+unsafe extern "C" fn target_get_dynamic(target: *const RustAmqpTarget, dynamic: *mut bool) -> i32 {
+    let target = &*target;
     if let Some(dynamic_val) = target.inner.dynamic() {
-        unsafe { *dynamic = *dynamic_val };
+        *dynamic = *dynamic_val;
         0
     } else {
-        unsafe { *dynamic = false };
+        *dynamic = false;
         0
     }
 }
 
 #[no_mangle]
-extern "C" fn target_get_capabilities(
+unsafe extern "C" fn target_get_capabilities(
     target: *const RustAmqpTarget,
     capabilities: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let target = unsafe { &*target };
+    let target = &*target;
     if let Some(c) = target.inner.capabilities() {
         *capabilities = Box::into_raw(Box::new(RustAmqpValue {
             inner: AmqpValue::Array(c.clone()),
@@ -208,11 +206,11 @@ extern "C" fn target_get_capabilities(
 }
 
 #[no_mangle]
-extern "C" fn target_get_dynamic_node_properties(
+unsafe extern "C" fn target_get_dynamic_node_properties(
     target: *const RustAmqpTarget,
     properties: &mut *mut RustAmqpValue,
 ) -> i32 {
-    let target = unsafe { &*target };
+    let target = &*target;
     if let Some(p) = target.inner.dynamic_node_properties() {
         let p: AmqpOrderedMap<AmqpValue, AmqpValue> = p
             .clone()
@@ -234,49 +232,51 @@ pub struct RustAmqpTargetBuilder {
 }
 
 #[no_mangle]
-extern "C" fn target_builder_create() -> *mut RustAmqpTargetBuilder {
+unsafe extern "C" fn target_builder_create() -> *mut RustAmqpTargetBuilder {
     Box::into_raw(Box::new(RustAmqpTargetBuilder {
         inner: AmqpTarget::builder(),
     }))
 }
 
 #[no_mangle]
-extern "C" fn target_builder_destroy(builder: *mut RustAmqpTargetBuilder) {
-    unsafe {
-        std::mem::drop(Box::from_raw(builder));
-    }
+unsafe extern "C" fn target_builder_destroy(builder: *mut RustAmqpTargetBuilder) {
+    std::mem::drop(Box::from_raw(builder));
 }
 
 #[no_mangle]
-extern "C" fn target_builder_build(
+unsafe extern "C" fn target_builder_build(
     builder: *mut RustAmqpTargetBuilder,
     target: &mut *mut RustAmqpTarget,
 ) -> i32 {
-    let builder = unsafe { &mut *builder };
+    let builder = &mut *builder;
     *target = Box::into_raw(Box::new(RustAmqpTarget::new(builder.inner.build())));
     0
 }
 
 #[no_mangle]
-unsafe extern "C" fn target_set_address(
+unsafe extern "C" fn target_builder_set_address(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpTargetBuilder,
-    address: *const RustAmqpValue,
+    address: *const c_char,
 ) -> *mut RustAmqpTargetBuilder {
+    let call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let address = unsafe { &*address };
-    match &address.inner {
-        AmqpValue::String(value) => Box::into_raw(Box::new(RustAmqpTargetBuilder {
-            inner: builder.inner.with_address(value.clone()),
+    let address = std::ffi::CStr::from_ptr(address).to_str();
+    match address {
+        Ok(address) => Box::into_raw(Box::new(RustAmqpTargetBuilder {
+            inner: builder.inner.with_address(address),
         })),
-        _ => {
-            warn!("Expected string value for address");
+        Err(e) => {
+            warn!("Failed to convert address to string: {:?}", e);
+            call_context.set_error(Box::new(e));
             std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn target_set_durable(
+unsafe extern "C" fn target_builder_set_durable(
+    _call_context: *mut RustCallContext,
     builder: *mut RustAmqpTargetBuilder,
     durable: RustTerminusDurability,
 ) -> *mut RustAmqpTargetBuilder {
@@ -297,7 +297,8 @@ unsafe extern "C" fn target_set_durable(
 }
 
 #[no_mangle]
-unsafe extern "C" fn target_set_expiry_policy(
+unsafe extern "C" fn target_builder_set_expiry_policy(
+    _call_context: *mut RustCallContext,
     builder: *mut RustAmqpTargetBuilder,
     expiry_policy: RustExpiryPolicy,
 ) -> *mut RustAmqpTargetBuilder {
@@ -321,7 +322,8 @@ unsafe extern "C" fn target_set_expiry_policy(
 }
 
 #[no_mangle]
-unsafe extern "C" fn target_set_timeout(
+unsafe extern "C" fn target_builder_set_timeout(
+    _call_context: *mut RustCallContext,
     builder: *mut RustAmqpTargetBuilder,
     timeout: u32,
 ) -> *mut RustAmqpTargetBuilder {
@@ -332,7 +334,8 @@ unsafe extern "C" fn target_set_timeout(
 }
 
 #[no_mangle]
-unsafe extern "C" fn target_set_dynamic(
+unsafe extern "C" fn target_builder_set_dynamic(
+    _call_context: *mut RustCallContext,
     builder: *mut RustAmqpTargetBuilder,
     dynamic: bool,
 ) -> *mut RustAmqpTargetBuilder {
@@ -343,30 +346,35 @@ unsafe extern "C" fn target_set_dynamic(
 }
 
 #[no_mangle]
-unsafe extern "C" fn target_set_capabilities(
+unsafe extern "C" fn target_builder_set_capabilities(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpTargetBuilder,
     capabilities: *const RustAmqpValue,
 ) -> *mut RustAmqpTargetBuilder {
+    let call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let capabilities = unsafe { &*capabilities };
+    let capabilities = &*capabilities;
     match &capabilities.inner {
         AmqpValue::Array(value) => Box::into_raw(Box::new(RustAmqpTargetBuilder {
             inner: builder.inner.with_capabilities(value.clone()),
         })),
         _ => {
             warn!("Expected array value for capabilities");
+            call_context.set_error(error_from_str("Expected array value for capabilities"));
             std::ptr::null_mut()
         }
     }
 }
 
 #[no_mangle]
-unsafe extern "C" fn target_set_dynamic_node_properties(
+unsafe extern "C" fn target_builder_set_dynamic_node_properties(
+    call_context: *mut RustCallContext,
     builder: *mut RustAmqpTargetBuilder,
     properties: *const RustAmqpValue,
 ) -> *mut RustAmqpTargetBuilder {
+    let call_context = call_context_from_ptr_mut(call_context);
     let builder = Box::from_raw(builder);
-    let properties = unsafe { &*properties };
+    let properties = &*properties;
     match &properties.inner {
         AmqpValue::Map(value) => {
             let value: AmqpOrderedMap<String, AmqpValue> = value
@@ -386,6 +394,15 @@ unsafe extern "C" fn target_set_dynamic_node_properties(
                 inner: builder.inner.with_dynamic_node_properties(value.clone()),
             }))
         }
-        _ => std::ptr::null_mut(),
+        _ => {
+            warn!(
+                "Expected map value for dynamic node properties, found: {:?}",
+                properties.inner
+            );
+            call_context.set_error(error_from_str(
+                "Expected map value for dynamic node properties",
+            ));
+            std::ptr::null_mut()
+        }
     }
 }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/value.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/value.rs
@@ -53,7 +53,7 @@ pub enum RustAmqpValueType {
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn amqpvalue_get_type(value: *const RustAmqpValue) -> RustAmqpValueType {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::Null => RustAmqpValueType::AmqpValueNull,
         AmqpValue::Boolean(_) => RustAmqpValueType::AmqpValueBoolean,
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn amqpvalue_get_type(value: *const RustAmqpValue) -> Rust
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn amqpvalue_clone(value: *const RustAmqpValue) -> *mut RustAmqpValue {
-    let value = unsafe { &*value };
+    let value = &*value;
     let amqp_value = RustAmqpValue {
         inner: value.inner.clone(),
     };
@@ -104,15 +104,15 @@ pub unsafe extern "C" fn amqpvalue_are_equal(
     value1: *const RustAmqpValue,
     value2: *const RustAmqpValue,
 ) -> bool {
-    let value1 = unsafe { &*value1 };
-    let value2 = unsafe { &*value2 };
+    let value1 = &*value1;
+    let value2 = &*value2;
     value1.inner == value2.inner
 }
 
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn amqpvalue_to_string(value: *const RustAmqpValue) -> *mut c_char {
-    let value = unsafe { &*value };
+    let value = &*value;
     let s = format!("{:?}", value.inner);
     let c_str = CString::new(s).unwrap();
     c_str.into_raw()
@@ -140,10 +140,10 @@ pub unsafe extern "C" fn amqpvalue_get_boolean(
     value: *const RustAmqpValue,
     bool_value: *mut bool,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::Boolean(b) => {
-            unsafe { *bool_value = b };
+            *bool_value = b;
             0
         }
         _ => -1,
@@ -164,10 +164,10 @@ pub unsafe extern "C" fn amqpvalue_get_ubyte(
     value: *const RustAmqpValue,
     ubyte_value: *mut u8,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::UByte(b) => {
-            unsafe { *ubyte_value = b };
+            *ubyte_value = b;
             0
         }
         _ => -1,
@@ -188,10 +188,10 @@ pub unsafe extern "C" fn amqpvalue_get_byte(
     value: *const RustAmqpValue,
     byte_value: *mut i8,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::Byte(b) => {
-            unsafe { *byte_value = b };
+            *byte_value = b;
             0
         }
         _ => -1,
@@ -212,10 +212,10 @@ pub unsafe extern "C" fn amqpvalue_get_ushort(
     value: *const RustAmqpValue,
     ushort_value: *mut u16,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::UShort(b) => {
-            unsafe { *ushort_value = b };
+            *ushort_value = b;
             0
         }
         _ => -1,
@@ -236,10 +236,10 @@ pub unsafe extern "C" fn amqpvalue_get_short(
     value: *const RustAmqpValue,
     short_value: *mut i16,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::Short(b) => {
-            unsafe { *short_value = b };
+            *short_value = b;
             0
         }
         _ => -1,
@@ -260,10 +260,10 @@ pub unsafe extern "C" fn amqpvalue_get_uint(
     value: *const RustAmqpValue,
     uint_value: *mut u32,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::UInt(b) => {
-            unsafe { *uint_value = b };
+            *uint_value = b;
             0
         }
         _ => -1,
@@ -284,10 +284,10 @@ pub unsafe extern "C" fn amqpvalue_get_int(
     value: *const RustAmqpValue,
     int_value: *mut i32,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::Int(b) => {
-            unsafe { *int_value = b };
+            *int_value = b;
             0
         }
         _ => -1,
@@ -308,10 +308,10 @@ pub unsafe extern "C" fn amqpvalue_get_ulong(
     value: *const RustAmqpValue,
     ulong_value: *mut u64,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::ULong(b) => {
-            unsafe { *ulong_value = b };
+            *ulong_value = b;
             0
         }
         _ => -1,
@@ -332,10 +332,10 @@ pub unsafe extern "C" fn amqpvalue_get_long(
     value: *const RustAmqpValue,
     long_value: *mut i64,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::Long(b) => {
-            unsafe { *long_value = b };
+            *long_value = b;
             0
         }
         _ => -1,
@@ -356,10 +356,10 @@ pub unsafe extern "C" fn amqpvalue_get_float(
     value: *const RustAmqpValue,
     float_value: *mut f32,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::Float(b) => {
-            unsafe { *float_value = b };
+            *float_value = b;
             0
         }
         _ => -1,
@@ -380,10 +380,10 @@ pub unsafe extern "C" fn amqpvalue_get_double(
     value: *const RustAmqpValue,
     double_value: *mut f64,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::Double(b) => {
-            unsafe { *double_value = b };
+            *double_value = b;
             0
         }
         _ => -1,
@@ -404,10 +404,10 @@ pub unsafe extern "C" fn amqpvalue_get_char(
     value: *const RustAmqpValue,
     char_value: *mut u32,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match value.inner {
         AmqpValue::Char(b) => {
-            unsafe { *char_value = b as u32 };
+            *char_value = b as u32;
             0
         }
         _ => -1,
@@ -431,15 +431,13 @@ pub unsafe extern "C" fn amqpvalue_get_timestamp(
     value: *const RustAmqpValue,
     timestamp_value: *mut i64,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::TimeStamp(v) => {
-            unsafe {
-                *timestamp_value =
-                    v.0.duration_since(std::time::SystemTime::UNIX_EPOCH)
-                        .unwrap()
-                        .as_millis() as i64
-            };
+            *timestamp_value =
+                v.0.duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis() as i64;
             0
         }
         _ => -1,
@@ -450,7 +448,7 @@ pub unsafe extern "C" fn amqpvalue_get_timestamp(
 #[no_mangle]
 pub unsafe extern "C" fn amqpvalue_create_uuid(uuid_value: *const [u8; 16]) -> *mut RustAmqpValue {
     let amqp_value = RustAmqpValue {
-        inner: unsafe { AmqpValue::Uuid(uuid::Uuid::from_bytes(*uuid_value)) },
+        inner: AmqpValue::Uuid(uuid::Uuid::from_bytes(*uuid_value)),
     };
     Box::into_raw(Box::new(amqp_value))
 }
@@ -461,10 +459,10 @@ pub unsafe extern "C" fn amqpvalue_get_uuid(
     value: *const RustAmqpValue,
     uuid_value: *mut [u8; 16],
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Uuid(b) => {
-            unsafe { (*uuid_value).copy_from_slice(b.as_bytes()) };
+            (*uuid_value).copy_from_slice(b.as_bytes());
             0
         }
         _ => -1,
@@ -476,7 +474,7 @@ pub unsafe extern "C" fn amqpvalue_get_uuid(
 pub unsafe extern "C" fn amqpvalue_create_string(
     string_value: *const c_char,
 ) -> *mut RustAmqpValue {
-    let string_value = unsafe { std::ffi::CStr::from_ptr(string_value).to_str().unwrap() };
+    let string_value = std::ffi::CStr::from_ptr(string_value).to_str().unwrap();
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::String(string_value.to_string()),
     };
@@ -489,10 +487,10 @@ pub unsafe extern "C" fn amqpvalue_get_string(
     value: *const RustAmqpValue,
     string_value: *mut *const std::os::raw::c_char,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::String(b) => {
-            unsafe { *string_value = std::ffi::CString::new(b.clone()).unwrap().into_raw() };
+            *string_value = std::ffi::CString::new(b.clone()).unwrap().into_raw();
             0
         }
         _ => -1,
@@ -504,7 +502,7 @@ pub unsafe extern "C" fn amqpvalue_get_string(
 pub unsafe extern "C" fn amqpvalue_create_symbol(
     symbol_value: *const c_char,
 ) -> *mut RustAmqpValue {
-    let symbol_value = unsafe { std::ffi::CStr::from_ptr(symbol_value).to_str().unwrap() };
+    let symbol_value = std::ffi::CStr::from_ptr(symbol_value).to_str().unwrap();
     let amqp_value = RustAmqpValue {
         inner: AmqpValue::Symbol(AmqpSymbol::from(symbol_value.to_string())),
     };
@@ -517,10 +515,10 @@ pub unsafe extern "C" fn amqpvalue_get_symbol(
     value: *const RustAmqpValue,
     symbol_value: *mut *const std::os::raw::c_char,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Symbol(b) => {
-            unsafe { *symbol_value = std::ffi::CString::new(b.0.clone()).unwrap().into_raw() };
+            *symbol_value = std::ffi::CString::new(b.0.clone()).unwrap().into_raw();
             0
         }
         _ => -1,
@@ -551,19 +549,15 @@ pub unsafe extern "C" fn amqpvalue_get_binary(
     binary_value: *mut *const u8,
     size: *mut u32,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Binary(b) => {
             if !b.is_empty() {
-                unsafe {
-                    *binary_value = b.as_ptr();
-                    *size = b.len() as u32
-                };
+                *binary_value = b.as_ptr();
+                *size = b.len() as u32;
             } else {
-                unsafe {
-                    *binary_value = null();
-                    *size = 0;
-                }
+                *binary_value = null();
+                *size = 0;
             }
             0
         }
@@ -585,8 +579,8 @@ pub unsafe extern "C" fn amqpvalue_add_array_item(
     value: *mut RustAmqpValue,
     array_item_value: *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &mut *value };
-    let array_item_value = unsafe { &*array_item_value };
+    let value = &mut *value;
+    let array_item_value = &*array_item_value;
     match &mut value.inner {
         AmqpValue::Array(v) => {
             v.push(array_item_value.inner.clone());
@@ -602,7 +596,7 @@ pub unsafe extern "C" fn amqpvalue_get_array_item(
     value: *const RustAmqpValue,
     index: u32,
 ) -> *mut RustAmqpValue {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Array(v) => {
             let amqp_value = RustAmqpValue {
@@ -620,12 +614,12 @@ pub unsafe extern "C" fn amqpvalue_get_array_item_count(
     value: *const RustAmqpValue,
     count: *mut u32,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
-        AmqpValue::Array(v) => unsafe {
+        AmqpValue::Array(v) => {
             *count = v.len() as u32;
             0
-        },
+        }
         _ => -1,
     }
 }
@@ -644,8 +638,8 @@ pub unsafe extern "C" fn amqpvalue_add_list_item(
     value: *mut RustAmqpValue,
     list_item_value: *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &mut *value };
-    let list_item_value = unsafe { &*list_item_value };
+    let value = &mut *value;
+    let list_item_value = &*list_item_value;
     match &mut value.inner {
         AmqpValue::List(v) => {
             v.push(list_item_value.inner.clone());
@@ -661,7 +655,7 @@ pub unsafe extern "C" fn amqpvalue_get_list_item(
     value: *const RustAmqpValue,
     index: u32,
 ) -> *mut RustAmqpValue {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::List(v) => {
             let amqp_value = RustAmqpValue {
@@ -679,12 +673,12 @@ pub unsafe extern "C" fn amqpvalue_get_list_item_count(
     value: *const RustAmqpValue,
     count: *mut u32,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
-        AmqpValue::List(v) => unsafe {
+        AmqpValue::List(v) => {
             *count = v.0.len() as u32;
             0
-        },
+        }
         _ => -1,
     }
 }
@@ -695,7 +689,7 @@ pub unsafe extern "C" fn amqpvalue_set_list_item_count(
     value: *mut RustAmqpValue,
     count: u32,
 ) -> i32 {
-    let value = unsafe { &mut *value };
+    let value = &mut *value;
     match &mut value.inner {
         AmqpValue::List(v) => {
             v.0.resize(count as usize, AmqpValue::Null);
@@ -712,8 +706,8 @@ pub unsafe extern "C" fn amqpvalue_set_list_item(
     index: u32,
     list_item_value: *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &mut *value };
-    let list_item_value = unsafe { &*list_item_value };
+    let value = &mut *value;
+    let list_item_value = &*list_item_value;
     match &mut value.inner {
         AmqpValue::List(v) => {
             v.0[index as usize] = list_item_value.inner.clone();
@@ -739,9 +733,9 @@ pub unsafe extern "C" fn amqpvalue_add_map_item(
     key: *mut RustAmqpValue,
     map_item_value: *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &mut *value };
-    let key = unsafe { &*key };
-    let map_item_value = unsafe { &*map_item_value };
+    let value = &mut *value;
+    let key = &*key;
+    let map_item_value = &*map_item_value;
     match &mut value.inner {
         AmqpValue::Map(v) => {
             v.insert(key.inner.clone(), map_item_value.inner.clone());
@@ -758,9 +752,9 @@ pub unsafe extern "C" fn amqpvalue_set_map_value(
     key: *mut RustAmqpValue,
     map_item_value: *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &mut *value };
-    let key = unsafe { &*key };
-    let map_item_value = unsafe { &*map_item_value };
+    let value = &mut *value;
+    let key = &*key;
+    let map_item_value = &*map_item_value;
     match &mut value.inner {
         AmqpValue::Map(v) => {
             v.insert(key.inner.clone(), map_item_value.inner.clone());
@@ -776,8 +770,8 @@ pub unsafe extern "C" fn amqpvalue_get_map_item(
     value: *const RustAmqpValue,
     key: *mut RustAmqpValue,
 ) -> *mut RustAmqpValue {
-    let value = unsafe { &*value };
-    let key = unsafe { &*key };
+    let value = &*value;
+    let key = &*key;
     match &value.inner {
         AmqpValue::Map(v) => {
             let amqp_value = RustAmqpValue {
@@ -797,17 +791,15 @@ pub unsafe extern "C" fn amqpvalue_get_map_key_value_pair(
     key: *mut *mut RustAmqpValue,
     map_item_value: *mut *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Map(v) => {
             let (k, m) = v.iter().nth(index as usize).unwrap();
             let amqp_key = RustAmqpValue { inner: k.clone() };
             let amqp_map_item = RustAmqpValue { inner: m.clone() };
-            unsafe {
-                *key = Box::into_raw(Box::new(amqp_key));
-                *map_item_value = Box::into_raw(Box::new(amqp_map_item));
-                0
-            }
+            *key = Box::into_raw(Box::new(amqp_key));
+            *map_item_value = Box::into_raw(Box::new(amqp_map_item));
+            0
         }
         _ => -1,
     }
@@ -819,12 +811,12 @@ pub unsafe extern "C" fn amqpvalue_get_map_pair_count(
     value: *const RustAmqpValue,
     count: *mut u32,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
-        AmqpValue::Map(v) => unsafe {
+        AmqpValue::Map(v) => {
             *count = v.len() as u32;
             0
-        },
+        }
         _ => -1,
     }
 }
@@ -835,8 +827,8 @@ pub unsafe extern "C" fn amqpvalue_create_described(
     descriptor: *const RustAmqpValue,
     value: *const RustAmqpValue,
 ) -> *mut RustAmqpValue {
-    let value = unsafe { &*value };
-    let descriptor = unsafe { &*descriptor };
+    let value = &*value;
+    let descriptor = &*descriptor;
     let amqp_value = match &descriptor.inner {
         AmqpValue::ULong(v) => AmqpValue::Described(Box::new(AmqpDescribed::new(
             AmqpDescriptor::Code(*v),
@@ -858,7 +850,7 @@ pub unsafe extern "C" fn amqpvalue_get_inplace_descriptor(
     value: *const RustAmqpValue,
     descriptor: *mut *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Described(d) => {
             let amqp_value = RustAmqpValue {
@@ -867,9 +859,7 @@ pub unsafe extern "C" fn amqpvalue_get_inplace_descriptor(
                     AmqpDescriptor::Name(v) => AmqpValue::Symbol(v.clone()),
                 },
             };
-            unsafe {
-                *descriptor = Box::into_raw(Box::new(amqp_value));
-            }
+            *descriptor = Box::into_raw(Box::new(amqp_value));
             0
         }
         AmqpValue::Composite(c) => {
@@ -879,9 +869,7 @@ pub unsafe extern "C" fn amqpvalue_get_inplace_descriptor(
                     AmqpDescriptor::Name(v) => AmqpValue::Symbol(v.clone()),
                 },
             };
-            unsafe {
-                *descriptor = Box::into_raw(Box::new(amqp_value));
-            }
+            *descriptor = Box::into_raw(Box::new(amqp_value));
             0
         }
         _ => -1,
@@ -894,15 +882,13 @@ pub unsafe extern "C" fn amqpvalue_get_inplace_described_value(
     value: *const RustAmqpValue,
     described_value: *mut *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Described(d) => {
             let amqp_value = RustAmqpValue {
                 inner: d.value().clone(),
             };
-            unsafe {
-                *described_value = Box::into_raw(Box::new(amqp_value));
-            }
+            *described_value = Box::into_raw(Box::new(amqp_value));
             0
         }
         _ => -1,
@@ -915,7 +901,7 @@ pub unsafe extern "C" fn amqpvalue_create_composite(
     descriptor: *const RustAmqpValue,
     size: usize,
 ) -> *mut RustAmqpValue {
-    let descriptor = unsafe { &*descriptor };
+    let descriptor = &*descriptor;
     let amqp_value = match &descriptor.inner {
         AmqpValue::ULong(v) => AmqpValue::Composite(Box::new(AmqpComposite::new(
             AmqpDescriptor::Code(*v),
@@ -942,8 +928,8 @@ pub unsafe extern "C" fn amqpvalue_set_composite_item(
     index: u32,
     composite_item: *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &mut *value };
-    let composite_item = unsafe { &*composite_item };
+    let value = &mut *value;
+    let composite_item = &*composite_item;
 
     if match &value.inner {
         AmqpValue::Composite(v) => v.value().0.capacity(),
@@ -973,12 +959,12 @@ pub unsafe extern "C" fn amqpvalue_get_composite_item_count(
     value: *const RustAmqpValue,
     count: *mut u32,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
-        AmqpValue::Composite(v) => unsafe {
+        AmqpValue::Composite(v) => {
             *count = v.value().len() as u32;
             0
-        },
+        }
         _ => -1,
     }
 }
@@ -990,15 +976,13 @@ pub unsafe extern "C" fn amqpvalue_get_composite_item_in_place(
     index: u32,
     composite_item: *mut *mut RustAmqpValue,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     match &value.inner {
         AmqpValue::Composite(v) => {
             let amqp_value = RustAmqpValue {
                 inner: v.value().0[index as usize].clone(),
             };
-            unsafe {
-                *composite_item = Box::into_raw(Box::new(amqp_value));
-            }
+            *composite_item = Box::into_raw(Box::new(amqp_value));
             0
         }
         _ => -1,
@@ -1011,12 +995,10 @@ pub unsafe extern "C" fn amqpvalue_get_encoded_size(
     value: *const RustAmqpValue,
     size: *mut usize,
 ) -> i32 {
-    let value = unsafe { &*value };
+    let value = &*value;
     let encoded_size = Serializable::encoded_size(&value.inner);
     if encoded_size.is_ok() {
-        unsafe {
-            *size = encoded_size.unwrap();
-        }
+        *size = encoded_size.unwrap();
         0
     } else {
         error!(
@@ -1034,8 +1016,8 @@ pub unsafe extern "C" fn amqpvalue_encode(
     buffer: *mut u8,
     size: usize,
 ) -> i32 {
-    let value = unsafe { &*value };
-    let buffer = unsafe { std::slice::from_raw_parts_mut(buffer, size) };
+    let value = &*value;
+    let buffer = std::slice::from_raw_parts_mut(buffer, size);
     match Serializable::serialize(&value.inner, buffer) {
         Ok(_) => 0,
         Err(_) => -1,
@@ -1049,11 +1031,11 @@ pub unsafe extern "C" fn amqpvalue_decode_bytes(
     size: usize,
     value: *mut *mut RustAmqpValue,
 ) -> i32 {
-    let buffer = unsafe { std::slice::from_raw_parts(buffer, size) };
+    let buffer = std::slice::from_raw_parts(buffer, size);
     match <AmqpValue as Deserializable<AmqpValue>>::decode(buffer) {
         Ok(v) => {
             let amqp_value = RustAmqpValue { inner: v };
-            unsafe {
+            {
                 *value = Box::into_raw(Box::new(amqp_value));
             }
             0

--- a/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
@@ -158,24 +158,24 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     _detail::UniqueMessageHeaderBuilderHandle builder{header_builder_create()};
     if (header.Durable)
     {
-      invoke_builder_api(header_set_durable, builder, header.Durable);
+      InvokeBuilderApi(header_set_durable, builder, header.Durable);
     }
     if (header.Priority != 4)
     {
-      invoke_builder_api(header_set_priority, builder, header.Priority);
+      InvokeBuilderApi(header_set_priority, builder, header.Priority);
     }
     if (header.TimeToLive.HasValue())
     {
-      invoke_builder_api(header_set_ttl, builder, header.TimeToLive.Value().count());
+      InvokeBuilderApi(header_set_ttl, builder, header.TimeToLive.Value().count());
     }
 
     if (header.IsFirstAcquirer)
     {
-      invoke_builder_api(header_set_first_acquirer, builder, header.IsFirstAcquirer);
+      InvokeBuilderApi(header_set_first_acquirer, builder, header.IsFirstAcquirer);
     }
     if (header.DeliveryCount != 0)
     {
-      invoke_builder_api(header_set_delivery_count, builder, header.DeliveryCount);
+      InvokeBuilderApi(header_set_delivery_count, builder, header.DeliveryCount);
     }
 
     // Now that we've set all the builder parameters, actually build the header.

--- a/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
@@ -13,6 +13,7 @@
 
 #include <azure_uamqp_c/amqp_definitions_header.h>
 #elif ENABLE_RUST_AMQP
+#include <azure/core/amqp/internal/common/runtime_context.hpp>
 using namespace Azure::Core::Amqp::_detail::RustInterop;
 #endif
 
@@ -49,6 +50,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
 namespace Azure { namespace Core { namespace Amqp { namespace Models {
 #if ENABLE_RUST_AMQP
+  using namespace Common::_detail;
   namespace _detail {
     using UniqueMessageHeaderBuilderHandle = Azure::Core::Amqp::_detail::UniqueHandle<
         Azure::Core::Amqp::_detail::HeaderBuilderImplementation>;
@@ -156,44 +158,24 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     _detail::UniqueMessageHeaderBuilderHandle builder{header_builder_create()};
     if (header.Durable)
     {
-      builder.reset(header_set_durable(builder.release(), header.Durable));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set durable value.");
-      }
+      invoke_builder_api(header_set_durable, builder, header.Durable);
     }
     if (header.Priority != 4)
     {
-      builder.reset(header_set_priority(builder.release(), header.Priority));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set priority value.");
-      }
+      invoke_builder_api(header_set_priority, builder, header.Priority);
     }
     if (header.TimeToLive.HasValue())
     {
-      builder.reset(header_set_ttl(builder.release(), header.TimeToLive.Value().count()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set header TTL.");
-      }
+      invoke_builder_api(header_set_ttl, builder, header.TimeToLive.Value().count());
     }
 
     if (header.IsFirstAcquirer)
     {
-      builder.reset(header_set_first_acquirer(builder.release(), header.IsFirstAcquirer));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set first acquirer value.");
-      }
+      invoke_builder_api(header_set_first_acquirer, builder, header.IsFirstAcquirer);
     }
     if (header.DeliveryCount != 0)
     {
-      builder.reset(header_set_delivery_count(builder.release(), header.DeliveryCount));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set delivery count value.");
-      }
+      invoke_builder_api(header_set_delivery_count, builder, header.DeliveryCount);
     }
 
     // Now that we've set all the builder parameters, actually build the header.

--- a/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
@@ -13,8 +13,8 @@
 
 #include <azure_uamqp_c/amqp_definitions_header.h>
 #elif ENABLE_RUST_AMQP
-#include <azure/core/amqp/internal/common/runtime_context.hpp>
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+#include "azure/core/amqp/internal/common/runtime_context.hpp"
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 #endif
 
 #include <chrono>
@@ -30,7 +30,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #if ENABLE_RUST_AMQP
 
   using HeaderBuilderImplementation
-      = Azure::Core::Amqp::_detail::RustInterop::RustMessageHeaderBuilder;
+      = Azure::Core::Amqp::RustInterop::_detail::RustMessageHeaderBuilder;
 
   template <> struct UniqueHandleHelper<HeaderBuilderImplementation>
   {

--- a/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
@@ -309,7 +309,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
   UniqueMessageHandle _detail::AmqpMessageFactory::ToImplementation(AmqpMessage const& message)
   {
 #if ENABLE_UAMQP
-    UniqueMessageHandle builder(message_create());
+    UniqueMessageHandle rv(message_create());
 
     // AMQP 1.0 specifies a message format of 0, but EventHubs uses other values.
     if (message_set_message_format(rv.get(), message.MessageFormat))

--- a/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
@@ -19,8 +19,8 @@
 #include <azure_uamqp_c/message.h>
 using NativeMessageBodyType = MESSAGE_BODY_TYPE;
 #elif ENABLE_RUST_AMQP
-#include <azure/core/amqp/internal/common/runtime_context.hpp>
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+#include "azure/core/amqp/internal/common/runtime_context.hpp"
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 
 constexpr auto AMQP_TYPE_DESCRIBED = RustAmqpValueType::AmqpValueDescribed;
 constexpr auto AMQP_TYPE_MAP = RustAmqpValueType::AmqpValueMap;

--- a/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_message.cpp
@@ -437,24 +437,24 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 #else
     UniqueMessageBuilderHandle builder(messagebuilder_create());
 
-    invoke_builder_api(
+    InvokeBuilderApi(
         messagebuilder_set_header,
         builder,
         _detail::MessageHeaderFactory::ToImplementation(message.Header).get());
-    invoke_builder_api(
+    InvokeBuilderApi(
         messagebuilder_set_properties,
         builder,
         _detail::MessagePropertiesFactory::ToImplementation(message.Properties).get());
     if (!message.DeliveryAnnotations.empty())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           messagebuilder_set_delivery_annotations,
           builder,
           _detail::AmqpValueFactory::ToImplementation(message.DeliveryAnnotations.AsAmqpValue()));
     }
     if (!message.MessageAnnotations.empty())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           messagebuilder_set_message_annotations,
           builder,
           _detail::AmqpValueFactory::ToImplementation(message.MessageAnnotations.AsAmqpValue()));
@@ -475,7 +475,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
         }
         appProperties.emplace(val);
       }
-      invoke_builder_api(
+      InvokeBuilderApi(
           messagebuilder_set_application_properties,
           builder,
           _detail::AmqpValueFactory::ToImplementation(appProperties.AsAmqpValue()));
@@ -483,7 +483,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
     if (!message.Footer.empty())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           messagebuilder_set_footer,
           builder,
           _detail::AmqpValueFactory::ToImplementation(message.Footer.AsAmqpValue()));
@@ -495,21 +495,21 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
       case MessageBodyType::Data:
         for (auto const& binaryVal : message.m_binaryDataBody)
         {
-          invoke_builder_api(
+          InvokeBuilderApi(
               messagebuilder_add_body_amqp_data, builder, binaryVal.data(), binaryVal.size());
         }
         break;
       case MessageBodyType::Sequence:
         for (auto const& sequenceVal : message.m_amqpSequenceBody)
         {
-          invoke_builder_api(
+          InvokeBuilderApi(
               messagebuilder_add_body_amqp_sequence,
               builder,
               _detail::AmqpValueFactory::ToImplementation(sequenceVal.AsAmqpValue()));
         }
         break;
       case MessageBodyType::Value:
-        invoke_builder_api(
+        InvokeBuilderApi(
             messagebuilder_set_body_amqp_value,
             builder,
             _detail::AmqpValueFactory::ToImplementation(message.m_amqpValueBody));

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -221,7 +221,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     if (properties.To.HasValue())
     {
       if (properties_set_to(
-              returnValue.get(), _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value())))
+              returnValue.get(),
+              _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value())))
       {
         throw std::runtime_error("Could not set to");
       }
@@ -316,18 +317,20 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     if (properties.MessageId.HasValue())
     {
       builder.reset(properties_set_message_id(
-              builder.release(),
-              _detail::AmqpValueFactory::ToImplementation(properties.MessageId.Value())))
-      ;if (!builder) {
+          builder.release(),
+          _detail::AmqpValueFactory::ToImplementation(properties.MessageId.Value())));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set message id");
       }
     }
     if (properties.CorrelationId.HasValue())
     {
-builder.reset(properties_set_correlation_id(
-              builder.release(),
-              _detail::AmqpValueFactory::ToImplementation(properties.CorrelationId.Value())))
-      ; if (!builder) {
+      builder.reset(properties_set_correlation_id(
+          builder.release(),
+          _detail::AmqpValueFactory::ToImplementation(properties.CorrelationId.Value())));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set correlation id");
       }
     }
@@ -335,10 +338,11 @@ builder.reset(properties_set_correlation_id(
     if (properties.UserId.HasValue())
     {
       builder.reset(properties_set_user_id(
-              builder.release(),
-              properties.UserId.Value().data(),
-              static_cast<uint32_t>(properties.UserId.Value().size())))
-      ; if (!builder) {
+          builder.release(),
+          properties.UserId.Value().data(),
+          static_cast<uint32_t>(properties.UserId.Value().size())));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set user id");
       }
     }
@@ -346,35 +350,39 @@ builder.reset(properties_set_correlation_id(
     if (properties.To.HasValue())
     {
       builder.reset(properties_set_to(
-              builder.release(),
-              static_cast<std::string>(properties.To.Value()).c_str()))
-      ; if (!builder) {
+          builder.release(), static_cast<std::string>(properties.To.Value()).c_str()));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set to");
       }
     }
 
     if (properties.Subject.HasValue())
     {
-      builder.reset(properties_set_subject(builder.release(), properties.Subject.Value().data()))
-      ; if (!builder) {
+      builder.reset(properties_set_subject(builder.release(), properties.Subject.Value().data()));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set subject");
       }
     }
 
     if (properties.ReplyTo.HasValue())
     {
-builder.reset(properties_set_reply_to(
-              builder.release(),
-              _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value())))
-      ; if (!builder) {
+      builder.reset(properties_set_reply_to(
+          builder.release(),
+          _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value())));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set reply to");
       }
     }
 
     if (properties.ContentType.HasValue())
     {
-      builder.reset(properties_set_content_type(builder.release(), properties.ContentType.Value().data()))
-      ; if (!builder) {
+      builder.reset(
+          properties_set_content_type(builder.release(), properties.ContentType.Value().data()));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set content type");
       }
     }
@@ -382,8 +390,9 @@ builder.reset(properties_set_reply_to(
     if (properties.ContentEncoding.HasValue())
     {
       builder.reset(properties_set_content_encoding(
-              builder.release(), properties.ContentEncoding.Value().data()))
-      ; if (!builder) {
+          builder.release(), properties.ContentEncoding.Value().data()));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set content type");
       }
     }
@@ -393,8 +402,9 @@ builder.reset(properties_set_reply_to(
       auto timeStamp{std::chrono::duration_cast<std::chrono::milliseconds>(
           properties.AbsoluteExpiryTime.Value().time_since_epoch())};
 
-      builder.reset(properties_set_absolute_expiry_time(builder.release(), timeStamp.count()))
-     ;if(!builder){
+      builder.reset(properties_set_absolute_expiry_time(builder.release(), timeStamp.count()));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set absolute expiry time");
       }
     }
@@ -404,24 +414,28 @@ builder.reset(properties_set_reply_to(
       auto timeStamp{std::chrono::duration_cast<std::chrono::milliseconds>(
           properties.CreationTime.Value().time_since_epoch())};
 
-      builder.reset(properties_set_creation_time(builder.release(), timeStamp.count()))
-      ; if (!builder) {
+      builder.reset(properties_set_creation_time(builder.release(), timeStamp.count()));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set absolute expiry time");
       }
     }
 
     if (properties.GroupId.HasValue())
     {
-      builder.reset(properties_set_group_id(builder.release(), properties.GroupId.Value().data()))
-      ; if (!builder) {
+      builder.reset(properties_set_group_id(builder.release(), properties.GroupId.Value().data()));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set group id");
       }
     }
 
     if (properties.GroupSequence.HasValue())
     {
-      builder.reset(properties_set_group_sequence(builder.release(), properties.GroupSequence.Value()))
-      ; if (!builder) {
+      builder.reset(
+          properties_set_group_sequence(builder.release(), properties.GroupSequence.Value()));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set group sequence");
       }
     }
@@ -429,8 +443,9 @@ builder.reset(properties_set_reply_to(
     if (properties.ReplyToGroupId.HasValue())
     {
       builder.reset(properties_set_reply_to_group_id(
-              builder.release(), properties.ReplyToGroupId.Value().data()))
-      ; if (!builder){
+          builder.release(), properties.ReplyToGroupId.Value().data()));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set reply-to group id");
       }
     }

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -188,10 +188,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
   {
 #if ENABLE_UAMQP
     UniquePropertiesHandle returnValue(properties_create());
-#elif ENABLE_RUST_AMQP
-    _detail::UniqueMessagePropertiesBuilderHandle returnValue{properties_builder_create()};
-#endif
-
     if (properties.MessageId.HasValue())
     {
       if (properties_set_message_id(
@@ -213,7 +209,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
     if (properties.UserId.HasValue())
     {
-#if ENABLE_UAMQP
       amqp_binary value{
           properties.UserId.Value().data(),
           static_cast<uint32_t>(properties.UserId.Value().size())};
@@ -221,22 +216,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
       {
         throw std::runtime_error("Could not set user id");
       }
-#elif ENABLE_RUST_AMQP
-      if (properties_set_user_id(
-              returnValue.get(),
-              properties.UserId.Value().data(),
-              static_cast<uint32_t>(properties.UserId.Value().size())))
-      {
-        throw std::runtime_error("Could not set user id");
-      }
-#endif
     }
 
     if (properties.To.HasValue())
     {
       if (properties_set_to(
-              returnValue.get(),
-              _detail::AmqpValueFactory::ToImplementation(properties.To.Value())))
+              returnValue.get(), static_cast<std::string>(properties.To.Value()).c_str()))
       {
         throw std::runtime_error("Could not set to");
       }
@@ -324,16 +309,139 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
       }
     }
 
-#if ENABLE_RUST_AMQP
+    return returnValue;
+#elif ENABLE_RUST_AMQP
+    _detail::UniqueMessagePropertiesBuilderHandle builder{properties_builder_create()};
+
+    if (properties.MessageId.HasValue())
+    {
+      builder.reset(properties_set_message_id(
+              builder.release(),
+              _detail::AmqpValueFactory::ToImplementation(properties.MessageId.Value())))
+      ;if (!builder) {
+        throw std::runtime_error("Could not set message id");
+      }
+    }
+    if (properties.CorrelationId.HasValue())
+    {
+builder.reset(properties_set_correlation_id(
+              builder.release(),
+              _detail::AmqpValueFactory::ToImplementation(properties.CorrelationId.Value())))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set correlation id");
+      }
+    }
+
+    if (properties.UserId.HasValue())
+    {
+      builder.reset(properties_set_user_id(
+              builder.release(),
+              properties.UserId.Value().data(),
+              static_cast<uint32_t>(properties.UserId.Value().size())))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set user id");
+      }
+    }
+
+    if (properties.To.HasValue())
+    {
+      builder.reset(properties_set_to(
+              builder.release(),
+              static_cast<std::string>(properties.To.Value()).c_str()))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set to");
+      }
+    }
+
+    if (properties.Subject.HasValue())
+    {
+      builder.reset(properties_set_subject(builder.release(), properties.Subject.Value().data()))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set subject");
+      }
+    }
+
+    if (properties.ReplyTo.HasValue())
+    {
+builder.reset(properties_set_reply_to(
+              builder.release(),
+              _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value())))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set reply to");
+      }
+    }
+
+    if (properties.ContentType.HasValue())
+    {
+      builder.reset(properties_set_content_type(builder.release(), properties.ContentType.Value().data()))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set content type");
+      }
+    }
+
+    if (properties.ContentEncoding.HasValue())
+    {
+      builder.reset(properties_set_content_encoding(
+              builder.release(), properties.ContentEncoding.Value().data()))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set content type");
+      }
+    }
+
+    if (properties.AbsoluteExpiryTime.HasValue())
+    {
+      auto timeStamp{std::chrono::duration_cast<std::chrono::milliseconds>(
+          properties.AbsoluteExpiryTime.Value().time_since_epoch())};
+
+      builder.reset(properties_set_absolute_expiry_time(builder.release(), timeStamp.count()))
+     ;if(!builder){
+        throw std::runtime_error("Could not set absolute expiry time");
+      }
+    }
+
+    if (properties.CreationTime.HasValue())
+    {
+      auto timeStamp{std::chrono::duration_cast<std::chrono::milliseconds>(
+          properties.CreationTime.Value().time_since_epoch())};
+
+      builder.reset(properties_set_creation_time(builder.release(), timeStamp.count()))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set absolute expiry time");
+      }
+    }
+
+    if (properties.GroupId.HasValue())
+    {
+      builder.reset(properties_set_group_id(builder.release(), properties.GroupId.Value().data()))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set group id");
+      }
+    }
+
+    if (properties.GroupSequence.HasValue())
+    {
+      builder.reset(properties_set_group_sequence(builder.release(), properties.GroupSequence.Value()))
+      ; if (!builder) {
+        throw std::runtime_error("Could not set group sequence");
+      }
+    }
+
+    if (properties.ReplyToGroupId.HasValue())
+    {
+      builder.reset(properties_set_reply_to_group_id(
+              builder.release(), properties.ReplyToGroupId.Value().data()))
+      ; if (!builder){
+        throw std::runtime_error("Could not set reply-to group id");
+      }
+    }
+
     // Now that we've set all the builder parameters, actually build the header.
     Azure::Core::Amqp::_detail::PropertiesImplementation* implementation;
-    if (properties_build(returnValue.get(), &implementation))
+    if (properties_build(builder.release(), &implementation))
     {
       throw std::runtime_error("Could not build header.");
     }
     return _detail::UniquePropertiesHandle{implementation};
-#elif ENABLE_UAMQP
-    return returnValue;
 #endif
   }
 

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -469,6 +469,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
   {
     AmqpValue value{AmqpValue::Deserialize(data, size)};
     Azure::Core::Amqp::_detail::PropertiesImplementation* handle;
+#if ENABLE_RUST_AMQP
     CallContext callContext;
     if (amqpvalue_get_properties(
             callContext.GetCallContext(),
@@ -478,6 +479,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
       throw std::runtime_error(
           "Could not convert value to AMQP Properties: " + callContext.GetError());
     }
+#elif ENABLE_UAMQP
+    if (amqpvalue_get_properties(_detail::AmqpValueFactory::ToImplementation(value), &handle))
+    {
+      throw std::runtime_error("Could not convert value to AMQP Properties");
+    }
+#endif
     _detail::UniquePropertiesHandle uniqueHandle{handle};
     handle = nullptr;
     return _detail::MessagePropertiesFactory::FromImplementation(uniqueHandle);

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -222,7 +222,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     {
       if (properties_set_to(
               returnValue.get(),
-              _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value())))
+              _detail::AmqpValueFactory::ToImplementation(properties.To.Value())))
       {
         throw std::runtime_error("Could not set to");
       }

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -14,7 +14,9 @@
 #include <azure_uamqp_c/amqp_definitions_properties.h>
 
 #elif ENABLE_RUST_AMQP
+#include <azure/core/amqp/internal/common/runtime_context.hpp>
 using namespace Azure::Core::Amqp::_detail::RustInterop;
+using namespace Azure::Core::Amqp::Common::_detail;
 #endif // ENABLE_UAMQP
 #include <iomanip>
 #include <iostream>
@@ -316,85 +318,57 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
     if (properties.MessageId.HasValue())
     {
-      builder.reset(properties_set_message_id(
-          builder.release(),
-          _detail::AmqpValueFactory::ToImplementation(properties.MessageId.Value())));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set message id");
-      }
+      invoke_builder_api(
+          properties_set_message_id,
+          builder,
+          _detail::AmqpValueFactory::ToImplementation(properties.MessageId.Value()));
     }
     if (properties.CorrelationId.HasValue())
     {
-      builder.reset(properties_set_correlation_id(
-          builder.release(),
-          _detail::AmqpValueFactory::ToImplementation(properties.CorrelationId.Value())));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set correlation id");
-      }
+      invoke_builder_api(
+          properties_set_correlation_id,
+          builder,
+          _detail::AmqpValueFactory::ToImplementation(properties.CorrelationId.Value()));
     }
 
     if (properties.UserId.HasValue())
     {
-      builder.reset(properties_set_user_id(
-          builder.release(),
+      invoke_builder_api(
+          properties_set_user_id,
+          builder,
           properties.UserId.Value().data(),
-          static_cast<uint32_t>(properties.UserId.Value().size())));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set user id");
-      }
+          static_cast<uint32_t>(properties.UserId.Value().size()));
     }
 
     if (properties.To.HasValue())
     {
-      builder.reset(properties_set_to(
-          builder.release(), static_cast<std::string>(properties.To.Value()).c_str()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set to");
-      }
+      invoke_builder_api(
+          properties_set_to, builder, static_cast<std::string>(properties.To.Value()).c_str());
     }
 
     if (properties.Subject.HasValue())
     {
-      builder.reset(properties_set_subject(builder.release(), properties.Subject.Value().data()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set subject");
-      }
+      invoke_builder_api(properties_set_subject, builder, properties.Subject.Value().data());
     }
 
     if (properties.ReplyTo.HasValue())
     {
-      builder.reset(properties_set_reply_to(
-          builder.release(),
-          _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value())));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set reply to");
-      }
+      invoke_builder_api(
+          properties_set_reply_to,
+          builder,
+          _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value()));
     }
 
     if (properties.ContentType.HasValue())
     {
-      builder.reset(
-          properties_set_content_type(builder.release(), properties.ContentType.Value().data()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set content type");
-      }
+      invoke_builder_api(
+          properties_set_content_type, builder, properties.ContentType.Value().data());
     }
 
     if (properties.ContentEncoding.HasValue())
     {
-      builder.reset(properties_set_content_encoding(
-          builder.release(), properties.ContentEncoding.Value().data()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set content type");
-      }
+      invoke_builder_api(
+          properties_set_content_encoding, builder, properties.ContentEncoding.Value().data());
     }
 
     if (properties.AbsoluteExpiryTime.HasValue())
@@ -402,11 +376,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
       auto timeStamp{std::chrono::duration_cast<std::chrono::milliseconds>(
           properties.AbsoluteExpiryTime.Value().time_since_epoch())};
 
-      builder.reset(properties_set_absolute_expiry_time(builder.release(), timeStamp.count()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set absolute expiry time");
-      }
+      invoke_builder_api(properties_set_absolute_expiry_time, builder, timeStamp.count());
     }
 
     if (properties.CreationTime.HasValue())
@@ -414,47 +384,31 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
       auto timeStamp{std::chrono::duration_cast<std::chrono::milliseconds>(
           properties.CreationTime.Value().time_since_epoch())};
 
-      builder.reset(properties_set_creation_time(builder.release(), timeStamp.count()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set absolute expiry time");
-      }
+      invoke_builder_api(properties_set_creation_time, builder, timeStamp.count());
     }
 
     if (properties.GroupId.HasValue())
     {
-      builder.reset(properties_set_group_id(builder.release(), properties.GroupId.Value().data()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set group id");
-      }
+      invoke_builder_api(properties_set_group_id, builder, properties.GroupId.Value().data());
     }
 
     if (properties.GroupSequence.HasValue())
     {
-      builder.reset(
-          properties_set_group_sequence(builder.release(), properties.GroupSequence.Value()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set group sequence");
-      }
+      invoke_builder_api(properties_set_group_sequence, builder, properties.GroupSequence.Value());
     }
 
     if (properties.ReplyToGroupId.HasValue())
     {
-      builder.reset(properties_set_reply_to_group_id(
-          builder.release(), properties.ReplyToGroupId.Value().data()));
-      if (!builder)
-      {
-        throw std::runtime_error("Could not set reply-to group id");
-      }
+      invoke_builder_api(
+          properties_set_reply_to_group_id, builder, properties.ReplyToGroupId.Value().data());
     }
 
     // Now that we've set all the builder parameters, actually build the header.
     Azure::Core::Amqp::_detail::PropertiesImplementation* implementation;
-    if (properties_build(builder.release(), &implementation))
+    CallContext callContext;
+    if (properties_build(callContext.GetCallContext(), builder.release(), &implementation))
     {
-      throw std::runtime_error("Could not build header.");
+      throw std::runtime_error("Could not build header." + callContext.GetError());
     }
     return _detail::UniquePropertiesHandle{implementation};
 #endif
@@ -515,9 +469,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
   {
     AmqpValue value{AmqpValue::Deserialize(data, size)};
     Azure::Core::Amqp::_detail::PropertiesImplementation* handle;
-    if (amqpvalue_get_properties(_detail::AmqpValueFactory::ToImplementation(value), &handle))
+    CallContext callContext;
+    if (amqpvalue_get_properties(
+            callContext.GetCallContext(),
+            _detail::AmqpValueFactory::ToImplementation(value),
+            &handle))
     {
-      throw std::runtime_error("Could not convert value to AMQP Properties.");
+      throw std::runtime_error(
+          "Could not convert value to AMQP Properties: " + callContext.GetError());
     }
     _detail::UniquePropertiesHandle uniqueHandle{handle};
     handle = nullptr;

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -318,14 +318,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
     if (properties.MessageId.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           properties_set_message_id,
           builder,
           _detail::AmqpValueFactory::ToImplementation(properties.MessageId.Value()));
     }
     if (properties.CorrelationId.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           properties_set_correlation_id,
           builder,
           _detail::AmqpValueFactory::ToImplementation(properties.CorrelationId.Value()));
@@ -333,7 +333,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
     if (properties.UserId.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           properties_set_user_id,
           builder,
           properties.UserId.Value().data(),
@@ -342,18 +342,18 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
     if (properties.To.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           properties_set_to, builder, static_cast<std::string>(properties.To.Value()).c_str());
     }
 
     if (properties.Subject.HasValue())
     {
-      invoke_builder_api(properties_set_subject, builder, properties.Subject.Value().data());
+      InvokeBuilderApi(properties_set_subject, builder, properties.Subject.Value().data());
     }
 
     if (properties.ReplyTo.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           properties_set_reply_to,
           builder,
           _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value()));
@@ -361,13 +361,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
 
     if (properties.ContentType.HasValue())
     {
-      invoke_builder_api(
-          properties_set_content_type, builder, properties.ContentType.Value().data());
+      InvokeBuilderApi(properties_set_content_type, builder, properties.ContentType.Value().data());
     }
 
     if (properties.ContentEncoding.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           properties_set_content_encoding, builder, properties.ContentEncoding.Value().data());
     }
 
@@ -376,7 +375,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
       auto timeStamp{std::chrono::duration_cast<std::chrono::milliseconds>(
           properties.AbsoluteExpiryTime.Value().time_since_epoch())};
 
-      invoke_builder_api(properties_set_absolute_expiry_time, builder, timeStamp.count());
+      InvokeBuilderApi(properties_set_absolute_expiry_time, builder, timeStamp.count());
     }
 
     if (properties.CreationTime.HasValue())
@@ -384,22 +383,22 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
       auto timeStamp{std::chrono::duration_cast<std::chrono::milliseconds>(
           properties.CreationTime.Value().time_since_epoch())};
 
-      invoke_builder_api(properties_set_creation_time, builder, timeStamp.count());
+      InvokeBuilderApi(properties_set_creation_time, builder, timeStamp.count());
     }
 
     if (properties.GroupId.HasValue())
     {
-      invoke_builder_api(properties_set_group_id, builder, properties.GroupId.Value().data());
+      InvokeBuilderApi(properties_set_group_id, builder, properties.GroupId.Value().data());
     }
 
     if (properties.GroupSequence.HasValue())
     {
-      invoke_builder_api(properties_set_group_sequence, builder, properties.GroupSequence.Value());
+      InvokeBuilderApi(properties_set_group_sequence, builder, properties.GroupSequence.Value());
     }
 
     if (properties.ReplyToGroupId.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           properties_set_reply_to_group_id, builder, properties.ReplyToGroupId.Value().data());
     }
 

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -221,7 +221,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models {
     if (properties.To.HasValue())
     {
       if (properties_set_to(
-              returnValue.get(), static_cast<std::string>(properties.To.Value()).c_str()))
+              returnValue.get(), _detail::AmqpValueFactory::ToImplementation(properties.ReplyTo.Value())))
       {
         throw std::runtime_error("Could not set to");
       }

--- a/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_properties.cpp
@@ -14,8 +14,8 @@
 #include <azure_uamqp_c/amqp_definitions_properties.h>
 
 #elif ENABLE_RUST_AMQP
-#include <azure/core/amqp/internal/common/runtime_context.hpp>
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+#include "azure/core/amqp/internal/common/runtime_context.hpp"
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 using namespace Azure::Core::Amqp::Common::_detail;
 #endif // ENABLE_UAMQP
 #include <iomanip>
@@ -36,7 +36,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #if ENABLE_RUST_AMQP
 
   using PropertiesBuilderImplementation
-      = Azure::Core::Amqp::_detail::RustInterop::RustMessagePropertiesBuilder;
+      = Azure::Core::Amqp::RustInterop::_detail::RustMessagePropertiesBuilder;
 
   template <> struct UniqueHandleHelper<PropertiesBuilderImplementation>
   {

--- a/sdk/core/azure-core-amqp/src/models/amqp_value.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_value.cpp
@@ -23,7 +23,7 @@
 #include "rust_amqp_wrapper.h"
 
 #include <cstring>
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 
 constexpr auto AMQP_TYPE_SYMBOL = RustAmqpValueType::AmqpValueSymbol;
 #endif

--- a/sdk/core/azure-core-amqp/src/models/message_source.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_source.cpp
@@ -215,9 +215,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     }
 
     builder.reset(source_set_address(
-            builder.release(),
-            _detail::UniqueAmqpValueHandle{amqpvalue_create_string(address.c_str())}.get()))
-    ; if (!builder) {
+        builder.release(),
+        _detail::UniqueAmqpValueHandle{amqpvalue_create_string(address.c_str())}.get()));
+    if (!builder)
+    {
       throw std::runtime_error("Could not set address.");
     }
     Azure::Core::Amqp::_detail::AmqpSourceImplementation* sourceHandle;
@@ -257,8 +258,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     }
 
     builder.reset(source_set_address(
-            builder.release(), _detail::UniqueAmqpValueHandle{amqpvalue_create_string(address)}.get()))
-    ; if (!builder) {
+        builder.release(), _detail::UniqueAmqpValueHandle{amqpvalue_create_string(address)}.get()));
+    if (!builder)
+    {
       throw std::runtime_error("Could not set address.");
     }
     Azure::Core::Amqp::_detail::AmqpSourceImplementation* sourceHandle;
@@ -538,8 +540,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     if (!options.Address.IsNull())
     {
       builder.reset(source_set_address(
-              builder.release(), _detail::AmqpValueFactory::ToImplementation(options.Address)))
-      ; if (!builder) {
+          builder.release(), _detail::AmqpValueFactory::ToImplementation(options.Address)));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set source address.");
       }
     }
@@ -561,8 +564,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
           throw std::logic_error("Unknown terminus durability.");
       }
 
-      builder.reset(source_set_durable(builder.release(), durability))
-      ; if (!builder) {
+      builder.reset(source_set_durable(builder.release(), durability));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set durable.");
       }
     }
@@ -586,26 +590,29 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         default:
           throw std::logic_error("Unknown terminus durability.");
       }
-      builder.reset(source_set_expiry_policy(builder.release(), policy))
-      ; if (!builder) {
+      builder.reset(source_set_expiry_policy(builder.release(), policy));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set durable.");
       }
     }
     if (options.Timeout.HasValue())
     {
       builder.reset(source_set_timeout(
-              builder.release(),
-              static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
-                                        options.Timeout.Value().time_since_epoch())
-                                        .count())))
-      ; if (!builder) {
+          builder.release(),
+          static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
+                                    options.Timeout.Value().time_since_epoch())
+                                    .count())));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set value.");
       }
     }
     if (options.Dynamic.HasValue())
     {
-      builder.reset(source_set_dynamic(builder.release(), *options.Dynamic))
-      ; if (!builder) {
+      builder.reset(source_set_dynamic(builder.release(), *options.Dynamic));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set dynamic.");
       }
     }
@@ -613,27 +620,30 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     {
       AmqpValue dynamicNodeProperties(options.DynamicNodeProperties.AsAmqpValue());
       builder.reset(source_set_dynamic_node_properties(
-              builder.release(), _detail::AmqpValueFactory::ToImplementation(dynamicNodeProperties)))
-      ; if (!builder) {
+          builder.release(), _detail::AmqpValueFactory::ToImplementation(dynamicNodeProperties)));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set dynamic node properties.");
       }
     }
     if (options.DistributionMode.HasValue())
     {
       builder.reset(source_set_distribution_mode(
-              builder.release(),
-              _detail::AmqpValueFactory::ToImplementation(
-                  options.DistributionMode.Value().AsAmqpValue())))
-      ; if (!builder) {
+          builder.release(),
+          _detail::AmqpValueFactory::ToImplementation(
+              options.DistributionMode.Value().AsAmqpValue())));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set distribution mode.");
       }
     }
     if (!options.Filter.empty())
     {
       builder.reset(source_set_filter(
-              builder.release(),
-              _detail::AmqpValueFactory::ToImplementation(options.Filter.AsAmqpValue())))
-      ; if (!builder) {
+          builder.release(),
+          _detail::AmqpValueFactory::ToImplementation(options.Filter.AsAmqpValue())));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set filter set.");
       }
     }
@@ -645,29 +655,33 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       }
       if (options.DefaultOutcome.AsSymbol() == "amqp:accepted:list")
       {
-        builder.reset(source_set_default_outcome(builder.release(), RustDeliveryOutcome::Accepted))
-        ; if (!builder) {
+        builder.reset(source_set_default_outcome(builder.release(), RustDeliveryOutcome::Accepted));
+        if (!builder)
+        {
           throw std::runtime_error("Could not set default outcome.");
         }
       }
       else if (options.DefaultOutcome.AsSymbol() == "amqp:rejected:list")
       {
-        builder.reset(source_set_default_outcome(builder.release(), RustDeliveryOutcome::Rejected))
-        ; if (!builder) {
+        builder.reset(source_set_default_outcome(builder.release(), RustDeliveryOutcome::Rejected));
+        if (!builder)
+        {
           throw std::runtime_error("Could not set default outcome.");
         }
       }
       else if (options.DefaultOutcome.AsSymbol() == "amqp:released:list")
       {
-        builder.reset(source_set_default_outcome(builder.release(), RustDeliveryOutcome::Released))
-        ; if (!builder) {
+        builder.reset(source_set_default_outcome(builder.release(), RustDeliveryOutcome::Released));
+        if (!builder)
+        {
           throw std::runtime_error("Could not set default outcome.");
         }
       }
       else if (options.DefaultOutcome.AsSymbol() == "amqp:modified:list")
       {
-        builder.reset(source_set_default_outcome(builder.release(), RustDeliveryOutcome::Modified))
-        ; if (!builder) {
+        builder.reset(source_set_default_outcome(builder.release(), RustDeliveryOutcome::Modified));
+        if (!builder)
+        {
           throw std::runtime_error("Could not set default outcome.");
         }
       }
@@ -679,18 +693,20 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     if (!options.Outcomes.empty())
     {
       builder.reset(source_set_outcomes(
-              builder.release(),
-              _detail::AmqpValueFactory::ToImplementation(options.Outcomes.AsAmqpValue())))
-      ;if (!builder) {
+          builder.release(),
+          _detail::AmqpValueFactory::ToImplementation(options.Outcomes.AsAmqpValue())));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set outcomes.");
       }
     }
     if (!options.Capabilities.empty())
     {
       builder.reset(source_set_capabilities(
-              builder.release(),
-              _detail::AmqpValueFactory::ToImplementation(options.Capabilities.AsAmqpValue())))
-      ; if (!builder) {
+          builder.release(),
+          _detail::AmqpValueFactory::ToImplementation(options.Capabilities.AsAmqpValue())));
+      if (!builder)
+      {
         throw std::runtime_error("Could not set capabilities.");
       }
     }

--- a/sdk/core/azure-core-amqp/src/models/message_source.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_source.cpp
@@ -18,9 +18,8 @@
 #include <azure_uamqp_c/amqp_definitions_source.h>
 #include <azure_uamqp_c/amqpvalue.h>
 #elif ENABLE_RUST_AMQP
-#include "rust_amqp_wrapper.h"
-
 #include "azure/core/amqp/internal/common/runtime_context.hpp"
+#include "rust_amqp_wrapper.h"
 using namespace Azure::Core::Amqp::RustInterop::_detail;
 using namespace Azure::Core::Amqp::Common::_detail;
 #endif // ENABLE_UAMQP
@@ -37,8 +36,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   // @endcond
 
 #if ENABLE_RUST_AMQP
-  using AmqpSourceBuilderImplementation
-      = RustAmqpSourceBuilder;
+  using AmqpSourceBuilderImplementation = RustAmqpSourceBuilder;
 
   template <> struct UniqueHandleHelper<AmqpSourceBuilderImplementation>
   {
@@ -217,7 +215,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       throw std::runtime_error("Could not create source.");
     }
 
-    invoke_builder_api(source_builder_set_address, builder, address.c_str());
+    InvokeBuilderApi(source_builder_set_address, builder, address.c_str());
     Azure::Core::Amqp::_detail::AmqpSourceImplementation* sourceHandle;
     if (source_builder_build(builder.release(), &sourceHandle))
     {
@@ -254,7 +252,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       throw std::runtime_error("Could not create source.");
     }
 
-    invoke_builder_api(source_builder_set_address, builder, address);
+    InvokeBuilderApi(source_builder_set_address, builder, address);
     Azure::Core::Amqp::_detail::AmqpSourceImplementation* sourceHandle;
     if (source_builder_build(builder.get(), &sourceHandle))
     {
@@ -535,7 +533,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       {
         throw std::runtime_error("Message target must be a string.");
       }
-      invoke_builder_api(
+      InvokeBuilderApi(
           source_builder_set_address, builder, static_cast<std::string>(options.Address).c_str());
     }
     if (options.SourceTerminusDurability.HasValue())
@@ -556,7 +554,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
           throw std::logic_error("Unknown terminus durability.");
       }
 
-      invoke_builder_api(source_builder_set_durable, builder, durability);
+      InvokeBuilderApi(source_builder_set_durable, builder, durability);
     }
     if (options.SourceTerminusExpiryPolicy.HasValue())
     {
@@ -578,11 +576,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         default:
           throw std::logic_error("Unknown terminus durability.");
       }
-      invoke_builder_api(source_builder_set_expiry_policy, builder, policy);
+      InvokeBuilderApi(source_builder_set_expiry_policy, builder, policy);
     }
     if (options.Timeout.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           source_builder_set_timeout,
           builder,
           static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
@@ -591,19 +589,19 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     }
     if (options.Dynamic.HasValue())
     {
-      invoke_builder_api(source_builder_set_dynamic, builder, *options.Dynamic);
+      InvokeBuilderApi(source_builder_set_dynamic, builder, *options.Dynamic);
     }
     if (!options.DynamicNodeProperties.empty())
     {
       AmqpValue dynamicNodeProperties(options.DynamicNodeProperties.AsAmqpValue());
-      invoke_builder_api(
+      InvokeBuilderApi(
           source_builder_set_dynamic_node_properties,
           builder,
           _detail::AmqpValueFactory::ToImplementation(dynamicNodeProperties));
     }
     if (options.DistributionMode.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           source_builder_set_distribution_mode,
           builder,
           _detail::AmqpValueFactory::ToImplementation(
@@ -611,7 +609,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     }
     if (!options.Filter.empty())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           source_builder_set_filter,
           builder,
           _detail::AmqpValueFactory::ToImplementation(options.Filter.AsAmqpValue()));
@@ -624,22 +622,22 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       }
       if (options.DefaultOutcome.AsSymbol() == "amqp:accepted:list")
       {
-        invoke_builder_api(
+        InvokeBuilderApi(
             source_builder_set_default_outcome, builder, RustDeliveryOutcome::Accepted);
       }
       else if (options.DefaultOutcome.AsSymbol() == "amqp:rejected:list")
       {
-        invoke_builder_api(
+        InvokeBuilderApi(
             source_builder_set_default_outcome, builder, RustDeliveryOutcome::Rejected);
       }
       else if (options.DefaultOutcome.AsSymbol() == "amqp:released:list")
       {
-        invoke_builder_api(
+        InvokeBuilderApi(
             source_builder_set_default_outcome, builder, RustDeliveryOutcome::Released);
       }
       else if (options.DefaultOutcome.AsSymbol() == "amqp:modified:list")
       {
-        invoke_builder_api(
+        InvokeBuilderApi(
             source_builder_set_default_outcome, builder, RustDeliveryOutcome::Modified);
       }
       else
@@ -649,14 +647,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     }
     if (!options.Outcomes.empty())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           source_builder_set_outcomes,
           builder,
           _detail::AmqpValueFactory::ToImplementation(options.Outcomes.AsAmqpValue()));
     }
     if (!options.Capabilities.empty())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           source_builder_set_capabilities,
           builder,
           _detail::AmqpValueFactory::ToImplementation(options.Capabilities.AsAmqpValue()));

--- a/sdk/core/azure-core-amqp/src/models/message_source.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_source.cpp
@@ -20,8 +20,8 @@
 #elif ENABLE_RUST_AMQP
 #include "rust_amqp_wrapper.h"
 
-#include <azure/core/amqp/internal/common/runtime_context.hpp>
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+#include "azure/core/amqp/internal/common/runtime_context.hpp"
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 using namespace Azure::Core::Amqp::Common::_detail;
 #endif // ENABLE_UAMQP
 
@@ -38,7 +38,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
 #if ENABLE_RUST_AMQP
   using AmqpSourceBuilderImplementation
-      = Azure::Core::Amqp::_detail::RustInterop::RustAmqpSourceBuilder;
+      = RustAmqpSourceBuilder;
 
   template <> struct UniqueHandleHelper<AmqpSourceBuilderImplementation>
   {

--- a/sdk/core/azure-core-amqp/src/models/message_target.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_target.cpp
@@ -20,9 +20,9 @@
 #include <azure_uamqp_c/amqp_definitions_target.h>
 #include <azure_uamqp_c/amqpvalue.h>
 #elif ENABLE_RUST_AMQP
-#include <azure/core/amqp/internal/common/runtime_context.hpp>
+#include "azure/core/amqp/internal/common/runtime_context.hpp"
 using namespace Azure::Core::Amqp::Common::_detail;
-using namespace Azure::Core::Amqp::_detail::RustInterop;
+using namespace Azure::Core::Amqp::RustInterop::_detail;
 #endif // ENABLE_UAMQP
 
 #include <iostream>
@@ -40,16 +40,16 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   // @endcond
 
 #if ENABLE_RUST_AMQP
-  template <> struct UniqueHandleHelper<RustInterop::RustAmqpTargetBuilder>
+  template <> struct UniqueHandleHelper<RustAmqpTargetBuilder>
   {
-    static void FreeMessageTargetBuilder(RustInterop::RustAmqpTargetBuilder* obj);
+    static void FreeMessageTargetBuilder(RustAmqpTargetBuilder* obj);
 
-    using type = Core::_internal::
-        BasicUniqueHandle<RustInterop::RustAmqpTargetBuilder, FreeMessageTargetBuilder>;
+    using type
+        = Core::_internal::BasicUniqueHandle<RustAmqpTargetBuilder, FreeMessageTargetBuilder>;
   };
 
-  void UniqueHandleHelper<RustInterop::RustAmqpTargetBuilder>::FreeMessageTargetBuilder(
-      RustInterop::RustAmqpTargetBuilder* obj)
+  void UniqueHandleHelper<RustAmqpTargetBuilder>::FreeMessageTargetBuilder(
+      RustAmqpTargetBuilder* obj)
   {
     target_builder_destroy(obj);
   }
@@ -138,7 +138,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace _detail {
 #if ENABLE_RUST_AMQP
   using UniqueMessageTargetBuilderHandle = Azure::Core::Amqp::_detail::UniqueHandle<
-      Azure::Core::Amqp::_detail::RustInterop::RustAmqpTargetBuilder>;
+      RustAmqpTargetBuilder>;
 #endif
 
   MessageTargetImpl::MessageTargetImpl(Models::AmqpValue const& target)
@@ -161,10 +161,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 
   MessageTargetImpl::MessageTargetImpl(std::string const& address)
 #if ENABLE_UAMQP
-      : m_target
-  {
-    target_create()
-  }
+      : m_target{target_create()}
 #endif
   {
 #if ENABLE_UAMQP
@@ -229,10 +226,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 
   MessageTargetImpl::MessageTargetImpl()
 #if ENABLE_UAMQP
-      : m_target
-  {
-    target_create()
-  }
+      : m_target{target_create()}
 #endif
   {
 #if ENABLE_RUST_AMQP

--- a/sdk/core/azure-core-amqp/src/models/message_target.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_target.cpp
@@ -163,19 +163,16 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 #endif
   {
 #if ENABLE_UAMQP
-    UniqueMessageTargetHandle target{target_create()};
-    if (!target)
+    if (!m_target)
     {
       throw std::runtime_error("Could not create source.");
     }
-
     if (target_set_address(
-            target.get(),
+            m_target.get(),
             _detail::UniqueAmqpValueHandle(amqpvalue_create_string(address.c_str())).get()))
     {
       throw std::runtime_error("Could not set address.");
     }
-    m_target = std::move(target);
 #elif ENABLE_RUST_AMQP
     UniqueMessageTargetBuilderHandle builder{target_builder_create()};
     if (!builder)

--- a/sdk/core/azure-core-amqp/src/models/message_target.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_target.cpp
@@ -137,8 +137,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 
 namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace _detail {
 #if ENABLE_RUST_AMQP
-  using UniqueMessageTargetBuilderHandle = Azure::Core::Amqp::_detail::UniqueHandle<
-      RustAmqpTargetBuilder>;
+  using UniqueMessageTargetBuilderHandle
+      = Azure::Core::Amqp::_detail::UniqueHandle<RustAmqpTargetBuilder>;
 #endif
 
   MessageTargetImpl::MessageTargetImpl(Models::AmqpValue const& target)
@@ -161,7 +161,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 
   MessageTargetImpl::MessageTargetImpl(std::string const& address)
 #if ENABLE_UAMQP
-      : m_target{target_create()}
+      : m_target
+  {
+    target_create()
+  }
 #endif
   {
 #if ENABLE_UAMQP
@@ -182,7 +185,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       throw std::runtime_error("Could not create source.");
     }
 
-    invoke_builder_api(target_builder_set_address, builder, address.c_str());
+    InvokeBuilderApi(target_builder_set_address, builder, address.c_str());
     Azure::Core::Amqp::_detail::AmqpTargetImplementation* targetHandle;
     if (target_builder_build(builder.release(), &targetHandle) != 0)
     {
@@ -214,7 +217,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       throw std::runtime_error("Could not create source.");
     }
 
-    invoke_builder_api(target_builder_set_address, builder, address);
+    InvokeBuilderApi(target_builder_set_address, builder, address);
     Azure::Core::Amqp::_detail::AmqpTargetImplementation* targetHandle;
     if (target_builder_build(builder.release(), &targetHandle) != 0)
     {
@@ -226,7 +229,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 
   MessageTargetImpl::MessageTargetImpl()
 #if ENABLE_UAMQP
-      : m_target{target_create()}
+      : m_target
+  {
+    target_create()
+  }
 #endif
   {
 #if ENABLE_RUST_AMQP
@@ -416,7 +422,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
       {
         throw std::runtime_error("Message target must be a string.");
       }
-      invoke_builder_api(
+      InvokeBuilderApi(
           target_builder_set_address, builder, static_cast<std::string>(options.Address).c_str());
     }
     if (options.TerminusDurabilityValue.HasValue())
@@ -436,7 +442,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         default:
           throw std::logic_error("Unknown terminus durability.");
       }
-      invoke_builder_api(target_builder_set_durable, builder, durability);
+      InvokeBuilderApi(target_builder_set_durable, builder, durability);
       if (!builder)
       {
         throw std::runtime_error("Could not set durable.");
@@ -462,7 +468,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
         default:
           throw std::logic_error("Unknown terminus durability.");
       }
-      invoke_builder_api(target_builder_set_expiry_policy, builder, policy);
+      InvokeBuilderApi(target_builder_set_expiry_policy, builder, policy);
       if (!builder)
       {
         throw std::runtime_error("Could not set durable.");
@@ -470,7 +476,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     }
     if (options.Timeout.HasValue())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           target_builder_set_timeout,
           builder,
           static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
@@ -479,12 +485,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     }
     if (options.Dynamic.HasValue())
     {
-      invoke_builder_api(target_builder_set_dynamic, builder, *options.Dynamic);
+      InvokeBuilderApi(target_builder_set_dynamic, builder, *options.Dynamic);
     }
 
     if (!options.DynamicNodeProperties.empty())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           target_builder_set_dynamic_node_properties,
           builder,
           _detail::AmqpValueFactory::ToImplementation(options.DynamicNodeProperties.AsAmqpValue()));
@@ -492,7 +498,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 
     if (!options.Capabilities.empty())
     {
-      invoke_builder_api(
+      InvokeBuilderApi(
           target_builder_set_capabilities,
           builder,
           _detail::AmqpValueFactory::ToImplementation(options.Capabilities.AsAmqpValue()));

--- a/sdk/core/azure-core-amqp/src/models/message_target.cpp
+++ b/sdk/core/azure-core-amqp/src/models/message_target.cpp
@@ -159,7 +159,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 
   MessageTargetImpl::MessageTargetImpl(std::string const& address)
 #if ENABLE_UAMQP
-      : m_target{target_create()}
+      : m_target
+  {
+    target_create()
+  }
 #endif
   {
 #if ENABLE_UAMQP
@@ -183,7 +186,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
     builder.reset(target_set_address(
         builder.release(),
         _detail::UniqueAmqpValueHandle(amqpvalue_create_string(address.c_str())).get()));
-    if (!builder) {
+    if (!builder)
+    {
       throw std::runtime_error("Could not set address.");
     }
     Azure::Core::Amqp::_detail::AmqpTargetImplementation* targetHandle;
@@ -236,7 +240,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace
 
   MessageTargetImpl::MessageTargetImpl()
 #if ENABLE_UAMQP
-      : m_target{target_create()}
+      : m_target
+  {
+    target_create()
+  }
 #endif
   {
 #if ENABLE_RUST_AMQP

--- a/sdk/core/azure-core-amqp/src/models/private/header_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/models/private/header_impl.hpp
@@ -26,7 +26,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #if ENABLE_UAMQP
   using HeaderImplementation = std::remove_pointer<HEADER_HANDLE>::type;
 #elif ENABLE_RUST_AMQP
-  using HeaderImplementation = Azure::Core::Amqp::_detail::RustInterop::RustMessageHeader;
+  using HeaderImplementation = Azure::Core::Amqp::RustInterop::_detail::RustMessageHeader;
 #endif
 
   template <> struct UniqueHandleHelper<HeaderImplementation>

--- a/sdk/core/azure-core-amqp/src/models/private/message_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/models/private/message_impl.hpp
@@ -23,6 +23,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using MessageImplementation = std::remove_pointer<MESSAGE_HANDLE>::type;
 #elif ENABLE_RUST_AMQP
   using MessageImplementation = Azure::Core::Amqp::_detail::RustInterop::RustAmqpMessage;
+  using MessageBuilderImplementation = Azure::Core::Amqp::_detail::RustInterop::RustAmqpMessageBuilder;
 #endif
 
   template <> struct UniqueHandleHelper<MessageImplementation>
@@ -31,11 +32,24 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     using type = Core::_internal::BasicUniqueHandle<MessageImplementation, FreeAmqpMessage>;
   };
+
+  #if ENABLE_RUST_AMQP
+  template <> struct UniqueHandleHelper<MessageBuilderImplementation>
+  {
+    static void FreeAmqpMessageBuilder(MessageBuilderImplementation* obj);
+
+    using type = Core::_internal::BasicUniqueHandle<MessageBuilderImplementation, FreeAmqpMessageBuilder>;
+  };
+#endif
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace _detail {
   using UniqueMessageHandle
       = Amqp::_detail::UniqueHandle<Azure::Core::Amqp::_detail::MessageImplementation>;
+  #if ENABLE_RUST_AMQP
+  using UniqueMessageBuilderHandle
+      = Amqp::_detail::UniqueHandle<Azure::Core::Amqp::_detail::MessageBuilderImplementation>;
+#endif
   /**
    * @brief uAMQP interoperability functions to convert a Message to a uAMQP
    * MESSAGE_HANDLE and back.

--- a/sdk/core/azure-core-amqp/src/models/private/message_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/models/private/message_impl.hpp
@@ -22,9 +22,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #if ENABLE_UAMQP
   using MessageImplementation = std::remove_pointer<MESSAGE_HANDLE>::type;
 #elif ENABLE_RUST_AMQP
-  using MessageImplementation = Azure::Core::Amqp::_detail::RustInterop::RustAmqpMessage;
+  using MessageImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpMessage;
   using MessageBuilderImplementation
-      = Azure::Core::Amqp::_detail::RustInterop::RustAmqpMessageBuilder;
+      = Azure::Core::Amqp::RustInterop::_detail::RustAmqpMessageBuilder;
 #endif
 
   template <> struct UniqueHandleHelper<MessageImplementation>

--- a/sdk/core/azure-core-amqp/src/models/private/message_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/models/private/message_impl.hpp
@@ -23,7 +23,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using MessageImplementation = std::remove_pointer<MESSAGE_HANDLE>::type;
 #elif ENABLE_RUST_AMQP
   using MessageImplementation = Azure::Core::Amqp::_detail::RustInterop::RustAmqpMessage;
-  using MessageBuilderImplementation = Azure::Core::Amqp::_detail::RustInterop::RustAmqpMessageBuilder;
+  using MessageBuilderImplementation
+      = Azure::Core::Amqp::_detail::RustInterop::RustAmqpMessageBuilder;
 #endif
 
   template <> struct UniqueHandleHelper<MessageImplementation>
@@ -33,12 +34,13 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     using type = Core::_internal::BasicUniqueHandle<MessageImplementation, FreeAmqpMessage>;
   };
 
-  #if ENABLE_RUST_AMQP
+#if ENABLE_RUST_AMQP
   template <> struct UniqueHandleHelper<MessageBuilderImplementation>
   {
     static void FreeAmqpMessageBuilder(MessageBuilderImplementation* obj);
 
-    using type = Core::_internal::BasicUniqueHandle<MessageBuilderImplementation, FreeAmqpMessageBuilder>;
+    using type
+        = Core::_internal::BasicUniqueHandle<MessageBuilderImplementation, FreeAmqpMessageBuilder>;
   };
 #endif
 }}}} // namespace Azure::Core::Amqp::_detail
@@ -46,7 +48,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 namespace Azure { namespace Core { namespace Amqp { namespace Models { namespace _detail {
   using UniqueMessageHandle
       = Amqp::_detail::UniqueHandle<Azure::Core::Amqp::_detail::MessageImplementation>;
-  #if ENABLE_RUST_AMQP
+#if ENABLE_RUST_AMQP
   using UniqueMessageBuilderHandle
       = Amqp::_detail::UniqueHandle<Azure::Core::Amqp::_detail::MessageBuilderImplementation>;
 #endif

--- a/sdk/core/azure-core-amqp/src/models/private/properties_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/models/private/properties_impl.hpp
@@ -20,7 +20,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #if ENABLE_UAMQP
   using PropertiesImplementation = std::remove_pointer<PROPERTIES_HANDLE>::type;
 #elif ENABLE_RUST_AMQP
-  using PropertiesImplementation = Azure::Core::Amqp::_detail::RustInterop::RustMessageProperties;
+  using PropertiesImplementation = Azure::Core::Amqp::RustInterop::_detail::RustMessageProperties;
 #endif
 
   template <> struct UniqueHandleHelper<PropertiesImplementation>

--- a/sdk/core/azure-core-amqp/src/models/private/source_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/models/private/source_impl.hpp
@@ -26,7 +26,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #if ENABLE_UAMQP
   using AmqpSourceImplementation = std::remove_pointer<SOURCE_HANDLE>::type;
 #elif ENABLE_RUST_AMQP
-  using AmqpSourceImplementation = Azure::Core::Amqp::_detail::RustInterop::RustAmqpSource;
+  using AmqpSourceImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpSource;
 #endif
 
   template <> struct UniqueHandleHelper<AmqpSourceImplementation>

--- a/sdk/core/azure-core-amqp/src/models/private/target_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/models/private/target_impl.hpp
@@ -26,7 +26,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 #if ENABLE_UAMQP
   using AmqpTargetImplementation = std::remove_pointer<TARGET_HANDLE>::type;
 #elif ENABLE_RUST_AMQP
-  using AmqpTargetImplementation = Azure::Core::Amqp::_detail::RustInterop::RustAmqpTarget;
+  using AmqpTargetImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpTarget;
 #endif
 
   template <> struct UniqueHandleHelper<AmqpTargetImplementation>

--- a/sdk/core/azure-core-amqp/src/models/private/value_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/models/private/value_impl.hpp
@@ -19,8 +19,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using AmqpValueImplementation = std::remove_pointer<AMQP_VALUE>::type;
   using AmqpValueImplementationType = AMQP_TYPE;
 #elif ENABLE_RUST_AMQP
-  using AmqpValueImplementation = Azure::Core::Amqp::_detail::RustInterop::RustAmqpValue;
-  using AmqpValueImplementationType = Azure::Core::Amqp::_detail::RustInterop::RustAmqpValueType;
+  using AmqpValueImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpValue;
+  using AmqpValueImplementationType = Azure::Core::Amqp::RustInterop::_detail::RustAmqpValueType;
 #endif
 
   template <> struct UniqueHandleHelper<AmqpValueImplementation>

--- a/sdk/core/azure-core-amqp/test/ut/azure_core_amqp_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/azure_core_amqp_tests.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
 
 #if ENABLE_RUST_AMQP
   // Initialize the Rust AMQP logging.
-  Azure::Core::Amqp::_detail::RustInterop::enable_tracing_integration();
+  Azure::Core::Amqp::RustInterop::_detail::enable_tracing_integration();
 #endif
 
   // Declare a signal handler to report unhandled exceptions on Windows - this is not needed for

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -533,7 +533,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       options.MessageSource = "ingress";
       options.Name = "sender-link";
       MessageSender sender(session.CreateMessageSender("localhost/ingress", options));
-      MessageSender sender(session.CreateMessageSender("localhost/ingress", options));
       EXPECT_FALSE(sender.Open());
 
       Azure::Core::Amqp::Models::AmqpMessage message;

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -533,6 +533,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       options.MessageSource = "ingress";
       options.Name = "sender-link";
       MessageSender sender(session.CreateMessageSender("localhost/ingress", options));
+      MessageSender sender(session.CreateMessageSender("localhost/ingress", options));
       EXPECT_FALSE(sender.Open());
 
       Azure::Core::Amqp::Models::AmqpMessage message;


### PR DESCRIPTION
# Convert AMQP builders to comply with rust SDK guidelines.

The bulk of this PR updates the AMQP builders to be compliant with the Rust SDK guidelines. This results in a somewhat awkward pattern from C++ but it is not horrible to use.

From:
```cpp
amqpconnectionoptionsbuilder_set_buffer_size(builder.get(), bufferSize);
```

the pattern moves to:

```cpp
builder.reset(amqpconnectionoptionsbuilder_set_buffersize(builder.release(), bufferSize);
```

Basically, the builder APIs now accept a builder and return a *new* builder updated with the new contents.

To simplify this pattern, a helper function `invoke_builder_api` has been written, so the pattern becomes:

```cpp
invoke_builder_api(amqpconnectionoptionsbuilder_set_buffersize, builder, bufferSize);
```

Under the covers, if the builder API call fails, it will throw an exception with detailed information about the actual cause of the error.


The other part of this PR is that the message related APIs now use the builder pattern for creating an AMQP message rather than mimicking the uAMQP pattern - this allowed a significant simplification in the Rust message structure and moved it to be much closer to the guidelines.



## Copilot summary
This pull request focuses on improving the builder pattern usage in the `azure-core-amqp` library by ensuring consistent assignment of builder objects. The changes mainly involve modifying the way builder methods are chained to ensure the builder object is reassigned after each method call.

### Builder Pattern Improvements:

* [`sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp`](diffhunk://#diff-7c735f86f5bf02f6e4a8a1cdb149943acf8dcfff8f525a5a3d95a3d300acc0bfL105-R122): Changed the assignment of `optionsBuilder` to use `reset` and `release` methods for setting various options.
* [`sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_fields.rs`](diffhunk://#diff-be947f1e33f1dae86f3f63bbf9a6134d19254c2b2fe1c23bd94fc07234423219R343-R389): Modified the `amqp_message_properties_builder` to reassign itself after each `with_*` method call.
* [`sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_source.rs`](diffhunk://#diff-91eced7891973521ceb02be7789b794aa162cbcb3b5adcf27b80aa548c89b5f8L80-R82): Updated the `amqp_source_builder` to reassign itself after each `with_*` method call. [[1]](diffhunk://#diff-91eced7891973521ceb02be7789b794aa162cbcb3b5adcf27b80aa548c89b5f8L80-R82) [[2]](diffhunk://#diff-91eced7891973521ceb02be7789b794aa162cbcb3b5adcf27b80aa548c89b5f8L95-R114)
* [`sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/mod.rs`](diffhunk://#diff-248c1aefda8637e7c71a18f720da837212bc9012e148368c9e39c3866a58d8a0R80-R87): Ensured `amqp_message_builder` is reassigned after each `with_*` method call. [[1]](diffhunk://#diff-248c1aefda8637e7c71a18f720da837212bc9012e148368c9e39c3866a58d8a0R80-R87) [[2]](diffhunk://#diff-248c1aefda8637e7c71a18f720da837212bc9012e148368c9e39c3866a58d8a0L95-R96) [[3]](diffhunk://#diff-248c1aefda8637e7c71a18f720da837212bc9012e148368c9e39c3866a58d8a0L106-R107) [[4]](diffhunk://#diff-248c1aefda8637e7c71a18f720da837212bc9012e148368c9e39c3866a58d8a0L128-R151) [[5]](diffhunk://#diff-248c1aefda8637e7c71a18f720da837212bc9012e148368c9e39c3866a58d8a0L214-R252) [[6]](diffhunk://#diff-248c1aefda8637e7c71a18f720da837212bc9012e148368c9e39c3866a58d8a0L272-R274) [[7]](diffhunk://#diff-248c1aefda8637e7c71a18f720da837212bc9012e148368c9e39c3866a58d8a0L288-R293) [[8]](diffhunk://#diff-248c1aefda8637e7c71a18f720da837212bc9012e148368c9e39c3866a58d8a0L317-R342)
* [`sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs`](diffhunk://#diff-2dd21925a6e32a7decbc75e2d445e83f0f7a1a7e6ade10101cd0d54c79e23e8cL242-R255): Adjusted the `builder` reassignment for `AmqpTarget` and `AmqpSource` conversions from `AmqpList`. [[1]](diffhunk://#diff-2dd21925a6e32a7decbc75e2d445e83f0f7a1a7e6ade10101cd0d54c79e23e8cL242-R255) [[2]](diffhunk://#diff-2dd21925a6e32a7decbc75e2d445e83f0f7a1a7e6ade10101cd0d54c79e23e8cL265-R275) [[3]](diffhunk://#diff-2dd21925a6e32a7decbc75e2d445e83f0f7a1a7e6ade10101cd0d54c79e23e8cL285-R290) [[4]](diffhunk://#diff-2dd21925a6e32a7decbc75e2d445e83f0f7a1a7e6ade10101cd0d54c79e23e8cL388-R401) [[5]](diffhunk://#diff-2dd21925a6e32a7decbc75e2d445e83f0f7a1a7e6ade10101cd0d54c79e23e8cL411-R421)

## Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
