### PR TITLE
Remove GitHub Actions from Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
 version: 2
 enable-beta-ecosystems: true
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: weekly
-
   - package-ecosystem: "vcpkg"
     directory: "/"
     schedule:


### PR DESCRIPTION
Removed GitHub Actions updates from Dependabot configuration. The actions should only be updated from the tools repo.
