### PR TITLE
chore: add @j7nw4r, @SwayGom, and @sagar0207 to messaging CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,10 +53,10 @@
 # ServiceOwners:                                                   @danieljurek @LarryOsterman @RickWinter @weshaggard
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/                                                    @axisc @hmlam @sjkwak
+/sdk/eventhubs/                                                    @axisc @hmlam @sjkwak @j7nw4r @SwayGom
 
 # ServiceLabel: %Event Hubs
-# ServiceOwners:                                                   @axisc @hmlam @sjkwak
+# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @SwayGom
 
 # PRLabel: %KeyVault
 /sdk/keyvault/                                                     @Azure/azure-sdk-write-keyvault

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,10 +53,10 @@
 # ServiceOwners:                                                   @danieljurek @LarryOsterman @RickWinter @weshaggard
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/                                                    @axisc @hmlam @sjkwak @j7nw4r @SwayGom
+/sdk/eventhubs/                                                    @axisc @hmlam @sjkwak @j7nw4r @SwayGom @sagar0207
 
 # ServiceLabel: %Event Hubs
-# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @SwayGom
+# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @SwayGom @sagar0207
 
 # PRLabel: %KeyVault
 /sdk/keyvault/                                                     @Azure/azure-sdk-write-keyvault


### PR DESCRIPTION
Adding myself and my coworkers @SwayGom and @sagar0207 to the Event Hubs CODEOWNERS line (and the matching `# ServiceOwners:` comment that Azure SDK tooling reads). We're on the Microsoft messaging team and already own these surfaces in the other language SDKs.

No other entries changed.
