### PR TITLE
Add samples for AppConfig Pageable GetLabels with comparisons of what we'd expect the user experience to be.

### DIFF
--- a/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
+++ b/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
@@ -14,6 +14,66 @@
 using namespace Azure::Data::AppConfiguration;
 using namespace Azure::Identity;
 
+// Retreive labels based on filters
+static void RetreiveLabels(ConfigurationClient& configurationClient)
+{
+  // Current
+
+  {
+    GetLabelsOptions options;
+    // To get all labels, don't set Name or use the any wildcard ("*").
+    options.Name = "production*";
+    options.AcceptDatetime = "Fri, 10 Jan 2025 00:00:00 GMT";
+
+    for (GetLabelsPagedResponse labelsPage = configurationClient.GetLabels("accept", options);
+         labelsPage.HasPage();
+         labelsPage.MoveToNextPage())
+    {
+      if (labelsPage.Items.HasValue())
+      {
+        std::vector<Label> list = labelsPage.Items.Value();
+        std::cout << "Label List Size: " << list.size() << std::endl;
+        for (Label label : list)
+        {
+          if (label.Name.HasValue())
+          {
+            std::cout << label.Name.Value() << std::endl;
+          }
+        }
+      }
+    }
+  }
+
+  // Expected
+
+#if 0
+  {
+    GetLabelsOptions options;
+    // To get all labels, don't set Name or use the any wildcard ("*").
+    options.Name = "production*";
+    options.AcceptDatetime = Azure::DateTime(2025, 01, 10, 0, 0, 0);
+
+    for (GetLabelsPagedResponse labelsPage = configurationClient.GetLabels(options);
+         labelsPage.HasPage();
+         labelsPage.MoveToNextPage())
+    {
+      if (labelsPage.Items.HasValue())
+      {
+        std::vector<Label> list = labelsPage.Items.Value();
+        std::cout << "Label List Size: " << list.size() << std::endl;
+        for (Label label : list)
+        {
+          if (label.Name.HasValue())
+          {
+            std::cout << label.Name.Value() << std::endl;
+          }
+        }
+      }
+    }
+  }
+#endif
+}
+
 int main()
 {
   try
@@ -119,6 +179,9 @@ int main()
       }
     }
 #endif
+
+    // Retreive labels based on filters
+    RetreiveLabels(configurationClient);
 
     // Delete a configuration setting
 


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/6292
The expected user experience is under `#if 0` for now since it won't compile.

The goal here is to leverage the hero scenario samples for AppConfig to concretely highlight and track the gap between what is generated today vs what we want the end user experience and API design to be.

These particular endpoints highlight newer emitter issues around pageable correctness for url construction from nextpagetokens, and the general pageable pattern: 
https://github.com/Azure/autorest.cpp/issues/466
https://github.com/Azure/autorest.cpp/issues/427

Additionally, it requires follow-up on client.tsp modification (assuming TCGC and the emitter support the `@alternateType` decorator) and investigating a missing response header:
https://github.com/Azure/azure-sdk-for-cpp/issues/6335
https://github.com/Azure/azure-sdk-for-cpp/issues/6337

