### PR TITLE
Add CODEOWNERS entry for .github/skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -89,6 +89,7 @@
 /eng/common/             @Azure/azure-sdk-eng
 /.github/workflows/      @Azure/azure-sdk-eng
 /.github/CODEOWNERS      @rickwinter @Azure/azure-sdk-eng @xirzec
+/.github/skills/         @Azure/azsdk-cli
 
 /.config/1espt/          @benbp @mikeharder
 


### PR DESCRIPTION
Adds a CODEOWNERS entry assigning ownership of the skill definitions under `.github/skills/` to the `@Azure/azsdk-cli` team.

The entry is grouped with the other `.github/` ownership rules in the Eng Sys section:

```
/.github/skills/         @Azure/azsdk-cli
```

This ensures changes to skill definitions are routed to the appropriate team for review.