### PR TITLE
Remove the RequestId option within the protocol layer to check if anyone is using or setting it.

### DIFF
--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/rest_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/rest_client.hpp
@@ -361,7 +361,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     public:
       struct ListFileSystemPathsOptions final
       {
-        Nullable<std::string> RequestId;
+        //Nullable<std::string> RequestId;
         Nullable<std::int32_t> Timeout;
         Nullable<std::string> ContinuationToken;
         Nullable<std::string> Path;
@@ -379,7 +379,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     public:
       struct CreatePathOptions final
       {
-        Nullable<std::string> RequestId;
+        //Nullable<std::string> RequestId;
         Nullable<std::int32_t> Timeout;
         Nullable<Models::PathResourceType> Resource;
         Nullable<std::string> ContinuationToken;
@@ -422,7 +422,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           const Core::Context& context);
       struct DeletePathOptions final
       {
-        Nullable<std::string> RequestId;
+        //Nullable<std::string> RequestId;
         Nullable<std::int32_t> Timeout;
         Nullable<bool> Recursive;
         Nullable<std::string> ContinuationToken;

--- a/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/rest_client.hpp
+++ b/sdk/storage/azure-storage-files-datalake/inc/azure/storage/files/datalake/rest_client.hpp
@@ -361,7 +361,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     public:
       struct ListFileSystemPathsOptions final
       {
-        //Nullable<std::string> RequestId;
+        // Nullable<std::string> RequestId;
         Nullable<std::int32_t> Timeout;
         Nullable<std::string> ContinuationToken;
         Nullable<std::string> Path;
@@ -379,7 +379,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     public:
       struct CreatePathOptions final
       {
-        //Nullable<std::string> RequestId;
+        // Nullable<std::string> RequestId;
         Nullable<std::int32_t> Timeout;
         Nullable<Models::PathResourceType> Resource;
         Nullable<std::string> ContinuationToken;
@@ -422,7 +422,7 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
           const Core::Context& context);
       struct DeletePathOptions final
       {
-        //Nullable<std::string> RequestId;
+        // Nullable<std::string> RequestId;
         Nullable<std::int32_t> Timeout;
         Nullable<bool> Recursive;
         Nullable<std::string> ContinuationToken;

--- a/sdk/storage/azure-storage-files-datalake/src/rest_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/rest_client.cpp
@@ -53,10 +53,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     {
       auto request = Core::Http::Request(Core::Http::HttpMethod::Get, url);
       request.GetUrl().AppendQueryParameter("resource", "filesystem");
-      if (options.RequestId.HasValue() && !options.RequestId.Value().empty())
+      /*if (options.RequestId.HasValue() && !options.RequestId.Value().empty())
       {
         request.SetHeader("x-ms-client-request-id", options.RequestId.Value());
-      }
+      }*/
       if (options.Timeout.HasValue())
       {
         request.GetUrl().AppendQueryParameter("timeout", std::to_string(options.Timeout.Value()));
@@ -149,10 +149,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         const Core::Context& context)
     {
       auto request = Core::Http::Request(Core::Http::HttpMethod::Put, url);
-      if (options.RequestId.HasValue() && !options.RequestId.Value().empty())
+      /*if (options.RequestId.HasValue() && !options.RequestId.Value().empty())
       {
         request.SetHeader("x-ms-client-request-id", options.RequestId.Value());
-      }
+      }*/
       if (options.Timeout.HasValue())
       {
         request.GetUrl().AppendQueryParameter("timeout", std::to_string(options.Timeout.Value()));
@@ -337,10 +337,10 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
         const Core::Context& context)
     {
       auto request = Core::Http::Request(Core::Http::HttpMethod::Delete, url);
-      if (options.RequestId.HasValue() && !options.RequestId.Value().empty())
+      /*if (options.RequestId.HasValue() && !options.RequestId.Value().empty())
       {
         request.SetHeader("x-ms-client-request-id", options.RequestId.Value());
-      }
+      }*/
       if (options.Timeout.HasValue())
       {
         request.GetUrl().AppendQueryParameter("timeout", std::to_string(options.Timeout.Value()));


### PR DESCRIPTION
It seems like these are unnecessary implementation detail.