### PR TITLE
Removed the TablesAudience field from TableClientOptions since it is not required.

### DIFF
--- a/sdk/tables/azure-data-tables/CHANGELOG.md
+++ b/sdk/tables/azure-data-tables/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- Removed the `TablesAudience` field from `TableClientOptions` since it is not required.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/tables/azure-data-tables/inc/azure/data/tables/tables_clients.hpp
+++ b/sdk/tables/azure-data-tables/inc/azure/data/tables/tables_clients.hpp
@@ -117,27 +117,6 @@ namespace Azure { namespace Data { namespace Tables {
   };
 
   /**
-   * @brief Audiences available for Blobs
-   *
-   */
-  class TablesAudience final
-      : public Azure::Core::_internal::ExtendableEnumeration<TablesAudience> {
-  public:
-    /**
-     * @brief Construct a new TablesAudience object
-     *
-     * @param tablesAudience The Azure Active Directory audience to use when forming authorization
-     * scopes. For the Language service, this value corresponds to a URL that identifies the Azure
-     * cloud where the resource is located. For more information: See
-     * https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory
-     */
-    explicit TablesAudience(std::string tablesAudience)
-        : ExtendableEnumeration(std::move(tablesAudience))
-    {
-    }
-  };
-
-  /**
    * @brief Optional parameters for constructing a new TableClient.
    */
   struct TableClientOptions final : Azure::Core::_internal::ClientOptions
@@ -153,12 +132,6 @@ namespace Azure { namespace Data { namespace Tables {
      * to prompt a challenge in order to discover the correct tenant for the resource.
      */
     bool EnableTenantDiscovery = false;
-
-    /**
-     * The Audience to use for authentication with Azure Active Directory (AAD).
-     *
-     */
-    Azure::Nullable<TablesAudience> Audience;
   };
 
   /**

--- a/sdk/tables/azure-data-tables/src/tables_clients.cpp
+++ b/sdk/tables/azure-data-tables/src/tables_clients.cpp
@@ -71,9 +71,7 @@ TableServiceClient::TableServiceClient(
   perRetryPolicies.emplace_back(std::make_unique<TimeoutPolicy>());
   {
     Azure::Core::Credentials::TokenRequestContext tokenContext;
-    tokenContext.Scopes.emplace_back(
-        newOptions.Audience.HasValue() ? newOptions.Audience.Value().ToString()
-                                       : m_url.GetAbsoluteUrl() + "/.default");
+    tokenContext.Scopes.emplace_back(m_url.GetAbsoluteUrl() + "/.default");
 
     perRetryPolicies.emplace_back(std::make_unique<TenantBearerTokenAuthenticationPolicy>(
         credential, tokenContext, newOptions.EnableTenantDiscovery));
@@ -360,9 +358,7 @@ TableClient::TableClient(
   perRetryPolicies.emplace_back(std::make_unique<TimeoutPolicy>());
   {
     Azure::Core::Credentials::TokenRequestContext tokenContext;
-    tokenContext.Scopes.emplace_back(
-        newOptions.Audience.HasValue() ? newOptions.Audience.Value().ToString()
-                                       : m_url.GetAbsoluteUrl() + "/.default");
+    tokenContext.Scopes.emplace_back(m_url.GetAbsoluteUrl() + "/.default");
 
     perRetryPolicies.emplace_back(std::make_unique<TenantBearerTokenAuthenticationPolicy>(
         credential, tokenContext, newOptions.EnableTenantDiscovery));


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-cpp/issues/6144