### PR TITLE
Add experimental (_detail) support for literally null Nullable

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Added internal support for representing null values in `Nullable<T>`. 
+
 ## 1.15.0-beta.2 (2025-01-09)
 
 ### Features Added

--- a/sdk/core/azure-core/inc/azure/core/nullable.hpp
+++ b/sdk/core/azure-core/inc/azure/core/nullable.hpp
@@ -107,9 +107,10 @@ public:
   {
     if (m_hasValue > 0)
     {
-      m_hasValue = 0;
       m_value.~T();
     }
+
+    m_hasValue = 0;
   }
 
   /**

--- a/sdk/core/azure-core/inc/azure/core/nullable.hpp
+++ b/sdk/core/azure-core/inc/azure/core/nullable.hpp
@@ -405,7 +405,7 @@ namespace _detail {
 
     template <typename T> static constexpr bool IsNull(Nullable<T> const& nullable)
     {
-      return nullable.m_hasValue == -1;
+      return nullable.m_hasValue < 0;
     }
   };
 } // namespace _detail

--- a/sdk/core/azure-core/inc/azure/core/nullable.hpp
+++ b/sdk/core/azure-core/inc/azure/core/nullable.hpp
@@ -140,7 +140,7 @@ public:
       std::swap(m_hasValue, other.m_hasValue);
       other.m_value.~T();
     }
-    else
+    else if (m_hasValue != other.m_hasValue)
     {
       std::swap(m_value, other.m_value);
     }
@@ -201,7 +201,7 @@ public:
           int>::type
       = 0>
   Nullable& operator=(U&& other) noexcept(
-      std::is_nothrow_constructible<T, U>::value && std::is_nothrow_assignable<T&, U>::value)
+      std::is_nothrow_constructible<T, U>::value&& std::is_nothrow_assignable<T&, U>::value)
   {
     if (m_hasValue > 0)
     {

--- a/sdk/core/azure-core/inc/azure/core/nullable.hpp
+++ b/sdk/core/azure-core/inc/azure/core/nullable.hpp
@@ -131,7 +131,7 @@ public:
       else
       {
         ::new (static_cast<void*>(&other.m_value)) T(std::move(m_value)); // throws
-        std::swap(other.m_hasValue, m_hasValue);
+        std::swap(m_hasValue, other.m_hasValue);
         m_value.~T();
       }
     }
@@ -143,7 +143,7 @@ public:
     }
     else if (m_hasValue != other.m_hasValue)
     {
-      std::swap(m_value, other.m_value);
+      std::swap(m_hasValue, other.m_hasValue);
     }
   }
 

--- a/sdk/core/azure-core/test/ut/nullable_test.cpp
+++ b/sdk/core/azure-core/test/ut/nullable_test.cpp
@@ -289,3 +289,109 @@ TEST(Nullable, ConstexprAndRvalue)
   std::string str(Nullable<std::string>(std::string("hello")).Value());
   EXPECT_EQ(str, "hello");
 }
+
+TEST(Nullable, NullValue)
+{
+  {
+    Nullable<int> null = _detail::NullableHelper::CreateNull<int>();
+    EXPECT_FALSE(null.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(null));
+
+    null.Reset();
+    EXPECT_FALSE(null.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(null));
+
+    _detail::NullableHelper::SetNull(null);
+    EXPECT_FALSE(null.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(null));
+  }
+  {
+    Nullable<int> empty;
+    EXPECT_FALSE(empty.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(empty));
+
+    _detail::NullableHelper::SetNull(empty);
+    EXPECT_FALSE(empty.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(empty));
+
+    empty = Nullable<int>();
+    EXPECT_FALSE(empty.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(empty));
+  }
+  {
+    Nullable<int> value = 1;
+    EXPECT_TRUE(value.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(value));
+    _detail::NullableHelper::SetNull(value);
+
+    EXPECT_FALSE(value.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(value));
+
+    value = 1;
+    EXPECT_TRUE(value.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(value));
+  }
+  {
+    Nullable<int> null{_detail::NullableHelper::CreateNull<int>()};
+    Nullable<int> empty;
+    Nullable<int> value{1};
+
+    EXPECT_FALSE(null.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(null));
+
+    EXPECT_FALSE(empty.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(empty));
+
+    EXPECT_TRUE(value.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(value));
+
+    null.Swap(empty);
+    EXPECT_FALSE(empty.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(empty));
+
+    EXPECT_FALSE(null.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(null));
+
+    empty.Swap(null);
+    EXPECT_FALSE(null.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(null));
+
+    EXPECT_FALSE(empty.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(empty));
+
+    null.Swap(value);
+    EXPECT_TRUE(null.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(null));
+
+    EXPECT_FALSE(value.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(value));
+
+    value.Swap(null);
+    EXPECT_FALSE(null.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(null));
+
+    EXPECT_TRUE(value.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(value));
+  }
+  {
+    auto null = _detail::NullableHelper::CreateNull<int>();
+    EXPECT_FALSE(null.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(null));
+
+    null.Emplace(1);
+    EXPECT_TRUE(null.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(null));
+
+    _detail::NullableHelper::SetNull(null);
+    EXPECT_FALSE(null.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(null));
+
+    Nullable<long> null2 = null;
+    EXPECT_FALSE(null2.HasValue());
+    EXPECT_TRUE(_detail::NullableHelper::IsNull(null2));
+
+    null2 = 2L;
+    EXPECT_TRUE(null2.HasValue());
+    EXPECT_FALSE(_detail::NullableHelper::IsNull(null2));
+  }
+}

--- a/sdk/core/azure-core/test/ut/nullable_test.cpp
+++ b/sdk/core/azure-core/test/ut/nullable_test.cpp
@@ -386,11 +386,11 @@ TEST(Nullable, NullValue)
     EXPECT_FALSE(null.HasValue());
     EXPECT_TRUE(_detail::NullableHelper::IsNull(null));
 
-    Nullable<long> null2 = null;
+    Nullable<int> null2 = null;
     EXPECT_FALSE(null2.HasValue());
     EXPECT_TRUE(_detail::NullableHelper::IsNull(null2));
 
-    null2 = 2L;
+    null2 = 2;
     EXPECT_TRUE(null2.HasValue());
     EXPECT_FALSE(_detail::NullableHelper::IsNull(null2));
   }


### PR DESCRIPTION
After closing #6322 without merging, and thinking more about it, I am proposing to add this and utilize it in Codegen, to cover tests and make sure that everything gets serialized correctly.
JSON merge-patch implementation may use it.

Other language SDKs do have support for literally null value, so we should not be overly hesitant to add it, especially like this, when it is minimally intrusive.

We will be able to make sure that we can achieve what we want with this.
If we decide to go with it, we will make it _internal, or maybe even public (with API similar to #6322, or maybe as an explicit template specialization for `Nullable<std::nullptr_t>` which you could "assign" to a `Nullable<T>`). But the thing is, the main logic, with tri-state `m_hasValue` will be the same.

Otherwise, it is `_detail`, with a comment that nobody should use it. If we decide to revert it, it will be easy to get rid of it.

Basically, this fixes #6308 and enables us to cover https://github.com/Azure/autorest.cpp/issues/330.

There are typespec tests for this scenario -  https://github.com/microsoft/typespec/blob/6f34e0d39499741be64a8a7d87f2f990d5061509/packages/http-specs/specs/type/property/nullable/mockapi.ts

