### PR TITLE
Make ApiVersion field within client options settable for keyvault packages

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-administration/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Allow the `ApiVersion` field within `SettingsClientOptions` to be settable.
+
 ### Other Changes
 
 ## 4.0.0-beta.5 (2024-08-06)

--- a/sdk/keyvault/azure-security-keyvault-administration/inc/azure/keyvault/administration/settings_client_options.hpp
+++ b/sdk/keyvault/azure-security-keyvault-administration/inc/azure/keyvault/administration/settings_client_options.hpp
@@ -27,7 +27,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Administra
      * @brief Service Version used.
      *
      */
-    const std::string ApiVersion{"7.4"};
+    std::string ApiVersion{"7.4"};
   };
 
 }}}} // namespace Azure::Security::KeyVault::Administration

--- a/sdk/keyvault/azure-security-keyvault-administration/test/ut/settings_client_test.cpp
+++ b/sdk/keyvault/azure-security-keyvault-administration/test/ut/settings_client_test.cpp
@@ -107,3 +107,19 @@ TEST_F(SettingsClientTest, UpdateSetting_RECORDEDONLY_)
     SkipTest();
   }
 }
+
+TEST(KeyVaultSettingsClientTest, ServiceVersion)
+{
+  auto credential
+      = std::make_shared<Azure::Identity::ClientSecretCredential>("tenantID", "AppId", "SecretId");
+  // Default - 7.4
+  EXPECT_NO_THROW(auto options = SettingsClientOptions(); SettingsClient settingsClient(
+                      "http://account.vault.azure.net", credential, options);
+                  EXPECT_EQ(options.ApiVersion, "7.4"););
+
+  // 7.4
+  EXPECT_NO_THROW(
+      auto options = SettingsClientOptions(); options.ApiVersion = "7.4";
+      SettingsClient settingsClient("http://account.vault.azure.net", credential, options);
+      EXPECT_EQ(options.ApiVersion, "7.4"););
+}

--- a/sdk/keyvault/azure-security-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-certificates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Allow the `ApiVersion` field within `CertificateClientOptions` to be settable.
+
 ### Other Changes
 
 ## 4.3.0-beta.2 (2024-06-11)

--- a/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client_options.hpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/inc/azure/keyvault/certificates/certificate_client_options.hpp
@@ -29,7 +29,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Certificat
      * @brief Service Version used.
      *
      */
-    const std::string ApiVersion{"7.5"};
+    std::string ApiVersion{"7.5"};
   };
 
 }}}} // namespace Azure::Security::KeyVault::Certificates

--- a/sdk/keyvault/azure-security-keyvault-certificates/test/ut/certificate_client_test.cpp
+++ b/sdk/keyvault/azure-security-keyvault-certificates/test/ut/certificate_client_test.cpp
@@ -900,8 +900,14 @@ TEST_F(KeyVaultCertificateClientTest, ServiceVersion)
 {
   auto credential
       = std::make_shared<Azure::Identity::ClientSecretCredential>("tenantID", "AppId", "SecretId");
-  // 7.5
+  // Default - 7.5
   EXPECT_NO_THROW(auto options = CertificateClientOptions(); CertificateClient certificateClient(
                       "http://account.vault.azure.net", credential, options);
                   EXPECT_EQ(options.ApiVersion, "7.5"););
+
+  // 7.4
+  EXPECT_NO_THROW(
+      auto options = CertificateClientOptions(); options.ApiVersion = "7.4";
+      CertificateClient certificateClient("http://account.vault.azure.net", credential, options);
+      EXPECT_EQ(options.ApiVersion, "7.4"););
 }

--- a/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Allow the `ApiVersion` field within `KeyClientOptions` to be settable.
+
 ### Other Changes
 
 ## 4.5.0-beta.2 (2024-06-11)

--- a/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client_options.hpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/inc/azure/keyvault/keys/key_client_options.hpp
@@ -59,7 +59,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Keys {
      * @brief Service Version used.
      *
      */
-    const std::string ApiVersion{"7.5"};
+    std::string ApiVersion{"7.5"};
   };
 
   /**

--- a/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_test.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/test/ut/key_client_test.cpp
@@ -32,10 +32,15 @@ TEST(KeyVaultKeyClientUnitTest, ServiceVersion)
 {
   auto credential
       = std::make_shared<Azure::Identity::ClientSecretCredential>("tenantID", "AppId", "SecretId");
-  // 7.5
+  // Default - 7.5
   EXPECT_NO_THROW(auto options = KeyClientOptions();
                   KeyClient keyClient("http://account.vault.azure.net", credential, options);
                   EXPECT_EQ(options.ApiVersion, "7.5"););
+
+  // 7.4
+  EXPECT_NO_THROW(auto options = KeyClientOptions(); options.ApiVersion = "7.4";
+                  KeyClient keyClient("http://account.vault.azure.net", credential, options);
+                  EXPECT_EQ(options.ApiVersion, "7.4"););
 }
 
 TEST(KeyVaultKeyClientUnitTest, GetUrl)

--- a/sdk/keyvault/azure-security-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-secrets/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Allow the `ApiVersion` field within `SecretClientOptions` to be settable.
+
 ### Other Changes
 
 ## 4.3.0-beta.2 (2024-06-11)

--- a/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/keyvault_options.hpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/inc/azure/keyvault/secrets/keyvault_options.hpp
@@ -22,7 +22,7 @@ namespace Azure { namespace Security { namespace KeyVault { namespace Secrets {
      * @brief Service Version used.
      *
      */
-    const std::string ApiVersion{"7.5"};
+    std::string ApiVersion{"7.5"};
   };
 
   /**

--- a/sdk/keyvault/azure-security-keyvault-secrets/test/ut/secret_client_test.cpp
+++ b/sdk/keyvault/azure-security-keyvault-secrets/test/ut/secret_client_test.cpp
@@ -30,10 +30,15 @@ TEST(SecretClient, ServiceVersion)
 {
   auto credential
       = std::make_shared<Azure::Identity::ClientSecretCredential>("tenantID", "AppId", "SecretId");
-  // 7.5
+  // Default - 7.5
   EXPECT_NO_THROW(auto options = SecretClientOptions();
                   SecretClient SecretClient("http://account.vault.azure.net", credential, options);
                   EXPECT_EQ(options.ApiVersion, "7.5"););
+
+  // 7.4
+  EXPECT_NO_THROW(auto options = SecretClientOptions(); options.ApiVersion = "7.4";
+                  SecretClient SecretClient("http://account.vault.azure.net", credential, options);
+                  EXPECT_EQ(options.ApiVersion, "7.4"););
 }
 
 TEST(SecretClient, GetUrl)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/6126