### PR TITLE
Disable libcurl SSL connection sharing

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -390,6 +390,7 @@
         "lordgamez",
         "sjoubert",
         "sourav",
+        "sushshring",
         "Sylvain"
       ]
     },

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- [[#6535]](https://github.com/Azure/azure-sdk-for-cpp/issues/6535) Enable SSL caching for libcurl transport by default, which is backwards compatible behavior with older libcurl versions, so using the default settings won't result in transport error when using libcurl >= 8.12. The option is controlled by `CurlTransportOptions::EnableCurlSslCaching`, and is on by default. (A community contribution, courtesy of _[chewi](https://github.com/sushshring)_)
+- [[#6535]](https://github.com/Azure/azure-sdk-for-cpp/issues/6535) Disable SSL caching for libcurl transport, which fixes using SSL connections when using libcurl >= 8.12. (A community contribution, courtesy of _[chewi](https://github.com/sushshring)_)
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Features Added
 
-- [[#6535]](https://github.com/Azure/azure-sdk-for-cpp/issues/6535) Disable SSL caching for libcurl transport, which fixes using SSL connections when using libcurl >= 8.12. (A community contribution, courtesy of _[chewi](https://github.com/sushshring)_)
-
 ### Breaking Changes
+
+- [[#6535]](https://github.com/Azure/azure-sdk-for-cpp/issues/6535) Disable SSL caching for libcurl transport, which fixes using SSL connections when using libcurl >= 8.12. (A community contribution, courtesy of _[sushshring](https://github.com/sushshring)_)
 
 ### Bugs Fixed
 

--- a/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/curl_transport.hpp
@@ -194,11 +194,6 @@ namespace Azure { namespace Core { namespace Http {
      * @brief If set, integrates libcurl's internal tracing with Azure logging.
      */
     bool EnableCurlTracing = false;
-
-    /**
-     * @brief If set, enables libcurl's internal SSL session caching.
-     */
-    bool EnableCurlSslCaching = true;
   };
 
   /**

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2314,41 +2314,12 @@ CurlConnection::CurlConnection(
   }
   CURLcode result;
 
-  m_sslShareHandle = std::make_unique<Azure::Core::_detail::CURLSHWrapper>();
-  if (!m_sslShareHandle->share_handle)
+  // Disable SSL session ID caching
+  if (!SetLibcurlOption(m_handle, CURLOPT_SSL_SESSIONID_CACHE, 0L, &result))
   {
     throw Azure::Core::Http::TransportException(
         _detail::DefaultFailedToGetNewConnectionTemplate + hostDisplayName + ". "
-        + std::string("curl_share_init returned Null"));
-  }
-
-  if (!options.EnableCurlSslCaching)
-  {
-    // Disable SSL session ID caching
-    if (!SetLibcurlOption(m_handle, CURLOPT_SSL_SESSIONID_CACHE, 0L, &result))
-    {
-      throw Azure::Core::Http::TransportException(
-          _detail::DefaultFailedToGetNewConnectionTemplate + hostDisplayName + ". "
-          + std::string(curl_easy_strerror(result)));
-    }
-  }
-  else
-  {
-    CURLSHcode shResult;
-    if (!SetLibcurlShareOption(
-            m_sslShareHandle, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION, &shResult))
-    {
-      throw Azure::Core::Http::TransportException(
-          _detail::DefaultFailedToGetNewConnectionTemplate + hostDisplayName + ". "
-          + std::string(curl_share_strerror(shResult)));
-    }
-
-    if (!SetLibcurlOption(m_handle, CURLOPT_SHARE, m_sslShareHandle.get(), &result))
-    {
-      throw Azure::Core::Http::TransportException(
-          _detail::DefaultFailedToGetNewConnectionTemplate + hostDisplayName + ". "
-          + std::string(curl_easy_strerror(result)));
-    }
+        + std::string(curl_easy_strerror(result)));
   }
 
   if (options.EnableCurlTracing)

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -82,17 +82,6 @@ inline bool SetLibcurlOption(
   *outError = curl_easy_setopt(handle.get(), option, value);
   return *outError == CURLE_OK;
 }
-
-inline bool SetLibcurlShareOption(
-    std::unique_ptr<Azure::Core::_detail::CURLSHWrapper> const& handle,
-    CURLSHoption option,
-    curl_lock_data value,
-    CURLSHcode* outError)
-{
-  *outError = curl_share_setopt(handle->share_handle, option, value);
-  return *outError == CURLSHE_OK;
-}
-
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif

--- a/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
@@ -42,33 +42,6 @@ namespace Azure { namespace Core {
     {
       using type = _internal::BasicUniqueHandle<CURL, curl_easy_cleanup>;
     };
-
-    /**
-     *
-     * @brief Unique handle wrapper for CURLSH handles.
-     *
-     * @note Internally, CURL and CURLSH are declared as the same void type,
-     * so to avoid collisions we need this wrapper.
-     */
-    struct CURLSHWrapper
-    {
-      CURLSH* share_handle;
-
-      CURLSHWrapper() : share_handle{curl_share_init()} {};
-
-      ~CURLSHWrapper()
-      {
-        if (share_handle != nullptr)
-        {
-          curl_share_cleanup(share_handle);
-        }
-      }
-    };
-
-    /**
-     * @brief Unique handle for CURLSHWrapper handles
-     */
-    using UniqueCURLSHHandle = std::unique_ptr<CURLSHWrapper>;
   } // namespace _detail
 
   namespace Http {

--- a/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
+++ b/sdk/core/azure-core/src/http/curl/curl_connection_private.hpp
@@ -142,7 +142,6 @@ namespace Azure { namespace Core {
     class CurlConnection final : public CurlNetworkConnection {
     private:
       Azure::Core::_internal::UniqueHandle<CURL> m_handle;
-      Azure::Core::_detail::UniqueCURLSHHandle m_sslShareHandle;
       curl_socket_t m_curlSocket;
       std::chrono::steady_clock::time_point m_lastUseTime;
       std::string m_connectionKey;

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -1670,6 +1670,10 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
   std::unique_ptr<RawResponse> WinHttpRequest::SendRequestAndGetResponse(HttpMethod requestMethod)
   {
+    // Suppress unused parameter warning (C4100).
+    // Keeping 'requestMethod' in the signature preserves API compatibility.
+    (void)requestMethod;
+
     // First, use WinHttpQueryHeaders to obtain the size of the buffer.
     // The call is expected to fail since no destination buffer is provided.
     DWORD sizeOfHeaders = 0;

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -51,8 +51,8 @@ extends:
       CtestRegex: azure-core.|json-test
       LiveTestCtestRegex: azure-core.|json-test
       LiveTestTimeoutInMinutes: 90 # default is 60 min. We need a little longer on worst case for Win+jsonTests
-      LineCoverageTarget: 84
-      BranchCoverageTarget: 62
+      LineCoverageTarget: 85
+      BranchCoverageTarget: 63
       PreTestSteps:
         - pwsh: |
             $(Build.SourcesDirectory)/sdk/core/azure-core-amqp/Test-Setup.ps1


### PR DESCRIPTION
Fixes #6535.

When running unit tests with libcurl >= 8.12, and `EnableCurlSslCaching` is `true`, Curl connection pool unit tests do fail.
Everything is green when `EnableCurlSslCaching == false`, so I propose to disable it, and remove the option.

This PR verifies that setting that option does not fail when using libcurl < 8.12, #6574 verifies it with libcurl >= 8.12.