### PR TITLE
Remove TableServiceClient ctor that only accepts options with no url or auth mechanism.

### DIFF
--- a/sdk/tables/azure-data-tables/inc/azure/data/tables/tables_clients.hpp
+++ b/sdk/tables/azure-data-tables/inc/azure/data/tables/tables_clients.hpp
@@ -390,14 +390,6 @@ namespace Azure { namespace Data { namespace Tables {
   class TableServiceClient final {
   public:
     /**
-     * @brief Initializes a new instance of tableServiceClient.
-     *
-     * @param options Optional client options that define the transport pipeline policies for
-     * authentication, retries, etc., that are applied to every request.
-     */
-    explicit TableServiceClient(const TableClientOptions& options = {});
-
-    /**
      * @brief Initializes a new instance of tableClient.
      *
      * @param serviceUrl A url referencing the table that includes the name of the account and the

--- a/sdk/tables/azure-data-tables/src/tables_clients.cpp
+++ b/sdk/tables/azure-data-tables/src/tables_clients.cpp
@@ -18,22 +18,6 @@ using namespace Azure::Data::Tables::_detail::Xml;
 using namespace Azure::Data::Tables::Credentials::_detail;
 using namespace Azure::Data::Tables::_detail;
 
-TableServiceClient::TableServiceClient(const TableClientOptions& options)
-{
-  TableClientOptions newOptions = options;
-  std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-  std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-  perRetryPolicies.emplace_back(std::make_unique<TimeoutPolicy>());
-  perOperationPolicies.emplace_back(
-      std::make_unique<ServiceVersionPolicy>(newOptions.ApiVersion.ToString()));
-  m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-      newOptions,
-      _detail::TablesServicePackageName,
-      _detail::ApiVersion,
-      std::move(perRetryPolicies),
-      std::move(perOperationPolicies));
-}
-
 TableServiceClient::TableServiceClient(
     const std::string& serviceUrl,
     const TableClientOptions& options)
@@ -56,8 +40,6 @@ TableServiceClient::TableServiceClient(
     const std::string& serviceUrl,
     std::shared_ptr<Core::Credentials::TokenCredential> credential,
     const TableClientOptions& options)
-    : TableServiceClient(options)
-
 {
   m_tokenCredential = credential;
   TableClientOptions newOptions = options;
@@ -165,7 +147,7 @@ TableServiceClient TableServiceClient::CreateFromConnectionString(
   }
   else
   {
-    return TableServiceClient(options);
+    return TableServiceClient(tablesUrl.GetAbsoluteUrl(), options);
   }
 }
 


### PR DESCRIPTION
It isn't clear what the intended usage of such a ctor could be. There doesn't seem to be any valid usage pattern for this.

Any instance methods on a client constructed with no parameters will fail since the underlying url will be empty.

```C++
  TEST_F(SerializersTest, TempTest)
  {
    auto client = TableServiceClient();
    // This fails with 
    // unknown file: error: C++ exception with description "Error while getting a connection handle. Error Code: 12005: The URL is invalid." thrown in the test body.
    client.CreateTable("foo");

    // This fails with
    // unknown file: error: C++ exception with description "TableServiceClient is not properly initialized." thrown in the test body.
    client.GetTableClient("bar");
  }
```

https://github.com/Azure/azure-sdk-for-cpp/blob/d835e1a3b1970e53ceda94ef1c6d0596cd103d02/sdk/tables/azure-data-tables/src/tables_clients.cpp#L151

https://github.com/Azure/azure-sdk-for-cpp/blob/d835e1a3b1970e53ceda94ef1c6d0596cd103d02/sdk/tables/azure-data-tables/src/tables_clients.cpp#L456-L457

I didn't find similar overloads in .NET/GoLang (cc @christothes, @jhendrixMSFT in case I missed something):
https://github.com/Azure/azure-sdk-for-net/blob/fbf67572a675e0152f04827fc6d6ae8f96a06de7/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs#L115-L122

https://github.com/Azure/azure-sdk-for-go/blob/9591fab0ac0e5e3e2707d6db579331b136fb00ea/sdk/data/aztables/service_client.go#L34-L70