### PR TITLE
Disable Rust AMQP when building in vcpkg

### DIFF
--- a/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
@@ -27,6 +27,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DWARNINGS_AS_ERRORS=OFF
         -DBUILD_TESTING=OFF
+        -DDISABLE_RUST_IN_BUILD=ON
 )
 
 vcpkg_cmake_install()


### PR DESCRIPTION
Rust is not available in vcpkg pipelines.
This is to fix vcpkg daily verification PR (https://github.com/microsoft/vcpkg/pull/34835).
Without this, the validation PR is broken and does not give us information on whether the rest of the packages would compile in vcpkg's CI, finding some problems before we release, #6732 being the most recent example.