### PR TITLE
Add samples for AppConfig LRO CreateSnapshot with comparisons of what we'd expect the user experience to be.

### DIFF
--- a/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
+++ b/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
@@ -90,27 +90,27 @@ static void SetConfigurationSetting(ConfigurationClient& configurationClient)
   // Expected
 
 #if 0
+  {
+    ConfigurationSetting setting;
+    setting.Key = "some-key";
+    setting.Value = "another-value";
+
+    SetSettingOptions options;
+    options.Label = "some-label";
+
+    Azure::Response<ConfigurationSetting> setResult
+        = configurationClient.SetConfigurationSetting(setting, options);
+
+    ConfigurationSetting result = setResult.Value;
+    Azure::Nullable<std::string> valueOfKey = result.Value;
+
+    std::cout << result.Key << std::endl; // some-key
+
+    if (valueOfKey.HasValue())
     {
-      ConfigurationSetting setting;
-      setting.Key = "some-key";
-      setting.Value = "another-value";
-
-      SetSettingOptions options;
-      options.Label = "some-label";
-
-      Azure::Response<ConfigurationSetting> setResult
-          = configurationClient.SetConfigurationSetting(setting, options);
-
-      ConfigurationSetting result = setResult.Value;
-      Azure::Nullable<std::string> valueOfKey = result.Value;
-
-      std::cout << result.Key << std::endl; // some-key
-
-      if (valueOfKey.HasValue())
-      {
-        std::cout << valueOfKey.Value() << std::endl; // another-value
-      }
+      std::cout << valueOfKey.Value() << std::endl; // another-value
     }
+  }
 #endif
 }
 
@@ -695,7 +695,7 @@ static void CreateSnapshot(ConfigurationClient& configurationClient)
 
     if (result.Status.HasValue())
     {
-      std::cout << " : " << result.Status.Value().ToString() << std::endl; // Provisioning
+      std::cout << result.Status.Value().ToString() << std::endl; // Provisioning
     }
 
     // Manually poll for up to a maximum of 30 seconds.
@@ -747,6 +747,13 @@ static void CreateSnapshot(ConfigurationClient& configurationClient)
 
     StartCreateSnapshotOperation createSnapshotOperation
         = configurationClient.StartCreateSnapshot("snapshot-name", entity, options);
+
+    Snapshot result = createSnapshotOperation.GetInitialResult();
+
+    if (result.Status.HasValue())
+    {
+      std::cout << result.Status.Value().ToString() << std::endl; // Provisioning
+    }
 
     // Waits for the operation to finish, checking for status every 1 second.
     Azure::Response<OperationDetails> operationResult

--- a/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
+++ b/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
@@ -713,10 +713,10 @@ static void CreateSnapshot(ConfigurationClient& configurationClient)
       std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
 
-    Azure::Response<Snapshot> getSnapshotResult
+    Azure::Response<GetSnapshotResult> getSnapshotResult
         = configurationClient.GetSnapshot("snapshot-name", "accept");
 
-    Snapshot snapshot = getSnapshotResult.Value;
+    GetSnapshotResult snapshot = getSnapshotResult.Value;
 
     std::cout << snapshot.Name; // snapshot-name
 

--- a/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
+++ b/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
@@ -152,9 +152,15 @@ static void CreateSnapshot(ConfigurationClient& configurationClient)
         = configurationClient.StartCreateSnapshot("snapshot-name", entity, options);
 
     // Waits for the operation to finish, checking for status every 1 second.
-    Azure::Response<Snapshot> snapshotResult
+    Azure::Response<OperationDetails> operationResult
         = createSnapshotOperation.PollUntilDone(std::chrono::milliseconds(1000));
-    Snapshot snapshot = snapshotResult.Value;
+
+    std::cout << operationResult.Value.Status.ToString() << std::endl; // Succeeded
+
+    Azure::Response<Snapshot> getSnapshotResult
+        = configurationClient.GetSnapshot("snapshot-name", "accept");
+
+    Snapshot snapshot = getSnapshotResult.Value;
 
     std::cout << snapshot.Name; // snapshot-name
 

--- a/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
+++ b/sdk/appconfiguration/azure-data-appconfiguration/samples/appconfig_basic_operation.cpp
@@ -10,6 +10,7 @@
 #include <azure/identity.hpp>
 
 #include <iostream>
+#include <thread>
 
 using namespace Azure::Data::AppConfiguration;
 using namespace Azure::Identity;


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-cpp/issues/6297
The expected user experience is under `#if 0` for now since it won't compile.

The goal here is to leverage the hero scenario samples for AppConfig to concretely highlight and track the gap between what is generated today vs what we want the end user experience and API design to be.

These particular endpoints highlight newer emitter issues around LRO correctness for error JSON parsing when calling `GetOperationDetails()`, and the general LRO pattern:
https://github.com/Azure/autorest.cpp/issues/471
https://github.com/Azure/autorest.cpp/issues/413

