### PR TITLE
Make Uuid's default constructor implicit

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
+++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
@@ -37,7 +37,7 @@ namespace Azure { namespace Core {
      */
     // Nil UUID, per RFC9562, consists of all zeros:
     // https://www.rfc-editor.org/rfc/rfc9562.html#name-nil-uuid
-    constexpr explicit Uuid() : m_uuid{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} {}
+    constexpr Uuid() : m_uuid{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} {}
 
     /**
      * @brief Gets Uuid as a string.


### PR DESCRIPTION
This is not a breaking change. (The other way around - to make an implicit constructor explicit - would've been a breaking change)

MSVC does not complain about this, but Clang and GCC do.
To avoid the error, our codegen had to have a special logic to `{}`-initialize Uuids in structures (https://github.com/Azure/autorest.cpp/issues/424).

Example: https://godbolt.org/z/qc1scoMcG
```cpp
struct ExplicitUuid {
    explicit ExplicitUuid(){};
};

struct ImplicitUuid {
    ImplicitUuid(){};
};

struct Options1 {
    ExplicitUuid Uuid;
    //ExplicitUuid Uuid{};
    // ^ "{}" is required for the f1(= {}) to compile
    // Comment line 10 and uncomment line 11, and it will compile.
};

struct Options2 {
    ImplicitUuid Uuid;
};

void f1(Options1 o1 = {}) { static_cast<void>(o1); }
void f2(Options2 o2 = {}) { static_cast<void>(o2); }

int main() {
}

// <source>:19:24: error: chosen constructor is explicit in copy-initialization
//   19 | void f1(Options1 o1 = {}) { static_cast<void>(o1); }
//      |                        ^
// <source>:2:14: note: explicit constructor declared here
//    2 |     explicit ExplicitUuid(){};
//      |              ^
// <source>:10:18: note: in implicit initialization of field 'Uuid' with omitted initializer
//   10 |     ExplicitUuid Uuid;
//      |                  ^
// <source>:19:18: note: passing argument to parameter 'o1' here
//   19 | void f1(Options1 o1 = {}) { static_cast<void>(o1); }
//      |                  ^
// 1 error generated.
```