### PR TITLE
Add samples for Get, Set, and Delete Configuration Settings with comparisons of what we'd expect the user experience to be.

### DIFF
--- a/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
+++ b/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
@@ -3,7 +3,7 @@
 
 /**
  * @brief This sample provides the code implementation to use the App Configuration client SDK for
- * C++ to get one or more configuration settings.
+ * C++ to create, retrieve and delete a configuration setting.
  */
 
 #include <azure/data/appconfiguration.hpp>
@@ -21,24 +21,151 @@ int main()
     std::string url = "https://<your-appconfig-name>.azconfig.io";
     auto credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
 
-    // create client
+    // Create a ConfigurationClient
     ConfigurationClient configurationClient(url, credential);
 
-    Azure::Response<GetKeyValueResult> response = configurationClient.GetKeyValue("key", "accept");
+    // Create a configuration setting
 
-    GetKeyValueResult result = response.Value;
-    Azure::Nullable<std::string> valueOfKey = result.Value;
+    // Current
+    {
+      KeyValue entity;
+      entity.Value = "some-value";
 
-    if (valueOfKey.HasValue())
-    {
-      std::cout << valueOfKey.Value() << std::endl;
+      PutKeyValueOptions options;
+      options.Label = "some-label";
+      options.Entity = entity;
+
+      Azure::Response<PutKeyValueResult> putKeyValueResult = configurationClient.PutKeyValue(
+          PutKeyValueRequestContentType::ApplicationJson, "some-key", "accept", options);
+
+      PutKeyValueResult result = putKeyValueResult.Value;
+      Azure::Nullable<std::string> valueOfKey = result.Value;
+
+      std::cout << result.Key << std::endl; // some-key
+
+      if (valueOfKey.HasValue())
+      {
+        std::cout << valueOfKey.Value() << std::endl; // some-value
+      }
     }
-    else
+
+    // Expected
+
+#if 0
     {
-      std::cout << "Value for: '"
-                << "key"
-                << "' does not exist." << std::endl;
+      ConfigurationSetting setting;
+      setting.Key = "some-key";
+      setting.Value = "some-value";
+
+      SetSettingOptions options;
+      options.Label = "some-label";
+
+      Azure::Response<ConfigurationSetting> setResult
+          = configurationClient.SetConfigurationSetting(setting, options);
+
+      ConfigurationSetting result = setResult.Value;
+      Azure::Nullable<std::string> valueOfKey = result.Value;
+
+      std::cout << result.Key << std::endl; // some-key
+
+      if (valueOfKey.HasValue())
+      {
+        std::cout << valueOfKey.Value() << std::endl; // some-value
+      }
     }
+#endif
+
+    // Retrieve a configuration setting
+
+    // Current
+    {
+      GetKeyValueOptions options;
+      options.Label = "some-label";
+      Azure::Response<GetKeyValueResult> getKeyValueResult
+          = configurationClient.GetKeyValue("some-key", "accept", options);
+
+      GetKeyValueResult result = getKeyValueResult.Value;
+      Azure::Nullable<std::string> valueOfKey = result.Value;
+
+      if (valueOfKey.HasValue())
+      {
+        std::cout << valueOfKey.Value() << std::endl; // some-value
+      }
+      else
+      {
+        std::cout << "Value for: '" << result.Key << "' does not exist." << std::endl;
+      }
+    }
+
+    // Expected
+
+#if 0
+    {
+      GetConfigurationSettingOptions options;
+      options.Label = "some-label";
+      Azure::Response<ConfigurationSetting> getResult
+          = configurationClient.GetConfigurationSetting("some-key", options);
+
+      ConfigurationSetting result = getResult.Value;
+      Azure::Nullable<std::string> valueOfKey = result.Value;
+
+      if (valueOfKey.HasValue())
+      {
+        std::cout << valueOfKey.Value() << std::endl; // some-value
+      }
+      else
+      {
+        std::cout << "Value for: '" << result.Key << "' does not exist." << std::endl;
+      }
+    }
+#endif
+
+    // Delete a configuration setting
+
+    // Current
+    {
+      DeleteKeyValueOptions options;
+      options.Label = "some-label";
+
+      Azure::Response<DeleteKeyValueResult> deleteKeyValueResult
+          = configurationClient.DeleteKeyValue("some-key", "accept", options);
+
+      DeleteKeyValueResult result = deleteKeyValueResult.Value;
+      Azure::Nullable<std::string> valueOfKey = result.Value;
+
+      if (valueOfKey.HasValue())
+      {
+        std::cout << valueOfKey.Value() << std::endl; // some-value
+      }
+      else
+      {
+        std::cout << "Value for: '" << result.Key << "' does not exist." << std::endl;
+      }
+    }
+
+    // Expected
+
+#if 0
+    {
+      DeleteKeyValueOptions options;
+      options.Label = "some-label";
+
+      Azure::Response<ConfigurationSetting> deleteKeyValueResult
+          = configurationClient.DeleteConfigurationSetting("some-key", options);
+
+      ConfigurationSetting result = deleteKeyValueResult.Value;
+      Azure::Nullable<std::string> valueOfKey = result.Value;
+
+      if (valueOfKey.HasValue())
+      {
+        std::cout << valueOfKey.Value() << std::endl; // some-value
+      }
+      else
+      {
+        std::cout << "Value for: '" << result.Key << "' does not exist." << std::endl;
+      }
+    }
+#endif
   }
   catch (Azure::Core::Credentials::AuthenticationException const& e)
   {


### PR DESCRIPTION
The expected user experience is under `#if 0` for now since it won't compile.

The goal here is to leverage the hero scenario samples for AppConfig to concretely highlight and track the gap between what is generated today vs what we want the end user experience and API design to be.

These particular endpoints highlight newer emitter issues around visibility decorators, model round-tripping, and some implementation detail correctness in the emitter around gracefully handling missing data. Some of these require design discussions:
https://github.com/Azure/autorest.cpp/issues/446
https://github.com/Azure/autorest.cpp/issues/447
https://github.com/Azure/autorest.cpp/issues/450
https://github.com/Azure/autorest.cpp/issues/435

Additionally. the models and method signatures for these endpoints will require emitter fixes from these:
https://github.com/Azure/autorest.cpp/issues/436
https://github.com/Azure/autorest.cpp/issues/437
https://github.com/Azure/autorest.cpp/issues/432
