### PR TITLE
Use init syntax to try to set ApiVersion via an options ctor to investigate behavior

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-administration/test/ut/settings_client_base_test.hpp
+++ b/sdk/keyvault/azure-security-keyvault-administration/test/ut/settings_client_base_test.hpp
@@ -45,7 +45,7 @@ namespace Azure {
     }
     void CreateHSMClientForTest(std::string hsmUrl = "")
     {
-      SettingsClientOptions options;
+      SettingsClientOptions options = SettingsClientOptions{"7.4"};
       m_client = InitTestClient<
           Azure::Security::KeyVault::Administration::SettingsClient,
           Azure::Security::KeyVault::Administration::SettingsClientOptions>(


### PR DESCRIPTION
Not intended to merge, just checking the expected build error in CI as part of https://github.com/Azure/azure-sdk-for-cpp/issues/6126#issuecomment-2438670300