### PR TITLE
Tolerate missing x-ms-blob-type response header

### DIFF
--- a/sdk/storage/azure-storage-blobs/src/rest_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/rest_client.cpp
@@ -3814,7 +3814,10 @@ namespace Azure { namespace Storage { namespace Blobs {
         response.Details.SequenceNumber
             = std::stoll(pRawResponse->GetHeaders().at("x-ms-blob-sequence-number"));
       }
-      response.BlobType = Models::BlobType(pRawResponse->GetHeaders().at("x-ms-blob-type"));
+      if (pRawResponse->GetHeaders().count("x-ms-blob-type") != 0)
+      {
+        response.BlobType = Models::BlobType(pRawResponse->GetHeaders().at("x-ms-blob-type"));
+      }
       if (pRawResponse->GetHeaders().count("x-ms-copy-completion-time") != 0)
       {
         response.Details.CopyCompletedOn = DateTime::Parse(
@@ -4060,7 +4063,10 @@ namespace Azure { namespace Storage { namespace Blobs {
         response.ObjectReplicationDestinationPolicyId
             = pRawResponse->GetHeaders().at("x-ms-or-policy-id");
       }
-      response.BlobType = Models::BlobType(pRawResponse->GetHeaders().at("x-ms-blob-type"));
+      if (pRawResponse->GetHeaders().count("x-ms-blob-type") != 0)
+      {
+        response.BlobType = Models::BlobType(pRawResponse->GetHeaders().at("x-ms-blob-type"));
+      }
       if (pRawResponse->GetHeaders().count("x-ms-copy-completion-time") != 0)
       {
         response.CopyCompletedOn = DateTime::Parse(

--- a/sdk/storage/azure-storage-blobs/swagger/README.md
+++ b/sdk/storage/azure-storage-blobs/swagger/README.md
@@ -1044,6 +1044,8 @@ directive:
         $[status_code].headers["x-ms-legal-hold"]["x-nullable"] = true;
         $[status_code].headers["x-ms-immutability-policy-until-date"]["x-ms-client-path"] = "Details.ImmutabilityPolicy.ExpiresOn";
         $[status_code].headers["x-ms-immutability-policy-mode"]["x-ms-client-path"] = "Details.ImmutabilityPolicy.PolicyMode";
+        $[status_code].headers["x-ms-blob-type"]["x-nullable"] = true;
+        $[status_code].headers["x-ms-blob-type"]["x-ms-client-default"] = "";
         delete $[status_code].headers["Accept-Ranges"];
         delete $[status_code].headers["Content-Length"];
         delete $[status_code].headers["Content-Range"];
@@ -1150,6 +1152,8 @@ directive:
       $["x-ms-legal-hold"]["x-ms-client-name"] = "HasLegalHold";
       $["x-ms-legal-hold"]["x-ms-client-default"] = false;
       $["x-ms-legal-hold"]["x-nullable"] = true;
+      $["x-ms-blob-type"]["x-nullable"] = true;
+      $["x-ms-blob-type"]["x-ms-client-default"] = "";
       delete $["Accept-Ranges"];
       delete $["x-ms-or"];
 ```


### PR DESCRIPTION
Fixes #7180.

## Description

`BlobClient::GetProperties()` and `BlobClient::Download()` throw `std::out_of_range` when a successful (2xx) response omits the `x-ms-blob-type` header, because it is generated as a required header (an unguarded `GetHeaders().at("x-ms-blob-type")`). The SDK then crashes — with a non-`StorageException` — on an otherwise-valid 200, e.g. from the OneLake / ADLS Gen2 `*.dfs.` endpoint serving the Blob API, which returns 200 without that header.

This marks `x-ms-blob-type` optional on the `Blob_GetProperties` and `Blob_Download` responses so the generator guards it with the existing `count(...) != 0` idiom — the same treatment `ETag` / `Last-Modified` already receive on those responses — and applies the matching guard in the generated `rest_client.cpp`. When the header is absent, `BlobType` defaults to an empty `Models::BlobType` and the read otherwise succeeds.

Mirrors the "striped blob" compatibility fix for `x-ms-blob-sequence-number` (PR #3932, commit 0e00a3a5): same class of problem, same mechanism (an `x-nullable` directive plus the matching generated-file guard, committed together).

`rest_client.cpp` is AutoRest-generated and the C++ emitter is not publicly runnable, so the generated-file edit here is by hand to match the directive (as #3932 did). Please regenerate to confirm the directive reproduces this output.

## Pull Request Checklist

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs — N/A (no public API surface change)
- [ ] Unit tests — not added, mirroring #3932 (which changed only these two files). A mock-transport test (per `storage_retry_policy_test.cpp`) asserting `GetProperties`/`Download` tolerate a 200 without `x-ms-blob-type` can be added if preferred.
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source — N/A (generated file)
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated — N/A
- [x] Self review of PR done
- [x] Any breaking changes? — No
