### PR TITLE
Remove Cargo.toml when being installed via vcpkg

### DIFF
--- a/sdk/appconfiguration/azure-data-appconfiguration/vcpkg/portfile.cmake
+++ b/sdk/appconfiguration/azure-data-appconfiguration/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/appconfiguration/azure-data-appconfiguration")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/appconfiguration/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
+++ b/sdk/attestation/azure-security-attestation/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/attestation/azure-security-attestation")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/attestation/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-amqp/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/core/azure-core-amqp")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/core/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core-tracing-opentelemetry/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/core/azure-core-tracing-opentelemetry")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/core/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/core/azure-core/vcpkg/portfile.cmake
+++ b/sdk/core/azure-core/vcpkg/portfile.cmake
@@ -22,6 +22,9 @@ vcpkg_check_features(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/core/azure-core")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/core/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/vcpkg/portfile.cmake
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/eventhubs/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
+++ b/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/eventhubs/azure-messaging-eventhubs")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/eventhubs/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/identity/azure-identity/vcpkg/portfile.cmake
+++ b/sdk/identity/azure-identity/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/identity/azure-identity")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/identity/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-administration/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-administration")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/keyvault/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-certificates/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-certificates")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/keyvault/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-keys/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-keys")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/keyvault/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
+++ b/sdk/keyvault/azure-security-keyvault-secrets/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/keyvault/azure-security-keyvault-secrets")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/keyvault/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-blobs/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-blobs")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-common/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-common")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-datalake/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-files-datalake")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-files-shares/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-files-shares")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
+++ b/sdk/storage/azure-storage-queues/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/storage/azure-storage-queues")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/storage/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/tables/azure-data-tables/vcpkg/portfile.cmake
+++ b/sdk/tables/azure-data-tables/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/tables/azure-data-tables")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/tables/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")

--- a/sdk/template/azure-template/vcpkg/portfile.cmake
+++ b/sdk/template/azure-template/vcpkg/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
 file(GLOB_RECURSE unused "${SOURCE_PATH}/cgmanifest.json")
 file(REMOVE_RECURSE ${unused})
 
+file(GLOB_RECURSE unused "${SOURCE_PATH}/Cargo.toml")
+file(REMOVE_RECURSE ${unused})
+
 if(EXISTS "${SOURCE_PATH}/sdk/template/azure-template")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/template/_")
   file(REMOVE_RECURSE "${SOURCE_PATH}/sdk/_")


### PR DESCRIPTION
Remove `Cargo.toml` files from the source tree when being installed via vcpkg.
This will remove false component governance alerts for our clients, so they won't scan for outdated dependencies in Rust code.
We never build Rust when being installed via vcpkg - `azure-core-amqp-cpp` ships with `-DDISABLE_RUST_IN_BUILD=ON`.