### PR TITLE
Update for KeyVault CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,12 +48,12 @@
 # PRLabel: %Event Hubs
 /sdk/eventhubs/           @LarryOsterman @antkmsft @RickWinter
 
-# AzureSdkOwners: @rickwinter
+# AzureSdkOwners: @rickwinter @Azure/azure-sdk-write-keyvault
 # ServiceLabel:  %KeyVault
-# ServiceOwners:         @cheathamb36 @chen-karen @lgonsoulin
+# ServiceOwners:         @cheathamb36 @chen-karen @Azure/azure-sdk-write-keyvault
 
 # PRLabel: %KeyVault
-/sdk/keyvault/           @antkmsft @rickwinter @LarryOsterman
+/sdk/keyvault/           @antkmsft @rickwinter @LarryOsterman @Azure/azure-sdk-write-keyvault
 
 # ServiceOwners:@vinjiang @Jinming-Hu @microzchang
 # ServiceLabel: %Storage


### PR DESCRIPTION
This adds the `azure-sdk-write-keyvault` team as code owners, removing `lgonsoulin`.

# Pull Request Checklist

Please leverage this checklist as a reminder to address commonly occurring feedback when submitting a pull request to make sure your PR can be reviewed quickly:

See the detailed list in the [contributing guide](https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests).

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [x] Doxygen docs
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes?
