### PR TITLE
Fix Windows error for failing curl SSL cache

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -263,6 +263,7 @@
     "stoull",
     "STREQ",
     "Sushrut",
+    "sushshring",
     "Sutou",
     "testid",
     "swedencentral",

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- [[#6535]](https://github.com/Azure/azure-sdk-for-cpp/issues/6535) Enable SSL caching for libcurl transport by default, which is backwards compatible behavior with older libcurl versions, so using the default settings won't result in transport error when using libcurl >= 8.12. The option is controlled by `CurlTransportOptions::EnableCurlSslCaching`, and is on by default. (A community contribution, courtesy of _[chewi](https://github.com/sushshring)_)
+- [[#6535]](https://github.com/Azure/azure-sdk-for-cpp/issues/6535) Enable SSL caching for libcurl transport by default, which is backwards compatible behavior with older libcurl versions, so using the default settings won't result in transport error when using libcurl >= 8.12. The option is controlled by `CurlTransportOptions::EnableCurlSslCaching`, and is on by default. (A community contribution, courtesy of _[sushshring](https://github.com/sushshring)_)
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2314,14 +2314,6 @@ CurlConnection::CurlConnection(
   }
   CURLcode result;
 
-  m_sslShareHandle = std::make_unique<Azure::Core::_detail::CURLSHWrapper>();
-  if (!m_sslShareHandle->share_handle)
-  {
-    throw Azure::Core::Http::TransportException(
-        _detail::DefaultFailedToGetNewConnectionTemplate + hostDisplayName + ". "
-        + std::string("curl_share_init returned Null"));
-  }
-
   if (!options.EnableCurlSslCaching)
   {
     // Disable SSL session ID caching
@@ -2334,6 +2326,15 @@ CurlConnection::CurlConnection(
   }
   else
   {
+    m_sslShareHandle = std::make_unique<Azure::Core::_detail::CURLSHWrapper>();
+
+    if (!m_sslShareHandle->share_handle)
+    {
+      throw Azure::Core::Http::TransportException(
+          _detail::DefaultFailedToGetNewConnectionTemplate + hostDisplayName + ". "
+          + std::string("curl_share_init returned Null"));
+    }
+
     CURLSHcode shResult;
     if (!SetLibcurlShareOption(
             m_sslShareHandle, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION, &shResult))

--- a/sdk/core/azure-core/src/http/curl/curl.cpp
+++ b/sdk/core/azure-core/src/http/curl/curl.cpp
@@ -2343,7 +2343,7 @@ CurlConnection::CurlConnection(
           + std::string(curl_share_strerror(shResult)));
     }
 
-    if (!SetLibcurlOption(m_handle, CURLOPT_SHARE, m_sslShareHandle.get(), &result))
+    if (!SetLibcurlOption(m_handle, CURLOPT_SHARE, m_sslShareHandle->share_handle, &result))
     {
       throw Azure::Core::Http::TransportException(
           _detail::DefaultFailedToGetNewConnectionTemplate + hostDisplayName + ". "

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -1670,6 +1670,10 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
   std::unique_ptr<RawResponse> WinHttpRequest::SendRequestAndGetResponse(HttpMethod requestMethod)
   {
+    // Suppress unused parameter warning (C4100).
+    // Keeping 'requestMethod' in the signature preserves API compatibility.
+    (void)requestMethod;
+
     // First, use WinHttpQueryHeaders to obtain the size of the buffer.
     // The call is expected to fail since no destination buffer is provided.
     DWORD sizeOfHeaders = 0;


### PR DESCRIPTION
This is a follow-up PR to #6537. After testing updated Curl versions with @antkmsft, we noticed that the handle passed to Curl for SSL caching was incorrect. Curl seems to have default behavior for non-Windows, so it ended up a no-op, but Windows is where issue #6535 reproduces.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs
- [ ] Unit tests
- [ ] No unwanted commits/changes
- [ ] Descriptive title/description
  - [ ] PR is single purpose
  - [ ] Related issue listed
- [ ] Comments in source
- [ ] No typos
- [ ] Update changelog
- [ ] Not work-in-progress
- [ ] External references or docs updated
- [ ] Self review of PR done
- [ ] Any breaking changes?
