### PR TITLE
Fix formatting in verify-setup instructions

### DIFF
--- a/eng/common/instructions/azsdk-tools/verify-setup.instructions.md
+++ b/eng/common/instructions/azsdk-tools/verify-setup.instructions.md
@@ -5,7 +5,7 @@ description: 'Verify Setup'
 ## Goal
 This tool verifies the developer's environment for SDK development and release tasks. It returns what requirements are missing for the specified languages and repo, or success if all requirements are satisfied.
 
-Your goal is to identify the project repo root, and pass in the `packagePath` to the Verify Setup tool. For a language repo, pass in the language of the repo.
+Your goal is to identify the project repo root, and pass in the `packagePath` to the Verify Setup tool. For a language repo, pass in the language of the repo. 
 
 ## Examples
 - in `azure-sdk-for-js`, run `azsdk_verify_setup` with `(langs=javascript, packagePath=<path>/azure-sdk-for-js)`.


### PR DESCRIPTION
when I merged the last sync, I removed a trailing space here and now it's out of sync with the source in azure-sdk-tools, causing a CI patch error (https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5896418&view=logs&j=96791242-dbf3-587e-3a06-ae5af5c1a705&t=fbf31884-d9d9-5100-bd3c-5381a778af04 )

adding back the trailing space just so I can resync new changes to this file (in this PR https://github.com/Azure/azure-sdk-tools/pull/13896 )

