### PR TITLE
Use authenticated npmrc

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -90,6 +90,7 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         Package.EnableSBOMSigning: true
       steps:
+        - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
         - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
         - template: /eng/common/pipelines/templates/steps/check-spelling.yml
           parameters:


### PR DESCRIPTION
This pull request updates the Azure DevOps pipeline for the SDK client archetype to ensure authenticated npm operations by configuring a custom `.npmrc` file. The changes focus on securely providing npm credentials for steps that require npm access, particularly when installing global npm packages and generating documentation artifacts.

**Pipeline authentication improvements:**

* Added the `create-authenticated-npmrc.yml` template step to generate an authenticated `.npmrc` file at `$(Agent.TempDirectory)/gen_release/.npmrc` for use during pipeline execution.
* Updated the `npm install -g moxygen` step to use the authenticated `.npmrc` by setting the `npm_config_userconfig` environment variable, ensuring npm commands have the necessary credentials.
* Set the `npm_config_userconfig` environment variable for the documentation artifact generation step, so any npm usage in this context also uses the authenticated `.npmrc`.

[cpp - template](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6468205&view=results)