### PR TITLE
Demo: Explicit null support for Nullable<T>

### DIFF
--- a/sdk/core/azure-core/test/ut/nullable_test.cpp
+++ b/sdk/core/azure-core/test/ut/nullable_test.cpp
@@ -289,3 +289,14 @@ TEST(Nullable, ConstexprAndRvalue)
   std::string str(Nullable<std::string>(std::string("hello")).Value());
   EXPECT_EQ(str, "hello");
 }
+
+TEST(Nullable, ExplicitNull)
+{
+  Nullable<int> x;
+  EXPECT_FALSE(x.HasValue());
+  EXPECT_NE(x, nullptr);
+
+  x = nullptr;
+  EXPECT_FALSE(x.HasValue());
+  EXPECT_EQ(x, nullptr);
+}


### PR DESCRIPTION
Closes #6308. This is how we can do it if we need it.

Problem: we have something as both optional and nullable, there is no way to explicitly send `null` value - there's no way to distinguish between "null" and "not set".

Current logic:
1. Non-optional, non-nullable: `void f(int x)` sends the following payload `{ nonOptionalNonNullable: 42 }`.
2. Non-optional, nullable: `void f(Nullable<int> x)` sends the following payload `{ nonOptionalNullable: null }` or `{ nonOptionalNonNullable: 42 }`.
3. Optional, non-nullable: `struct Options{ Nullable<int> X }; void f(Options o)` sends the following payload `{ optionalNonNullable: 42 }` or `{}`.
4. Optional, nullable: `struct Options{ Nullable<int> X }; void f(Options o)` sends the following payload `{ optionaNullable: 42 }` or `{}`.

However, in case 4, there is no way to send `{ optionalNullable: null }`. I was told that Azure should not have such API, but it could matter when doing JSON merge patch.

This PR adds `std::nullptr_t` operators that would allow us to do that, while being minimally intrusive. 
If you set something to nullptr_t, it is basically the same as `Reset()`. `HasValue()` is still `false`.
However, when we serialize, and we need to send optional nullable, we specifically check it as `if (x == nullptr)`:
```cpp
if (x.HasValue()) {
   // send { x: x.Value() }
} else if (x == nullptr) {
  // send { x: null }
} else {
   // send {}
}
```

in all other contexts, nullptr Nullables behave exactly the same as those whose values are not set.