### PR TITLE
Catch exceptions in EventHubs client destructors

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugs Fixed
 
 - [[#6957]](https://github.com/Azure/azure-sdk-for-cpp/issues/6957) Catch and log exceptions thrown from `Close()` inside the `ProducerClient`, `ConsumerClient`, and `PartitionClient` destructors so cleanup failures no longer terminate the program via `std::terminate`.
+- `ProducerClient::Close` and `ConsumerClient::Close` now perform best-effort teardown: a throw from one step no longer skips remaining cleanup. The first exception encountered is rethrown to the caller after every step has been attempted.
 
 ### Other Changes
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bugs Fixed
 
+- [[#6957]](https://github.com/Azure/azure-sdk-for-cpp/issues/6957) Catch and log exceptions thrown from `Close()` inside the `ProducerClient`, `ConsumerClient`, and `PartitionClient` destructors so cleanup failures no longer terminate the program via `std::terminate`.
+
 ### Other Changes
 
 ## 1.0.0-beta.10 (2024-11-01)

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
@@ -158,6 +158,10 @@ namespace Azure { namespace Messaging { namespace EventHubs {
      * partition clients.
      *
      * @param context The context for the operation can be used for request cancellation.
+     *
+     * @remark Performs best-effort teardown: if one step throws, the remaining
+     * steps are still attempted. The first exception encountered is rethrown
+     * to the caller after all steps have run.
      */
     void Close(Azure::Core::Context const& context);
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
@@ -106,7 +106,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     /** Move a consumer client */
     ConsumerClient& operator=(ConsumerClient&& other) = delete;
 
-    ~ConsumerClient();
+    ~ConsumerClient() noexcept;
 
     /** @brief Getter for event hub name
      *

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/partition_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/partition_client.hpp
@@ -70,7 +70,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
 
     /** Destroy this partition client.
      */
-    virtual ~PartitionClient();
+    virtual ~PartitionClient() noexcept;
 
     /** Receive events from the partition.
      *

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
@@ -103,6 +103,10 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     /** @brief Close all the connections and sessions.
      *
      * @param context Context for the operation can be used for request cancellation.
+     *
+     * @remark Performs best-effort teardown: if one step throws, the remaining
+     * steps are still attempted. The first exception encountered is rethrown
+     * to the caller after all steps have run.
      */
     void Close(Azure::Core::Context const& context = {});
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
@@ -98,7 +98,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     /** Default Constructor for a ProducerClient */
     ProducerClient() = default;
 
-    ~ProducerClient() { Close(); }
+    ~ProducerClient() noexcept;
 
     /** @brief Close all the connections and sessions.
      *

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
@@ -68,45 +68,85 @@ namespace Azure { namespace Messaging { namespace EventHubs {
 
   void ConsumerClient::Close(Azure::Core::Context const& context)
   {
-    Log::Stream(Logger::Level::Verbose) << "Close producer client.";
+    Log::Stream(Logger::Level::Verbose) << "Close consumer client.";
+
+    // Best-effort teardown: a throw from one step must not skip the rest. The
+    // first exception encountered is captured and rethrown after every step
+    // has been attempted.
+    std::exception_ptr firstException;
+    auto attemptStep
+        = [&firstException](auto&& step, char const* description) noexcept {
+            try
+            {
+              step();
+            }
+            catch (std::exception const& e)
+            {
+              if (!firstException)
+              {
+                firstException = std::current_exception();
+              }
+              try
+              {
+                Log::Stream(Logger::Level::Warning)
+                    << "ConsumerClient::Close: " << description << " failed: " << e.what();
+              }
+              catch (...)
+              {
+              }
+            }
+            catch (...)
+            {
+              if (!firstException)
+              {
+                firstException = std::current_exception();
+              }
+              try
+              {
+                Log::Stream(Logger::Level::Warning) << "ConsumerClient::Close: " << description
+                                                    << " failed with unknown exception.";
+              }
+              catch (...)
+              {
+              }
+            }
+          };
+
     {
       std::unique_lock<std::mutex> lock(m_propertiesClientLock);
       if (m_propertiesClient)
       {
-        m_propertiesClient->Close(context);
+        attemptStep([&] { m_propertiesClient->Close(context); }, "properties client");
         m_propertiesClient.reset();
       }
     }
-    Log::Stream(Logger::Level::Verbose) << "Closing message senders.";
-    // Tear down the sessions and then the connections, in that order.
+    Log::Stream(Logger::Level::Verbose) << "Closing message receivers.";
     for (auto& receiver : m_receivers)
     {
-      receiver.second.Close(context);
+      attemptStep([&] { receiver.second.Close(context); }, "message receiver");
     }
 
 #if ENABLE_RUST_AMQP
     Log::Stream(Logger::Level::Verbose) << "Closing sessions.";
     for (auto& session : m_sessions)
     {
-      session.second.End(context);
+      attemptStep([&] { session.second.End(context); }, "session");
     }
     Log::Stream(Logger::Level::Verbose) << "Closing connections.";
     for (auto& connection : m_connections)
     {
-      connection.second.Close(context);
+      attemptStep([&] { connection.second.Close(context); }, "connection");
     }
 #endif
 
-    while (!m_sessions.empty())
-    {
-      m_sessions.erase(m_sessions.begin());
-    }
-
-    while (!m_connections.empty())
-    {
-      m_connections.erase(m_connections.begin());
-    };
+    m_sessions.clear();
+    m_connections.clear();
     m_receivers.clear();
+
+    if (firstException)
+    {
+      std::rethrow_exception(firstException);
+    }
   }
 
   Azure::Core::Amqp::_internal::Connection ConsumerClient::CreateConnection(

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
@@ -28,11 +28,42 @@ namespace Azure { namespace Messaging { namespace EventHubs {
         + _detail::EventHubsConsumerGroupsPath + m_consumerGroup;
   }
 
-  ConsumerClient::~ConsumerClient()
+  ConsumerClient::~ConsumerClient() noexcept
   {
-    Log::Stream(Logger::Level::Informational) << "Destroy consumer client.";
+    try
+    {
+      Log::Stream(Logger::Level::Informational) << "Destroy consumer client.";
+    }
+    catch (...)
+    {
+    }
 
-    Close({});
+    try
+    {
+      Close({});
+    }
+    catch (std::exception const& e)
+    {
+      try
+      {
+        Log::Stream(Logger::Level::Warning)
+            << "~ConsumerClient(): exception thrown during Close(): " << e.what();
+      }
+      catch (...)
+      {
+      }
+    }
+    catch (...)
+    {
+      try
+      {
+        Log::Stream(Logger::Level::Warning)
+            << "~ConsumerClient(): unknown exception thrown during Close().";
+      }
+      catch (...)
+      {
+      }
+    }
   }
 
   void ConsumerClient::Close(Azure::Core::Context const& context)

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/partition_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/partition_client.cpp
@@ -208,11 +208,43 @@ namespace Azure { namespace Messaging { namespace EventHubs {
   {
   }
 
-  PartitionClient::~PartitionClient()
+  PartitionClient::~PartitionClient() noexcept
   {
-    Log::Stream(Logger::Level::Verbose) << "~PartitionClient() "
-                                        << "Close Receiver.";
-    m_receiver.Close();
+    try
+    {
+      Log::Stream(Logger::Level::Verbose) << "~PartitionClient() "
+                                          << "Close Receiver.";
+    }
+    catch (...)
+    {
+    }
+
+    try
+    {
+      m_receiver.Close();
+    }
+    catch (std::exception const& e)
+    {
+      try
+      {
+        Log::Stream(Logger::Level::Warning)
+            << "~PartitionClient(): exception thrown during m_receiver.Close(): " << e.what();
+      }
+      catch (...)
+      {
+      }
+    }
+    catch (...)
+    {
+      try
+      {
+        Log::Stream(Logger::Level::Warning)
+            << "~PartitionClient(): unknown exception thrown during m_receiver.Close().";
+      }
+      catch (...)
+      {
+      }
+    }
   }
 
   /** Receive events from the partition.

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
@@ -33,6 +33,36 @@ namespace Azure { namespace Messaging { namespace EventHubs {
   {
   }
 
+  ProducerClient::~ProducerClient() noexcept
+  {
+    try
+    {
+      Close();
+    }
+    catch (std::exception const& e)
+    {
+      try
+      {
+        Log::Stream(Logger::Level::Warning)
+            << "~ProducerClient(): exception thrown during Close(): " << e.what();
+      }
+      catch (...)
+      {
+      }
+    }
+    catch (...)
+    {
+      try
+      {
+        Log::Stream(Logger::Level::Warning)
+            << "~ProducerClient(): unknown exception thrown during Close().";
+      }
+      catch (...)
+      {
+      }
+    }
+  }
+
   void ProducerClient::Close(Azure::Core::Context const& context)
   {
     Log::Stream(Logger::Level::Verbose) << "Close producer client.";

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
@@ -66,18 +66,61 @@ namespace Azure { namespace Messaging { namespace EventHubs {
   void ProducerClient::Close(Azure::Core::Context const& context)
   {
     Log::Stream(Logger::Level::Verbose) << "Close producer client.";
+
+    // Best-effort teardown: a throw from one step must not skip the rest. The
+    // first exception encountered is captured and rethrown after every step
+    // has been attempted.
+    std::exception_ptr firstException;
+    auto attemptStep
+        = [&firstException](auto&& step, char const* description) noexcept {
+            try
+            {
+              step();
+            }
+            catch (std::exception const& e)
+            {
+              if (!firstException)
+              {
+                firstException = std::current_exception();
+              }
+              try
+              {
+                Log::Stream(Logger::Level::Warning)
+                    << "ProducerClient::Close: " << description << " failed: " << e.what();
+              }
+              catch (...)
+              {
+              }
+            }
+            catch (...)
+            {
+              if (!firstException)
+              {
+                firstException = std::current_exception();
+              }
+              try
+              {
+                Log::Stream(Logger::Level::Warning) << "ProducerClient::Close: " << description
+                                                    << " failed with unknown exception.";
+              }
+              catch (...)
+              {
+              }
+            }
+          };
+
     {
       std::unique_lock<std::mutex> lock(m_propertiesClientLock);
       if (m_propertiesClient)
       {
-        m_propertiesClient->Close(context);
+        attemptStep([&] { m_propertiesClient->Close(context); }, "properties client");
         m_propertiesClient.reset();
       }
     }
     Log::Stream(Logger::Level::Verbose) << "Closing message senders.";
     for (auto& sender : m_senders)
     {
-      sender.second.Close(context);
+      attemptStep([&] { sender.second.Close(context); }, "message sender");
     }
     m_senders.clear();
 
@@ -85,17 +128,22 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     Log::Stream(Logger::Level::Verbose) << "Closing sessions.";
     for (auto& session : m_sessions)
     {
-      session.second.End(context);
+      attemptStep([&] { session.second.End(context); }, "session");
     }
     Log::Stream(Logger::Level::Verbose) << "Closing connections.";
     for (auto& connection : m_connections)
     {
-      connection.second.Close(context);
+      attemptStep([&] { connection.second.Close(context); }, "connection");
     }
 #endif
     // Remove all the sessions and connections after they've been closed.
     m_sessions.clear();
     m_connections.clear();
+
+    if (firstException)
+    {
+      std::rethrow_exception(firstException);
+    }
   }
 
   EventDataBatch ProducerClient::CreateBatch(


### PR DESCRIPTION
## Summary

  Two related fixes for cleanup behavior in the EventHubs clients.

  ### 1. Catch exceptions in destructors (`Fixes #6957`)

  `ProducerClient::~ProducerClient`, `ConsumerClient::~ConsumerClient`, and `PartitionClient::~PartitionClient` each call `Close()` (or
  `m_receiver.Close()`) without exception handling. Destructors are implicitly `noexcept` in C++11+, so a throw from cleanup invokes `std::terminate`
   and kills the program with no chance to recover.

  - Wrap the `Close()` call in each of the three destructors with `try` / `catch (std::exception const&)` / `catch (...)`; log at `Warning` and never
   rethrow.
  - Mark each destructor explicitly `noexcept` to document the contract and let `clang-tidy bugprone-exception-escape` flag future regressions.
  - Move `~ProducerClient` out-of-line into `producer_client.cpp` so the public header no longer pulls in the internal logging header.
  - Each `Log::Stream` call inside the catch handlers is wrapped in its own inner `try`/`catch (...)`. `Log::Stream` allocates a `std::stringstream`
  and its destructor invokes the user-installed log listener, so it can throw and would otherwise re-trigger `std::terminate` from inside the
  `noexcept` destructor frame.

  ### 2. Best-effort teardown in `Close()`

  Previously, if the first step in `ProducerClient::Close` / `ConsumerClient::Close` threw, every subsequent step was skipped — leaking senders,
  sessions, and connections.

  - Refactored both `Close()` methods so each teardown step (properties client, sender/receiver loop, session loop, connection loop) runs in its own
  try/catch.
  - The first exception encountered is captured via `std::exception_ptr` and rethrown to the caller after every step has been attempted; later
  exceptions are logged and swallowed.
  - This is the safety net that makes (1) meaningful: a single bad sender no longer prevents the rest of the client from tearing down.
  - Doxygen on `Close()` updated to document the best-effort contract.

  ### Drive-by cleanup

  - Fixed two copy-paste typos in `ConsumerClient::Close` log messages: `"Close producer client."` → `"Close consumer client."`, `"Closing message
  senders."` → `"Closing message receivers."`.
  - Replaced the equivalent-but-cryptic `while (!m_sessions.empty()) m_sessions.erase(begin)` drain pattern in `ConsumerClient::Close` with
  `clear()`, matching `ProducerClient`.

  ## Test plan

  - [ ] **Pre-fix reproduction (destructor):** on a scratch branch off `main`, insert `throw std::runtime_error("forced");` at the top of
  `ProducerClient::Close`, construct + destroy a `ProducerClient`. Expected: process aborts with `terminate called after throwing...`.
  - [ ] **Post-fix validation (destructor):** apply this PR with the same scratch `throw` in place. Expected: clean exit; `Warning`-level log emitted
   (with a registered listener).
  - [ ] **Pre-fix reproduction (Close):** on a scratch branch off `main`, populate `m_senders` then make `m_propertiesClient->Close()` throw.
  Expected: senders never get `.Close()` called, leaking AMQP state.
  - [ ] **Post-fix validation (Close):** same setup with this PR. Expected: every sender gets `.Close()`, the original properties-client exception is
   rethrown to the caller, intermediate failures are logged.
  - [ ] Repeat for `ConsumerClient`.
  - [ ] CI: `azure-messaging-eventhubs-test` non-live unit tests pass — they exercise both Close paths through happy-path destruction and verify no
  regression.

  No automated regression test added: `ProducerClient`/`ConsumerClient`/`PartitionClient` hold concrete
  `Azure::Core::Amqp::_internal::MessageSender`/`MessageReceiver`/`Session`/`Connection` instances by value with no mockable seam. Forcing `Close()`
  to throw deterministically from a test would require introducing a mock AMQP interface — a much larger change than this fix.

  ## Breaking changes

  None for callers who don't call `Close()` explicitly. For callers who do: if the first step of `Close()` throws, the *same* exception is still
  rethrown, but subsequent steps now also run (and may log additional warnings) before the rethrow. This is a strict improvement in cleanup
  guarantees; no API or signature change.
