### PR TITLE
Identity: Log Client ID used in ManagedIdentityCredential

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added `Subscription` to `AzureCliCredentialOptions` which allows the caller to specify an Azure subscription that does not match the current Azure CLI subscription.
+- [[#6321]](https://github.com/Azure/azure-sdk-for-cpp/issues/6321) Log Client ID used in `ManagedIdentityCredential`.
 
 ### Breaking Changes
 

--- a/sdk/identity/azure-identity/src/private/managed_identity_source.hpp
+++ b/sdk/identity/azure-identity/src/private/managed_identity_source.hpp
@@ -32,7 +32,8 @@ namespace Azure { namespace Identity { namespace _detail {
         std::string const& credName,
         std::string const& url,
         char const* envVarName,
-        std::string const& credSource);
+        std::string const& credSource,
+        std::string const& clientId);
 
     explicit ManagedIdentitySource(
         std::string clientId,

--- a/sdk/identity/azure-identity/test/ut/managed_identity_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/managed_identity_credential_test.cpp
@@ -753,8 +753,7 @@ namespace Azure { namespace Identity { namespace Test {
           EXPECT_EQ(
               log[1].second,
               "Identity: ManagedIdentityCredential will be created with App Service 2017 source"
-              " and Client ID 'fedcba98-7654-3210-0123-456789abcdef'."
-            );
+              " and Client ID 'fedcba98-7654-3210-0123-456789abcdef'.");
 
           log.clear();
 

--- a/sdk/identity/azure-identity/test/ut/managed_identity_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/managed_identity_credential_test.cpp
@@ -2634,7 +2634,7 @@ namespace Azure { namespace Identity { namespace Test {
     }
     {
       auto const actual = CredentialTestHelper::SimulateTokenRequest(
-          [](auto transport) {
+          [&](auto transport) {
             ManagedIdentityCredentialOptions options;
             options.Transport.Transport = transport;
             options.IdentityId = ManagedIdentityId::FromUserAssignedClientId(


### PR DESCRIPTION
Fixes #6321

During creation of ManagedIdentityCredential, messages will look like this:
```
[VERBOSE] Identity: ManagedIdentityCredential: Environment is not set up
          for the credential to be created with App Service 2019 source.
[VERBOSE] Identity: ManagedIdentityCredential: Environment is not set up
          for the credential to be created with App Service 2017 source.
[VERBOSE] Identity: ManagedIdentityCredential: Environment is not set up
          for the credential to be created with Cloud Shell source.
[VERBOSE] Identity: ManagedIdentityCredential: Environment is not set up
          for the credential to be created with Azure Arc source.
```

and then
```
[INFO] Identity: ManagedIdentityCredential will be created
       with Azure Instance Metadata Service source
       and Client ID 'fedcba98-7654-3210-0123-456789abcdef'.

       Successful creation does not guarantee
       further successful token retrieval.
```

This is similar to what Go did: https://github.com/Azure/azure-sdk-for-go/pull/24048/files