### PR TITLE
Support token type in bearer auth policy

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
+++ b/sdk/core/azure-core/inc/azure/core/credentials/credentials.hpp
@@ -36,6 +36,12 @@ namespace Azure { namespace Core { namespace Credentials {
      *
      */
     DateTime ExpiresOn;
+
+    /**
+     * @brief Token type used in the Authorization header. Empty means "Bearer".
+     *
+     */
+    std::string TokenType;
   };
 
   /**

--- a/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
+++ b/sdk/core/azure-core/src/http/bearer_token_authentication_policy.cpp
@@ -80,7 +80,8 @@ void ApplyBearerToken(
     Azure::Core::Http::Request& request,
     Azure::Core::Credentials::AccessToken const& token)
 {
-  request.SetHeader("authorization", "Bearer " + token.Token);
+  request.SetHeader(
+      "authorization", (token.TokenType.empty() ? "Bearer" : token.TokenType) + " " + token.Token);
 }
 } // namespace
 

--- a/sdk/core/azure-core/test/ut/bearer_token_authentication_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/bearer_token_authentication_policy_test.cpp
@@ -118,6 +118,39 @@ TEST(BearerTokenAuthenticationPolicy, InitialGet)
   }
 }
 
+TEST(BearerTokenAuthenticationPolicy, InitialGetUsesTokenType)
+{
+  using namespace std::chrono_literals;
+  auto accessToken = std::make_shared<AccessToken>();
+
+  std::vector<std::unique_ptr<HttpPolicy>> policies;
+
+  TokenRequestContext tokenRequestContext;
+  tokenRequestContext.Scopes = {"https://microsoft.com/.default"};
+
+  policies.emplace_back(std::make_unique<BearerTokenAuthenticationPolicy>(
+      std::make_shared<TestTokenCredential>(accessToken), tokenRequestContext));
+
+  policies.emplace_back(std::make_unique<TestTransportPolicy>());
+
+  HttpPipeline pipeline(policies);
+
+  {
+    Request request(HttpMethod::Get, Url("https://www.azure.com"));
+
+    *accessToken = {"ACCESSTOKEN1", std::chrono::system_clock::now() + 1h, "PoP"};
+
+    pipeline.Send(request, Context());
+
+    {
+      auto const headers = request.GetHeaders();
+      auto const authHeader = headers.find("authorization");
+      EXPECT_NE(authHeader, headers.end());
+      EXPECT_EQ(authHeader->second, "PoP ACCESSTOKEN1");
+    }
+  }
+}
+
 TEST(BearerTokenAuthenticationPolicy, ReuseWhileValid)
 {
   using namespace std::chrono_literals;


### PR DESCRIPTION
Adds an optional AccessToken TokenType field and updates BearerTokenAuthenticationPolicy to use it when setting the Authorization header. This is a Core prerequisite for PoP/MSI token binding flows while preserving Bearer as the default.\n\nValidation:\n- Not run locally: no C++ compiler is installed on this machine (cl, g++, clang++ unavailable).\n- CMake and Ninja were installed successfully.