### PR TITLE
Remove Azure AD reference from Identity README

### DIFF
--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -1,6 +1,6 @@
 # Azure Identity client library for C++
 
-The Azure Identity library provides Microsoft Entra ID ([formerly Azure Active Directory](https://learn.microsoft.com/entra/fundamentals/new-name)) token authentication support across the Azure SDK. It provides a set of `TokenCredential` implementations which can be used to construct Azure SDK clients which support Microsoft Entra token authentication.
+The Azure Identity library provides [Microsoft Entra ID](https://learn.microsoft.com/entra/fundamentals/whatis) token-based authentication support across the Azure SDK. It provides a set of `TokenCredential` implementations which can be used to construct Azure SDK clients which support Microsoft Entra token authentication.
 This library follows the [Azure SDK Design Guidelines for C++][azure_sdk_cpp_development_guidelines].
 
 [Source code][source] | [Package (vcpkg)][identity_vcpkg] | [API reference documentation][doxygen] | [Microsoft Entra ID documentation][meid_doc] | [Samples][samples]


### PR DESCRIPTION
Removes the Azure AD reference from the Identity library's README, per the recommendation at https://learn.microsoft.com/entra/fundamentals/how-to-rename-azure-ad#communicate-the-change-to-your-customers to keep the old name reference for only 1 year.