### PR TITLE
Remove use of GetScopeFromUrl in KeyClient

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/key_client.cpp
@@ -74,7 +74,7 @@ KeyClient::KeyClient(
   std::vector<std::unique_ptr<HttpPolicy>> perRetryPolicies;
   {
     Azure::Core::Credentials::TokenRequestContext tokenContext;
-    tokenContext.Scopes = {_internal::UrlScope::GetScopeFromUrl(m_vaultUrl)};
+    // tokenContext.Scopes = {_internal::UrlScope::GetScopeFromUrl(m_vaultUrl)};
 
     perRetryPolicies.emplace_back(
         std::make_unique<_internal::KeyVaultChallengeBasedAuthenticationPolicy>(


### PR DESCRIPTION
Testing to see if there's any behavioral change or test failures as part of https://github.com/Azure/azure-sdk-for-cpp/issues/6271