### PR TITLE
Add samples for Lock and Unlock Configuration Settings with comparisons of what we'd expect the user experience to be.

### DIFF
--- a/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
+++ b/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
@@ -14,6 +14,151 @@
 using namespace Azure::Data::AppConfiguration;
 using namespace Azure::Identity;
 
+// Make the setting read-only
+static void SetReadOnly(ConfigurationClient& configurationClient)
+{
+  // Current
+
+  {
+    PutLockOptions options;
+    options.Label = "some-label";
+
+    Azure::Response<PutLockResult> putLockResult
+        = configurationClient.PutLock("some-key", "accept", options);
+
+    PutLockResult result = putLockResult.Value;
+    Azure::Nullable<bool> isLocked = result.Locked;
+
+    std::cout << result.Key << std::endl; // some-key
+
+    if (isLocked.HasValue())
+    {
+      std::cout << "isLocked: " << isLocked.Value() << std::endl; // true
+    }
+  }
+
+  // Expected
+
+#if 0
+  {
+    SetReadOnlyOptions options;
+    options.Label = "some-label";
+
+    Azure::Response<ConfigurationSetting> setReadOnlyResult
+        = configurationClient.SetReadOnly("some-key", true, options);
+
+    ConfigurationSetting result = setReadOnlyResult.Value;
+    Azure::Nullable<bool> isReadOnly = result.IsReadOnly;
+
+    std::cout << result.Key << std::endl; // some-key
+
+    if (isReadOnly.HasValue())
+    {
+      std::cout << "isReadOnly: " << isReadOnly.Value() << std::endl; // true
+    }
+  }
+#endif
+}
+
+// Try modifying a read-only setting and then modify a read-write setting
+static void SetConfigurationSetting(ConfigurationClient& configurationClient)
+{
+  // Current
+  {
+    KeyValue entity;
+    entity.Value = "another-value";
+
+    PutKeyValueOptions options;
+    options.Label = "some-label";
+    options.Entity = entity;
+
+    Azure::Response<PutKeyValueResult> putKeyValueResult = configurationClient.PutKeyValue(
+        PutKeyValueRequestContentType::ApplicationJson, "some-key", "accept", options);
+
+    PutKeyValueResult result = putKeyValueResult.Value;
+    Azure::Nullable<std::string> valueOfKey = result.Value;
+
+    std::cout << result.Key << std::endl; // some-key
+
+    if (valueOfKey.HasValue())
+    {
+      std::cout << valueOfKey.Value() << std::endl; // another-value
+    }
+  }
+
+  // Expected
+
+#if 0
+    {
+      ConfigurationSetting setting;
+      setting.Key = "some-key";
+      setting.Value = "another-value";
+
+      SetSettingOptions options;
+      options.Label = "some-label";
+
+      Azure::Response<ConfigurationSetting> setResult
+          = configurationClient.SetConfigurationSetting(setting, options);
+
+      ConfigurationSetting result = setResult.Value;
+      Azure::Nullable<std::string> valueOfKey = result.Value;
+
+      std::cout << result.Key << std::endl; // some-key
+
+      if (valueOfKey.HasValue())
+      {
+        std::cout << valueOfKey.Value() << std::endl; // another-value
+      }
+    }
+#endif
+}
+
+// Make the setting read-write
+static void SetReadWrite(ConfigurationClient& configurationClient)
+{
+  // Current
+
+  {
+    DeleteLockOptions options;
+    options.Label = "some-label";
+
+    Azure::Response<DeleteLockResult> deleteLockResult
+        = configurationClient.DeleteLock("some-key", "accept", options);
+
+    DeleteLockResult result = deleteLockResult.Value;
+    Azure::Nullable<bool> isLocked = result.Locked;
+
+    std::cout << result.Key << std::endl; // some-key
+
+    if (isLocked.HasValue())
+    {
+      std::cout << "isLocked: " << isLocked.Value() << std::endl; // false
+    }
+  }
+
+  // Expected
+
+#if 0
+  {
+    SetReadOnlyOptions options;
+    options.Label = "some-label";
+
+    Azure::Response<ConfigurationSetting> setReadOnlyResult
+        = configurationClient.SetReadOnly("some-key", false, options);
+
+    ConfigurationSetting result = setReadOnlyResult.Value;
+    Azure::Nullable<bool> isReadOnly = result.IsReadOnly;
+
+    std::cout << result.Key << std::endl; // some-key
+
+    if (isReadOnly.HasValue())
+    {
+      std::cout << "isReadOnly: " << isReadOnly.Value() << std::endl; // false
+    }
+  }
+#endif
+}
+
 // Retreive labels based on filters
 static void RetreiveLabels(ConfigurationClient& configurationClient)
 {
@@ -180,6 +325,28 @@ int main()
     }
 #endif
 
+    // Make the setting read-only
+    SetReadOnly(configurationClient);
+
+    try
+    {
+      // Trying to modify a read-only setting is expected to throw an exception because it cannot be
+      // updated.
+      SetConfigurationSetting(configurationClient);
+    }
+    catch (Azure::Core::RequestFailedException const& e)
+    {
+      std::cout << "Client request failed error when trying to modify a read-only setting:"
+                << std::endl
+                << e.what() << std::endl;
+    }
+
+    // Make the setting read-write
+    SetReadWrite(configurationClient);
+
+    // Trying to modify a read-write setting should succeed
+    SetConfigurationSetting(configurationClient);
+
     // Retreive labels based on filters
     RetreiveLabels(configurationClient);
 
@@ -198,7 +365,7 @@ int main()
 
       if (valueOfKey.HasValue())
       {
-        std::cout << valueOfKey.Value() << std::endl; // some-value
+        std::cout << valueOfKey.Value() << std::endl; // another-value
       }
       else
       {
@@ -221,7 +388,7 @@ int main()
 
       if (valueOfKey.HasValue())
       {
-        std::cout << valueOfKey.Value() << std::endl; // some-value
+        std::cout << valueOfKey.Value() << std::endl; // another-value
       }
       else
       {


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/6293, https://github.com/Azure/azure-sdk-for-cpp/issues/6294
The expected user experience is under `#if 0` for now since it won't compile.

The goal here is to leverage the hero scenario samples for AppConfig to concretely highlight and track the gap between what is generated today vs what we want the end user experience and API design to be.

No new emitter or API design issues discovered.