### PR TITLE
Update `AZURE_LOG_LEVEL` to use `debug` instead of `verbose`

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -93,7 +93,7 @@ jobs:
     - name: AZURE_TEST_MODE
       value: "PLAYBACK"
     - name: AZURE_LOG_LEVEL
-      value: "verbose"
+      value: "debug"
     - name: Codeql.Enabled
       value: true
     - name: Codeql.BuildIdentifier

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -94,7 +94,7 @@ jobs:
     - name: AZURE_TEST_MODE
       value: "LIVE"
     - name: AZURE_LOG_LEVEL
-      value: "verbose"
+      value: "debug"
       # Surface the ServiceDirectory parameter as an environment variable so tests can take advantage of it.
     - name: AZURE_SERVICE_DIRECTORY
       value: ${{ parameters.ServiceDirectory }}

--- a/sdk/identity/azure-identity/samples/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/samples/azure_cli_credential.cpp
@@ -11,7 +11,7 @@ int main()
   try
   {
     // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
-    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'debug' before running
     // this sample to see more details.
 
     // Step 1: Initialize Azure CLI Credential.

--- a/sdk/identity/azure-identity/samples/chained_token_credential.cpp
+++ b/sdk/identity/azure-identity/samples/chained_token_credential.cpp
@@ -14,7 +14,7 @@ int main()
   try
   {
     // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
-    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'debug' before running
     // this sample to see more details.
 
     // Step 1: Initialize Chained Token Credential.

--- a/sdk/identity/azure-identity/samples/client_certificate_credential.cpp
+++ b/sdk/identity/azure-identity/samples/client_certificate_credential.cpp
@@ -19,7 +19,7 @@ int main()
   try
   {
     // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
-    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'debug' before running
     // this sample to see more details.
 
     // Step 1: Initialize Client Certificate Credential.

--- a/sdk/identity/azure-identity/samples/client_secret_credential.cpp
+++ b/sdk/identity/azure-identity/samples/client_secret_credential.cpp
@@ -19,7 +19,7 @@ int main()
   try
   {
     // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
-    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'debug' before running
     // this sample to see more details.
 
     // Step 1: Initialize Client Secret Credential.

--- a/sdk/identity/azure-identity/samples/default_azure_credential.cpp
+++ b/sdk/identity/azure-identity/samples/default_azure_credential.cpp
@@ -15,7 +15,7 @@ int main()
     // It is not recommended used it in a production environment.
 
     // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
-    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'debug' before running
     // this sample to see more details.
 
     auto defaultAzureCredential = std::make_shared<Azure::Identity::DefaultAzureCredential>();

--- a/sdk/identity/azure-identity/samples/environment_credential.cpp
+++ b/sdk/identity/azure-identity/samples/environment_credential.cpp
@@ -11,7 +11,7 @@ int main()
   try
   {
     // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
-    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'debug' before running
     // this sample to see more details.
 
     // Step 1: Create an EnvironmentCredential instance.

--- a/sdk/identity/azure-identity/samples/managed_identity_credential.cpp
+++ b/sdk/identity/azure-identity/samples/managed_identity_credential.cpp
@@ -69,7 +69,7 @@ int main()
   try
   {
     // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
-    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'debug' before running
     // this sample to see more details.
 
     // Step 1: Create a ManagedIdentityCredential instance.

--- a/sdk/identity/azure-identity/samples/workload_identity_credential.cpp
+++ b/sdk/identity/azure-identity/samples/workload_identity_credential.cpp
@@ -16,7 +16,7 @@ int main()
   try
   {
     // To diagnose, see https://aka.ms/azsdk/cpp/identity/troubleshooting
-    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'verbose' before running
+    // For example, try setting 'AZURE_LOG_LEVEL' environment variable to 'debug' before running
     // this sample to see more details.
 
     // Step 1: Initialize Workload Identity Credential.


### PR DESCRIPTION
Our CI fails, because it uses Azure CLI, which uses Azure SDK for Python, which doesn't recognize `verbose` for `AZURE_LOG_LEVEL`, only `debug`. We recognize both, they mean the same thing (https://github.com/Azure/azure-sdk-for-cpp/tree/48530b7cb3d18660359f278047ecb72119296a7e/sdk/core/azure-core#sdk-log-messages).

Issue for Python to fix: https://github.com/Azure/azure-sdk-for-python/issues/46592

Meanwhile, this PR updates our CI yamls, as well in the comments for samples, we now also replacing recommending `verbose` to `debug` - even if not our fault, I want the maximum success for our customers, and using `debug` will give them less problems currently.