### PR TITLE
Removed builders from AMQP layer to conform to Rust guidelines; Fixed AMQP bug in message sender tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,8 @@ license = "MIT"
 repository = "https://github.com/azure/azure-sdk-for-rust"
 rust-version = "1.76"
 
-
 [workspace.dependencies.azure_core_amqp]
 path = "sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp"
-
 
 [workspace.dependencies]
 azure_core = { version = "0.18" }
@@ -23,9 +21,11 @@ azure_identity = "0.18"
 async-lock = "3.0"
 async-process = "2.0"
 async-std = { version = "1.12", features = ["attributes"] }
+async-stream = { version = "0.3.5" }
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1.0"
+cargo_metadata = "0.18.1"
 cbindgen = "0.26.0"
 clap = { version = "4.4.16", features = ["derive"] }
 dyn-clone = "1.0"
@@ -38,11 +38,13 @@ futures = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 hmac = { version = "0.12" }
 http-types = { version = "2.12", default-features = false }
+log = "0.4"
 oauth2 = { version = "4.0.0", default-features = false }
 once_cell = "1.18"
 openssl = { version = "0.10.46" }
 paste = "1.0"
 pin-project = "1.0"
+proc-macro2 = "1.0.86"
 quick-xml = { version = "0.31", features = ["serialize", "serde-types"] }
 rand = "0.8"
 reqwest = { version = "0.12", features = [
@@ -51,12 +53,14 @@ reqwest = { version = "0.12", features = [
 ], default-features = false }
 rustc_version = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-serde_amqp = { version = "0.12.2", features = ["uuid"] }
+serde_amqp = { version = "0.12", features = ["uuid"] }
 serde_bytes = { version = "0.11" }
 serde_json = "1.0"
 serde_test = "1"
 serial_test = "3.0"
 sha2 = { version = "0.10" }
+syn = { version = "2.0.74", features = ["full"] }
+quote = "1.0.36"
 thiserror = "1.0"
 time = { version = "0.3.10", features = [
     "serde-well-known",
@@ -64,7 +68,6 @@ time = { version = "0.3.10", features = [
     "wasm-bindgen",
 ] }
 tokio = { version = "1.0", default-features = false, features = [
-    "rt-multi-thread",
     "macros",
     "time",
 ] }
@@ -74,4 +77,5 @@ tz-rs = { version = "0.6" }
 url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 
-[workspace.lints]
+[workspace.lints.clippy]
+large_futures = "deny"

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
@@ -134,5 +134,28 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
     builder.reset(raw);
   }
 
+  /**
+   * Invoke a simple Rust AMQP API, checking for error.
+   *
+   * @param api - Flat C API to invoke. The first parameter MUST be a RustCallContext object, the
+   * second parameter must be a Rust client object.
+   * @param amqpObject - Unique Pointer to a Rust AMQP object.
+   * @param args - remaining arguments to the flat C API.
+   *
+   * This function will check the return from the API, and if it is not 0, will throw an exception
+   * with error information from the callContext.
+   *
+   */
+  template <typename Api, typename T, typename... Args>
+  void InvokeAmqpApi(Api& api, T& amqpObject, Args&&... args)
+  {
+    CallContext callContext;
+    auto result = api(callContext.GetCallContext(), amqpObject.get(), std::forward<Args>(args)...);
+    if (result)
+    {
+      throw std::runtime_error("Error processing builder API: " + callContext.GetError());
+    }
+  }
+
 }}}}} // namespace Azure::Core::Amqp::Common::_detail
 #endif // ENABLE_RUST_AMQP

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/runtime_context.hpp
@@ -146,8 +146,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
    * with error information from the callContext.
    *
    */
-  template <typename Api, typename T, typename... Args>
-  void InvokeAmqpApi(Api& api, T& amqpObject, Args&&... args)
+  template <typename Api, typename T, typename H, typename... Args>
+  void InvokeAmqpApi(Api& api, std::unique_ptr<T, H>& amqpObject, Args&&... args)
   {
     CallContext callContext;
     auto result = api(callContext.GetCallContext(), amqpObject.get(), std::forward<Args>(args)...);

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/connection_impl.hpp
@@ -27,8 +27,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using AmqpConnectionImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnection;
   using AmqpConnectionOptionsImplementation
       = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnectionOptions;
-  using AmqpConnectionOptionsBuilderImplementation
-      = Azure::Core::Amqp::RustInterop::_detail::RustAmqpConnectionOptionsBuilder;
 
   template <> struct UniqueHandleHelper<AmqpConnectionImplementation>
   {
@@ -46,15 +44,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         BasicUniqueHandle<AmqpConnectionOptionsImplementation, FreeAmqpConnectionOptions>;
   };
 
-  template <> struct UniqueHandleHelper<AmqpConnectionOptionsBuilderImplementation>
-  {
-    static void FreeAmqpConnectionOptionsBuilder(AmqpConnectionOptionsBuilderImplementation* obj);
-
-    using type = Core::_internal::BasicUniqueHandle<
-        AmqpConnectionOptionsBuilderImplementation,
-        FreeAmqpConnectionOptionsBuilder>;
-  };
-
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
@@ -62,8 +51,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       = UniqueHandle<Azure::Core::Amqp::_detail::AmqpConnectionImplementation>;
   using UniqueAmqpConnectionOptions
       = UniqueHandle<Azure::Core::Amqp::_detail::AmqpConnectionOptionsImplementation>;
-  using UniqueAmqpConnectionOptionsBuilder
-      = UniqueHandle<Azure::Core::Amqp::_detail::AmqpConnectionOptionsBuilderImplementation>;
 
   class ClaimsBasedSecurity;
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/session_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/private/session_impl.hpp
@@ -15,8 +15,6 @@
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using AmqpSessionImplementation = Azure::Core::Amqp::RustInterop::_detail::RustAmqpSession;
   using AmqpSessionOptions = Azure::Core::Amqp::RustInterop::_detail::RustAmqpSessionOptions;
-  using AmqpSessionOptionsBuilder
-      = Azure::Core::Amqp::RustInterop::_detail::RustAmqpSessionOptionsBuilder;
 
   template <> struct UniqueHandleHelper<AmqpSessionImplementation>
   {
@@ -30,19 +28,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     using type = Core::_internal::BasicUniqueHandle<AmqpSessionOptions, FreeAmqpSessionOptions>;
   };
-  template <> struct UniqueHandleHelper<AmqpSessionOptionsBuilder>
-  {
-    static void FreeAmqpSessionOptionsBuilder(AmqpSessionOptionsBuilder* obj);
-
-    using type = Core::_internal::
-        BasicUniqueHandle<AmqpSessionOptionsBuilder, FreeAmqpSessionOptionsBuilder>;
-  };
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   using UniqueAmqpSession = UniqueHandle<AmqpSessionImplementation>;
   using UniqueAmqpSessionOptions = UniqueHandle<AmqpSessionOptions>;
-  using UniqueAmqpSessionOptionsBuilder = UniqueHandle<AmqpSessionOptionsBuilder>;
 
   class SessionFactory final {
   public:

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/session.cpp
@@ -23,12 +23,6 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     amqpsessionoptions_destroy(value);
   }
-  void UniqueHandleHelper<AmqpSessionOptionsBuilder>::FreeAmqpSessionOptionsBuilder(
-      AmqpSessionOptionsBuilder* value)
-  {
-    amqpsessionoptionsbuilder_destroy(value);
-  }
-
 }}}} // namespace Azure::Core::Amqp::_detail
 
 namespace Azure { namespace Core { namespace Amqp { namespace _internal {
@@ -99,34 +93,30 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             ->GetRuntimeContext(),
         context};
 
-    UniqueAmqpSessionOptionsBuilder optionsBuilder{amqpsessionoptionsbuilder_create()};
+    UniqueAmqpSessionOptions sessionOptions{amqpsessionoptions_create()};
 
     if (m_options.MaximumLinkCount.HasValue())
     {
-      InvokeBuilderApi(
-          amqpsessionoptionsbuilder_set_handle_max,
-          optionsBuilder,
-          m_options.MaximumLinkCount.Value());
+      InvokeAmqpApi(
+          amqpsessionoptions_set_handle_max, sessionOptions, m_options.MaximumLinkCount.Value());
     }
     if (m_options.InitialIncomingWindowSize.HasValue())
     {
-      InvokeBuilderApi(
-          amqpsessionoptionsbuilder_set_incoming_window,
-          optionsBuilder,
+      InvokeAmqpApi(
+          amqpsessionoptions_set_incoming_window,
+          sessionOptions,
           m_options.InitialIncomingWindowSize.Value());
     }
     if (m_options.InitialOutgoingWindowSize.HasValue())
     {
-      InvokeBuilderApi(
-          amqpsessionoptionsbuilder_set_outgoing_window,
-          optionsBuilder,
+      InvokeAmqpApi(
+          amqpsessionoptions_set_outgoing_window,
+          sessionOptions,
           m_options.InitialOutgoingWindowSize.Value());
     }
     if (!m_options.DesiredCapabilities.empty())
     {
     }
-    UniqueAmqpSessionOptions sessionOptions{
-        amqpsessionoptionsbuilder_build(optionsBuilder.release())};
     if (amqpsession_begin(
             callContext.GetCallContext(),
             m_session.get(),

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/README.md
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/README.md
@@ -8,7 +8,7 @@ This crate is part of a collection of crates: for more information please refer 
 
 ## Example
 
-```no_run,rust
+```rust,no_run
 use azure_messaging::*;
 
 #[tokio::main]

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/README.md
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/README.md
@@ -8,7 +8,7 @@ This crate is part of a collection of crates: for more information please refer 
 
 ## Example
 
-```rust,no_run
+```rust no_run
 use azure_messaging::*;
 
 #[tokio::main]

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/connection.rs
@@ -15,67 +15,36 @@ type ConnectionImplementation = super::noop::NoopAmqpConnection;
 
 #[derive(Debug, Default, Clone)]
 pub struct AmqpConnectionOptions {
-    pub(crate) max_frame_size: Option<u32>,
-    pub(crate) channel_max: Option<u16>,
-    pub(crate) idle_timeout: Option<Duration>,
-    pub(crate) outgoing_locales: Option<Vec<String>>,
-    pub(crate) incoming_locales: Option<Vec<String>>,
-    pub(crate) offered_capabilities: Option<Vec<AmqpSymbol>>,
-    pub(crate) desired_capabilities: Option<Vec<AmqpSymbol>>,
-    pub(crate) properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-    pub(crate) buffer_size: Option<usize>,
+    pub max_frame_size: Option<u32>,
+    pub channel_max: Option<u16>,
+    pub idle_timeout: Option<Duration>,
+    pub outgoing_locales: Option<Vec<String>>,
+    pub incoming_locales: Option<Vec<String>>,
+    pub offered_capabilities: Option<Vec<AmqpSymbol>>,
+    pub desired_capabilities: Option<Vec<AmqpSymbol>>,
+    pub properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
+    pub buffer_size: Option<usize>,
 }
 
-impl AmqpConnectionOptions {
-    pub fn builder() -> builders::AmqpConnectionOptionsBuilder {
-        builders::AmqpConnectionOptionsBuilder::new()
-    }
-    pub fn max_frame_size(&self) -> Option<u32> {
-        self.max_frame_size
-    }
-    pub fn channel_max(&self) -> Option<u16> {
-        self.channel_max
-    }
-    pub fn idle_timeout(&self) -> Option<Duration> {
-        self.idle_timeout
-    }
-    pub fn outgoing_locales(&self) -> Option<Vec<String>> {
-        self.outgoing_locales.clone()
-    }
-    pub fn incoming_locales(&self) -> Option<Vec<String>> {
-        self.incoming_locales.clone()
-    }
-    pub fn offered_capabilities(&self) -> Option<Vec<AmqpSymbol>> {
-        self.offered_capabilities.clone()
-    }
-    pub fn desired_capabilities(&self) -> Option<Vec<AmqpSymbol>> {
-        self.desired_capabilities.clone()
-    }
-    pub fn properties(&self) -> Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>> {
-        self.properties.clone()
-    }
-    pub fn buffer_size(&self) -> Option<usize> {
-        self.buffer_size
-    }
-}
+impl AmqpConnectionOptions {}
 
 pub trait AmqpConnectionApis {
     fn open(
         &self,
-        name: impl Into<String>,
+        name: String,
         url: Url,
         options: Option<AmqpConnectionOptions>,
     ) -> impl std::future::Future<Output = Result<()>>;
     fn close(&self) -> impl std::future::Future<Output = Result<()>>;
     fn close_with_error(
         &self,
-        condition: impl Into<AmqpSymbol>,
+        condition: AmqpSymbol,
         description: Option<String>,
         info: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
     ) -> impl std::future::Future<Output = Result<()>>;
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct AmqpConnection {
     pub(crate) implementation: ConnectionImplementation,
 }
@@ -83,7 +52,7 @@ pub struct AmqpConnection {
 impl AmqpConnectionApis for AmqpConnection {
     fn open(
         &self,
-        name: impl Into<String>,
+        name: String,
         url: Url,
         options: Option<AmqpConnectionOptions>,
     ) -> impl std::future::Future<Output = Result<()>> {
@@ -94,7 +63,7 @@ impl AmqpConnectionApis for AmqpConnection {
     }
     fn close_with_error(
         &self,
-        condition: impl Into<AmqpSymbol>,
+        condition: AmqpSymbol,
         description: Option<String>,
         info: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
     ) -> impl std::future::Future<Output = Result<()>> {
@@ -111,127 +80,69 @@ impl AmqpConnection {
     }
 }
 
-pub mod builders {
-    use super::*;
-    pub struct AmqpConnectionOptionsBuilder {
-        options: AmqpConnectionOptions,
-    }
-
-    impl AmqpConnectionOptionsBuilder {
-        pub(super) fn new() -> Self {
-            Self {
-                options: Default::default(),
-            }
-        }
-        pub fn build(self) -> AmqpConnectionOptions {
-            self.options
-        }
-        pub fn with_max_frame_size(mut self, max_frame_size: u32) -> Self {
-            self.options.max_frame_size = Some(max_frame_size);
-            self
-        }
-        pub fn with_channel_max(mut self, channel_max: u16) -> Self {
-            self.options.channel_max = Some(channel_max);
-            self
-        }
-        pub fn with_idle_timeout(mut self, idle_timeout: Duration) -> Self {
-            self.options.idle_timeout = Some(idle_timeout);
-            self
-        }
-        pub fn with_outgoing_locales(mut self, outgoing_locales: Vec<String>) -> Self {
-            self.options.outgoing_locales = Some(outgoing_locales);
-            self
-        }
-        pub fn with_incoming_locales(mut self, incoming_locales: Vec<String>) -> Self {
-            self.options.incoming_locales = Some(incoming_locales);
-            self
-        }
-        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.offered_capabilities = Some(offered_capabilities);
-            self
-        }
-        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.desired_capabilities = Some(desired_capabilities);
-            self
-        }
-        pub fn with_properties<K, V>(mut self, properties: impl Into<AmqpOrderedMap<K, V>>) -> Self
-        where
-            K: Into<AmqpSymbol> + Debug + Default + PartialEq,
-            V: Into<AmqpValue> + Debug + Default,
-        {
-            let properties_map: AmqpOrderedMap<K, V> = properties.into();
-            let properties_map = properties_map
-                .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
-                .collect();
-            self.options.properties = Some(properties_map);
-            self
-        }
-        pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
-            self.options.buffer_size = Some(buffer_size);
-            self
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_amqp_connection_builder_with_max_frame_size() {
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_max_frame_size(1024)
-            .build();
-
+    fn test_amqp_connection_options_with_max_frame_size() {
+        let connection_options = AmqpConnectionOptions {
+            max_frame_size: Some(1024),
+            ..Default::default()
+        };
         assert_eq!(connection_options.max_frame_size, Some(1024));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_channel_max() {
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_channel_max(16)
-            .build();
+    fn test_amqp_connection_options_with_channel_max() {
+        let connection_options = AmqpConnectionOptions {
+            channel_max: Some(16),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.channel_max, Some(16));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_idle_timeout() {
+    fn test_amqp_connection_options_with_idle_timeout() {
         let idle_timeout = time::Duration::seconds(60);
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_idle_timeout(idle_timeout)
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            idle_timeout: Some(idle_timeout),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.idle_timeout, Some(idle_timeout));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_outgoing_locales() {
+    fn test_amqp_connection_options_with_outgoing_locales() {
         let outgoing_locales = vec!["en-US".to_string()];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_outgoing_locales(outgoing_locales.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            outgoing_locales: Some(outgoing_locales.clone()),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.outgoing_locales, Some(outgoing_locales));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_incoming_locales() {
+    fn test_amqp_connection_options_with_incoming_locales() {
         let incoming_locales = vec!["en-US".to_string()];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_incoming_locales(incoming_locales.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            incoming_locales: Some(incoming_locales.clone()),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.incoming_locales, Some(incoming_locales));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_offered_capabilities() {
+    fn test_amqp_connection_options_with_offered_capabilities() {
         let offered_capabilities = vec!["capability".into()];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_offered_capabilities(offered_capabilities.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            offered_capabilities: Some(offered_capabilities.clone()),
+            ..Default::default()
+        };
 
         assert_eq!(
             connection_options.offered_capabilities,
@@ -240,11 +151,12 @@ mod tests {
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_desired_capabilities() {
+    fn test_amqp_connection_options_with_desired_capabilities() {
         let desired_capabilities = vec!["capability".into()];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_desired_capabilities(desired_capabilities.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            desired_capabilities: Some(desired_capabilities.clone()),
+            ..Default::default()
+        };
 
         assert_eq!(
             connection_options.desired_capabilities,
@@ -253,11 +165,17 @@ mod tests {
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_properties() {
+    fn test_amqp_connection_options_with_properties() {
         let properties = vec![("key", "value")];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_properties(properties.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            properties: Some(
+                properties
+                    .iter()
+                    .map(|(k, v)| (AmqpSymbol::from(*k), AmqpValue::from(*v)))
+                    .collect(),
+            ),
+            ..Default::default()
+        };
 
         let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
             .into_iter()
@@ -268,28 +186,34 @@ mod tests {
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_buffer_size() {
+    fn test_amqp_connection_options_with_buffer_size() {
         let buffer_size = 1024;
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_buffer_size(buffer_size)
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            buffer_size: Some(buffer_size),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.buffer_size, Some(buffer_size));
     }
 
     #[test]
-    fn test_amqp_connection_builder() {
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_max_frame_size(1024)
-            .with_channel_max(16)
-            .with_idle_timeout(time::Duration::seconds(60))
-            .with_outgoing_locales(vec!["en-US".to_string()])
-            .with_incoming_locales(vec!["en-US".to_string()])
-            .with_offered_capabilities(vec!["capability".into()])
-            .with_desired_capabilities(vec!["capability".into()])
-            .with_properties(vec![("key", "value")])
-            .with_buffer_size(1024)
-            .build();
+    fn test_amqp_connection_options() {
+        let connection_options = AmqpConnectionOptions {
+            max_frame_size: Some(1024),
+            channel_max: Some(16),
+            idle_timeout: Some(time::Duration::seconds(60)),
+            outgoing_locales: Some(vec!["en-US".to_string()]),
+            incoming_locales: Some(vec!["en-US".to_string()]),
+            offered_capabilities: Some(vec!["capability".into()]),
+            desired_capabilities: Some(vec!["capability".into()]),
+            properties: Some(
+                vec![("key", "value")]
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), v.into()))
+                    .collect(),
+            ),
+            buffer_size: Some(1024),
+        };
 
         assert_eq!(connection_options.max_frame_size, Some(1024));
         assert_eq!(connection_options.channel_max, Some(16));

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/connection.rs
@@ -39,7 +39,7 @@ impl Drop for Fe2o3AmqpConnection {
 impl AmqpConnectionApis for Fe2o3AmqpConnection {
     async fn open(
         &self,
-        id: impl Into<String>,
+        id: String,
         url: Url,
         options: Option<AmqpConnectionOptions>,
     ) -> Result<()> {
@@ -133,7 +133,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
     }
     async fn close_with_error(
         &self,
-        condition: impl Into<AmqpSymbol>,
+        condition: AmqpSymbol,
         description: Option<String>,
         info: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
     ) -> Result<()> {
@@ -152,7 +152,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
             .borrow_mut()
             .close_with_error(fe2o3_amqp::types::definitions::Error::new(
                 fe2o3_amqp::types::definitions::ErrorCondition::Custom(
-                    fe2o3_amqp_types::primitives::Symbol::from(condition.into()),
+                    fe2o3_amqp_types::primitives::Symbol::from(condition),
                 ),
                 description,
                 info.map(|i| i.into()),

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/management.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/management.rs
@@ -9,7 +9,6 @@ use crate::{
     session::AmqpSession,
     value::{AmqpOrderedMap, AmqpValue},
 };
-
 use async_std::sync::Mutex;
 use azure_core::{
     auth::AccessToken,
@@ -40,7 +39,7 @@ impl Drop for Fe2o3AmqpManagement {
 impl Fe2o3AmqpManagement {
     pub fn new(
         session: AmqpSession,
-        client_node_name: impl Into<String>,
+        client_node_name: String,
         access_token: AccessToken,
     ) -> Result<Self> {
         // Session::get() returns a clone of the underlying session handle.
@@ -48,7 +47,7 @@ impl Fe2o3AmqpManagement {
 
         Ok(Self {
             access_token,
-            client_node_name: client_node_name.into(),
+            client_node_name,
             session,
             management: OnceLock::new(),
         })
@@ -85,7 +84,7 @@ impl AmqpManagementApis for Fe2o3AmqpManagement {
 
     async fn call(
         &self,
-        operation_type: impl Into<String>,
+        operation_type: String,
         application_properties: AmqpOrderedMap<String, AmqpValue>,
     ) -> Result<AmqpOrderedMap<String, AmqpValue>> {
         let mut management = self
@@ -122,19 +121,19 @@ struct WithApplicationPropertiesRequest<'a> {
 
 impl<'a> WithApplicationPropertiesRequest<'a> {
     pub fn new(
-        entity_type: impl Into<String>,
+        entity_type: String,
         access_token: &'a AccessToken,
         application_properties: AmqpOrderedMap<String, AmqpValue>,
     ) -> Self {
         Self {
-            entity_type: entity_type.into(),
+            entity_type,
             access_token,
             application_properties,
         }
     }
 }
 
-impl<'a> fe2o3_amqp_management::Request for WithApplicationPropertiesRequest<'a> {
+impl fe2o3_amqp_management::Request for WithApplicationPropertiesRequest<'_> {
     const OPERATION: &'static str = "READ";
     type Response = ReadResponse;
     type Body = ();

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
@@ -127,7 +127,7 @@ impl From<fe2o3_amqp_types::messaging::ApplicationProperties>
     fn from(application_properties: fe2o3_amqp_types::messaging::ApplicationProperties) -> Self {
         let mut properties = AmqpOrderedMap::<String, AmqpValue>::new();
         for (key, value) in application_properties.0 {
-            properties.insert(key, value);
+            properties.insert(key, value.into());
         }
         AmqpApplicationProperties(properties)
     }
@@ -135,32 +135,27 @@ impl From<fe2o3_amqp_types::messaging::ApplicationProperties>
 
 impl From<fe2o3_amqp_types::messaging::Header> for AmqpMessageHeader {
     fn from(header: fe2o3_amqp_types::messaging::Header) -> Self {
-        println!("Source Header: {:?}", header);
-        let rv = AmqpMessageHeader::builder()
-            .with_durable(header.durable)
-            .with_priority(header.priority.into())
-            .with_time_to_live(
-                header
-                    .ttl
-                    .map(|t| std::time::Duration::from_millis(t as u64)),
-            )
-            .with_first_acquirer(header.first_acquirer)
-            .with_delivery_count(header.delivery_count)
-            .build();
-        println!("Converted Header: {:?}", rv);
-        rv
+        AmqpMessageHeader {
+            durable: header.durable,
+            priority: header.priority.into(),
+            time_to_live: header
+                .ttl
+                .map(|t| std::time::Duration::from_millis(t as u64)),
+            first_acquirer: (header.first_acquirer),
+            delivery_count: (header.delivery_count),
+        }
     }
 }
 
 impl From<AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
     fn from(header: AmqpMessageHeader) -> Self {
-        fe2o3_amqp_types::messaging::Header::builder()
-            .durable(header.durable())
-            .priority(fe2o3_amqp_types::messaging::Priority(header.priority()))
-            .ttl(header.time_to_live().map(|t| t.as_millis() as u32))
-            .first_acquirer(header.first_acquirer())
-            .delivery_count(header.delivery_count())
-            .build()
+        fe2o3_amqp_types::messaging::Header {
+            durable: header.durable,
+            priority: fe2o3_amqp_types::messaging::Priority(header.priority),
+            ttl: header.time_to_live.map(|t| t.as_millis() as u32),
+            first_acquirer: header.first_acquirer,
+            delivery_count: header.delivery_count,
+        }
     }
 }
 
@@ -278,7 +273,7 @@ impl From<fe2o3_amqp_types::messaging::Annotations> for AmqpAnnotations {
     fn from(annotations: fe2o3_amqp_types::messaging::Annotations) -> Self {
         let mut amqp_annotations = AmqpOrderedMap::<AmqpAnnotationKey, AmqpValue>::new();
         for (key, value) in annotations {
-            amqp_annotations.insert(key, value);
+            amqp_annotations.insert(key.into(), value.into());
         }
         AmqpAnnotations(amqp_annotations)
     }
@@ -337,59 +332,48 @@ fn test_message_annotation_conversion() {
 
 impl From<fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
     fn from(properties: fe2o3_amqp_types::messaging::Properties) -> Self {
-        let mut amqp_message_properties_builder = AmqpMessageProperties::builder();
+        let mut amqp_message_properties = AmqpMessageProperties::default();
 
         if let Some(message_id) = properties.message_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_message_id(message_id);
+            amqp_message_properties.message_id = Some(message_id.into());
         }
         if let Some(user_id) = properties.user_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_user_id(user_id.to_vec());
+            amqp_message_properties.user_id = Some(user_id.to_vec());
         }
         if let Some(to) = properties.to {
-            amqp_message_properties_builder = amqp_message_properties_builder.with_to(to);
+            amqp_message_properties.to = Some(to);
         }
         if let Some(subject) = properties.subject {
-            amqp_message_properties_builder = amqp_message_properties_builder.with_subject(subject);
+            amqp_message_properties.subject = Some(subject);
         }
         if let Some(reply_to) = properties.reply_to {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_reply_to(reply_to);
+            amqp_message_properties.reply_to = Some(reply_to);
         }
         if let Some(correlation_id) = properties.correlation_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_correlation_id(correlation_id);
+            amqp_message_properties.correlation_id = Some(correlation_id.into());
         }
         if let Some(content_type) = properties.content_type {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_content_type(content_type);
+            amqp_message_properties.content_type = Some(content_type.into());
         }
         if let Some(content_encoding) = properties.content_encoding {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_content_encoding(content_encoding);
+            amqp_message_properties.content_encoding = Some(content_encoding.into());
         }
         if let Some(absolute_expiry_time) = properties.absolute_expiry_time {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_absolute_expiry_time(absolute_expiry_time);
+            amqp_message_properties.absolute_expiry_time = Some(absolute_expiry_time.into());
         }
         if let Some(creation_time) = properties.creation_time {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_creation_time(creation_time);
+            amqp_message_properties.creation_time = Some(creation_time.into());
         }
         if let Some(group_id) = properties.group_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_group_id(group_id);
+            amqp_message_properties.group_id = Some(group_id);
         }
         if let Some(group_sequence) = properties.group_sequence {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_group_sequence(group_sequence);
+            amqp_message_properties.group_sequence = Some(group_sequence);
         }
         if let Some(reply_to_group_id) = properties.reply_to_group_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_reply_to_group_id(reply_to_group_id);
+            amqp_message_properties.reply_to_group_id = Some(reply_to_group_id);
         }
-        amqp_message_properties_builder.build()
+        amqp_message_properties
     }
 }
 
@@ -397,45 +381,45 @@ impl From<AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
     fn from(properties: AmqpMessageProperties) -> Self {
         let mut properties_builder = fe2o3_amqp_types::messaging::Properties::builder();
 
-        if let Some(message_id) = properties.message_id() {
+        if let Some(message_id) = &properties.message_id {
             properties_builder = properties_builder.message_id(message_id.clone());
         }
-        if let Some(user_id) = properties.user_id() {
+        if let Some(user_id) = &properties.user_id {
             properties_builder = properties_builder.user_id(user_id.clone());
         }
-        if let Some(to) = properties.to() {
+        if let Some(to) = properties.to {
             properties_builder = properties_builder.to(to.clone());
         }
-        if let Some(subject) = properties.subject() {
+        if let Some(subject) = properties.subject {
             properties_builder = properties_builder.subject(subject.clone());
         }
-        if let Some(reply_to) = properties.reply_to() {
+        if let Some(reply_to) = properties.reply_to {
             properties_builder = properties_builder.reply_to(reply_to.clone());
         }
-        if let Some(correlation_id) = properties.correlation_id() {
+        if let Some(correlation_id) = properties.correlation_id {
             properties_builder = properties_builder.correlation_id(correlation_id.clone());
         }
-        if let Some(content_type) = properties.content_type() {
+        if let Some(content_type) = properties.content_type {
             properties_builder = properties_builder.content_type(content_type.clone());
         }
-        if let Some(content_encoding) = properties.content_encoding() {
+        if let Some(content_encoding) = properties.content_encoding {
             properties_builder = properties_builder.content_encoding(content_encoding.clone());
         }
-        if let Some(absolute_expiry_time) = properties.absolute_expiry_time() {
+        if let Some(absolute_expiry_time) = properties.absolute_expiry_time {
             properties_builder =
                 properties_builder.absolute_expiry_time(Some(absolute_expiry_time.clone().into()));
         }
-        if let Some(creation_time) = properties.creation_time() {
+        if let Some(creation_time) = properties.creation_time {
             properties_builder =
                 properties_builder.creation_time(Some(creation_time.clone().into()));
         }
-        if let Some(group_id) = properties.group_id() {
+        if let Some(group_id) = properties.group_id {
             properties_builder = properties_builder.group_id(group_id.clone());
         }
-        if let Some(group_sequence) = properties.group_sequence() {
-            properties_builder = properties_builder.group_sequence(*group_sequence);
+        if let Some(group_sequence) = properties.group_sequence {
+            properties_builder = properties_builder.group_sequence(group_sequence);
         }
-        if let Some(reply_to_group_id) = properties.reply_to_group_id() {
+        if let Some(reply_to_group_id) = properties.reply_to_group_id {
             properties_builder = properties_builder.reply_to_group_id(reply_to_group_id.clone());
         }
         properties_builder.build()
@@ -478,21 +462,21 @@ fn test_properties_conversion() {
         let time_now: std::time::SystemTime =
             std::time::UNIX_EPOCH + std::time::Duration::from_millis(time_now as u64);
 
-        let properties = AmqpMessageProperties::builder()
-            .with_absolute_expiry_time(time_now)
-            .with_content_encoding("content_encoding")
-            .with_content_type("content_type")
-            .with_correlation_id("correlation_id")
-            .with_creation_time(time_now)
-            .with_group_id("group_id")
-            .with_group_sequence(3)
-            .with_message_id("test")
-            .with_reply_to("reply_to")
-            .with_reply_to_group_id("reply_to_group_id")
-            .with_subject("subject")
-            .with_to("to")
-            .with_user_id(vec![1, 2, 3])
-            .build();
+        let properties = AmqpMessageProperties {
+            absolute_expiry_time: Some(time_now.into()),
+            content_encoding: Some(crate::value::AmqpSymbol("content_encoding".to_string())),
+            content_type: Some(crate::value::AmqpSymbol("content_type".to_string())),
+            correlation_id: Some("correlation_id".into()),
+            creation_time: Some(time_now.into()),
+            group_id: Some("group_id".to_string()),
+            group_sequence: Some(3),
+            message_id: Some("test".into()),
+            reply_to: Some("reply_to".to_string()),
+            reply_to_group_id: Some("reply_to_group_id".to_string()),
+            subject: Some("subject".to_string()),
+            to: Some("to".to_string()),
+            user_id: Some(vec![1, 2, 3]),
+        };
 
         let fe2o3_properties: fe2o3_amqp_types::messaging::Properties = properties.clone().into();
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_source.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/message_source.rs
@@ -222,7 +222,7 @@ fn message_source_conversion_fe2o3_amqp() {
 #[test]
 fn message_source_conversion_amqp_fe2o3() {
     let amqp_source = AmqpSource::builder()
-        .with_address("test")
+        .with_address("test".to_string())
         .with_durable(TerminusDurability::UnsettledState)
         .with_expiry_policy(TerminusExpiryPolicy::SessionEnd)
         .with_timeout(95)

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -521,35 +521,31 @@ mod tests {
                 std::time::UNIX_EPOCH + std::time::Duration::from_millis(timestamp as u64);
 
             let amqp_message = AmqpMessage::builder()
-                .add_application_property("abc", "23 skiddoo")
-                .add_application_property("What?", 29.5)
+                .add_application_property("abc".to_string(), "23 skiddoo")
+                .add_application_property("What?".to_string(), 29.5)
                 .with_body(AmqpValue::from("hello"))
-                .with_properties(
-                    AmqpMessageProperties::builder()
-                        .with_absolute_expiry_time(timestamp)
-                        .with_content_encoding(AmqpSymbol::from("utf-8"))
-                        .with_content_type(AmqpSymbol::from("text/plain"))
-                        .with_correlation_id("abc")
-                        .with_creation_time(timestamp)
-                        .with_group_id(AmqpSymbol::from("group"))
-                        .with_group_sequence(5)
-                        .with_message_id("message")
-                        .with_reply_to(AmqpSymbol::from("reply"))
-                        .with_reply_to_group_id(AmqpSymbol::from("reply_group"))
-                        .with_subject(AmqpSymbol::from("subject"))
-                        .with_to(AmqpSymbol::from("to"))
-                        .with_user_id(vec![39, 20, 54])
-                        .build(),
-                )
-                .with_header(
-                    AmqpMessageHeader::builder()
-                        .with_delivery_count(95)
-                        .with_first_acquirer(true)
-                        .with_durable(true)
-                        .with_time_to_live(Some(std::time::Duration::from_millis(1000)))
-                        .with_priority(3)
-                        .build(),
-                )
+                .with_properties(AmqpMessageProperties {
+                    absolute_expiry_time: Some(timestamp.into()),
+                    content_encoding: Some(AmqpSymbol::from("utf-8")),
+                    content_type: Some(AmqpSymbol::from("text/plain")),
+                    correlation_id: Some("abc".into()),
+                    creation_time: Some(timestamp.into()),
+                    group_id: Some("group".to_string()),
+                    group_sequence: Some(5),
+                    message_id: Some("message".into()),
+                    reply_to: Some("reply".to_string()),
+                    reply_to_group_id: Some("reply_group".to_string()),
+                    subject: Some("subject".to_string()),
+                    to: Some("to".to_string()),
+                    user_id: Some(vec![39, 20, 54]),
+                })
+                .with_header(AmqpMessageHeader {
+                    delivery_count: 95,
+                    first_acquirer: true,
+                    durable: true,
+                    time_to_live: Some(std::time::Duration::from_millis(1000)),
+                    priority: 3,
+                })
                 .with_delivery_annotations(AmqpAnnotations::from(vec![
                     (AmqpAnnotationKey::from(93), 123),
                     (AmqpAnnotationKey::from(128), 95),

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/receiver.rs
@@ -12,7 +12,7 @@ use std::borrow::BorrowMut;
 use std::sync::{Arc, OnceLock};
 use tracing::trace;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct Fe2o3AmqpReceiver {
     receiver: OnceLock<Arc<Mutex<fe2o3_amqp::Receiver>>>,
 }
@@ -42,10 +42,10 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             .into());
         }
         let options = options.unwrap_or_default();
-        let name = options.name().clone().unwrap_or_default();
-        let credit_mode = options.credit_mode().clone().unwrap_or_default();
-        let auto_accept = options.auto_accept();
-        let properties = options.properties().clone().unwrap_or_default();
+        let name = options.name.unwrap_or_default();
+        let credit_mode = options.credit_mode.clone().unwrap_or_default();
+        let auto_accept = options.auto_accept;
+        let properties = options.properties.clone().unwrap_or_default();
         let source = source.into();
 
         let receiver = fe2o3_amqp::Receiver::builder()
@@ -84,7 +84,6 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             .max_message_size())
     }
 
-    #[tracing::instrument]
     async fn receive(&self) -> Result<AmqpMessage> {
         let mut receiver = self
             .receiver

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/fe2o3/sender.rs
@@ -2,6 +2,10 @@
 // Licensed under the MIT license.
 //cspell: words amqp
 
+use super::error::{
+    AmqpDeliveryRejected, AmqpLinkDetach, AmqpNotAccepted, AmqpSenderAttach, AmqpSenderSend,
+    Fe2o3AmqpError,
+};
 use crate::messaging::{AmqpMessage, AmqpTarget};
 use crate::sender::{AmqpSendOptions, AmqpSenderApis, AmqpSenderOptions};
 use crate::session::AmqpSession;
@@ -9,13 +13,9 @@ use async_std::sync::Mutex;
 use azure_core::Result;
 use std::borrow::BorrowMut;
 use std::sync::OnceLock;
+use tracing::{info, warn};
 
-use super::error::{
-    AmqpDeliveryRejected, AmqpLinkDetach, AmqpNotAccepted, AmqpSenderAttach, AmqpSenderSend,
-    Fe2o3AmqpError,
-};
-
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct Fe2o3AmqpSender {
     sender: OnceLock<Mutex<fe2o3_amqp::Sender>>,
 }
@@ -24,7 +24,7 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
     async fn attach(
         &self,
         session: &AmqpSession,
-        name: impl Into<String>,
+        name: String,
         target: impl Into<AmqpTarget>,
         options: Option<AmqpSenderOptions>,
     ) -> Result<()> {
@@ -63,7 +63,7 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
             }
         }
         let sender = session_builder
-            .name(name.into())
+            .name(name)
             .target(target.into())
             .attach(session.implementation.get()?.lock().await.borrow_mut())
             .await
@@ -84,12 +84,24 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
                 "Message Sender not set.",
             )
         })?;
-        sender
+        let res = sender
             .into_inner()
             .detach()
             .await
-            .map_err(|e| AmqpLinkDetach::from(e.1))?;
-        Ok(())
+            .map_err(|e| AmqpLinkDetach::from(e.1));
+        match res {
+            Ok(_) => Ok(()),
+            Err(e) => match e.0 {
+                fe2o3_amqp::link::DetachError::ClosedByRemote => {
+                    info!("Error detaching sender: {:?}", e);
+                    Ok(())
+                }
+                _ => {
+                    warn!("Error detaching sender: {:?}", e);
+                    Err(e.into())
+                }
+            },
+        }
     }
 
     fn max_message_size(&self) -> azure_core::Result<Option<u64>> {
@@ -106,7 +118,6 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
             .max_message_size())
     }
 
-    #[tracing::instrument]
     async fn send(
         &self,
         message: impl Into<AmqpMessage> + std::fmt::Debug,

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/management.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/management.rs
@@ -7,7 +7,6 @@ use super::{
     value::{AmqpOrderedMap, AmqpValue},
 };
 use azure_core::{auth::AccessToken, error::Result};
-use std::fmt::Debug;
 
 #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]
 type ManagementImplementation = super::fe2o3::management::Fe2o3AmqpManagement;
@@ -22,12 +21,11 @@ pub trait AmqpManagementApis {
     #[allow(unused_variables)]
     fn call(
         &self,
-        operation_type: impl Into<String>,
+        operation_type: String,
         application_properties: AmqpOrderedMap<String, AmqpValue>,
     ) -> impl std::future::Future<Output = Result<AmqpOrderedMap<String, AmqpValue>>>;
 }
 
-#[derive(Debug)]
 pub struct AmqpManagement {
     implementation: ManagementImplementation,
 }
@@ -41,7 +39,7 @@ impl AmqpManagementApis for AmqpManagement {
     }
     async fn call(
         &self,
-        operation_type: impl Into<String>,
+        operation_type: String,
         application_properties: AmqpOrderedMap<String, AmqpValue>,
     ) -> Result<AmqpOrderedMap<String, AmqpValue>> {
         self.implementation
@@ -53,7 +51,7 @@ impl AmqpManagementApis for AmqpManagement {
 impl AmqpManagement {
     pub fn new(
         session: AmqpSession,
-        client_node_name: impl Into<String>,
+        client_node_name: String,
         access_token: AccessToken,
     ) -> Result<Self> {
         Ok(Self {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/messaging.rs
@@ -523,13 +523,14 @@ impl From<AmqpSource> for AmqpList {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AmqpMessageHeader {
-    durable: bool,
-    priority: u8,
-    time_to_live: Option<std::time::Duration>,
-    first_acquirer: bool,
-    delivery_count: u32,
+    pub durable: bool,
+    pub priority: u8,
+    pub time_to_live: Option<std::time::Duration>,
+    pub first_acquirer: bool,
+    pub delivery_count: u32,
 }
 
+// The AMQP protocol specification
 impl Default for AmqpMessageHeader {
     fn default() -> Self {
         Self {
@@ -542,31 +543,7 @@ impl Default for AmqpMessageHeader {
     }
 }
 
-impl AmqpMessageHeader {
-    pub fn builder() -> builders::AmqpMessageHeaderBuilder {
-        builders::AmqpMessageHeaderBuilder::new()
-    }
-
-    pub fn durable(&self) -> bool {
-        self.durable
-    }
-
-    pub fn priority(&self) -> u8 {
-        self.priority
-    }
-
-    pub fn time_to_live(&self) -> Option<&std::time::Duration> {
-        self.time_to_live.as_ref()
-    }
-
-    pub fn first_acquirer(&self) -> bool {
-        self.first_acquirer
-    }
-
-    pub fn delivery_count(&self) -> u32 {
-        self.delivery_count
-    }
-}
+impl AmqpMessageHeader {}
 
 /// Extract an AmqpMessageHeader from an AmqpList.
 ///
@@ -579,36 +556,34 @@ impl AmqpMessageHeader {
 #[cfg(feature = "cplusplus")]
 impl From<AmqpList> for AmqpMessageHeader {
     fn from(list: AmqpList) -> Self {
-        let mut builder = AmqpMessageHeader::builder();
+        let mut header = AmqpMessageHeader::default();
         let field_count = list.len();
         if field_count >= 1 {
             if let Some(AmqpValue::Boolean(durable)) = list.0.first() {
-                builder = builder.with_durable(*durable);
+                header.durable = *durable;
             }
         }
         if field_count >= 2 {
             if let Some(AmqpValue::UByte(priority)) = list.0.get(1) {
-                builder = builder.with_priority(*priority);
+                header.priority = *priority;
             }
         }
         if field_count >= 3 {
             if let Some(AmqpValue::UInt(time_to_live)) = list.0.get(2) {
-                builder = builder.with_time_to_live(Some(std::time::Duration::from_millis(
-                    *time_to_live as u64,
-                )));
+                header.time_to_live = Some(std::time::Duration::from_millis(*time_to_live as u64));
             }
         }
         if field_count >= 4 {
             if let Some(AmqpValue::Boolean(first_acquirer)) = list.0.get(3) {
-                builder = builder.with_first_acquirer(*first_acquirer);
+                header.first_acquirer = *first_acquirer;
             }
         }
         if field_count >= 5 {
             if let Some(AmqpValue::UInt(delivery_count)) = list.0.get(4) {
-                builder = builder.with_delivery_count(*delivery_count);
+                header.delivery_count = *delivery_count;
             }
         }
-        builder.build()
+        header
     }
 }
 
@@ -621,7 +596,7 @@ impl From<AmqpMessageHeader> for AmqpList {
         // value if there are other values to serialize.
 
         if header.durable {
-            list[0] = AmqpValue::Boolean(header.durable())
+            list[0] = AmqpValue::Boolean(header.durable)
         };
         if header.priority != 4 {
             list[1] = AmqpValue::UByte(header.priority)
@@ -650,82 +625,22 @@ impl From<AmqpMessageHeader> for AmqpList {
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct AmqpMessageProperties {
-    message_id: Option<AmqpMessageId>,
-    user_id: Option<Vec<u8>>,
-    to: Option<String>,
-    subject: Option<String>,
-    reply_to: Option<String>,
-    correlation_id: Option<AmqpMessageId>,
-    content_type: Option<AmqpSymbol>,
-    content_encoding: Option<AmqpSymbol>,
-    absolute_expiry_time: Option<AmqpTimestamp>,
-    creation_time: Option<AmqpTimestamp>,
-    group_id: Option<String>,
-    group_sequence: Option<u32>,
-    reply_to_group_id: Option<String>,
+    pub message_id: Option<AmqpMessageId>,
+    pub user_id: Option<Vec<u8>>,
+    pub to: Option<String>,
+    pub subject: Option<String>,
+    pub reply_to: Option<String>,
+    pub correlation_id: Option<AmqpMessageId>,
+    pub content_type: Option<AmqpSymbol>,
+    pub content_encoding: Option<AmqpSymbol>,
+    pub absolute_expiry_time: Option<AmqpTimestamp>,
+    pub creation_time: Option<AmqpTimestamp>,
+    pub group_id: Option<String>,
+    pub group_sequence: Option<u32>,
+    pub reply_to_group_id: Option<String>,
 }
 
-impl AmqpMessageProperties {
-    pub fn builder() -> builders::AmqpMessagePropertiesBuilder {
-        builders::AmqpMessagePropertiesBuilder::new()
-    }
-
-    pub fn message_id(&self) -> Option<&AmqpMessageId> {
-        self.message_id.as_ref()
-    }
-
-    pub fn user_id(&self) -> Option<&Vec<u8>> {
-        self.user_id.as_ref()
-    }
-
-    pub fn to(&self) -> Option<&String> {
-        self.to.as_ref()
-    }
-
-    pub fn subject(&self) -> Option<&String> {
-        self.subject.as_ref()
-    }
-
-    pub fn reply_to(&self) -> Option<&String> {
-        self.reply_to.as_ref()
-    }
-
-    pub fn correlation_id(&self) -> Option<&AmqpMessageId> {
-        self.correlation_id.as_ref()
-    }
-
-    pub fn content_type(&self) -> Option<&AmqpSymbol> {
-        self.content_type.as_ref()
-    }
-
-    pub fn content_encoding(&self) -> Option<&AmqpSymbol> {
-        self.content_encoding.as_ref()
-    }
-
-    pub fn absolute_expiry_time(&self) -> Option<&AmqpTimestamp> {
-        self.absolute_expiry_time.as_ref()
-    }
-
-    pub fn creation_time(&self) -> Option<&AmqpTimestamp> {
-        self.creation_time.as_ref()
-    }
-
-    pub fn group_id(&self) -> Option<&String> {
-        self.group_id.as_ref()
-    }
-
-    pub fn group_sequence(&self) -> Option<&u32> {
-        self.group_sequence.as_ref()
-    }
-
-    pub fn reply_to_group_id(&self) -> Option<&String> {
-        self.reply_to_group_id.as_ref()
-    }
-
-    pub fn set_message_id(&mut self, message_id: impl Into<AmqpMessageId>) {
-        self.message_id = Some(message_id.into());
-    }
-}
+impl AmqpMessageProperties {}
 
 /// Extract an AmqpMessageProperties from an AmqpList.
 ///
@@ -738,101 +653,100 @@ impl AmqpMessageProperties {
 #[cfg(feature = "cplusplus")]
 impl From<AmqpList> for AmqpMessageProperties {
     fn from(list: AmqpList) -> Self {
-        let mut builder = AmqpMessageProperties::builder();
+        let mut message_properties = AmqpMessageProperties::default();
         let field_count = list.len();
         if field_count >= 1 {
             match &list.0[0] {
                 AmqpValue::ULong(message_id) => {
-                    builder = builder.with_message_id(AmqpMessageId::Ulong(*message_id));
+                    message_properties.message_id = Some(AmqpMessageId::Ulong(*message_id));
                 }
                 AmqpValue::Uuid(message_id) => {
-                    builder = builder.with_message_id(AmqpMessageId::Uuid(*message_id));
+                    message_properties.message_id = Some(AmqpMessageId::Uuid(*message_id));
                 }
                 AmqpValue::Binary(message_id) => {
-                    builder = builder.with_message_id(AmqpMessageId::Binary(message_id.clone()));
+                    message_properties.message_id = Some(AmqpMessageId::Binary(message_id.clone()));
                 }
                 AmqpValue::String(message_id) => {
-                    builder = builder.with_message_id(AmqpMessageId::String(message_id.clone()));
+                    message_properties.message_id = Some(AmqpMessageId::String(message_id.clone()));
                 }
                 _ => {}
             }
         }
         if field_count >= 2 {
             if let AmqpValue::Binary(user_id) = &list.0[1] {
-                builder = builder.with_user_id(user_id.clone());
+                message_properties.user_id = Some(user_id.clone());
             }
         }
         if field_count >= 3 {
             if let AmqpValue::String(to) = &list.0[2] {
-                builder = builder.with_to(to.clone());
+                message_properties.to = Some(to.clone());
             }
         }
         if field_count >= 4 {
             if let AmqpValue::String(subject) = &list.0[3] {
-                builder = builder.with_subject(subject.clone());
+                message_properties.subject = Some(subject.clone());
             }
         }
         if field_count >= 5 {
             if let AmqpValue::String(reply_to) = &list.0[4] {
-                builder = builder.with_reply_to(reply_to.clone());
+                message_properties.reply_to = Some(reply_to.clone());
             }
         }
         if field_count >= 6 {
             match &list.0[5] {
                 AmqpValue::ULong(correlation_id) => {
-                    builder = builder.with_correlation_id(AmqpMessageId::Ulong(*correlation_id));
+                    message_properties.correlation_id = Some(AmqpMessageId::Ulong(*correlation_id));
                 }
                 AmqpValue::Uuid(correlation_id) => {
-                    builder = builder.with_correlation_id(AmqpMessageId::Uuid(*correlation_id));
+                    message_properties.correlation_id = Some(AmqpMessageId::Uuid(*correlation_id));
                 }
                 AmqpValue::Binary(correlation_id) => {
-                    builder =
-                        builder.with_correlation_id(AmqpMessageId::Binary(correlation_id.clone()));
+                    message_properties.correlation_id =
+                        Some(AmqpMessageId::Binary(correlation_id.clone()));
                 }
                 AmqpValue::String(correlation_id) => {
-                    builder =
-                        builder.with_correlation_id(AmqpMessageId::String(correlation_id.clone()));
+                    message_properties.correlation_id =
+                        Some(AmqpMessageId::String(correlation_id.clone()));
                 }
                 _ => {}
             }
         }
         if field_count >= 7 {
             if let AmqpValue::Symbol(content_type) = &list.0[6] {
-                builder = builder.with_content_type(content_type.clone());
+                message_properties.content_type = Some(content_type.clone());
             }
         }
         if field_count >= 8 {
             if let AmqpValue::Symbol(content_encoding) = &list.0[7] {
-                builder = builder.with_content_encoding(content_encoding.clone());
+                message_properties.content_encoding = Some(content_encoding.clone());
             }
         }
         if field_count >= 9 {
             if let AmqpValue::TimeStamp(absolute_expiry_time) = &list.0[8] {
-                builder = builder.with_absolute_expiry_time(absolute_expiry_time.clone());
+                message_properties.absolute_expiry_time = Some(absolute_expiry_time.clone());
             }
         }
         if field_count >= 10 {
             if let AmqpValue::TimeStamp(creation_time) = &list.0[9] {
-                builder = builder.with_creation_time(creation_time.clone());
+                message_properties.creation_time = Some(creation_time.clone());
             }
         }
         if field_count >= 11 {
             if let AmqpValue::String(group_id) = &list.0[10] {
-                builder = builder.with_group_id(group_id.clone());
+                message_properties.group_id = Some(group_id.clone());
             }
         }
         if field_count >= 12 {
             if let AmqpValue::UInt(group_sequence) = &list.0[11] {
-                builder = builder.with_group_sequence(*group_sequence);
+                message_properties.group_sequence = Some(*group_sequence);
             }
         }
         if field_count >= 13 {
             if let AmqpValue::String(reply_to_group_id) = &list.0[12] {
-                builder = builder.with_reply_to_group_id(reply_to_group_id.clone());
+                message_properties.reply_to_group_id = Some(reply_to_group_id.clone());
             }
         }
-
-        builder.build()
+        message_properties
     }
 }
 
@@ -1033,9 +947,9 @@ where
     V: Into<AmqpValue>,
 {
     fn from(vec: Vec<(K, V)>) -> Self {
-        let mut map = AmqpOrderedMap::new();
+        let mut map: AmqpOrderedMap<AmqpAnnotationKey, AmqpValue> = AmqpOrderedMap::new();
         for (k, v) in vec {
-            map.insert(k, v);
+            map.insert(k.into(), v.into());
         }
         AmqpAnnotations(map)
     }
@@ -1049,12 +963,13 @@ impl AmqpApplicationProperties {
         AmqpApplicationProperties(AmqpOrderedMap::new())
     }
 
-    pub fn insert(&mut self, key: impl Into<String>, value: impl Into<AmqpValue>) {
-        self.0.insert(key.into(), value.into());
+    pub fn insert(&mut self, key: String, value: impl Into<AmqpValue>) {
+        self.0.insert(key, value.into());
     }
 }
 
-/// An AMQP message
+/// An AMQP message.
+///
 /// This is a simplified version of the AMQP message
 /// that is used in the Azure SDK for Event Hubs
 /// and is not a complete implementation of the AMQP message
@@ -1125,14 +1040,13 @@ impl AmqpMessage {
     ///
     pub fn set_message_id(&mut self, message_id: impl Into<AmqpMessageId>) {
         if let Some(properties) = self.properties.as_mut() {
-            properties.set_message_id(message_id);
+            properties.message_id = Some(message_id.into());
             self.properties = Some(properties.clone());
         } else {
-            self.properties = Some(
-                AmqpMessageProperties::builder()
-                    .with_message_id(message_id)
-                    .build(),
-            );
+            self.properties = Some(AmqpMessageProperties {
+                message_id: Some(message_id.into()),
+                ..Default::default()
+            });
         }
     }
 
@@ -1147,21 +1061,18 @@ impl AmqpMessage {
     /// # Examples
     /// ```
     /// use azure_core_amqp::messaging::AmqpMessage;
+    /// use azure_core_amqp::value::AmqpSymbol;
     /// let mut message = AmqpMessage::default();
-    /// message.add_message_annotation("key", "value");
+    /// message.add_message_annotation(AmqpSymbol::from("key"), "value");
     /// ```
     ///
-    pub fn add_message_annotation(
-        &mut self,
-        name: impl Into<AmqpSymbol>,
-        value: impl Into<AmqpValue>,
-    ) {
+    pub fn add_message_annotation(&mut self, name: AmqpSymbol, value: impl Into<AmqpValue>) {
         if let Some(annotations) = self.message_annotations.as_mut() {
-            annotations.insert(name.into(), value.into());
+            annotations.insert(name, value.into());
             self.message_annotations = Some(annotations.clone());
         } else {
             let mut annotations = AmqpAnnotations::new();
-            annotations.insert(name.into(), value.into());
+            annotations.insert(name, value.into());
             self.message_annotations = Some(annotations);
         }
     }
@@ -1281,8 +1192,8 @@ pub mod builders {
                 source: Default::default(),
             }
         }
-        pub fn with_address(mut self, address: impl Into<String>) -> Self {
-            self.source.address = Some(address.into());
+        pub fn with_address(mut self, address: String) -> Self {
+            self.source.address = Some(address);
             self
         }
         pub fn with_durable(mut self, durable: TerminusDurability) -> Self {
@@ -1319,16 +1230,12 @@ pub mod builders {
             self.source.filter = Some(filter.into());
             self
         }
-        pub fn add_to_filter(
-            mut self,
-            key: impl Into<AmqpSymbol>,
-            value: impl Into<AmqpValue>,
-        ) -> Self {
+        pub fn add_to_filter(mut self, key: AmqpSymbol, value: impl Into<AmqpValue>) -> Self {
             if let Some(filter) = &mut self.source.filter {
-                filter.insert(key.into(), value.into());
+                filter.insert(key, value.into());
             } else {
                 let mut filter = AmqpOrderedMap::new();
-                filter.insert(key.into(), value.into());
+                filter.insert(key, value.into());
                 self.source.filter = Some(filter);
             }
             self
@@ -1363,8 +1270,8 @@ pub mod builders {
                 target: Default::default(),
             }
         }
-        pub fn with_address(mut self, address: impl Into<String>) -> Self {
-            self.target.address = Some(address.into());
+        pub fn with_address(mut self, address: String) -> Self {
+            self.target.address = Some(address);
             self
         }
         pub fn with_durable(mut self, durable: TerminusDurability) -> Self {
@@ -1392,111 +1299,6 @@ pub mod builders {
         }
         pub fn with_capabilities(mut self, capabilities: Vec<AmqpValue>) -> Self {
             self.target.capabilities = Some(capabilities);
-            self
-        }
-    }
-
-    pub struct AmqpMessageHeaderBuilder {
-        header: AmqpMessageHeader,
-    }
-
-    impl AmqpMessageHeaderBuilder {
-        pub fn build(&self) -> AmqpMessageHeader {
-            self.header.clone()
-        }
-        pub(super) fn new() -> AmqpMessageHeaderBuilder {
-            AmqpMessageHeaderBuilder {
-                header: Default::default(),
-            }
-        }
-        pub fn with_durable(mut self, durable: bool) -> Self {
-            self.header.durable = durable;
-            self
-        }
-        pub fn with_priority(mut self, priority: u8) -> Self {
-            self.header.priority = priority;
-            self
-        }
-        pub fn with_time_to_live(mut self, time_to_live: Option<std::time::Duration>) -> Self {
-            self.header.time_to_live = time_to_live;
-            self
-        }
-        pub fn with_first_acquirer(mut self, first_acquirer: bool) -> Self {
-            self.header.first_acquirer = first_acquirer;
-            self
-        }
-        pub fn with_delivery_count(mut self, delivery_count: u32) -> Self {
-            self.header.delivery_count = delivery_count;
-            self
-        }
-    }
-
-    pub struct AmqpMessagePropertiesBuilder {
-        properties: AmqpMessageProperties,
-    }
-
-    impl AmqpMessagePropertiesBuilder {
-        pub fn build(&self) -> AmqpMessageProperties {
-            self.properties.clone()
-        }
-        pub(super) fn new() -> AmqpMessagePropertiesBuilder {
-            AmqpMessagePropertiesBuilder {
-                properties: Default::default(),
-            }
-        }
-        pub fn with_message_id(mut self, message_id: impl Into<AmqpMessageId>) -> Self {
-            self.properties.message_id = Some(message_id.into());
-            self
-        }
-        pub fn with_user_id(mut self, user_id: impl Into<Vec<u8>>) -> Self {
-            self.properties.user_id = Some(user_id.into());
-            self
-        }
-        pub fn with_to(mut self, to: impl Into<String>) -> Self {
-            self.properties.to = Some(to.into());
-            self
-        }
-        pub fn with_subject(mut self, subject: impl Into<String>) -> Self {
-            self.properties.subject = Some(subject.into());
-            self
-        }
-        pub fn with_reply_to(mut self, reply_to: impl Into<String>) -> Self {
-            self.properties.reply_to = Some(reply_to.into());
-            self
-        }
-        pub fn with_correlation_id(mut self, correlation_id: impl Into<AmqpMessageId>) -> Self {
-            self.properties.correlation_id = Some(correlation_id.into());
-            self
-        }
-        pub fn with_content_type(mut self, content_type: impl Into<AmqpSymbol>) -> Self {
-            self.properties.content_type = Some(content_type.into());
-            self
-        }
-        pub fn with_content_encoding(mut self, content_encoding: impl Into<AmqpSymbol>) -> Self {
-            self.properties.content_encoding = Some(content_encoding.into());
-            self
-        }
-        pub fn with_absolute_expiry_time(
-            mut self,
-            absolute_expiry_time: impl Into<AmqpTimestamp>,
-        ) -> Self {
-            self.properties.absolute_expiry_time = Some(absolute_expiry_time.into());
-            self
-        }
-        pub fn with_creation_time(mut self, creation_time: impl Into<AmqpTimestamp>) -> Self {
-            self.properties.creation_time = Some(creation_time.into());
-            self
-        }
-        pub fn with_group_id(mut self, group_id: impl Into<String>) -> Self {
-            self.properties.group_id = Some(group_id.into());
-            self
-        }
-        pub fn with_group_sequence(mut self, group_sequence: u32) -> Self {
-            self.properties.group_sequence = Some(group_sequence);
-            self
-        }
-        pub fn with_reply_to_group_id(mut self, reply_to_group_id: impl Into<String>) -> Self {
-            self.properties.reply_to_group_id = Some(reply_to_group_id.into());
             self
         }
     }
@@ -1559,14 +1361,14 @@ pub mod builders {
         }
         pub fn add_application_property(
             mut self,
-            key: impl Into<String>,
+            key: String,
             value: impl Into<AmqpValue>,
         ) -> Self {
             if let Some(application_properties) = &mut self.message.application_properties {
-                application_properties.0.insert(key.into(), value.into());
+                application_properties.0.insert(key, value.into());
             } else {
                 let mut application_properties = AmqpOrderedMap::new();
-                application_properties.insert(key.into(), value.into());
+                application_properties.insert(key, value.into());
                 self.message.application_properties =
                     Some(AmqpApplicationProperties(application_properties));
             }
@@ -1602,14 +1404,13 @@ mod tests {
 
     #[test]
     fn test_amqp_message_header_builder() {
-        let header = AmqpMessageHeader::builder()
-            .with_durable(true)
-            .with_priority(5)
-            .with_time_to_live(Some(std::time::Duration::from_millis(1000)))
-            .with_first_acquirer(false)
-            .with_delivery_count(3)
-            .build();
-
+        let header = AmqpMessageHeader {
+            durable: true,
+            priority: 5,
+            time_to_live: Some(std::time::Duration::from_millis(1000)),
+            first_acquirer: false,
+            delivery_count: 3,
+        };
         assert!(header.durable);
         assert_eq!(header.priority, 5);
         assert_eq!(
@@ -1649,21 +1450,21 @@ mod tests {
         let time_now = SystemTime::now();
         let test_uuid1 = Uuid::new_v4();
         let test_uuid2 = Uuid::new_v4();
-        let properties = AmqpMessageProperties::builder()
-            .with_message_id(test_uuid1)
-            .with_user_id(vec![1, 2, 3])
-            .with_to("destination".to_string())
-            .with_subject("subject")
-            .with_reply_to("reply_to".to_string())
-            .with_correlation_id(test_uuid2)
-            .with_content_type("content_type")
-            .with_content_encoding(AmqpSymbol::from("content_encoding"))
-            .with_absolute_expiry_time(time_now)
-            .with_creation_time(time_now)
-            .with_group_id("group_id")
-            .with_group_sequence(1)
-            .with_reply_to_group_id("reply_to_group_id")
-            .build();
+        let properties = AmqpMessageProperties {
+            message_id: Some(test_uuid1.into()),
+            user_id: Some(vec![1, 2, 3]),
+            to: Some("destination".to_string()),
+            subject: Some("subject".to_string()),
+            reply_to: Some("reply_to".to_string()),
+            correlation_id: Some(test_uuid2.into()),
+            content_type: Some(AmqpSymbol::from("content_type")),
+            content_encoding: Some(AmqpSymbol::from("content_encoding")),
+            absolute_expiry_time: Some(time_now.into()),
+            creation_time: Some(time_now.into()),
+            group_id: Some("group_id".to_string()),
+            group_sequence: Some(1),
+            reply_to_group_id: Some("reply_to_group_id".to_string()),
+        };
 
         assert_eq!(properties.message_id, Some(test_uuid1.into()));
         assert_eq!(properties.user_id, Some(vec![1, 2, 3]));
@@ -1693,26 +1494,23 @@ mod tests {
     fn test_amqp_message_builder() {
         let message = AmqpMessage::builder()
             .with_body(AmqpMessageBody::Binary(vec![vec![1, 2, 3]]))
-            .with_header(AmqpMessageHeader::builder().build())
+            .with_header(AmqpMessageHeader::default())
             .with_application_properties(AmqpApplicationProperties::new())
             .add_application_property("key".to_string(), AmqpValue::from(123))
             .with_message_annotations(AmqpAnnotations::new())
             .with_delivery_annotations(AmqpAnnotations::new())
-            .with_properties(AmqpMessageProperties::builder().build())
+            .with_properties(AmqpMessageProperties::default())
             .with_footer(AmqpAnnotations::new())
             .build();
 
         assert_eq!(message.body, AmqpMessageBody::Binary(vec![vec![1, 2, 3]]));
-        assert_eq!(message.header, Some(AmqpMessageHeader::builder().build()));
+        assert_eq!(message.header, Some(AmqpMessageHeader::default()));
         let mut properties = AmqpApplicationProperties::new();
-        properties.insert("key", AmqpValue::from(123));
+        properties.insert("key".to_string(), AmqpValue::from(123));
         assert_eq!(message.application_properties, Some(properties));
         assert_eq!(message.message_annotations, Some(AmqpAnnotations::new()));
         assert_eq!(message.delivery_annotations, Some(AmqpAnnotations::new()));
-        assert_eq!(
-            message.properties,
-            Some(AmqpMessageProperties::builder().build())
-        );
+        assert_eq!(message.properties, Some(AmqpMessageProperties::default()));
         assert_eq!(message.footer, Some(AmqpAnnotations::new()));
     }
 
@@ -1780,7 +1578,7 @@ mod tests {
     #[test]
     fn test_amqp_source_builder() {
         let source = AmqpSource::builder()
-            .with_address("address")
+            .with_address("address".to_string())
             .with_durable(TerminusDurability::Configuration)
             .with_expiry_policy(TerminusExpiryPolicy::ConnectionClose)
             .with_timeout(10)
@@ -1810,7 +1608,7 @@ mod tests {
     #[test]
     fn test_amqp_target_builder() {
         let target = AmqpTarget::builder()
-            .with_address("address")
+            .with_address("address".to_string())
             .with_durable(TerminusDurability::Configuration)
             .with_expiry_policy(TerminusExpiryPolicy::ConnectionClose)
             .with_timeout(10)
@@ -1858,11 +1656,10 @@ mod tests {
         }
         {
             let message = AmqpMessage::builder()
-                .with_header(
-                    AmqpMessageHeader::builder()
-                        .with_time_to_live(Some(std::time::Duration::from_millis(23)))
-                        .build(),
-                )
+                .with_header(AmqpMessageHeader {
+                    time_to_live: (Some(std::time::Duration::from_millis(23))),
+                    ..Default::default()
+                })
                 .build();
             let serialized = AmqpMessage::serialize(&message).unwrap();
 
@@ -2034,13 +1831,15 @@ mod tests {
     #[test]
     fn test_message_with_header_serialization() {
         let message = AmqpMessage::builder()
-            .with_header(AmqpMessageHeader::builder().with_priority(5).build())
+            .with_header(AmqpMessageHeader {
+                priority: 5,
+                ..Default::default()
+            })
             .with_body(AmqpValue::from("String Value Body."))
-            .with_properties(
-                AmqpMessageProperties::builder()
-                    .with_message_id("12345")
-                    .build(),
-            )
+            .with_properties(AmqpMessageProperties {
+                message_id: Some("12345".into()),
+                ..Default::default()
+            })
             .build();
 
         let serialized = AmqpMessage::serialize(&message).unwrap();

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/noop.rs
@@ -16,22 +16,22 @@ use super::{
 use azure_core::{credentials::AccessToken, error::Result};
 use std::marker::PhantomData;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct NoopAmqpConnection {}
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct NoopAmqpManagement {}
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct NoopAmqpSender {}
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct NoopAmqpReceiver {}
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 pub(crate) struct NoopAmqpSession {}
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct NoopAmqpClaimsBasedSecurity<'a> {
     phantom: PhantomData<&'a AmqpSession>,
 }
@@ -44,7 +44,7 @@ impl NoopAmqpConnection {
 impl AmqpConnectionApis for NoopAmqpConnection {
     async fn open(
         &self,
-        name: impl Into<String>,
+        name: String,
         url: azure_core::Url,
         options: Option<AmqpConnectionOptions>,
     ) -> Result<()> {
@@ -56,7 +56,7 @@ impl AmqpConnectionApis for NoopAmqpConnection {
 
     async fn close_with_error(
         &self,
-        condition: impl Into<AmqpSymbol>,
+        condition: AmqpSymbol,
         description: Option<String>,
         info: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
     ) -> Result<()> {
@@ -101,8 +101,9 @@ impl<'a> AmqpClaimsBasedSecurityApis for NoopAmqpClaimsBasedSecurity<'a> {
     }
     async fn authorize_path(
         &self,
-        path: impl Into<String> + std::fmt::Debug,
-        secret: impl Into<String>,
+        path: String,
+        token_type: Option<String>,
+        secret: String,
         expires_on: time::OffsetDateTime,
     ) -> Result<()> {
         unimplemented!()
@@ -110,11 +111,7 @@ impl<'a> AmqpClaimsBasedSecurityApis for NoopAmqpClaimsBasedSecurity<'a> {
 }
 
 impl NoopAmqpManagement {
-    pub fn new(
-        session: AmqpSession,
-        name: impl Into<String>,
-        access_token: AccessToken,
-    ) -> Result<Self> {
+    pub fn new(session: AmqpSession, name: String, access_token: AccessToken) -> Result<Self> {
         Ok(Self {})
     }
 }
@@ -129,7 +126,7 @@ impl AmqpManagementApis for NoopAmqpManagement {
 
     async fn call(
         &self,
-        operation_type: impl Into<String>,
+        operation_type: String,
         application_properties: AmqpOrderedMap<String, AmqpValue>,
     ) -> Result<AmqpOrderedMap<String, AmqpValue>> {
         unimplemented!();
@@ -146,7 +143,7 @@ impl AmqpSenderApis for NoopAmqpSender {
     async fn attach(
         &self,
         session: &AmqpSession,
-        name: impl Into<String>,
+        name: String,
         target: impl Into<AmqpTarget>,
         options: Option<AmqpSenderOptions>,
     ) -> Result<()> {

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/sender.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/sender.rs
@@ -16,27 +16,23 @@ type SenderImplementation = super::noop::NoopAmqpSender;
 
 #[derive(Debug, Default, Clone)]
 pub struct AmqpSenderOptions {
-    pub(super) sender_settle_mode: Option<SenderSettleMode>,
-    pub(super) receiver_settle_mode: Option<ReceiverSettleMode>,
-    pub(super) source: Option<AmqpSource>,
-    pub(super) offered_capabilities: Option<Vec<AmqpSymbol>>,
-    pub(super) desired_capabilities: Option<Vec<AmqpSymbol>>,
-    pub(super) properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-    pub(super) initial_delivery_count: Option<u32>,
-    pub(super) max_message_size: Option<u64>,
+    pub sender_settle_mode: Option<SenderSettleMode>,
+    pub receiver_settle_mode: Option<ReceiverSettleMode>,
+    pub source: Option<AmqpSource>,
+    pub offered_capabilities: Option<Vec<AmqpSymbol>>,
+    pub desired_capabilities: Option<Vec<AmqpSymbol>>,
+    pub properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
+    pub initial_delivery_count: Option<u32>,
+    pub max_message_size: Option<u64>,
 }
-impl AmqpSenderOptions {
-    pub fn builder() -> builders::AmqpSenderOptionsBuilder {
-        builders::AmqpSenderOptionsBuilder::new()
-    }
-}
+impl AmqpSenderOptions {}
 
 #[allow(unused_variables)]
 pub trait AmqpSenderApis {
     fn attach(
         &self,
         session: &AmqpSession,
-        name: impl Into<String>,
+        name: String,
         target: impl Into<AmqpTarget>,
         options: Option<AmqpSenderOptions>,
     ) -> impl std::future::Future<Output = Result<()>>;
@@ -49,7 +45,7 @@ pub trait AmqpSenderApis {
     ) -> impl std::future::Future<Output = Result<()>>;
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct AmqpSender {
     implementation: SenderImplementation,
 }
@@ -58,7 +54,7 @@ impl AmqpSenderApis for AmqpSender {
     async fn attach(
         &self,
         session: &AmqpSession,
-        name: impl Into<String>,
+        name: String,
         target: impl Into<AmqpTarget>,
         options: Option<AmqpSenderOptions>,
     ) -> Result<()> {
@@ -100,105 +96,7 @@ pub struct AmqpSendOptions {
     pub settled: Option<bool>,
 }
 
-impl AmqpSendOptions {
-    pub fn builder() -> builders::AmqpSendOptionsBuilder {
-        builders::AmqpSendOptionsBuilder::new()
-    }
-}
-
-pub mod builders {
-    use super::*;
-
-    pub struct AmqpSendOptionsBuilder {
-        options: AmqpSendOptions,
-    }
-
-    impl AmqpSendOptionsBuilder {
-        pub(super) fn new() -> Self {
-            AmqpSendOptionsBuilder {
-                options: Default::default(),
-            }
-        }
-        #[allow(dead_code)]
-        pub fn with_message_format(mut self, message_format: u32) -> Self {
-            self.options.message_format = Some(message_format);
-            self
-        }
-        #[allow(dead_code)]
-        pub fn with_settled(mut self, settled: bool) -> Self {
-            self.options.settled = Some(settled);
-            self
-        }
-        pub fn build(self) -> Option<AmqpSendOptions> {
-            Some(self.options)
-        }
-    }
-
-    #[derive(Clone)]
-    pub struct AmqpSenderOptionsBuilder {
-        options: AmqpSenderOptions,
-    }
-
-    impl AmqpSenderOptionsBuilder {
-        pub(super) fn new() -> Self {
-            AmqpSenderOptionsBuilder {
-                options: Default::default(),
-            }
-        }
-
-        pub fn with_sender_settle_mode(mut self, sender_settle_mode: SenderSettleMode) -> Self {
-            self.options.sender_settle_mode = Some(sender_settle_mode);
-            self
-        }
-
-        pub fn with_receiver_settle_mode(
-            mut self,
-            receiver_settle_mode: ReceiverSettleMode,
-        ) -> Self {
-            self.options.receiver_settle_mode = Some(receiver_settle_mode);
-            self
-        }
-
-        pub fn with_source(mut self, source: impl Into<AmqpSource>) -> Self {
-            self.options.source = Some(source.into());
-            self
-        }
-        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.offered_capabilities = Some(offered_capabilities);
-            self
-        }
-        #[allow(dead_code)]
-        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.desired_capabilities = Some(desired_capabilities);
-            self
-        }
-
-        pub fn with_properties(
-            mut self,
-            properties: impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-        ) -> Self {
-            let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> =
-                properties.into().iter().collect();
-
-            self.options.properties = Some(properties_map);
-            self
-        }
-
-        pub fn with_initial_delivery_count(mut self, initial_delivery_count: u32) -> Self {
-            self.options.initial_delivery_count = Some(initial_delivery_count);
-            self
-        }
-
-        pub fn with_max_message_size(mut self, max_message_size: u64) -> Self {
-            self.options.max_message_size = Some(max_message_size);
-            self
-        }
-
-        pub fn build(self) -> AmqpSenderOptions {
-            self.options
-        }
-    }
-}
+impl AmqpSendOptions {}
 
 #[cfg(test)]
 mod tests {
@@ -209,19 +107,20 @@ mod tests {
         let mut properties: AmqpOrderedMap<AmqpSymbol, AmqpValue> = AmqpOrderedMap::new();
         properties.insert(AmqpSymbol::from("key"), AmqpValue::from("value"));
 
-        let sender_options = AmqpSenderOptions::builder()
-            .with_sender_settle_mode(SenderSettleMode::Unsettled)
-            .with_sender_settle_mode(SenderSettleMode::Settled)
-            .with_sender_settle_mode(SenderSettleMode::Mixed)
-            .with_receiver_settle_mode(ReceiverSettleMode::Second)
-            .with_receiver_settle_mode(ReceiverSettleMode::First)
-            .with_source(AmqpSource::builder().with_address("address").build())
-            .with_offered_capabilities(vec!["capability".into()])
-            .with_desired_capabilities(vec!["capability".into()])
-            .with_properties(properties)
-            .with_initial_delivery_count(27)
-            .with_max_message_size(1024)
-            .build();
+        let sender_options = AmqpSenderOptions {
+            sender_settle_mode: Some(SenderSettleMode::Mixed),
+            receiver_settle_mode: Some(ReceiverSettleMode::First),
+            source: Some(
+                AmqpSource::builder()
+                    .with_address("address".to_string())
+                    .build(),
+            ),
+            offered_capabilities: Some(vec!["capability".into()]),
+            desired_capabilities: Some(vec!["capability".into()]),
+            properties: Some(properties),
+            initial_delivery_count: Some(27),
+            max_message_size: Some(1024),
+        };
 
         assert_eq!(
             sender_options.sender_settle_mode,

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/session.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/azure_core_amqp/src/session.rs
@@ -17,21 +17,17 @@ type SessionImplementation = super::noop::NoopAmqpSession;
 
 #[derive(Debug, Default, Clone)]
 pub struct AmqpSessionOptions {
-    next_outgoing_id: Option<u32>,
-    incoming_window: Option<u32>,
-    outgoing_window: Option<u32>,
-    handle_max: Option<u32>,
-    offered_capabilities: Option<Vec<AmqpSymbol>>,
-    desired_capabilities: Option<Vec<AmqpSymbol>>,
-    properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-    buffer_size: Option<usize>,
+    pub next_outgoing_id: Option<u32>,
+    pub incoming_window: Option<u32>,
+    pub outgoing_window: Option<u32>,
+    pub handle_max: Option<u32>,
+    pub offered_capabilities: Option<Vec<AmqpSymbol>>,
+    pub desired_capabilities: Option<Vec<AmqpSymbol>>,
+    pub properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
+    pub buffer_size: Option<usize>,
 }
 
 impl AmqpSessionOptions {
-    pub fn builder() -> builders::AmqpSessionOptionsBuilder {
-        builders::AmqpSessionOptionsBuilder::new()
-    }
-
     pub fn next_outgoing_id(&self) -> Option<u32> {
         self.next_outgoing_id
     }
@@ -75,7 +71,7 @@ pub trait AmqpSessionApis {
     fn end(&self) -> impl std::future::Future<Output = Result<()>>;
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct AmqpSession {
     pub(crate) implementation: SessionImplementation,
 }
@@ -102,82 +98,27 @@ impl AmqpSession {
     }
 }
 
-pub mod builders {
-    use super::*;
-
-    pub struct AmqpSessionOptionsBuilder {
-        options: AmqpSessionOptions,
-    }
-
-    impl AmqpSessionOptionsBuilder {
-        pub(super) fn new() -> Self {
-            Self {
-                options: Default::default(),
-            }
-        }
-        pub fn build(&self) -> AmqpSessionOptions {
-            self.options.clone()
-        }
-        pub fn with_next_outgoing_id(mut self, next_outgoing_id: u32) -> Self {
-            self.options.next_outgoing_id = Some(next_outgoing_id);
-            self
-        }
-        pub fn with_incoming_window(mut self, incoming_window: u32) -> Self {
-            self.options.incoming_window = Some(incoming_window);
-            self
-        }
-        pub fn with_outgoing_window(mut self, outgoing_window: u32) -> Self {
-            self.options.outgoing_window = Some(outgoing_window);
-            self
-        }
-        pub fn with_handle_max(mut self, handle_max: u32) -> Self {
-            self.options.handle_max = Some(handle_max);
-            self
-        }
-        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.offered_capabilities = Some(offered_capabilities);
-            self
-        }
-        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.desired_capabilities = Some(desired_capabilities);
-            self
-        }
-        pub fn with_properties<K, V>(mut self, properties: impl Into<AmqpOrderedMap<K, V>>) -> Self
-        where
-            K: Into<AmqpSymbol> + PartialEq + Default + Debug,
-            V: Into<AmqpValue> + Default,
-        {
-            let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
-                .into()
-                .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
-                .collect();
-            self.options.properties = Some(properties_map);
-            self
-        }
-        pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
-            self.options.buffer_size = Some(buffer_size);
-            self
-        }
-    }
-}
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_amqp_session_options_builder() {
-        let session_options = AmqpSessionOptions::builder()
-            .with_next_outgoing_id(1)
-            .with_incoming_window(1)
-            .with_outgoing_window(1)
-            .with_handle_max(1)
-            .with_offered_capabilities(vec!["capability".into()])
-            .with_desired_capabilities(vec!["capability".into()])
-            .with_properties(vec![("key", "value")])
-            .with_buffer_size(1024)
-            .build();
-
+        let session_options = AmqpSessionOptions {
+            next_outgoing_id: Some(1),
+            incoming_window: Some(1),
+            outgoing_window: Some(1),
+            handle_max: Some(1),
+            offered_capabilities: Some(vec!["capability".into()]),
+            desired_capabilities: Some(vec!["capability".into()]),
+            properties: Some(
+                vec![("key", "value")]
+                    .into_iter()
+                    .map(|(k, v)| (AmqpSymbol::from(k), AmqpValue::from(v)))
+                    .collect(),
+            ),
+            buffer_size: Some(1024),
+        };
         assert_eq!(session_options.next_outgoing_id, Some(1));
         assert_eq!(session_options.incoming_window, Some(1));
         assert_eq!(session_options.outgoing_window, Some(1));
@@ -194,7 +135,7 @@ mod tests {
         let properties = session_options.properties.clone().unwrap();
         assert!(properties.contains_key("key"));
         assert_eq!(
-            *properties.get("key").unwrap(),
+            *properties.get(&AmqpSymbol::from("key")).unwrap(),
             AmqpValue::String("value".to_string())
         );
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/Cargo.toml
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/Cargo.toml
@@ -19,7 +19,7 @@ azure_core.workspace = true
 uuid.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 url.workspace = true
 time.workspace = true
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/cbs.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/cbs.rs
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn amqpclaimsbasedsecurity_authorize_path(
     let result = call_context
         .runtime_context()
         .runtime()
-        .block_on(cbs.authorize_path(path, secret, expires_on));
+        .block_on(cbs.authorize_path(path.to_string(), None, secret.to_string(), expires_on));
     if let Err(e) = result {
         error!("Failed to authorize path: {:?}", e);
         call_context.set_error(Box::new(e));
@@ -168,7 +168,7 @@ mod tests {
                 .runtime_context()
                 .runtime()
                 .block_on(connection.open(
-                    "testConnection",
+                    "testConnection".to_string(),
                     url::Url::parse("amqp://localhost:25672").unwrap(),
                     None,
                 ))

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/management.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/management.rs
@@ -44,7 +44,7 @@ impl AmqpManagementApis for RustAmqpManagement {
 
     async fn call(
         &self,
-        operation_type: impl Into<String>,
+        operation_type: String,
         application_properties: AmqpOrderedMap<String, AmqpValue>,
     ) -> Result<AmqpOrderedMap<String, AmqpValue>> {
         self.inner
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn amqpmanagement_create(
         OffsetDateTime::from(UNIX_EPOCH + Duration::from_secs(rust_access_token.expires_on)),
     );
 
-    let management = AmqpManagement::new(session.clone(), name, access_token);
+    let management = AmqpManagement::new(session.clone(), name.to_string(), access_token);
     match management {
         Ok(management) => Box::into_raw(Box::new(RustAmqpManagement::new(management))),
         Err(e) => {
@@ -179,7 +179,7 @@ pub unsafe extern "C" fn amqpmanagement_call(
         let result = call_context.runtime_context().runtime().block_on(
             management
                 .inner
-                .call(operation_type, application_properties),
+                .call(operation_type.to_string(), application_properties),
         );
         if let Err(err) = result {
             error!("Failed to call management: {:?}", err);

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/message_sender.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/message_sender.rs
@@ -319,7 +319,7 @@ pub unsafe extern "C" fn amqpmessagesenderoptions_set_offered_capabilities(
             _ => {
                 let call_context = call_context_from_ptr_mut(call_context);
                 call_context.set_error(error_from_string(format!(
-                    "Invalid offered capabiltiies: {:?}",
+                    "Invalid offered capabilities: {:?}",
                     offered_capabilities
                 )));
                 -1

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/session.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/session.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License.
-// cspell: words amqp amqpconnection amqpconnectionoptionsbuilder amqpconnectionoptions amqpsession amqpsessionoptions amqpsessionoptionsbuilder
+// cspell: words amqp amqpconnection amqpconnectionoptionsbuilder amqpconnectionoptions amqpsession amqpsessionoptions amqpsessionoptions
 
 use crate::{
     amqp::connection::RustAmqpConnection,
@@ -9,20 +9,14 @@ use crate::{
     model::value::RustAmqpValue,
 };
 use azure_core_amqp::{
-    session::{
-        builders::AmqpSessionOptionsBuilder, AmqpSession, AmqpSessionApis, AmqpSessionOptions,
-    },
+    session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions},
     value::{AmqpOrderedMap, AmqpSymbol, AmqpValue},
 };
-use std::{mem, ptr};
+use std::mem;
 use tracing::error;
 
 pub struct RustAmqpSession {
     inner: AmqpSession,
-}
-
-pub struct RustAmqpSessionOptionsBuilder {
-    inner: AmqpSessionOptionsBuilder,
 }
 
 pub struct RustAmqpSessionOptions {
@@ -130,199 +124,196 @@ pub unsafe extern "C" fn amqpsessionoptions_destroy(session_options: *mut RustAm
 /// # Safety
 ///
 #[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_create() -> *mut RustAmqpSessionOptionsBuilder {
-    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
-        inner: AmqpSessionOptions::builder(),
+pub unsafe extern "C" fn amqpsessionoptions_create() -> *mut RustAmqpSessionOptions {
+    Box::into_raw(Box::new(RustAmqpSessionOptions {
+        inner: AmqpSessionOptions::default(),
     }))
 }
 
 /// # Safety
 ///
 #[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_destroy(
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
-) {
-    mem::drop(Box::from_raw(session_options_builder));
-}
-
-/// # Safety
-///
-#[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_outgoing_window(
-    _call_context: *mut RustCallContext,
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
-    outgoing_window: u32,
-) -> *mut RustAmqpSessionOptionsBuilder {
-    let session_options_builder = Box::from_raw(session_options_builder);
-    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
-        inner: session_options_builder
-            .inner
-            .with_outgoing_window(outgoing_window),
-    }))
-}
-
-/// # Safety
-///
-#[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_incoming_window(
-    _call_context: *mut RustCallContext,
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
-    incoming_window: u32,
-) -> *mut RustAmqpSessionOptionsBuilder {
-    let session_options_builder = Box::from_raw(session_options_builder);
-    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
-        inner: session_options_builder
-            .inner
-            .with_incoming_window(incoming_window),
-    }))
-}
-
-/// # Safety
-///
-#[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_next_outgoing_id(
-    _call_context: *mut RustCallContext,
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
-    next_outgoing_id: u32,
-) -> *mut RustAmqpSessionOptionsBuilder {
-    let session_options_builder = Box::from_raw(session_options_builder);
-    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
-        inner: session_options_builder
-            .inner
-            .with_next_outgoing_id(next_outgoing_id),
-    }))
-}
-
-/// # Safety
-///
-#[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_handle_max(
-    _call_context: *mut RustCallContext,
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
-    handle_max: u32,
-) -> *mut RustAmqpSessionOptionsBuilder {
-    let session_options_builder = Box::from_raw(session_options_builder);
-    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
-        inner: session_options_builder.inner.with_handle_max(handle_max),
-    }))
-}
-
-/// # Safety
-///
-#[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_offered_capabilities(
+pub unsafe extern "C" fn amqpsessionoptions_set_outgoing_window(
     call_context: *mut RustCallContext,
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
+    session_options: *mut RustAmqpSessionOptions,
+    outgoing_window: u32,
+) -> i32 {
+    if session_options.is_null() {
+        let call_context = call_context_from_ptr_mut(call_context);
+        call_context.set_error(error_from_str("Session options builder is null"));
+        return -1;
+    }
+    let session_options = &mut *session_options;
+    session_options.inner.outgoing_window = Some(outgoing_window);
+    0
+}
+
+/// # Safety
+///
+#[no_mangle]
+pub unsafe extern "C" fn amqpsessionoptions_set_incoming_window(
+    call_context: *mut RustCallContext,
+    session_options: *mut RustAmqpSessionOptions,
+    incoming_window: u32,
+) -> i32 {
+    if session_options.is_null() {
+        let call_context = call_context_from_ptr_mut(call_context);
+        call_context.set_error(error_from_str("Session options builder is null"));
+        return -1;
+    }
+    let session_options = &mut *session_options;
+    session_options.inner.incoming_window = Some(incoming_window);
+    0
+}
+
+/// # Safety
+///
+#[no_mangle]
+pub unsafe extern "C" fn amqpsessionoptions_set_next_outgoing_id(
+    call_context: *mut RustCallContext,
+    session_options: *mut RustAmqpSessionOptions,
+    next_outgoing_id: u32,
+) -> i32 {
+    if session_options.is_null() {
+        let call_context = call_context_from_ptr_mut(call_context);
+        call_context.set_error(error_from_str("Session options builder is null"));
+        return -1;
+    }
+    let session_options = &mut *session_options;
+    session_options.inner.next_outgoing_id = Some(next_outgoing_id);
+    0
+}
+
+/// # Safety
+///
+#[no_mangle]
+pub unsafe extern "C" fn amqpsessionoptions_set_handle_max(
+    call_context: *mut RustCallContext,
+    session_options: *mut RustAmqpSessionOptions,
+    handle_max: u32,
+) -> i32 {
+    if session_options.is_null() {
+        let call_context = call_context_from_ptr_mut(call_context);
+        call_context.set_error(error_from_str("Session options builder is null"));
+        return -1;
+    }
+    let session_options = &mut *session_options;
+    session_options.inner.handle_max = Some(handle_max);
+    0
+}
+
+/// # Safety
+///
+#[no_mangle]
+pub unsafe extern "C" fn amqpsessionoptions_set_offered_capabilities(
+    call_context: *mut RustCallContext,
+    session_options: *mut RustAmqpSessionOptions,
     offered_capabilities: *mut RustAmqpValue,
-) -> *mut RustAmqpSessionOptionsBuilder {
+) -> i32 {
     let call_context = call_context_from_ptr_mut(call_context);
-    let session_options_builder = Box::from_raw(session_options_builder);
+    if session_options.is_null() {
+        call_context.set_error(error_from_str("Session options builder is null"));
+        return -1;
+    }
+
     let offered_capabilities = &*offered_capabilities;
     if let AmqpValue::List(offered_capabilities) = &offered_capabilities.inner {
         let offered_capabilities: Vec<AmqpSymbol> = offered_capabilities
             .iter()
             .map(|v| AmqpSymbol::from(v.clone()))
             .collect();
-        Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
-            inner: session_options_builder
-                .inner
-                .with_offered_capabilities(offered_capabilities),
-        }))
+        let session_options = &mut *session_options;
+        session_options.inner.offered_capabilities = Some(offered_capabilities);
+        0
     } else {
         call_context.set_error(error_from_str("Offered  Capabilities must be an AMQP list"));
-        ptr::null_mut()
+        -1
     }
 }
 
 /// # Safety
 ///
 #[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_desired_capabilities(
+pub unsafe extern "C" fn amqpsessionoptions_set_desired_capabilities(
     call_context: *mut RustCallContext,
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
+    session_options: *mut RustAmqpSessionOptions,
     desired_capabilities: *mut RustAmqpValue,
-) -> *mut RustAmqpSessionOptionsBuilder {
+) -> i32 {
     let call_context = call_context_from_ptr_mut(call_context);
-    let session_options_builder = Box::from_raw(session_options_builder);
+    if session_options.is_null() {
+        call_context.set_error(error_from_str("Session options builder is null"));
+        return -1;
+    }
     let desired_capabilities = &*desired_capabilities;
     if let AmqpValue::List(desired_capabilities) = &desired_capabilities.inner {
         let desired_capabilities: Vec<AmqpSymbol> = desired_capabilities
             .iter()
             .map(|v| AmqpSymbol::from(v.clone()))
             .collect();
-        Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
-            inner: session_options_builder
-                .inner
-                .with_desired_capabilities(desired_capabilities),
-        }))
+        let session_options = &mut *session_options;
+        session_options.inner.desired_capabilities = Some(desired_capabilities);
+        0
     } else {
         call_context.set_error(error_from_str("Desired Capabilities must be an AMQP list"));
-        ptr::null_mut()
+        -1
     }
 }
 
 /// # Safety
 ///
 #[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_properties(
+pub unsafe extern "C" fn amqpsessionoptions_set_properties(
     call_context: *mut RustCallContext,
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
+    session_options: *mut RustAmqpSessionOptions,
     properties: *mut RustAmqpValue,
-) -> *mut RustAmqpSessionOptionsBuilder {
+) -> i32 {
     let call_context = call_context_from_ptr_mut(call_context);
-    let session_options_builder = Box::from_raw(session_options_builder);
+    if session_options.is_null() {
+        call_context.set_error(error_from_str("Session options builder is null"));
+        return -1;
+    }
     let properties = &*properties;
     if let AmqpValue::Map(properties) = &properties.inner {
         let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
             .iter()
             .map(|(k, v)| (AmqpSymbol::from(k), v))
             .collect();
-        Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
-            inner: session_options_builder
-                .inner
-                .with_properties(properties_map),
-        }))
+        let session_options = &mut *session_options;
+        session_options.inner.properties = Some(properties_map);
+        0
     } else {
         call_context.set_error(error_from_str("Properties must be an AMQP map"));
-        ptr::null_mut()
+        -1
     }
 }
 
 /// # Safety
 ///
 #[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_set_buffer_size(
-    _call_context: *mut RustCallContext,
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
+pub unsafe extern "C" fn amqpsessionoptions_set_buffer_size(
+    call_context: *mut RustCallContext,
+    session_options: *mut RustAmqpSessionOptions,
     buffer_size: usize,
-) -> *mut RustAmqpSessionOptionsBuilder {
-    let session_options_builder = Box::from_raw(session_options_builder);
-    Box::into_raw(Box::new(RustAmqpSessionOptionsBuilder {
-        inner: session_options_builder.inner.with_buffer_size(buffer_size),
-    }))
-}
-
-/// # Safety
-///
-#[no_mangle]
-pub unsafe extern "C" fn amqpsessionoptionsbuilder_build(
-    session_options_builder: *mut RustAmqpSessionOptionsBuilder,
-) -> *mut RustAmqpSessionOptions {
-    let session_options_builder = &mut *session_options_builder;
-    Box::into_raw(Box::new(RustAmqpSessionOptions {
-        inner: session_options_builder.inner.build(),
-    }))
+) -> i32 {
+    let call_context = call_context_from_ptr_mut(call_context);
+    if session_options.is_null() {
+        call_context.set_error(error_from_str("Session options builder is null"));
+        return -1;
+    }
+    let session_options = &mut *session_options;
+    session_options.inner.buffer_size = Some(buffer_size);
+    0
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::call_context::call_context_delete;
     use crate::runtime_context::RuntimeContext;
     use azure_core_amqp::{
         connection::{AmqpConnection, AmqpConnectionApis},
         value::AmqpList,
     };
-    use crate::call_context::call_context_delete;
-    use super::*;
 
     #[test]
     fn test_amqpsession_create() {
@@ -335,118 +326,106 @@ mod tests {
     }
 
     #[test]
-    fn test_amqpsessionoptionsbuilder_create() {
+    fn test_amqpsessionoptions_create() {
         unsafe {
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
-            assert_ne!(session_options_builder, std::ptr::null_mut());
+            let session_options = { amqpsessionoptions_create() };
+            assert_ne!(session_options, std::ptr::null_mut());
 
-            amqpsessionoptionsbuilder_destroy(session_options_builder);
+            amqpsessionoptions_destroy(session_options);
         }
     }
 
     #[test]
-    fn test_amqpsessionoptionsbuilder_set_outgoing_window() {
+    fn test_amqpsessionoptions_set_outgoing_window() {
         unsafe {
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let session_options = { amqpsessionoptions_create() };
             let call_context = Box::into_raw(Box::new(RustCallContext::new(Box::into_raw(
                 Box::new(RuntimeContext::new().unwrap()),
             ))));
 
-            amqpsessionoptionsbuilder_set_outgoing_window(
-                call_context,
-                session_options_builder,
-                10,
-            );
+            amqpsessionoptions_set_outgoing_window(call_context, session_options, 10);
 
-            amqpsessionoptionsbuilder_destroy(session_options_builder);
+            amqpsessionoptions_destroy(session_options);
             call_context_delete(call_context);
         }
     }
 
     #[test]
-    fn test_amqpsessionoptionsbuilder_set_incoming_window() {
+    fn test_amqpsessionoptions_set_incoming_window() {
         unsafe {
             let call_context = Box::into_raw(Box::new(RustCallContext::new(Box::into_raw(
                 Box::new(RuntimeContext::new().unwrap()),
             ))));
 
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let session_options = { amqpsessionoptions_create() };
 
-            amqpsessionoptionsbuilder_set_incoming_window(
-                call_context,
-                session_options_builder,
-                10,
-            );
+            amqpsessionoptions_set_incoming_window(call_context, session_options, 10);
 
-            amqpsessionoptionsbuilder_destroy(session_options_builder);
+            amqpsessionoptions_destroy(session_options);
             call_context_delete(call_context);
         }
     }
 
     #[test]
-    fn test_amqpsessionoptionsbuilder_set_next_outgoing_id() {
+    fn test_amqpsessionoptions_set_next_outgoing_id() {
         unsafe {
             let call_context = Box::into_raw(Box::new(RustCallContext::new(Box::into_raw(
                 Box::new(RuntimeContext::new().unwrap()),
             ))));
 
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let session_options = { amqpsessionoptions_create() };
 
-            amqpsessionoptionsbuilder_set_next_outgoing_id(
-                call_context,
-                session_options_builder,
-                10,
-            );
+            amqpsessionoptions_set_next_outgoing_id(call_context, session_options, 10);
 
-            amqpsessionoptionsbuilder_destroy(session_options_builder);
+            amqpsessionoptions_destroy(session_options);
             call_context_delete(call_context);
         }
     }
 
     #[test]
-    fn test_amqpsessionoptionsbuilder_set_handle_max() {
+    fn test_amqpsessionoptions_set_handle_max() {
         unsafe {
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let session_options = { amqpsessionoptions_create() };
             let call_context = Box::into_raw(Box::new(RustCallContext::new(Box::into_raw(
                 Box::new(RuntimeContext::new().unwrap()),
             ))));
 
-            amqpsessionoptionsbuilder_set_handle_max(call_context, session_options_builder, 10);
+            amqpsessionoptions_set_handle_max(call_context, session_options, 10);
 
-            amqpsessionoptionsbuilder_destroy(session_options_builder);
+            amqpsessionoptions_destroy(session_options);
             call_context_delete(call_context);
         }
     }
 
     #[test]
-    fn test_amqpsessionoptionsbuilder_set_offered_capabilities() {
+    fn test_amqpsessionoptions_set_offered_capabilities() {
         unsafe {
             let call_context = Box::into_raw(Box::new(RustCallContext::new(Box::into_raw(
                 Box::new(RuntimeContext::new().unwrap()),
             ))));
 
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let session_options = { amqpsessionoptions_create() };
             let offered_capabilities = RustAmqpValue {
                 inner: AmqpValue::List(AmqpList::from(vec![AmqpValue::Symbol(AmqpSymbol::from(
                     "test",
                 ))])),
             };
 
-            amqpsessionoptionsbuilder_set_offered_capabilities(
+            amqpsessionoptions_set_offered_capabilities(
                 call_context,
-                session_options_builder,
+                session_options,
                 &offered_capabilities as *const RustAmqpValue as *mut RustAmqpValue,
             );
 
-            amqpsessionoptionsbuilder_destroy(session_options_builder);
+            amqpsessionoptions_destroy(session_options);
             call_context_delete(call_context);
         }
     }
 
     #[test]
-    fn test_amqpsessionoptionsbuilder_set_desired_capabilities() {
+    fn test_amqpsessionoptions_set_desired_capabilities() {
         unsafe {
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let session_options = { amqpsessionoptions_create() };
             let call_context = Box::into_raw(Box::new(RustCallContext::new(Box::into_raw(
                 Box::new(RuntimeContext::new().unwrap()),
             ))));
@@ -455,25 +434,25 @@ mod tests {
                 inner: AmqpValue::List(vec![AmqpValue::Symbol(AmqpSymbol::from("test"))].into()),
             };
 
-            amqpsessionoptionsbuilder_set_desired_capabilities(
+            amqpsessionoptions_set_desired_capabilities(
                 call_context,
-                session_options_builder,
+                session_options,
                 &desired_capabilities as *const RustAmqpValue as *mut RustAmqpValue,
             );
 
-            amqpsessionoptionsbuilder_destroy(session_options_builder);
+            amqpsessionoptions_destroy(session_options);
             call_context_delete(call_context);
         }
     }
 
     #[test]
-    fn test_amqpsessionoptionsbuilder_set_properties() {
+    fn test_amqpsessionoptions_set_properties() {
         unsafe {
             let call_context = Box::into_raw(Box::new(RustCallContext::new(Box::into_raw(
                 Box::new(RuntimeContext::new().unwrap()),
             ))));
 
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
+            let session_options = { amqpsessionoptions_create() };
             let properties = RustAmqpValue {
                 inner: AmqpValue::Map(
                     vec![(
@@ -485,39 +464,29 @@ mod tests {
                 ),
             };
 
-            amqpsessionoptionsbuilder_set_properties(
+            amqpsessionoptions_set_properties(
                 call_context,
-                session_options_builder,
+                session_options,
                 &properties as *const RustAmqpValue as *mut RustAmqpValue,
             );
 
-            amqpsessionoptionsbuilder_destroy(session_options_builder);
+            amqpsessionoptions_destroy(session_options);
             call_context_delete(call_context);
         }
     }
 
     #[test]
-    fn test_amqpsessionoptionsbuilder_set_buffer_size() {
+    fn test_amqpsessionoptions_set_buffer_size() {
         unsafe {
             let call_context = Box::into_raw(Box::new(RustCallContext::new(Box::into_raw(
                 Box::new(RuntimeContext::new().unwrap()),
             ))));
 
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
-            amqpsessionoptionsbuilder_set_buffer_size(call_context, session_options_builder, 1024);
+            let session_options = { amqpsessionoptions_create() };
+            amqpsessionoptions_set_buffer_size(call_context, session_options, 1024);
 
-            amqpsessionoptionsbuilder_destroy(session_options_builder);
-            call_context_delete(call_context);
-        }
-    }
-
-    #[test]
-    fn test_amqpsessionoptionsbuilder_build() {
-        unsafe {
-            let session_options_builder = { amqpsessionoptionsbuilder_create() };
-            let session_options = { amqpsessionoptionsbuilder_build(session_options_builder) };
-            assert_ne!(session_options, std::ptr::null_mut());
             amqpsessionoptions_destroy(session_options);
+            call_context_delete(call_context);
         }
     }
 
@@ -533,7 +502,7 @@ mod tests {
                 .runtime_context()
                 .runtime()
                 .block_on(connection.open(
-                    "testConnection",
+                    "testConnection".to_string(),
                     url::Url::parse("amqp://localhost:25672").unwrap(),
                     None,
                 ))
@@ -560,7 +529,7 @@ mod tests {
                 .runtime_context()
                 .runtime()
                 .block_on(connection.open(
-                    "testConnection",
+                    "testConnection".to_string(),
                     url::Url::parse("amqp://localhost:25672").unwrap(),
                     None,
                 ))
@@ -568,8 +537,7 @@ mod tests {
 
             let connection = Box::into_raw(Box::new(RustAmqpConnection::new(connection)));
 
-            let session_options_builder = amqpsessionoptionsbuilder_create();
-            let session_options = amqpsessionoptionsbuilder_build(session_options_builder);
+            let session_options = amqpsessionoptions_create();
             let result = amqpsession_begin(call_context, session, connection, session_options);
             assert_eq!(result, 0);
             amqpsession_destroy(session);

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/lib.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/lib.rs
@@ -29,3 +29,10 @@ pub(crate) fn error_from_str(msg: &'static str) -> Box<dyn std::error::Error + S
         msg,
     ))
 }
+
+pub(crate) fn error_from_string(msg: String) -> Box<dyn std::error::Error + Send + Sync> {
+    Box::new(azure_core::error::Error::message(
+        azure_core::error::ErrorKind::Other,
+        msg,
+    ))
+}

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/message_fields.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/message_fields.rs
@@ -90,7 +90,10 @@ mod tests {
                     assert_eq!(described.descriptor, AmqpDescriptor::Code(0x71));
                     match &described.value {
                         AmqpValue::Map(map) => {
-                            assert_eq!(map.get("key").unwrap(), &AmqpValue::String("value".into()));
+                            assert_eq!(
+                                map.get(&AmqpValue::from("key")).unwrap(),
+                                &AmqpValue::String("value".into())
+                            );
                         }
                         _ => panic!("Expected AmqpValue::Map"),
                     }
@@ -117,7 +120,10 @@ mod tests {
                     assert_eq!(described.descriptor, AmqpDescriptor::Code(0x72));
                     match &described.value {
                         AmqpValue::Map(map) => {
-                            assert_eq!(map.get("key").unwrap(), &AmqpValue::String("value".into()));
+                            assert_eq!(
+                                map.get(&AmqpValue::from("key")).unwrap(),
+                                &AmqpValue::String("value".into())
+                            );
                         }
                         _ => panic!("Expected AmqpValue::Map"),
                     }
@@ -144,7 +150,10 @@ mod tests {
                     assert_eq!(described.descriptor, AmqpDescriptor::Code(0x78));
                     match &described.value {
                         AmqpValue::Map(map) => {
-                            assert_eq!(map.get("key").unwrap(), &AmqpValue::String("value".into()));
+                            assert_eq!(
+                                map.get(&AmqpValue::from("key")).unwrap(),
+                                &AmqpValue::String("value".into())
+                            );
                         }
                         _ => panic!("Expected AmqpValue::Map"),
                     }
@@ -171,7 +180,10 @@ mod tests {
                     assert_eq!(described.descriptor, AmqpDescriptor::Code(0x74));
                     match &described.value {
                         AmqpValue::Map(map) => {
-                            assert_eq!(map.get("key").unwrap(), &AmqpValue::String("value".into()));
+                            assert_eq!(
+                                map.get(&AmqpValue::from("key")).unwrap(),
+                                &AmqpValue::String("value".into())
+                            );
                         }
                         _ => panic!("Expected AmqpValue::Map"),
                     }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/source.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/source.rs
@@ -403,7 +403,7 @@ unsafe extern "C" fn source_builder_set_address(
     let address = CStr::from_ptr(address).to_str();
     match address {
         Ok(address) => Box::into_raw(Box::new(RustAmqpSourceBuilder {
-            inner: builder.inner.with_address(address),
+            inner: builder.inner.with_address(address.to_string()),
         })),
         Err(err) => {
             call_context.set_error(Box::new(err));

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/target.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/model/target.rs
@@ -264,7 +264,7 @@ unsafe extern "C" fn target_builder_set_address(
     let address = std::ffi::CStr::from_ptr(address).to_str();
     match address {
         Ok(address) => Box::into_raw(Box::new(RustAmqpTargetBuilder {
-            inner: builder.inner.with_address(address),
+            inner: builder.inner.with_address(address.to_string()),
         })),
         Err(e) => {
             warn!("Failed to convert address to string: {:?}", e);

--- a/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
+++ b/sdk/core/azure-core-amqp/src/models/amqp_header.cpp
@@ -15,7 +15,6 @@
 #elif ENABLE_RUST_AMQP
 #include "azure/core/amqp/internal/common/runtime_context.hpp"
 
-#include <numeric>
 using namespace Azure::Core::Amqp::RustInterop::_detail;
 #endif
 

--- a/sdk/core/azure-core-amqp/test/ut/claim_based_security_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/claim_based_security_tests.cpp
@@ -227,6 +227,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
 #endif // !defined(AZ_PLATFORM_MAC)
 
 #if !defined(AZ_PLATFORM_MAC)
+  // The native broker doesn't support CBS or management APIs.
+#if !defined(USE_NATIVE_BROKER)
   TEST_F(TestCbs, CbsOpenAndPut)
   {
     auto connection{CreateConnection()};
@@ -257,9 +259,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     Cleanup(session);
     Cleanup(connection);
   }
+#endif
 #endif // !defined(AZ_PLATFORM_MAC)
 
 #if !defined(AZ_PLATFORM_MAC)
+  // The native broker doesn't support CBS or management APIs.
+#if !defined(USE_NATIVE_BROKER)
   TEST_F(TestCbs, CbsOpenAndPutError)
   {
     {
@@ -290,6 +295,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       Cleanup(connection);
     }
   }
+#endif
 
 #if ENABLE_RUST_CANCEL
 

--- a/sdk/core/azure-core-amqp/test/ut/management_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/management_tests.cpp
@@ -7,8 +7,18 @@
 #include "azure/core/amqp/internal/models/messaging_values.hpp"
 #include "azure/core/amqp/internal/session.hpp"
 #include "azure/core/platform.hpp"
-#include "mock_amqp_server.hpp"
 
+#if ENABLE_RUST_AMQP
+#define USE_NATIVE_BROKER
+#elif ENABLE_UAMQP
+#undef USE_NATIVE_BROKER
+#endif
+
+#if defined(USE_NATIVE_BROKER)
+constexpr const uint16_t nativeBrokerPort = 25672;
+#else
+#include "mock_amqp_server.hpp"
+#endif
 #include <gtest/gtest.h>
 
 // cspell: ignore abcdabcd


### PR DESCRIPTION
# Integrated Rust changes after API guidelines update which removed builders from ClientOptions related types. 

Updated the Rust wrapper to reflect those changes. Also added a new API Wrapper for Rust APIs to handle APIs which return an i32 as an error.

Also fixed a bug in `Rust MessageSender::detach` - ignore `SessionRemoteClosed` errors on `MessageSender::detach` calls since RemoteClosed is an expected error in that case.

Also synchronized the root cargo.toml file with the root cargo.toml file from the rust repo.

Note for Reviewers: All the azure_core_amqp changes were already reviewed in an earlier PR to the Rust library, with the exception of fe2o3\sender.rs (which has the fix to `detach` I mentioned above)

## CoPilot Summary
This pull request includes significant changes to the `azure-core-amqp` Rust and C++ codebase, focusing on simplifying the code by removing builder patterns and using a new `InvokeAmqpApi` function for error handling. Additionally, several dependencies in the `Cargo.toml` file have been updated.

### Dependency Updates:
* Added new dependencies: `async-stream`, `cargo_metadata`, `log`, `proc-macro2`, `syn`, and `quote` in `Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R28) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R41-R47) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L54-L67)
* Updated version of `serde_amqp` from `0.12.2` to `0.12`.
* Added a new lint rule for `clippy` to deny large futures.

### Code Simplification:
* Introduced `InvokeAmqpApi` function in `runtime_context.hpp` to handle Rust AMQP API calls and error checking.
* Removed builder patterns and replaced them with direct API calls using `InvokeAmqpApi` in `connection.cpp`. [[1]](diffhunk://#diff-42b9c4271988dc7b8b42fc437d17579f405d1f519a0ebe496b137c4a38dffaf0L116-R122) [[2]](diffhunk://#diff-42b9c4271988dc7b8b42fc437d17579f405d1f519a0ebe496b137c4a38dffaf0L146-R135) [[3]](diffhunk://#diff-42b9c4271988dc7b8b42fc437d17579f405d1f519a0ebe496b137c4a38dffaf0L161-R149) [[4]](diffhunk://#diff-42b9c4271988dc7b8b42fc437d17579f405d1f519a0ebe496b137c4a38dffaf0L176-R163) [[5]](diffhunk://#diff-42b9c4271988dc7b8b42fc437d17579f405d1f519a0ebe496b137c4a38dffaf0L191-R191)

### Removal of Builders:
* Removed builder-related code and replaced it with direct API calls in `message_sender.cpp`. [[1]](diffhunk://#diff-03292f503d8ef651c65dff1736c77e718fdf22227fb1cb8edb80bad0ff1c3105L42-L57) [[2]](diffhunk://#diff-03292f503d8ef651c65dff1736c77e718fdf22227fb1cb8edb80bad0ff1c3105L103-R100) [[3]](diffhunk://#diff-03292f503d8ef651c65dff1736c77e718fdf22227fb1cb8edb80bad0ff1c3105L121-R114) [[4]](diffhunk://#diff-03292f503d8ef651c65dff1736c77e718fdf22227fb1cb8edb80bad0ff1c3105L132-R133) [[5]](diffhunk://#diff-03292f503d8ef651c65dff1736c77e718fdf22227fb1cb8edb80bad0ff1c3105L154-R158)
* Removed builder-related code in `session.cpp` and replaced it with direct API calls. [[1]](diffhunk://#diff-7c735f86f5bf02f6e4a8a1cdb149943acf8dcfff8f525a5a3d95a3d300acc0bfL26-L31) [[2]](diffhunk://#diff-7c735f86f5bf02f6e4a8a1cdb149943acf8dcfff8f525a5a3d95a3d300acc0bfL102-L129)

### Cleanup:
* Removed unnecessary builder-related typedefs and functions in various header files (`connection_impl.hpp`, `session_impl.hpp`). [[1]](diffhunk://#diff-ef7f313614e4ae4919bb43919e8c4e813afdcda375dce0990648d0804ae70b17L30-L31) [[2]](diffhunk://#diff-ef7f313614e4ae4919bb43919e8c4e813afdcda375dce0990648d0804ae70b17L49-L66) [[3]](diffhunk://#diff-5875b83fb61471c328ff2079365e1981fe4c5940860a0ef38195aa275fbe40e9L18-L19) [[4]](diffhunk://#diff-5875b83fb61471c328ff2079365e1981fe4c5940860a0ef38195aa275fbe40e9L33-L45)
