### PR TITLE
Ubuntu 20 -> Ubuntu 22 migration

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -143,8 +143,8 @@ jobs:
       - bash: |
           # Run clang-format recursively on each source and header file within the repo sdk folder.
           echo "Check clang-formatting"
-          clang-format --version
-          find ./sdk \( -iname '*.hpp' -o -iname '*.cpp' \) ! -iname 'json.hpp' -exec clang-format -i {} \;
+          clang-format-11 --version
+          find ./sdk \( -iname '*.hpp' -o -iname '*.cpp' \) ! -iname 'json.hpp' -exec clang-format-11 -i {} \;
 
           if [[ `git status | grep modified | awk '{print $2}'` ]]; then
             echo Some files were not formatted correctly according to the .clang-format file.

--- a/eng/pipelines/templates/stages/platform-matrix-cmakegenerate.json
+++ b/eng/pipelines/templates/stages/platform-matrix-cmakegenerate.json
@@ -3,8 +3,8 @@
     "CmakeEnvArg": "",
     "OSConfig": {
       "Linux": {
-        "Pool": "env:LINUXNEXTPOOL",
-        "OSVmImage": "env:LINUXNEXTVMIMAGE",
+        "Pool": "env:LINUXPOOL",
+        "OSVmImage": "env:LINUXVMIMAGE",
         "AptDependencies": "libcurl4-openssl-dev",
         "VCPKG_DEFAULT_TRIPLET": "x64-linux"
       },

--- a/eng/pipelines/templates/stages/platform-matrix-cmakesourcegenerate.json
+++ b/eng/pipelines/templates/stages/platform-matrix-cmakesourcegenerate.json
@@ -7,8 +7,8 @@
         "CmakeEnvArg": ""
       },
       "Linux": {
-        "Pool": "env:LINUXNEXTPOOL",
-        "OSVmImage": "env:LINUXNEXTVMIMAGE",
+        "Pool": "env:LINUXPOOL",
+        "OSVmImage": "env:LINUXVMIMAGE",
         "CmakeEnvArg": "",
         "AptDependencies": "libcurl4-openssl-dev"
       },

--- a/eng/pipelines/templates/stages/platform-matrix-live.json
+++ b/eng/pipelines/templates/stages/platform-matrix-live.json
@@ -50,7 +50,7 @@
         }
       },
       "BuildConfig": {
-        "x64_with_unit_test": {
+        "x64_with_unit_test_release": {
           "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_SAMPLES=ON",
           "AZURE_CORE_ENABLE_JSON_TESTS": 1
         },

--- a/eng/pipelines/templates/stages/platform-matrix-live.json
+++ b/eng/pipelines/templates/stages/platform-matrix-live.json
@@ -36,20 +36,7 @@
           "CODE_COVERAGE": "enabled",
           "CODE_COVERAGE_COLLECT_ONLY": 1,
           "AZURE_CORE_ENABLE_JSON_TESTS": 1
-        }
-      }
-    },
-    {
-      "StaticConfigs": {
-        "Ubu22": {
-          "BuildArgs": "-j 4",
-          "Pool": "env:LINUXPOOL",
-          "OSVmImage": "env:LINUXVMIMAGE",
-          "VCPKG_DEFAULT_TRIPLET": "x64-linux",
-          "RunProxyTests": true
-        }
-      },
-      "BuildConfig": {
+        },
         "x64_with_unit_test_release": {
           "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_SAMPLES=ON",
           "AZURE_CORE_ENABLE_JSON_TESTS": 1

--- a/eng/pipelines/templates/stages/platform-matrix-live.json
+++ b/eng/pipelines/templates/stages/platform-matrix-live.json
@@ -41,7 +41,7 @@
     },
     {
       "StaticConfigs": {
-        "Ubu20": {
+        "Ubu22": {
           "BuildArgs": "-j 4",
           "Pool": "env:LINUXPOOL",
           "OSVmImage": "env:LINUXVMIMAGE",

--- a/eng/pipelines/templates/stages/platform-matrix-live.json
+++ b/eng/pipelines/templates/stages/platform-matrix-live.json
@@ -24,8 +24,8 @@
         "Ubu2204": {
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 4",
-          "Pool": "env:LINUXNEXTPOOL",
-          "OSVmImage": "env:LINUXNEXTVMIMAGE",
+          "Pool": "env:LINUXPOOL",
+          "OSVmImage": "env:LINUXVMIMAGE",
           "RunProxyTests": true
         }
       },

--- a/eng/pipelines/templates/stages/platform-matrix-quick.json
+++ b/eng/pipelines/templates/stages/platform-matrix-quick.json
@@ -6,8 +6,8 @@
           {
             "StaticConfigs": {
               "Ubuntu22": {
-                "OSVmImage": "env:LINUXNEXTVMIMAGE",
-                "Pool": "env:LINUXNEXTPOOL",
+                "OSVmImage": "env:LINUXVMIMAGE",
+                "Pool": "env:LINUXPOOL",
                 "VCPKG_DEFAULT_TRIPLET": "x64-linux",
                 "BuildArgs": "-j 10",
                 "RunProxyTests": true

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -141,8 +141,8 @@
     {
       "StaticConfigs": {
         "Ubuntu22": {
-          "OSVmImage": "env:LINUXNEXTVMIMAGE",
-          "Pool": "env:LINUXNEXTPOOL",
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",
           "BuildArgs": "-j 10",
           "RunProxyTests": true

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -189,25 +189,7 @@
     },
     {
       "StaticConfigs": {
-        "Ubuntu20": {
-          "OSVmImage": "env:LINUXVMIMAGE",
-          "Pool": "env:LINUXPOOL",
-          "VCPKG_DEFAULT_TRIPLET": "x64-linux",
-          "BuildArgs": "-j 10",
-          "RunProxyTests": true
-        }
-      },
-      "BuildSettings": {
-        "gpp-8": {
-          "AptDependencies": "g++-8",
-          "CC": "/usr/bin/gcc-8",
-          "CXX": "/usr/bin/g++-8"
-        }
-      }
-    },
-    {
-      "StaticConfigs": {
-        "Ubuntu20": {
+        "Ubuntu22": {
           "OSVmImage": "env:LINUXVMIMAGE",
           "Pool": "env:LINUXPOOL",
           "VCPKG_DEFAULT_TRIPLET": "x64-linux",

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -198,7 +198,8 @@
           "CXX": "/usr/bin/clang++-11",
           "CmakeArgs": " -DBUILD_TESTING=ON -DBUILD_PERFORMANCE_TESTS=ON -DRUN_LONG_UNIT_TESTS=ON",
           "PublishMapFiles": "true",
-          "RunProxyTests": true
+          "RunProxyTests": true,
+          "AptDependencies": "clang-11 clang-format-11"
         }
       },
       "BuildSettings": {

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -2,8 +2,6 @@
 
 variables:
   - name: LINUXPOOL
-    value: azsdk-pool-mms-ubuntu-2004-general
-  - name: LINUXNEXTPOOL
     value: azsdk-pool-mms-ubuntu-2204-general
   - name: WINDOWSPOOL
     value: azsdk-pool-mms-win-2022-general
@@ -13,8 +11,6 @@ variables:
     value: Azure Pipelines
 
   - name: LINUXVMIMAGE
-    value: azsdk-pool-mms-ubuntu-2004-1espt
-  - name: LINUXNEXTVMIMAGE
     value: azsdk-pool-mms-ubuntu-2204-1espt
   - name: WINDOWSVMIMAGE
     value: azsdk-pool-mms-win-2022-1espt

--- a/sdk/template/azure-template/README.md
+++ b/sdk/template/azure-template/README.md
@@ -68,5 +68,3 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 [c_compiler]: https://visualstudio.microsoft.com/vs/features/cplusplus/
 [cloud_shell]: https://learn.microsoft.com/azure/cloud-shell/overview
 [cloud_shell_bash]: https://shell.azure.com/bash
-
-Trivial change to trigger CI

--- a/sdk/template/azure-template/README.md
+++ b/sdk/template/azure-template/README.md
@@ -68,3 +68,5 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 [c_compiler]: https://visualstudio.microsoft.com/vs/features/cplusplus/
 [cloud_shell]: https://learn.microsoft.com/azure/cloud-shell/overview
 [cloud_shell_bash]: https://shell.azure.com/bash
+
+Trivial change to trigger CI


### PR DESCRIPTION
Many jobs are already running on Ubuntu 22 so this migration only affects a few tests. 

Notable changes: 

* Live tests 
    * Consolidate Ubuntu 20 and 22 into a single matrix entry, move a couple of jobs up to Ubuntu 22. The g++ version goes from [9.4](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4706365&view=logs&j=828a8b33-7b79-5873-31b0-6ca093e649a8&t=5ade604c-9b2f-5445-2fd5-d199db38dcd7&l=190) to [11.4](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4710157&view=logs&j=7ea248a1-b95f-5efd-2a5c-ecc8b0ddcb18&t=16959aa8-e90e-55c9-c381-520ef9804eff&l=191)
        * `x64_with_unit_test_release` -- Ubuntu 20 -> 22
        * `samples` -- Ubuntu 20 -> 22
        * `x64_no_rtti` -- Ubuntu 20 -> 22
* CI tests
    * Remove Ubuntu 20 g++-8 (g++ 8 is not available on Ubuntu 22) 
    * Update clang-11 job to Ubuntu 22, clang-11 and clang-format-11 still available on Ubuntu 22
