### PR TITLE
Add samples for Get, Archive, and Recover Snapshots with comparisons of what we'd expect the user experience to be.

### DIFF
--- a/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
+++ b/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
@@ -74,6 +74,181 @@ static void RetreiveLabels(ConfigurationClient& configurationClient)
 #endif
 }
 
+// Retrieve a snapshot
+static void RetrieveSnapshot(ConfigurationClient& configurationClient)
+{
+  // Current
+
+  {
+    Azure::Response<GetSnapshotResult> getSnapshotResult
+        = configurationClient.GetSnapshot("snapshot-name", "accept");
+
+    GetSnapshotResult result = getSnapshotResult.Value;
+
+    std::cout << result.Name; // snapshot-name
+
+    if (result.RetentionPeriod.HasValue())
+    {
+      std::cout << " : " << result.RetentionPeriod.Value();
+    }
+
+    if (result.Status.HasValue())
+    {
+      std::cout << " : " << result.Status.Value().ToString();
+    }
+    std::cout << std::endl;
+  }
+
+  // Expected
+
+#if 0
+  {
+    Azure::Response<Snapshot> getSnapshotResult = configurationClient.GetSnapshot("snapshot-name");
+
+    Snapshot snapshot = getSnapshotResult.Value;
+
+    std::cout << snapshot.Name; // snapshot-name
+
+    if (snapshot.RetentionPeriod.HasValue())
+    {
+      std::cout << " : " << snapshot.RetentionPeriod.Value();
+    }
+
+    if (snapshot.Status.HasValue())
+    {
+      std::cout << " : " << snapshot.Status.Value().ToString();
+    }
+    std::cout << std::endl;
+  }
+#endif
+}
+
+// Archive a snapshot
+static void ArchiveSnapshot(ConfigurationClient& configurationClient)
+{
+  // Current
+
+  {
+    SnapshotUpdateParameters entity = {};
+    entity.Status = SnapshotStatus::Archived;
+
+    Azure::Response<UpdateSnapshotResult> updateSnapshotResult = configurationClient.UpdateSnapshot(
+        UpdateSnapshotRequestContentType::ApplicationMergePatchJson,
+        "snapshot-name",
+        "accept",
+        entity);
+
+    UpdateSnapshotResult result = updateSnapshotResult.Value;
+
+    std::cout << result.Name; // snapshot-name
+
+    if (result.RetentionPeriod.HasValue())
+    {
+      std::cout << " : " << result.RetentionPeriod.Value();
+    }
+
+    if (result.Status.HasValue())
+    {
+      std::cout << " : " << result.Status.Value().ToString();
+    }
+
+    if (result.Expires.HasValue())
+    {
+      std::cout << " : " << result.Expires.Value();
+    }
+
+    std::cout << std::endl;
+  }
+
+  // Expected
+
+#if 0
+  {
+    Azure::Response<Snapshot> archiveSnapshotResult
+        = configurationClient.ArchiveSnapshot("snapshot-name");
+
+    Snapshot snapshot = archiveSnapshotResult.Value;
+
+    std::cout << snapshot.Name; // snapshot-name
+
+    if (snapshot.RetentionPeriod.HasValue())
+    {
+      std::cout << " : " << snapshot.RetentionPeriod.Value();
+    }
+
+    if (snapshot.Status.HasValue())
+    {
+      std::cout << " : " << snapshot.Status.Value().ToString();
+    }
+
+    if (snapshot.Expires.HasValue())
+    {
+      std::cout << " : " << snapshot.Expires.Value();
+    }
+
+    std::cout << std::endl;
+  }
+#endif
+}
+
+// Recover a snapshot
+static void RecoverSnapshot(ConfigurationClient& configurationClient)
+{
+  // Current
+
+  {
+    SnapshotUpdateParameters entity = {};
+    entity.Status = SnapshotStatus::Ready;
+
+    Azure::Response<UpdateSnapshotResult> updateSnapshotResult = configurationClient.UpdateSnapshot(
+        UpdateSnapshotRequestContentType::ApplicationMergePatchJson,
+        "snapshot-name",
+        "accept",
+        entity);
+
+    UpdateSnapshotResult result = updateSnapshotResult.Value;
+
+    std::cout << result.Name; // snapshot-name
+
+    if (result.RetentionPeriod.HasValue())
+    {
+      std::cout << " : " << result.RetentionPeriod.Value();
+    }
+
+    if (result.Status.HasValue())
+    {
+      std::cout << " : " << result.Status.Value().ToString();
+    }
+
+    std::cout << " : Has expires value? " << result.Expires.HasValue() << std::endl;
+  }
+
+  // Expected
+
+#if 0
+  {
+    Azure::Response<Snapshot> recoverSnapshotResult
+        = configurationClient.RecoverSnapshot("snapshot-name");
+
+    Snapshot snapshot = recoverSnapshotResult.Value;
+
+    std::cout << snapshot.Name; // snapshot-name
+
+    if (snapshot.RetentionPeriod.HasValue())
+    {
+      std::cout << " : " << snapshot.RetentionPeriod.Value();
+    }
+
+    if (snapshot.Status.HasValue())
+    {
+      std::cout << " : " << snapshot.Status.Value().ToString();
+    }
+
+    std::cout << " : Has expires value? " << snapshot.Expires.HasValue() << std::endl;
+  }
+#endif
+}
+
 int main()
 {
   try
@@ -182,6 +357,15 @@ int main()
 
     // Retreive labels based on filters
     RetreiveLabels(configurationClient);
+
+    // Retrieve a snapshot
+    RetrieveSnapshot(configurationClient);
+
+    // Archive a snapshot
+    ArchiveSnapshot(configurationClient);
+
+    // Recover a snapshot
+    RecoverSnapshot(configurationClient);
 
     // Delete a configuration setting
 


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/6298, https://github.com/Azure/azure-sdk-for-cpp/issues/6300, https://github.com/Azure/azure-sdk-for-cpp/issues/6301
The expected user experience is under `#if 0` for now since it won't compile.

The goal here is to leverage the hero scenario samples for AppConfig to concretely highlight and track the gap between what is generated today vs what we want the end user experience and API design to be.

The API design is impacted by the following existing issues:
https://github.com/Azure/autorest.cpp/issues/436 - in this case, content-type shouldn't be required as a parameter (similar to accept)
https://github.com/Azure/autorest.cpp/issues/447 - if the snapshot name is not set, throw

New design issue:
https://github.com/Azure/azure-sdk-for-cpp/issues/6343

No new emitter issues discovered.

