### PR TITLE
Identity samples: make sample service to invoke GetToken()

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -270,6 +270,7 @@ jobs:
         # Set fake authority host to ensure Managed Identity fail for Default Azure Credential
         # so "execute samples" step correctly picks up Azure CLI credential.
         AZURE_POD_IDENTITY_AUTHORITY_HOST: 'FakeAuthorityHost'
+        AZURE_SDK_IDENTITY_SAMPLE_SERVICE_GETTOKEN: 'disable'
 
   - ${{ else }}:
     - bash: |
@@ -299,6 +300,7 @@ jobs:
         # Set fake authority host to ensure Managed Identity fail for Default Azure Credential
         # so "execute samples" step correctly picks up Azure CLI credential.
         AZURE_POD_IDENTITY_AUTHORITY_HOST: 'FakeAuthorityHost'
+        AZURE_SDK_IDENTITY_SAMPLE_SERVICE_GETTOKEN: 'disable'
 
   # Make coverage targets (specified in coverage_targets.txt) and assemble
   # coverage report

--- a/samples/helpers/service/src/client.cpp
+++ b/samples/helpers/service/src/client.cpp
@@ -3,22 +3,28 @@
 
 #include "azure/service/client.hpp"
 
+#include <azure/core/internal/environment.hpp>
+#include <azure/core/internal/strings.hpp>
+
 void Azure::Service::Client::DoSomething(const Azure::Core::Context& context) const
 {
   static_cast<void>(context); // to suppress the "unused variable" warning.
 
-  // An oversimplified logic of what a typical Azure SDK client does is below:
-#if (0)
-  // Every client has its own scope. We use management.azure.com here as an example.
-  Core::Credentials::TokenRequestContext azureServiceClientContext;
-  azureServiceClientContext.Scopes = {"https://management.azure.com/.default"};
+  if (!Core::_internal::StringExtensions::LocaleInvariantCaseInsensitiveEqual(
+          Core::_internal::Environment::GetVariable("AZURE_SDK_IDENTITY_SAMPLE_SERVICE_GETTOKEN"),
+          "disable"))
+  {
+    // An oversimplified logic of what a typical Azure SDK client does is below:
+    // Every client has its own scope. We use management.azure.com here as an example.
+    Core::Credentials::TokenRequestContext azureServiceClientContext;
+    azureServiceClientContext.Scopes = {"https://management.azure.com/.default"};
 
-  auto authenticationToken = m_credential->GetToken(azureServiceClientContext, context);
+    auto authenticationToken = m_credential->GetToken(azureServiceClientContext, context);
 
-  // Now that it has a token, Client can authorize and DoSomething().
-  // ...
-  // ...
+    // Now that it has a token, Client can authorize and DoSomething().
+    // ...
+    // ...
 
-  static_cast<void>(authenticationToken); // to suppress the "unused variable" warning.
-#endif
+    static_cast<void>(authenticationToken); // to suppress the "unused variable" warning.
+  }
 }

--- a/sdk/identity/azure-identity/samples/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/samples/azure_cli_credential.cpp
@@ -10,6 +10,10 @@ int main()
 {
   try
   {
+    // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // this sample to see more details.
+
     // Step 1: Initialize Azure CLI Credential.
     auto azureCliCredential = std::make_shared<Azure::Identity::AzureCliCredential>();
 
@@ -24,9 +28,27 @@ int main()
   catch (const Azure::Core::Credentials::AuthenticationException& exception)
   {
     // Step 4: Handle authentication errors, if needed
-    // (Azure CLI invocation errors or process timeout).
+    // (invalid credential parameters, insufficient permissions).
     std::cout << "Authentication error: " << exception.what() << std::endl;
     return 1;
+  }
+  catch (const Azure::Core::RequestFailedException& exception)
+  {
+    // Authentication exceptions are thrown as AuthenticationExceptions, client errors are thrown as
+    // RequestFailedExceptions, so it is easier to differentiate whether the request has failed
+    // due to input data, or due to authentication errors.
+    std::cout << "Azure service request error: " << exception.what() << std::endl
+              << "Status: " << static_cast<int>(exception.StatusCode) << " "
+              << exception.ReasonPhrase << std::endl
+              << "Error code: " << exception.ErrorCode << std::endl
+              << "Request ID: " << exception.RequestId << std::endl
+              << "Message: " << exception.Message << std::endl;
+    return 2;
+  }
+  catch (const std::exception& exception)
+  {
+    std::cout << "Unexpected exception thrown: " << exception.what() << std::endl;
+    return 3;
   }
 
   return 0;

--- a/sdk/identity/azure-identity/samples/chained_token_credential.cpp
+++ b/sdk/identity/azure-identity/samples/chained_token_credential.cpp
@@ -13,6 +13,10 @@ int main()
 {
   try
   {
+    // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // this sample to see more details.
+
     // Step 1: Initialize Chained Token Credential.
     // A configuration demonstrated below would authenticate using EnvironmentCredential if it is
     // available, and if it is not available, would fall back to use AzureCliCredential, and then to
@@ -37,6 +41,24 @@ int main()
     // (invalid credential parameters, insufficient permissions).
     std::cout << "Authentication error: " << exception.what() << std::endl;
     return 1;
+  }
+  catch (const Azure::Core::RequestFailedException& exception)
+  {
+    // Authentication exceptions are thrown as AuthenticationExceptions, client errors are thrown as
+    // RequestFailedExceptions, so it is easier to differentiate whether the request has failed
+    // due to input data, or due to authentication errors.
+    std::cout << "Azure service request error: " << exception.what() << std::endl
+              << "Status: " << static_cast<int>(exception.StatusCode) << " "
+              << exception.ReasonPhrase << std::endl
+              << "Error code: " << exception.ErrorCode << std::endl
+              << "Request ID: " << exception.RequestId << std::endl
+              << "Message: " << exception.Message << std::endl;
+    return 2;
+  }
+  catch (const std::exception& exception)
+  {
+    std::cout << "Unexpected exception thrown: " << exception.what() << std::endl;
+    return 3;
   }
 
   return 0;

--- a/sdk/identity/azure-identity/samples/client_certificate_credential.cpp
+++ b/sdk/identity/azure-identity/samples/client_certificate_credential.cpp
@@ -18,6 +18,10 @@ int main()
 {
   try
   {
+    // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // this sample to see more details.
+
     // Step 1: Initialize Client Certificate Credential.
     auto clientCertificateCredential
         = std::make_shared<Azure::Identity::ClientCertificateCredential>(
@@ -37,6 +41,24 @@ int main()
     // (invalid credential parameters, insufficient permissions).
     std::cout << "Authentication error: " << exception.what() << std::endl;
     return 1;
+  }
+  catch (const Azure::Core::RequestFailedException& exception)
+  {
+    // Authentication exceptions are thrown as AuthenticationExceptions, client errors are thrown as
+    // RequestFailedExceptions, so it is easier to differentiate whether the request has failed
+    // due to input data, or due to authentication errors.
+    std::cout << "Azure service request error: " << exception.what() << std::endl
+              << "Status: " << static_cast<int>(exception.StatusCode) << " "
+              << exception.ReasonPhrase << std::endl
+              << "Error code: " << exception.ErrorCode << std::endl
+              << "Request ID: " << exception.RequestId << std::endl
+              << "Message: " << exception.Message << std::endl;
+    return 2;
+  }
+  catch (const std::exception& exception)
+  {
+    std::cout << "Unexpected exception thrown: " << exception.what() << std::endl;
+    return 3;
   }
 
   return 0;

--- a/sdk/identity/azure-identity/samples/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/samples/client_secret_credential.cpp
@@ -18,6 +18,10 @@ int main()
 {
   try
   {
+    // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // this sample to see more details.
+
     // Step 1: Initialize Client Secret Credential.
     auto clientSecretCredential = std::make_shared<Azure::Identity::ClientSecretCredential>(
         GetTenantId(), GetClientId(), GetClientSecret());

--- a/sdk/identity/azure-identity/samples/default_azure_credential.cpp
+++ b/sdk/identity/azure-identity/samples/default_azure_credential.cpp
@@ -13,7 +13,10 @@ int main()
     // Step 1: Initialize Default Azure Credential.
     // Default Azure Credential is good for samples and initial development stages only.
     // It is not recommended used it in a production environment.
+
     // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // this sample to see more details.
 
     auto defaultAzureCredential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
 
@@ -31,6 +34,24 @@ int main()
     // (invalid credential parameters, insufficient permissions).
     std::cout << "Authentication error: " << exception.what() << std::endl;
     return 1;
+  }
+  catch (const Azure::Core::RequestFailedException& exception)
+  {
+    // Authentication exceptions are thrown as AuthenticationExceptions, client errors are thrown as
+    // RequestFailedExceptions, so it is easier to differentiate whether the request has failed
+    // due to input data, or due to authentication errors.
+    std::cout << "Azure service request error: " << exception.what() << std::endl
+              << "Status: " << static_cast<int>(exception.StatusCode) << " "
+              << exception.ReasonPhrase << std::endl
+              << "Error code: " << exception.ErrorCode << std::endl
+              << "Request ID: " << exception.RequestId << std::endl
+              << "Message: " << exception.Message << std::endl;
+    return 2;
+  }
+  catch (const std::exception& exception)
+  {
+    std::cout << "Unexpected exception thrown: " << exception.what() << std::endl;
+    return 3;
   }
 
   return 0;

--- a/sdk/identity/azure-identity/samples/environment_credential.cpp
+++ b/sdk/identity/azure-identity/samples/environment_credential.cpp
@@ -10,6 +10,10 @@ int main()
 {
   try
   {
+    // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // this sample to see more details.
+
     // Step 1: Create an EnvironmentCredential instance.
     // Environment Credential would read its parameters from the environment variables, such as
     // AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET. See documentation for details.
@@ -29,6 +33,24 @@ int main()
     // (invalid credential parameters, insufficient permissions).
     std::cout << "Authentication error: " << exception.what() << std::endl;
     return 1;
+  }
+  catch (const Azure::Core::RequestFailedException& exception)
+  {
+    // Authentication exceptions are thrown as AuthenticationExceptions, client errors are thrown as
+    // RequestFailedExceptions, so it is easier to differentiate whether the request has failed
+    // due to input data, or due to authentication errors.
+    std::cout << "Azure service request error: " << exception.what() << std::endl
+              << "Status: " << static_cast<int>(exception.StatusCode) << " "
+              << exception.ReasonPhrase << std::endl
+              << "Error code: " << exception.ErrorCode << std::endl
+              << "Request ID: " << exception.RequestId << std::endl
+              << "Message: " << exception.Message << std::endl;
+    return 2;
+  }
+  catch (const std::exception& exception)
+  {
+    std::cout << "Unexpected exception thrown: " << exception.what() << std::endl;
+    return 3;
   }
 
   return 0;

--- a/sdk/identity/azure-identity/samples/managed_identity_credential.cpp
+++ b/sdk/identity/azure-identity/samples/managed_identity_credential.cpp
@@ -68,6 +68,10 @@ int main()
 {
   try
   {
+    // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // this sample to see more details.
+
     // Step 1: Create a ManagedIdentityCredential instance.
     // Managed Identity Credential would be available in some environments such as on Azure VMs.
     // See documentation for details.
@@ -87,6 +91,24 @@ int main()
     // (invalid credential parameters, insufficient permissions).
     std::cout << "Authentication error: " << exception.what() << std::endl;
     return 1;
+  }
+  catch (const Azure::Core::RequestFailedException& exception)
+  {
+    // Authentication exceptions are thrown as AuthenticationExceptions, client errors are thrown as
+    // RequestFailedExceptions, so it is easier to differentiate whether the request has failed
+    // due to input data, or due to authentication errors.
+    std::cout << "Azure service request error: " << exception.what() << std::endl
+              << "Status: " << static_cast<int>(exception.StatusCode) << " "
+              << exception.ReasonPhrase << std::endl
+              << "Error code: " << exception.ErrorCode << std::endl
+              << "Request ID: " << exception.RequestId << std::endl
+              << "Message: " << exception.Message << std::endl;
+    return 2;
+  }
+  catch (const std::exception& exception)
+  {
+    std::cout << "Unexpected exception thrown: " << exception.what() << std::endl;
+    return 3;
   }
 
   ShowDifferentManagedIdentityApproaches();

--- a/sdk/identity/azure-identity/samples/workload_identity_credential.cpp
+++ b/sdk/identity/azure-identity/samples/workload_identity_credential.cpp
@@ -15,6 +15,10 @@ int main()
 {
   try
   {
+    // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // this sample to see more details.
+
     // Step 1: Initialize Workload Identity Credential.
     auto workloadIdentityCredential
         = std::make_shared<Azure::Identity::WorkloadIdentityCredential>();
@@ -33,6 +37,24 @@ int main()
     // (invalid credential parameters, insufficient permissions).
     std::cout << "Authentication error: " << exception.what() << std::endl;
     return 1;
+  }
+  catch (const Azure::Core::RequestFailedException& exception)
+  {
+    // Authentication exceptions are thrown as AuthenticationExceptions, client errors are thrown as
+    // RequestFailedExceptions, so it is easier to differentiate whether the request has failed
+    // due to input data, or due to authentication errors.
+    std::cout << "Azure service request error: " << exception.what() << std::endl
+              << "Status: " << static_cast<int>(exception.StatusCode) << " "
+              << exception.ReasonPhrase << std::endl
+              << "Error code: " << exception.ErrorCode << std::endl
+              << "Request ID: " << exception.RequestId << std::endl
+              << "Message: " << exception.Message << std::endl;
+    return 2;
+  }
+  catch (const std::exception& exception)
+  {
+    std::cout << "Unexpected exception thrown: " << exception.what() << std::endl;
+    return 3;
   }
 
   return 0;


### PR DESCRIPTION
This is NOT a fix for #4899. I know many would suggest to use KeyVault instead. This PR does not fix that, that will be a separate PR, because it is more complex dependency-wise (Identity does not depend on KeyVault, so the samples should be moved out of identity).

This PR:
1. Adds comment suggestion to enable `AZURE_LOG_LEVEL`
2. Better demonstration of exception handling
3. Makes the sample service invoke `GetToken()` method

Making the sample service invoke `GetToken()` method is convenient because:
1. As a customer, I build the sample, I can run or debug it, and the same Identity code gets executed for the sample, and for my real app. If there are problems with the credential, for example - Azure CLI is not installed and customer tries to run AzureCliCredential sample, the sample won't print "Success" while my real world app fails.
2. As an Azure SDK dev, run the sample to quickly debug the credential, or to look at the experience end-to-end. For example, recently I updated ManagedIdentity IMDS to fail much faster if it is not available, which improved the experience when using DAC. To see whether using DAC is reasonable for the end user, whether it is fast enough, I ran the corresponding sample.

The sample service is now won't run the GetToken() only if `AZURE_SDK_IDENTITY_SAMPLE_SERVICE_GETTOKEN` env var is set to `disable`, which should happen only in our CI.
I don't see how we can easily enable running all samples in our CI - because when running samples in CI, we do also check that running sample succeeded. That would require us to set up the environment of our CI VMs so that every Azure SDK credential can successfully authenticate for real, which is not trivial.