### PR TITLE
Use the package version for telemetry, rather than api version.

### DIFF
--- a/sdk/tables/azure-data-tables/CHANGELOG.md
+++ b/sdk/tables/azure-data-tables/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Use the package version for telemetry, rather than api version.
+
 ### Other Changes
 
 ## 1.0.0-beta.4 (2024-08-06)

--- a/sdk/tables/azure-data-tables/src/tables_clients.cpp
+++ b/sdk/tables/azure-data-tables/src/tables_clients.cpp
@@ -3,6 +3,7 @@
 
 #include "azure/data/tables/tables_clients.hpp"
 
+#include "private/package_version.hpp"
 #include "private/policies/service_version_policy.hpp"
 #include "private/policies/shared_key_lite_policy.hpp"
 #include "private/policies/tenant_bearer_token_policy.hpp"
@@ -29,7 +30,7 @@ TableServiceClient::TableServiceClient(const TableClientOptions& options)
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       newOptions,
       _detail::TablesServicePackageName,
-      _detail::ApiVersion,
+      PackageVersion::ToString(),
       std::move(perRetryPolicies),
       std::move(perOperationPolicies));
 }
@@ -47,7 +48,7 @@ TableServiceClient::TableServiceClient(
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       options,
       _detail::TablesServicePackageName,
-      _detail::ApiVersion,
+      PackageVersion::ToString(),
       std::move(perRetryPolicies),
       std::move(perOperationPolicies));
 }
@@ -83,7 +84,7 @@ TableServiceClient::TableServiceClient(
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       newOptions,
       _detail::TablesServicePackageName,
-      _detail::ApiVersion,
+      PackageVersion::ToString(),
       std::move(perRetryPolicies),
       std::move(perOperationPolicies));
 }
@@ -103,7 +104,7 @@ TableServiceClient::TableServiceClient(
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       options,
       _detail::TablesServicePackageName,
-      _detail::ApiVersion,
+      PackageVersion::ToString(),
       std::move(perRetryPolicies),
       std::move(perOperationPolicies));
 
@@ -119,7 +120,7 @@ TableServiceClient::TableServiceClient(
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       newOptions,
       _detail::TablesServicePackageName,
-      _detail::ApiVersion,
+      PackageVersion::ToString(),
       std::move(perRetryPolicies2),
       std::move(perOperationPolicies2));
 }
@@ -336,7 +337,7 @@ TableClient::TableClient(
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       options,
       _detail::TablesServicePackageName,
-      _detail::ApiVersion,
+      PackageVersion::ToString(),
       std::move(perRetryPolicies),
       std::move(perOperationPolicies));
 }
@@ -372,7 +373,7 @@ TableClient::TableClient(
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       newOptions,
       _detail::TablesServicePackageName,
-      _detail::ApiVersion,
+      PackageVersion::ToString(),
       std::move(perRetryPolicies),
       std::move(perOperationPolicies));
 }
@@ -393,7 +394,7 @@ TableClient::TableClient(
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       options,
       _detail::TablesServicePackageName,
-      _detail::ApiVersion,
+      PackageVersion::ToString(),
       std::move(perRetryPolicies),
       std::move(perOperationPolicies));
 
@@ -409,7 +410,7 @@ TableClient::TableClient(
   m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
       newOptions,
       _detail::TablesServicePackageName,
-      _detail::ApiVersion,
+      PackageVersion::ToString(),
       std::move(perRetryPolicies2),
       std::move(perOperationPolicies2));
 }


### PR DESCRIPTION
Following precedence of other SDKs.

Before:
```text
user-agent : azsdk-cpp-data-tables/2019-02-02 (Linux 6.8.0-1015-azure x86_64 #17~22.04.2-Ubuntu SMP Sat Oct  5 16:32:09 UTC 2024 Cpp/-1)
```
After:
```
user-agent : azsdk-cpp-data-tables/1.0.0-beta.5 (Linux 6.8.0-1015-azure x86_64 #17~22.04.2-Ubuntu SMP Sat Oct  5 16:32:09 UTC 2024 Cpp/-1)
```