### PR TITLE
Switch PAT to GitHubApps

### DIFF
--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -284,6 +284,11 @@ stages:
                       $jwt_accessToken = az account get-access-token --resource "api://2789159d-8d8b-4d13-b90b-ca29c1707afd" --query "accessToken" --output tsv
                       Write-Host "##vso[task.setvariable variable=opensource-api-token;isSecret=true]$jwt_accessToken"
 
+                - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+                  parameters:
+                    TokenOwners: 
+                      - $(VcpkgPrRepoOwner)
+
                 # Workaround: -Fallback uses names from CODEOWNERS who
                 # should be notified about the release in the event of a
                 # failure to resolve the appropriate aliases.
@@ -299,7 +304,7 @@ stages:
                     }
 
                     ./eng/common/scripts/Add-IssueComment.ps1 `
-                      -AuthToken "$(azuresdk-github-pat)" `
+                      -AuthToken "$(GH_TOKEN)" `
                       -RepoOwner $(VcpkgPrRepoOwner) `
                       -RepoName $(VcpkgPrRepoName) `
                       -IssueNumber "$(Submitted.PullRequest.Number)" `


### PR DESCRIPTION
This pull request introduces updates to the `archetype-cpp-release.yml` pipeline template to improve authentication and GitHub integration. The main changes focus on standardizing token usage and ensuring proper authentication for GitHub operations.

**Authentication and GitHub Integration Updates:**

* Added a step to log in to GitHub using the `login-to-github.yml` template, parameterized with `TokenOwners` for proper token scoping.
* Updated the authentication token used by the `Add-IssueComment.ps1` script from `$(azuresdk-github-pat)` to `$(GH_TOKEN)` to align with the new login process.

[cpp - template](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6443944&view=results)

Part of resolving https://github.com/Azure/azure-sdk-tools/issues/9842