### PR TITLE
Update LiveTestCtestRegex within the ci.yml to match the CtestRegex value set

### DIFF
--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -1,4 +1,4 @@
-# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file. 
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 trigger:
   branches:
     include:

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -1,4 +1,4 @@
-# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file. 
 trigger:
   branches:
     include:

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -30,7 +30,7 @@ extends:
       CtestRegex: azure-data-tables.*
       LineCoverageTarget: 77
       BranchCoverageTarget: 42
-      LiveTestCtestRegex: azure-data-tables
+      LiveTestCtestRegex: azure-data-tables.*
       Artifacts:
         - Name: azure-data-tables
           Path: azure-data-tables


### PR DESCRIPTION
**Before:**
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4332699&view=logs&j=b480f431-cfd9-5d07-f486-b73452ab58e9&t=17eb15d2-6ebc-5155-18b3-76202a687fa3
> 100% tests passed, 0 tests failed out of 100

(no tests skipped)

**After:**
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4335700&view=logs&j=b480f431-cfd9-5d07-f486-b73452ab58e9&t=1e63cd11-2fcd-5751-b03e-76d95e2e6189
> 100% tests passed, 0 tests failed out of 100

(no tests skipped)

**Conclusion:** Explicitly specifying the wild-card isn't necessary here. The regex is already picking up on all the tests that start with `azure-data-tables`.

**All other instances** within the repo have the `LiveTestCtestRegex` value match `CtestRegex`, so we could consider cleaning that up, for consistency.

**Follow-up consistency issue across the repo:** https://github.com/Azure/azure-sdk-for-cpp/issues/6224
Some use wild-card (`*`), while others have it wrapped in quotes (`""`), while the rest leave it as plain-text:
https://github.com/search?q=repo%3AAzure%2Fazure-sdk-for-cpp%20LiveTestCtestRegex&type=code

https://github.com/Azure/azure-sdk-for-cpp/blob/384552adff3d6cdea46cdf8a345120b183bdcc1e/sdk/keyvault/ci.yml#L30-L31

https://github.com/Azure/azure-sdk-for-cpp/blob/384552adff3d6cdea46cdf8a345120b183bdcc1e/sdk/storage/ci.yml#L30-L33