### PR TITLE
Move UserAgentGenerator to internal and simplify scenario.

### DIFF
--- a/cmake-modules/AzureGlobalCompileOptions.cmake
+++ b/cmake-modules/AzureGlobalCompileOptions.cmake
@@ -14,7 +14,7 @@ if(MSVC)
 
   #https://stackoverflow.com/questions/37527946/warning-unreferenced-inline-function-has-been-removed
   add_compile_options(/permissive- /W4 ${WARNINGS_AS_ERRORS_FLAG} /wd5031 /wd4668 /wd4820 /wd4255 /wd4710)
-  #https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170
+  #https://learn.microsoft.com/cpp/build/reference/zc-cplusplus?view=msvc-170
   add_compile_options(/Zc:__cplusplus)
 
   # NOTE: Static analysis will slow building time considerably and it is run during CI gates.

--- a/cmake-modules/AzureGlobalCompileOptions.cmake
+++ b/cmake-modules/AzureGlobalCompileOptions.cmake
@@ -14,6 +14,8 @@ if(MSVC)
 
   #https://stackoverflow.com/questions/37527946/warning-unreferenced-inline-function-has-been-removed
   add_compile_options(/permissive- /W4 ${WARNINGS_AS_ERRORS_FLAG} /wd5031 /wd4668 /wd4820 /wd4255 /wd4710)
+  #https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170
+  add_compile_options(/Zc:__cplusplus)
 
   # NOTE: Static analysis will slow building time considerably and it is run during CI gates.
   # It is better to turn in on to debug errors reported by CI than have it ON all the time. 

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -525,7 +525,8 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
           : m_telemetryId(Azure::Core::Http::_internal::UserAgentGenerator::GenerateUserAgent(
               packageName,
               packageVersion,
-              options.ApplicationId))
+              options.ApplicationId,
+              __cplusplus))
       {
       }
 

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -49,10 +49,6 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     AZ_CORE_DLLEXPORT extern CaseInsensitiveSet const g_defaultAllowedHttpHeaders;
   } // namespace _detail
 
-  namespace _internal {
-    class TelemetryPolicy;
-  }
-
   /**
    * @brief Telemetry options, used to configure telemetry parameters.
    * @note See https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy.
@@ -73,25 +69,6 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
      * this will be the tracing provider specified in the application context.
      */
     std::shared_ptr<Azure::Core::Tracing::TracerProvider> TracingProvider;
-
-  private:
-    // The friend declaration is needed so that TelemetryPolicy could access CppStandardVersion,
-    // and it is not a struct's public field like the ones above to be set non-programmatically.
-    // When building the SDK, tests, or samples, the value of __cplusplus is ultimately controlled
-    // by the cmake files in this repo (i.e. C++14), therefore we set distinct values of 0, -1, etc
-    // when it is the case.
-    friend class _internal::TelemetryPolicy;
-    long CppStandardVersion =
-#if defined(_azure_BUILDING_SDK)
-        -2L
-#elif defined(_azure_BUILDING_TESTS)
-        -1L
-#elif defined(_azure_BUILDING_SAMPLES)
-        0L
-#else
-        __cplusplus
-#endif
-        ;
   };
 
   /**
@@ -271,7 +248,8 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     virtual std::unique_ptr<RawResponse> Send(
         Request& request,
         NextHttpPolicy nextPolicy,
-        Context const& context) const = 0;
+        Context const& context) const
+        = 0;
 
     /**
      * @brief Destructs `%HttpPolicy`.
@@ -545,11 +523,10 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
           std::string const& packageName,
           std::string const& packageVersion,
           TelemetryOptions options = TelemetryOptions())
-          : m_telemetryId(Azure::Core::Http::_detail::UserAgentGenerator::GenerateUserAgent(
+          : m_telemetryId(Azure::Core::Http::_internal::UserAgentGenerator::GenerateUserAgent(
               packageName,
               packageVersion,
-              options.ApplicationId,
-              options.CppStandardVersion))
+              options.ApplicationId))
       {
       }
 

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -248,8 +248,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     virtual std::unique_ptr<RawResponse> Send(
         Request& request,
         NextHttpPolicy nextPolicy,
-        Context const& context) const
-        = 0;
+        Context const& context) const = 0;
 
     /**
      * @brief Destructs `%HttpPolicy`.

--- a/sdk/core/azure-core/inc/azure/core/internal/http/user_agent.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/http/user_agent.hpp
@@ -23,6 +23,7 @@ namespace Azure { namespace Core { namespace Http { namespace _internal {
      * @param componentName the name of the SDK component.
      * @param componentVersion the version of the SDK component.
      * @param applicationId user application ID
+     * @param cplusplusValue value of the `__cplusplus` macro.
      *
      * @return User-Agent string.
      *
@@ -32,6 +33,7 @@ namespace Azure { namespace Core { namespace Http { namespace _internal {
     static std::string GenerateUserAgent(
         std::string const& componentName,
         std::string const& componentVersion,
-        std::string const& applicationId);
+        std::string const& applicationId,
+        long cplusplusValue);
   };
 }}}} // namespace Azure::Core::Http::_internal

--- a/sdk/core/azure-core/inc/azure/core/internal/http/user_agent.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/http/user_agent.hpp
@@ -11,23 +11,24 @@
 #include <string>
 
 namespace Azure { namespace Core { namespace Http { namespace _internal {
+  /**
+   * @brief Telemetry User-Agent string generator.
+   *
+   */
   class UserAgentGenerator {
-
-    // This doesn't behave as expected, locally, depending on how the tests are written.
-    // TODO: Consider removing these target_compile_definitions.
-    static const long CppStandardVersion =
-#if defined(_azure_BUILDING_SDK)
-        -2L
-#elif defined(_azure_BUILDING_TESTS)
-        -1L
-#elif defined(_azure_BUILDING_SAMPLES)
-        0L
-#else
-        __cplusplus
-#endif
-        ;
-
   public:
+    /**
+     * @brief Generates User-Agent string for telemetry.
+     *
+     * @param componentName the name of the SDK component.
+     * @param componentVersion the version of the SDK component.
+     * @param applicationId user application ID
+     *
+     * @return User-Agent string.
+     *
+     * @see https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy
+     *
+     */
     static std::string GenerateUserAgent(
         std::string const& componentName,
         std::string const& componentVersion,

--- a/sdk/core/azure-core/inc/azure/core/internal/http/user_agent.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/http/user_agent.hpp
@@ -10,26 +10,27 @@
 
 #include <string>
 
-namespace Azure { namespace Core { namespace Http { namespace _detail {
-  // NOTE: Treat Azure::Core::Http::_detail::UserAgentGenerator::GenerateUserAgent() as _internal -
-  // it is being/has been used by eventhubs.
+namespace Azure { namespace Core { namespace Http { namespace _internal {
   class UserAgentGenerator {
+
+    // This doesn't behave as expected, locally, depending on how the tests are written.
+    // TODO: Consider removing these target_compile_definitions.
+    static const long CppStandardVersion =
+#if defined(_azure_BUILDING_SDK)
+        -2L
+#elif defined(_azure_BUILDING_TESTS)
+        -1L
+#elif defined(_azure_BUILDING_SAMPLES)
+        0L
+#else
+        __cplusplus
+#endif
+        ;
+
   public:
     static std::string GenerateUserAgent(
         std::string const& componentName,
         std::string const& componentVersion,
-        std::string const& applicationId,
-        long cplusplusValue);
-
-    [[deprecated("Use an overload with additional cplusplusValue parameter.")]] static std::string
-    GenerateUserAgent(
-        std::string const& componentName,
-        std::string const& componentVersion,
-        std::string const& applicationId)
-    {
-      // The value of -3L is to signify that an old version of signature has been used (older
-      // version of eventhubs); we can't rely on cpp version reported by it.
-      return GenerateUserAgent(componentName, componentVersion, applicationId, -3L);
-    }
+        std::string const& applicationId);
   };
-}}}} // namespace Azure::Core::Http::_detail
+}}}} // namespace Azure::Core::Http::_internal

--- a/sdk/core/azure-core/src/http/user_agent.cpp
+++ b/sdk/core/azure-core/src/http/user_agent.cpp
@@ -153,7 +153,8 @@ namespace Azure { namespace Core { namespace Http { namespace _internal {
   std::string UserAgentGenerator::GenerateUserAgent(
       std::string const& componentName,
       std::string const& componentVersion,
-      std::string const& applicationId)
+      std::string const& applicationId,
+      long cplusplusValue)
   {
     // Spec: https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy
     std::ostringstream telemetryId;
@@ -165,7 +166,7 @@ namespace Azure { namespace Core { namespace Http { namespace _internal {
 
     static std::string const osVer = GetOSVersion();
     telemetryId << "azsdk-cpp-" << componentName << "/" << componentVersion << " (" << osVer << " "
-                << "Cpp/" << __cplusplus << ")";
+                << "Cpp/" << cplusplusValue << ")";
 
     return telemetryId.str();
   }

--- a/sdk/core/azure-core/src/http/user_agent.cpp
+++ b/sdk/core/azure-core/src/http/user_agent.cpp
@@ -165,7 +165,7 @@ namespace Azure { namespace Core { namespace Http { namespace _internal {
 
     static std::string const osVer = GetOSVersion();
     telemetryId << "azsdk-cpp-" << componentName << "/" << componentVersion << " (" << osVer << " "
-                << "Cpp/" << CppStandardVersion << ")";
+                << "Cpp/" << __cplusplus << ")";
 
     return telemetryId.str();
   }

--- a/sdk/core/azure-core/src/http/user_agent.cpp
+++ b/sdk/core/azure-core/src/http/user_agent.cpp
@@ -148,13 +148,12 @@ std::string TrimString(std::string s)
 }
 } // namespace
 
-namespace Azure { namespace Core { namespace Http { namespace _detail {
+namespace Azure { namespace Core { namespace Http { namespace _internal {
 
   std::string UserAgentGenerator::GenerateUserAgent(
       std::string const& componentName,
       std::string const& componentVersion,
-      std::string const& applicationId,
-      long cplusplusValue)
+      std::string const& applicationId)
   {
     // Spec: https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy
     std::ostringstream telemetryId;
@@ -166,8 +165,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     static std::string const osVer = GetOSVersion();
     telemetryId << "azsdk-cpp-" << componentName << "/" << componentVersion << " (" << osVer << " "
-                << "Cpp/" << cplusplusValue << ")";
+                << "Cpp/" << CppStandardVersion << ")";
 
     return telemetryId.str();
   }
-}}}} // namespace Azure::Core::Http::_detail
+}}}} // namespace Azure::Core::Http::_internal

--- a/sdk/core/azure-core/test/ut/telemetry_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/telemetry_policy_test.cpp
@@ -101,6 +101,13 @@ TEST(TelemetryPolicy, UserAgentCppVer)
     EXPECT_GE(ua.length(), 11);
     EXPECT_EQ(ua.substr(ua.length() - 11, ua.size()), "Cpp/199711)");
   }
+
+  {
+    std::ostringstream cppversion;
+    cppversion << "TEST: " << __cplusplus;
+
+    EXPECT_EQ(cppversion.str(), "TEST:201402L)");
+  }
 }
 
 TEST(TelemetryPolicy, NoOverwrite)

--- a/sdk/core/azure-core/test/ut/telemetry_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/telemetry_policy_test.cpp
@@ -59,7 +59,7 @@ TEST(TelemetryPolicy, telemetryString)
 
   constexpr auto TelemetryHeader = "user-agent";
   constexpr auto OSInfoMinLength = 10;
-  const std::string CppVersionSuffix = " Cpp/-1)";
+  const std::string CppVersionSuffix = " Cpp/199711)";
 
   for (auto const& test : UserAgentTests)
   {
@@ -95,19 +95,11 @@ TEST(TelemetryPolicy, telemetryString)
 TEST(TelemetryPolicy, UserAgentCppVer)
 {
   {
-    const std::string ua = Http::_detail::UserAgentGenerator::GenerateUserAgent(
-        "storage.blobs", "11.0.0-beta.1", "MyApp", 201402L);
+    const std::string ua = Http::_internal::UserAgentGenerator::GenerateUserAgent(
+        "storage.blobs", "11.0.0-beta.1", "MyApp");
 
     EXPECT_GE(ua.length(), 11);
-    EXPECT_EQ(ua.substr(ua.length() - 11, ua.size()), "Cpp/201402)");
-  }
-
-  {
-    const std::string ua = Http::_detail::UserAgentGenerator::GenerateUserAgent(
-        "storage.blobs", "11.0.0-beta.1", "MyApp", 201703L);
-
-    EXPECT_GE(ua.length(), 11);
-    EXPECT_EQ(ua.substr(ua.length() - 11, ua.size()), "Cpp/201703)");
+    EXPECT_EQ(ua.substr(ua.length() - 11, ua.size()), "Cpp/199711)");
   }
 }
 

--- a/sdk/core/azure-core/test/ut/telemetry_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/telemetry_policy_test.cpp
@@ -3,7 +3,6 @@
 
 #include <azure/core/http/policies/policy.hpp>
 #include <azure/core/internal/http/pipeline.hpp>
-#include <azure/core/platform.hpp>
 
 #include <gtest/gtest.h>
 
@@ -61,11 +60,7 @@ TEST(TelemetryPolicy, telemetryString)
   constexpr auto TelemetryHeader = "user-agent";
   constexpr auto OSInfoMinLength = 10;
 
-#if defined(AZ_PLATFORM_POSIX)
   const std::string CppVersionSuffix = " Cpp/201402)";
-#else
-  const std::string CppVersionSuffix = " Cpp/199711)";
-#endif
 
   for (auto const& test : UserAgentTests)
   {
@@ -103,20 +98,14 @@ TEST(TelemetryPolicy, UserAgentCppVer)
   {
     std::ostringstream cppversion;
     cppversion << "TEST:" << __cplusplus;
-
-    // The _cplusplus macro doesn't update its value on MSVC/Windows.
-#if defined(AZ_PLATFORM_POSIX)
     EXPECT_EQ(cppversion.str(), "TEST:201402");
-#else
-    EXPECT_EQ(cppversion.str(), "TEST:199711");
-#endif
   }
   {
     const std::string ua = Http::_internal::UserAgentGenerator::GenerateUserAgent(
         "storage.blobs", "11.0.0-beta.1", "MyApp");
 
     EXPECT_GE(ua.length(), 11);
-    EXPECT_EQ(ua.substr(ua.length() - 11, ua.size()), "Cpp/199711)");
+    EXPECT_EQ(ua.substr(ua.length() - 11, ua.size()), "Cpp/201402)");
   }
 }
 

--- a/sdk/core/azure-core/test/ut/telemetry_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/telemetry_policy_test.cpp
@@ -102,10 +102,17 @@ TEST(TelemetryPolicy, UserAgentCppVer)
   }
   {
     const std::string ua = Http::_internal::UserAgentGenerator::GenerateUserAgent(
-        "storage.blobs", "11.0.0-beta.1", "MyApp");
+        "storage.blobs", "11.0.0-beta.1", "MyApp", 201402L);
 
     EXPECT_GE(ua.length(), 11);
     EXPECT_EQ(ua.substr(ua.length() - 11, ua.size()), "Cpp/201402)");
+  }
+  {
+    const std::string ua = Http::_internal::UserAgentGenerator::GenerateUserAgent(
+        "storage.blobs", "11.0.0-beta.1", "MyApp", 201703L);
+
+    EXPECT_GE(ua.length(), 11);
+    EXPECT_EQ(ua.substr(ua.length() - 11, ua.size()), "Cpp/201703)");
   }
 }
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
@@ -20,8 +20,6 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     class EventHubsPropertiesClient;
   }
 
-  class ConsumerClient;
-
   /// @brief The default consumer group name.
   constexpr const char* DefaultConsumerGroup = "$Default";
 
@@ -40,25 +38,6 @@ namespace Azure { namespace Messaging { namespace EventHubs {
 
     /** @brief Name of the consumer client. */
     std::string Name{};
-
-  private:
-    // The friend declaration is needed so that ConsumerClient could access CppStandardVersion,
-    // and it is not a struct's public field like the ones above to be set non-programmatically.
-    // When building the SDK, tests, or samples, the value of __cplusplus is ultimately controlled
-    // by the cmake files in this repo (i.e. C++14), therefore we set distinct values of 0, -1, etc
-    // when it is the case.
-    friend class ConsumerClient;
-    long CppStandardVersion =
-#if defined(_azure_BUILDING_SDK)
-        -2L
-#elif defined(_azure_BUILDING_TESTS)
-        -1L
-#elif defined(_azure_BUILDING_SAMPLES)
-        0L
-#else
-        __cplusplus
-#endif
-        ;
   };
 
   /**

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
@@ -20,8 +20,6 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     class EventHubsPropertiesClient;
   } // namespace _detail
 
-  class ProducerClient;
-
   /**@brief Contains options for the ProducerClient creation
    */
   struct ProducerClientOptions final
@@ -42,25 +40,6 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     /**@brief  The maximum size of the message that can be sent.
      */
     Azure::Nullable<std::uint64_t> MaxMessageSize{};
-
-  private:
-    // The friend declaration is needed so that ProducerClient could access CppStandardVersion,
-    // and it is not a struct's public field like the ones above to be set non-programmatically.
-    // When building the SDK, tests, or samples, the value of __cplusplus is ultimately controlled
-    // by the cmake files in this repo (i.e. C++14), therefore we set distinct values of 0, -1, etc
-    // when it is the case.
-    friend class ProducerClient;
-    long CppStandardVersion =
-#if defined(_azure_BUILDING_SDK)
-        -2L
-#elif defined(_azure_BUILDING_TESTS)
-        -1L
-#elif defined(_azure_BUILDING_SAMPLES)
-        0L
-#else
-        __cplusplus
-#endif
-        ;
   };
 
   /**@brief  ProducerClient can be used to send events to an Event Hub.

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
@@ -97,9 +97,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     // Set the user agent related properties in the connectOptions based on the package
     // information and application ID.
     _detail::EventHubsUtilities::SetUserAgent(
-        connectOptions,
-        m_consumerClientOptions.ApplicationID,
-        m_consumerClientOptions.CppStandardVersion);
+        connectOptions, m_consumerClientOptions.ApplicationID);
 
     return Azure::Core::Amqp::_internal::Connection{
         m_fullyQualifiedNamespace, m_credential, connectOptions};

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
@@ -277,7 +277,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
       options.Properties.emplace(
           "user-agent",
           Azure::Core::Http::_internal::UserAgentGenerator::GenerateUserAgent(
-              packageName, PackageVersion::ToString(), applicationId));
+              packageName, PackageVersion::ToString(), applicationId, __cplusplus));
     }
 
     static void LogRawBuffer(std::ostream& os, std::vector<uint8_t> const& buffer);

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
@@ -261,8 +261,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
   class EventHubsUtilities {
 
   public:
-    template <typename T>
-    static void SetUserAgent(T& options, std::string const& applicationId, long cplusplusValue)
+    template <typename T> static void SetUserAgent(T& options, std::string const& applicationId)
     {
       constexpr const char* packageName = "azure-messaging-eventhubs-cpp";
 
@@ -277,8 +276,8 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
 #endif
       options.Properties.emplace(
           "user-agent",
-          Azure::Core::Http::_detail::UserAgentGenerator::GenerateUserAgent(
-              packageName, PackageVersion::ToString(), applicationId, cplusplusValue));
+          Azure::Core::Http::_internal::UserAgentGenerator::GenerateUserAgent(
+              packageName, PackageVersion::ToString(), applicationId));
     }
 
     static void LogRawBuffer(std::ostream& os, std::vector<uint8_t> const& buffer);

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
@@ -125,9 +125,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
 
     // Set the UserAgent related properties on this message sender.
     _detail::EventHubsUtilities::SetUserAgent(
-        connectOptions,
-        m_producerClientOptions.ApplicationID,
-        m_producerClientOptions.CppStandardVersion);
+        connectOptions, m_producerClientOptions.ApplicationID);
 
     return Azure::Core::Amqp::_internal::Connection{
         m_fullyQualifiedNamespace, m_credential, connectOptions};


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-cpp/pull/6067 and https://github.com/Azure/azure-sdk-for-cpp/pull/5662

1) Fixes issue on Windows/MSVC where the value of `__cplusplus` doesn't update (this only fixes SDK source, since that's where our compile options are used). Previously, on MSVC, we'd be getting skewed results with value `199711L`.
https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170
2) Rather than having friend classes, and different telemetry values for samples/tests/SDK sources, use the same `__cplusplus` value across the board
3) TODO: Cleanup unnecessary compile definitions within CMakeLists.txt after offline discussion on whether there is enough value for that differentiation for it to be worth the cost. We could evaluate other alternatives to differentiate between end customer usage and SDK/CI builds.