### PR TITLE
Add support for building with ICU 75.1 or later

### DIFF
--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Added support for ICU 75.1 or later.
+
 ## 12.10.0 (2025-03-11)
 
 ### Features Added

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -10,7 +10,13 @@
 
 ### Other Changes
 
-- Added support for ICU 75.1 or later.
+- Added support for ICU 75.1 or later. (A community contribution, courtesy of _[kou](https://github.com/kou)_)
+
+### Acknowledgments
+
+Thank you to our developer community members who helped to make Azure Storage better with their contributions to this release:
+
+- Sutou Kouhei _([GitHub](https://github.com/kou))_
 
 ## 12.10.0 (2025-03-11)
 

--- a/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
+++ b/sdk/storage/azure-storage-common/src/xml_wrapper.cpp
@@ -20,6 +20,10 @@
 #endif
 #include <webservices.h>
 #else
+// libxml2 uses ICU. ICU 75.1 or later requires C++17 but we use
+// C++14. It causes an error. We can disable ICU C++ API to avoid it
+// because we don't need ICU C++ API.
+#define U_SHOW_CPLUSPLUS_API 0
 #include <libxml/xmlreader.h>
 #include <libxml/xmlwriter.h>
 #endif

--- a/sdk/tables/azure-data-tables/CHANGELOG.md
+++ b/sdk/tables/azure-data-tables/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Added support for ICU 75.1 or later.
+
 ## 1.0.0-beta.6 (2025-01-22)
 
 ### Breaking Changes

--- a/sdk/tables/azure-data-tables/CHANGELOG.md
+++ b/sdk/tables/azure-data-tables/CHANGELOG.md
@@ -10,7 +10,13 @@
 
 ### Other Changes
 
-- Added support for ICU 75.1 or later.
+- Added support for ICU 75.1 or later. (A community contribution, courtesy of _[kou](https://github.com/kou)_)
+
+### Acknowledgments
+
+Thank you to our developer community members who helped to make Azure Data Tables better with their contributions to this release:
+
+- Sutou Kouhei _([GitHub](https://github.com/kou))_
 
 ## 1.0.0-beta.6 (2025-01-22)
 

--- a/sdk/tables/azure-data-tables/src/xml_wrapper.cpp
+++ b/sdk/tables/azure-data-tables/src/xml_wrapper.cpp
@@ -19,6 +19,10 @@
 #endif
 #include <webservices.h>
 #else
+// libxml2 uses ICU. ICU 75.1 or later requires C++17 but we use
+// C++14. It causes an error. We can disable ICU C++ API to avoid it
+// because we don't need ICU C++ API.
+#define U_SHOW_CPLUSPLUS_API 0
 #include <libxml/xmlreader.h>
 #include <libxml/xmlwriter.h>
 #endif


### PR DESCRIPTION
# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs: Not needed
- [ ] Unit tests: Not needed
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [ ] Related issue listed: Should I create an issue for this?
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [ ] External references or docs updated: Not needed
- [x] Self review of PR done
- [x] Any breaking changes?: No

We use ICU via libxml2 implicitly. ICU 75.1 or later require C++17 for its C++ API:

https://github.com/unicode-org/icu/releases/tag/release-75-1

> C++ code now requires C++17

But we use C++17. So `#include <libxml/xmlreader.h>` with ICU 75.1 or later causes an error:

    [1/177] Building CXX object sdk/storage/azure-storage-common/CMakeFiles/azure-storage-common.dir/src/xml_wrapper.cpp.o
    FAILED: sdk/storage/azure-storage-common/CMakeFiles/azure-storage-common.dir/src/xml_wrapper.cpp.o
    /bin/c++ -DAZ_RTTI -DBUILD_CURL_HTTP_TRANSPORT_ADAPTER -D_azure_BUILDING_SDK
    -Isdk/storage/azure-storage-common/inc -Isdk/core/azure-core/inc
    -isystem /usr/include/libxml2 -g -std=gnu++14 -fno-operator-names
    -Wold-style-cast -Wall -Wextra -pedantic -Werror -MD
    -MT sdk/storage/azure-storage-common/CMakeFiles/azure-storage-common.dir/src/xml_wrapper.cpp.o
    -MF sdk/storage/azure-storage-common/CMakeFiles/azure-storage-common.dir/src/xml_wrapper.cpp.o.d
    -o sdk/storage/azure-storage-common/CMakeFiles/azure-storage-common.dir/src/xml_wrapper.cpp.o
    -c sdk/storage/azure-storage-common/src/xml_wrapper.cpp
    In file included from /usr/include/unicode/uenum.h:25,
                     from /usr/include/unicode/ucnv.h:52,
                     from /usr/include/libxml2/libxml/encoding.h:31,
                     from /usr/include/libxml2/libxml/parser.h:812,
                     from /usr/include/libxml2/libxml/globals.h:18,
                     from /usr/include/libxml2/libxml/threads.h:35,
                     from /usr/include/libxml2/libxml/xmlmemory.h:218,
                     from /usr/include/libxml2/libxml/tree.h:1307,
                     from /usr/include/libxml2/libxml/xmlreader.h:14,
                     from sdk/storage/azure-storage-common/src/xml_wrapper.cpp:23:
    /usr/include/unicode/localpointer.h:561:26: error: 'auto' parameter not permitted in this context
      561 | template <typename Type, auto closeFunction>
          |                          ^~~~
    /usr/include/unicode/localpointer.h:573:76: error: template argument 2 is invalid
      573 |     explicit LocalOpenPointer(std::unique_ptr<Type, decltype(closeFunction)> &&p)
          |                                                                            ^
    /usr/include/unicode/localpointer.h:583:78: error: template argument 2 is invalid
      583 |     LocalOpenPointer &operator=(std::unique_ptr<Type, decltype(closeFunction)> &&p) {
          |                                                                              ^
    /usr/include/unicode/localpointer.h:599:59: error: template argument 2 is invalid
      599 |     operator std::unique_ptr<Type, decltype(closeFunction)> () && {
          |                                                           ^
    /usr/include/unicode/uenum.h:69:1: note: invalid template non-type parameter
       69 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUEnumerationPointer, UEnumeration, uenum_close);
          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/unicode/ucnv.h:597:1: note: invalid template non-type parameter
      597 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUConverterPointer, UConverter, ucnv_close);
          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~

We don't need ICU C++ API. So we can avoid this error by disabling ICU C++ API by defining `U_SHOW_CPLUSPLUS_API` as `0`.
