### PR TITLE
[CODEOWNERS] Messaging ownership transfer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,11 +53,10 @@
 # ServiceOwners:                                                   @danieljurek @weshaggard @LarryOsterman @RickWinter
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/                                                    @LarryOsterman @antkmsft @RickWinter
+/sdk/eventhubs/                                                    @axisc @sjkwak @hmlam
 
 # ServiceLabel: %Event Hubs
-# AzureSdkOwners:                                                  @LarryOsterman
-# ServiceOwners:                                                   @LarryOsterman @antkmsft @RickWinter
+# ServiceOwners:                                                   @axisc @sjkwak @hmlam
 
 # PRLabel: %KeyVault
 /sdk/keyvault/                                                     @antkmsft @rickwinter @LarryOsterman @Azure/azure-sdk-write-keyvault


### PR DESCRIPTION
# Summary

The focus of these changes is to transfer ownership of the Azure messaging services to the associated service teams.