### PR TITLE
chore(eventhubs): finalize beta.13 changelog for release

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -1,26 +1,10 @@
 # Release History
 
-## 1.0.0-beta.13 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
-## 1.0.0-beta.12 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.0-beta.13 (2026-06-17)
 
 ### Bugs Fixed
 
 - [[#7130]](https://github.com/Azure/azure-sdk-for-cpp/issues/7130) Fixed `RetryOperation::Execute` silently swallowing the final exception when every retry attempt threw, which caused `ProducerClient::Send` to return without delivering the batch and without surfacing the underlying failure. The last exception is now rethrown when retries are exhausted, and `ProducerClient::Send` throws if `Execute` ever reports failure as a defense in depth.
-
-### Other Changes
 
 ## 1.0.0-beta.11 (2026-05-14)
 


### PR DESCRIPTION
## Summary

The manual release of `azure-messaging-eventhubs` (build [6447788](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6447788)) failed at the `Verify CHANGELOG.md contents` gate. The gate validated `1.0.0-beta.12`, which still read `(Unreleased)` (no release date) and had empty sections. The release bot then merged #7172, incrementing to `beta.13` and stacking a second empty `Unreleased` entry on top, so the changelog had two stacked unreleased entries with the real fix buried under `beta.12`.

## Change

- Fold the #7130 / #7131 `RetryOperation::Execute` retry-rethrow fix into `1.0.0-beta.13`.
- Set the `beta.13` release date to `2026-06-17` and drop the empty sections.
- Remove the never-published `beta.12` block.

`package_version.hpp` already reads `beta.13`, so no version-file change is needed.

## Out of scope

`azure-messaging-eventhubs-checkpointstore-blob` has no real changes (`beta.3` and `beta.4` are both empty). It is intentionally left `Unreleased` and should be excluded from the release.

## Validation

Ran the pipeline's own gate locally against the edited changelog:

```
eng/common/scripts/Verify-ChangeLog.ps1 -ChangeLogLocation sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md -VersionString 1.0.0-beta.13 -ForRelease $true
# exit 0
```

## Next step

This gate reads the changelog from the build artifact, so the failed build cannot be re-run to recover. After this merges, a fresh `cpp - eventhubs` CI build is needed; release only `azure-messaging-eventhubs` from it.
