### PR TITLE
Minor code cleanups

### DIFF
--- a/sdk/core/azure-core-amqp/src/amqp/private/claims_based_security_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/amqp/private/claims_based_security_impl.hpp
@@ -22,6 +22,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
+  using UniqueAmqpCbsHandle = UniqueHandle<CBS_INSTANCE_TAG>;
   class ClaimsBasedSecurityImpl final : public _internal::ManagementClientEvents {
 
   public:

--- a/sdk/core/azure-core-amqp/src/amqp/private/claims_based_security_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/amqp/private/claims_based_security_impl.hpp
@@ -22,8 +22,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
-  using UniqueAmqpCbsHandle = UniqueHandle<CBS_INSTANCE_TAG>;
-
   class ClaimsBasedSecurityImpl final : public _internal::ManagementClientEvents {
 
   public:

--- a/sdk/core/azure-core-amqp/src/amqp/private/claims_based_security_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/amqp/private/claims_based_security_impl.hpp
@@ -23,6 +23,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using UniqueAmqpCbsHandle = UniqueHandle<CBS_INSTANCE_TAG>;
+
   class ClaimsBasedSecurityImpl final : public _internal::ManagementClientEvents {
 
   public:

--- a/sdk/core/azure-core/src/base64.cpp
+++ b/sdk/core/azure-core/src/base64.cpp
@@ -3,8 +3,6 @@
 
 #include "azure/core/base64.hpp"
 
-#include "azure/core/platform.hpp"
-
 #include <string>
 #include <vector>
 
@@ -336,15 +334,11 @@ std::string Base64Encode(uint8_t const* const data, size_t length)
   {
     int32_t result = Base64EncodeAndPadTwo(&data[sourceIndex]);
     Base64WriteIntAsFourBytes(destination, result);
-    destination += 4;
-    sourceIndex += 1;
   }
   else if (sourceIndex + 2 == inputSize)
   {
     int32_t result = Base64EncodeAndPadOne(&data[sourceIndex]);
     Base64WriteIntAsFourBytes(destination, result);
-    destination += 4;
-    sourceIndex += 2;
   }
 
   return encodedResult;
@@ -453,7 +447,6 @@ std::vector<uint8_t> Base64Decode(const std::string& text)
     }
 
     Base64WriteThreeLowOrderBytes(destinationPtr, i0);
-    destinationPtr += 3;
   }
   else if (i2 != EncodingPad)
   {
@@ -469,7 +462,6 @@ std::vector<uint8_t> Base64Decode(const std::string& text)
 
     destinationPtr[1] = static_cast<uint8_t>(i0 >> 8);
     destinationPtr[0] = static_cast<uint8_t>(i0 >> 16);
-    destinationPtr += 2;
   }
   else
   {
@@ -479,7 +471,6 @@ std::vector<uint8_t> Base64Decode(const std::string& text)
     }
 
     destinationPtr[0] = static_cast<uint8_t>(i0 >> 16);
-    destinationPtr += 1;
   }
 
   return destination;

--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -4,7 +4,6 @@
 #include "azure/core/datetime.hpp"
 
 #include "azure/core/internal/strings.hpp"
-#include "azure/core/platform.hpp"
 
 #include <algorithm>
 #include <ctime>

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -14,21 +14,9 @@
 #endif
 #endif
 
-#include "azure/core/platform.hpp"
-
-#if defined(AZ_PLATFORM_WINDOWS)
-#if !defined(WIN32_LEAN_AND_MEAN)
-#define WIN32_LEAN_AND_MEAN
-#endif
-#if !defined(NOMINMAX)
-#define NOMINMAX
-#endif
-#endif
-
 #include "azure/core/http/curl_transport.hpp"
 #include "azure/core/http/http.hpp"
 #include "azure/core/http/policies/policy.hpp"
-#include "azure/core/http/transport.hpp"
 #include "azure/core/internal/diagnostics/log.hpp"
 #include "azure/core/internal/strings.hpp"
 

--- a/sdk/core/azure-core/src/http/http.cpp
+++ b/sdk/core/azure-core/src/http/http.cpp
@@ -3,13 +3,11 @@
 
 #include "azure/core/http/http.hpp"
 
-#include "azure/core/http/policies/policy.hpp"
 #include "azure/core/internal/strings.hpp"
 #include "azure/core/url.hpp"
 
 #include <algorithm>
 #include <unordered_set>
-#include <utility>
 
 using namespace Azure::Core;
 using namespace Azure::Core::Http;

--- a/sdk/core/azure-core/src/http/log_policy.cpp
+++ b/sdk/core/azure-core/src/http/log_policy.cpp
@@ -4,11 +4,8 @@
 #include "azure/core/http/policies/policy.hpp"
 #include "azure/core/internal/diagnostics/log.hpp"
 
-#include <algorithm>
 #include <chrono>
-#include <iterator>
 #include <sstream>
-#include <type_traits>
 
 using Azure::Core::Context;
 using namespace Azure::Core;


### PR DESCRIPTION
As part of MQ, I am running different code analysis tools, and picking up some stuff from these reports that I like/easily understand/agree with.

`UniqueAmqpCbsHandle` - not used anywhere

`destination`, `sourceIndex` - not used after the value gets updated

`#include <.../platform.hpp> & #ifdefs` - duplicated right above

Bunch of `#include`s - nothing from these files is used in the cpp file

