### PR TITLE
Only invalidate the BearerTokenAuthenticationPolicy token cache if the policy is not part of the challenge-based authentication flow.

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Only invalidate the `BearerTokenAuthenticationPolicy` token cache if the policy is not part of the challenge-based authentication flow.
+
 ### Other Changes
 
 ## 1.14.1 (2024-11-01)

--- a/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
+++ b/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
@@ -111,7 +111,10 @@ void BearerTokenAuthenticationPolicy::AuthenticateAndAuthorizeRequest(
           m_accessToken, m_accessTokenContext, currentTime, tokenRequestContext, m_invalidateToken))
   {
     TokenRequestContext trcCopy = tokenRequestContext;
-    if (m_invalidateToken)
+
+    // Only invalidate the token cache if this policy isn't part of the challenged based auth flow.
+    if (m_invalidateToken && trcCopy.TenantId == m_tokenRequestContext.TenantId
+        && trcCopy.Scopes == m_tokenRequestContext.Scopes)
     {
       // Need to set this to invalidate the credential's token cache to ensure we fetch a new token
       // on subsequent GetToken calls.

--- a/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
+++ b/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
@@ -112,7 +112,7 @@ void BearerTokenAuthenticationPolicy::AuthenticateAndAuthorizeRequest(
   {
     TokenRequestContext trcCopy = tokenRequestContext;
 
-    // Only invalidate the token cache if this policy isn't part of the challenged based auth flow.
+    // Only invalidate the token cache if this policy isn't part of the challenge-based auth flow.
     if (m_invalidateToken && trcCopy.TenantId == m_tokenRequestContext.TenantId
         && trcCopy.Scopes == m_tokenRequestContext.Scopes)
     {


### PR DESCRIPTION
When the `AuthenticateAndAuthorizeRequest` function gets invoked from ChallengeBasedAuth in KeyVault, tokenRequestContext != m_tokenRequestContext.
When we use stock BearerTokenAuthenticationPolicy , tokenRequestContext == m_tokenRequestContext.