### PR TITLE
Trigger `storage` pipeline on any change to the repo

### DIFF
--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -6,9 +6,6 @@ trigger:
       - feature/*
       - release/*
       - hotfix/*
-  paths:
-    include:
-      - sdk/storage
 
 pr:
   branches:
@@ -17,10 +14,6 @@ pr:
       - feature/*
       - release/*
       - hotfix/*
-  paths:
-    include:
-      - sdk/storage
-      - eng/common/testproxy
 
 extends:
     template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
This is in preparation for retirement of `check-enforcer`. 

Per @LarryOsterman suggestion, `storage` is the only package shipping right now from this repo. As a result, we will make `storage` always triggered, so that it can be the `required` check in the repo.

Order of operations:

- This PR merges
- I make `cpp - storage - ci` the required check for the repo
- I disable check-enforcer.

Related to Azure/azure-sdk-tools#15160