### PR TITLE
Fix IMDS token requests for managed identities

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed IMDS token requests for managed identities, which were broken by an invalid URL path in 1.12.0-beta.1.
+
 ### Other Changes
 
 ## 1.13.0 (2025-08-05)

--- a/sdk/identity/azure-identity/src/managed_identity_source.cpp
+++ b/sdk/identity/azure-identity/src/managed_identity_source.cpp
@@ -527,7 +527,7 @@ std::unique_ptr<ManagedIdentitySource> ImdsManagedIdentitySource::Create(
 
     imdsUrl = Core::Url{imdsEndpointEnvVarValue};
   }
-  imdsUrl.SetPath("/metadata/identity/oauth2/token");
+  imdsUrl.SetPath("metadata/identity/oauth2/token");
 
   return std::unique_ptr<ManagedIdentitySource>(
       new ImdsManagedIdentitySource(clientId, objectId, resourceId, imdsUrl, options));


### PR DESCRIPTION
This was broken by a035ee5f9416ef9188533de40b4ab1c37fb7c0af, which accidentally constructed the IMDS URL with a double slash at the start of the path. This is not properly routed on the server side, leading to a 404 error with some very misleading XML.

```xml
<?xml version="1.0" encoding="utf-8"?>
<Error xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
    <Code>ResourceNotFound</Code>
    <Message>The specified resource does not exist.</Message>
    <Details>'' isn't a valid resource name.</Details>
</Error>
```

If I'm not mistaken, managed identities are completely broken right now, so I suggest getting this fix out soon.

# Pull Request Checklist

- [X] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs - N/A
- [ ] Unit tests - Maybe later?
- [X] No unwanted commits/changes
- [X] Descriptive title/description
  - [X] PR is single purpose
  - [ ] Related issue listed - N/A
- [ ] Comments in source - N/A
- [X] No typos
- [X] Update changelog
- [X] Not work-in-progress
- [ ] External references or docs updated - N/A
- [X] Self review of PR done
- [ ] Any breaking changes? - N/A
