### PR TITLE
Set token to be expired if response comes back as unauthorized, within BeareTokenAuthenticationPolicy.

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - Fixed warning for an unused function in curl.cpp when building the SDK using a version of libcurl older than 7.77.0.
-- Invalidate the token cache within `BearerTokenAuthenticationPolicy` whenever an auth request comes back with a 401 response.
+- Invalidate the token cache within `BearerTokenAuthenticationPolicy` whenever a token request comes back with a 401 response.
 
 ### Other Changes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed warning for an unused function in curl.cpp when building the SDK using a version of libcurl older than 7.77.0.
+- Invalidate the token cache within `BearerTokenAuthenticationPolicy` whenever an auth request comes back with a 401 response.
 
 ### Other Changes
 

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -576,7 +576,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
       mutable Credentials::AccessToken m_accessToken;
       mutable std::shared_timed_mutex m_accessTokenMutex;
       mutable Credentials::TokenRequestContext m_accessTokenContext;
-      mutable std::atomic<bool> m_invalidateToken = false;
+      mutable std::atomic<bool> m_invalidateToken = {false};
 
     public:
       /**

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -576,7 +576,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
       mutable Credentials::AccessToken m_accessToken;
       mutable std::shared_timed_mutex m_accessTokenMutex;
       mutable Credentials::TokenRequestContext m_accessTokenContext;
-      mutable bool m_invalidateToken = false;
+      mutable std::atomic<bool> m_invalidateToken = {false};
 
     public:
       /**
@@ -611,7 +611,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
         std::shared_lock<std::shared_timed_mutex> readLock(other.m_accessTokenMutex);
         m_accessToken = other.m_accessToken;
         m_accessTokenContext = other.m_accessTokenContext;
-        m_invalidateToken = other.m_invalidateToken;
+        m_invalidateToken.store(other.m_invalidateToken.load());
       }
 
       void operator=(BearerTokenAuthenticationPolicy const&) = delete;

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -576,6 +576,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
       mutable Credentials::AccessToken m_accessToken;
       mutable std::shared_timed_mutex m_accessTokenMutex;
       mutable Credentials::TokenRequestContext m_accessTokenContext;
+      mutable bool m_invalidateToken = false;
 
     public:
       /**
@@ -588,7 +589,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
           std::shared_ptr<Credentials::TokenCredential const> credential,
           Credentials::TokenRequestContext tokenRequestContext)
           : m_credential(std::move(credential)),
-            m_tokenRequestContext(std::move(tokenRequestContext))
+            m_tokenRequestContext(std::move(tokenRequestContext)), m_invalidateToken(false)
       {
       }
 
@@ -610,6 +611,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
         std::shared_lock<std::shared_timed_mutex> readLock(other.m_accessTokenMutex);
         m_accessToken = other.m_accessToken;
         m_accessTokenContext = other.m_accessTokenContext;
+        m_invalidateToken = other.m_invalidateToken;
       }
 
       void operator=(BearerTokenAuthenticationPolicy const&) = delete;

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -576,7 +576,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
       mutable Credentials::AccessToken m_accessToken;
       mutable std::shared_timed_mutex m_accessTokenMutex;
       mutable Credentials::TokenRequestContext m_accessTokenContext;
-      mutable std::atomic<bool> m_invalidateToken = {false};
+      mutable bool m_invalidateToken = false;
 
     public:
       /**
@@ -611,7 +611,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
         std::shared_lock<std::shared_timed_mutex> readLock(other.m_accessTokenMutex);
         m_accessToken = other.m_accessToken;
         m_accessTokenContext = other.m_accessTokenContext;
-        m_invalidateToken.store(other.m_invalidateToken.load());
+        m_invalidateToken = other.m_invalidateToken;
       }
 
       void operator=(BearerTokenAuthenticationPolicy const&) = delete;

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -576,7 +576,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
       mutable Credentials::AccessToken m_accessToken;
       mutable std::shared_timed_mutex m_accessTokenMutex;
       mutable Credentials::TokenRequestContext m_accessTokenContext;
-      mutable bool m_invalidateToken = false;
+      mutable std::atomic<bool> m_invalidateToken = false;
 
     public:
       /**
@@ -589,7 +589,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
           std::shared_ptr<Credentials::TokenCredential const> credential,
           Credentials::TokenRequestContext tokenRequestContext)
           : m_credential(std::move(credential)),
-            m_tokenRequestContext(std::move(tokenRequestContext)), m_invalidateToken(false)
+            m_tokenRequestContext(std::move(tokenRequestContext))
       {
       }
 
@@ -611,7 +611,7 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
         std::shared_lock<std::shared_timed_mutex> readLock(other.m_accessTokenMutex);
         m_accessToken = other.m_accessToken;
         m_accessTokenContext = other.m_accessTokenContext;
-        m_invalidateToken = other.m_invalidateToken;
+        m_invalidateToken.store(other.m_invalidateToken.load());
       }
 
       void operator=(BearerTokenAuthenticationPolicy const&) = delete;

--- a/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
+++ b/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
@@ -36,6 +36,10 @@ std::unique_ptr<RawResponse> BearerTokenAuthenticationPolicy::Send(
       std::unique_lock<std::shared_timed_mutex> writeLock(m_accessTokenMutex);
       m_accessToken.ExpiresOn = DateTime(std::chrono::system_clock::now());
     }
+
+    // We keep this check outside the lock to avoid blocking other threads while we are processing
+    // the challenge from the response. GetChallenge already checks the status code and returns an
+    // empty string if it is not 401.
     auto const& challenge = AuthorizationChallengeHelper::GetChallenge(response);
     if (!challenge.empty() && AuthorizeRequestOnChallenge(challenge, request, context))
     {

--- a/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
+++ b/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
@@ -32,10 +32,6 @@ std::unique_ptr<RawResponse> BearerTokenAuthenticationPolicy::Send(
   {
     auto const& response = *result;
     m_invalidateToken = (response.GetStatusCode() == HttpStatusCode::Unauthorized);
-
-    // We keep this check outside the lock to avoid blocking other threads while we are processing
-    // the challenge from the response. GetChallenge already checks the status code and returns an
-    // empty string if it is not 401.
     auto const& challenge = AuthorizationChallengeHelper::GetChallenge(response);
     if (!challenge.empty() && AuthorizeRequestOnChallenge(challenge, request, context))
     {


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/6022#issuecomment-2400588474

cc @chlowell @christothes 