### PR TITLE
Storage: introduce StorageRetryPolicy and shared pipeline helper

### DIFF
--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -17,8 +17,7 @@
 #include <azure/storage/common/internal/reliable_stream.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
 #include <azure/storage/common/internal/storage_bearer_token_auth.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/internal/storage_switch_to_secondary_policy.hpp>
 #include <azure/storage/common/internal/structured_message_decoding_stream.hpp>
 #include <azure/storage/common/storage_common.hpp>
@@ -59,23 +58,16 @@ namespace Azure { namespace Storage { namespace Blobs {
       const BlobClientOptions& options)
       : BlobClient(blobUrl, options)
   {
-    BlobClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::BlobServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_blobUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_blobUrl.GetHost(), newOptions.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::BlobServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   BlobClient::BlobClient(
@@ -84,29 +76,25 @@ namespace Azure { namespace Storage { namespace Blobs {
       const BlobClientOptions& options)
       : BlobClient(blobUrl, options)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_blobUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::BlobServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_blobUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
-              credential, tokenContext, options.EnableTenantDiscovery));
+      pipelineOptions.TokenAuthPolicy
+          = std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
+              credential, tokenContext, options.EnableTenantDiscovery);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::BlobServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   BlobClient::BlobClient(const std::string& blobUrl, const BlobClientOptions& options)
@@ -115,19 +103,15 @@ namespace Azure { namespace Storage { namespace Blobs {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_blobUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::BlobServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_blobUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::BlobServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   BlockBlobClient BlobClient::AsBlockBlobClient() const { return BlockBlobClient(*this); }

--- a/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
@@ -15,6 +15,7 @@
 #include <azure/storage/common/internal/shared_key_policy.hpp>
 #include <azure/storage/common/internal/storage_bearer_token_auth.hpp>
 #include <azure/storage/common/internal/storage_per_retry_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/internal/storage_service_version_policy.hpp>
 #include <azure/storage/common/internal/storage_switch_to_secondary_policy.hpp>
 #include <azure/storage/common/storage_common.hpp>
@@ -145,14 +146,18 @@ namespace Azure { namespace Storage { namespace Blobs {
         = _detail::ConstructBatchRequestPolicy(perRetryPolicies, perOperationPolicies, newOptions);
 
     m_batchSubrequestPipeline
-        = _detail::ConstructBatchSubrequestPolicy(nullptr, std::move(sharedKeyAuthPolicy), options);
+        = _detail::ConstructBatchSubrequestPolicy(nullptr, sharedKeyAuthPolicy->Clone(), options);
+
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::BlobServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_blobContainerUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::move(sharedKeyAuthPolicy);
 
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::BlobServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   BlobContainerClient::BlobContainerClient(
@@ -184,14 +189,18 @@ namespace Azure { namespace Storage { namespace Blobs {
         = _detail::ConstructBatchRequestPolicy(perRetryPolicies, perOperationPolicies, options);
 
     m_batchSubrequestPipeline
-        = _detail::ConstructBatchSubrequestPolicy(std::move(tokenAuthPolicy), nullptr, options);
+        = _detail::ConstructBatchSubrequestPolicy(tokenAuthPolicy->Clone(), nullptr, options);
+
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::BlobServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_blobContainerUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.TokenAuthPolicy = std::move(tokenAuthPolicy);
 
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::BlobServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   BlobContainerClient::BlobContainerClient(
@@ -215,12 +224,15 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     m_batchSubrequestPipeline = _detail::ConstructBatchSubrequestPolicy(nullptr, nullptr, options);
 
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::BlobServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_blobContainerUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::BlobServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   BlobClient BlobContainerClient::GetBlobClient(const std::string& blobName) const

--- a/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
@@ -12,6 +12,7 @@
 #include <azure/storage/common/internal/shared_key_policy.hpp>
 #include <azure/storage/common/internal/storage_bearer_token_auth.hpp>
 #include <azure/storage/common/internal/storage_per_retry_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/internal/storage_service_version_policy.hpp>
 #include <azure/storage/common/internal/storage_switch_to_secondary_policy.hpp>
 #include <azure/storage/common/storage_common.hpp>
@@ -58,14 +59,18 @@ namespace Azure { namespace Storage { namespace Blobs {
         = _detail::ConstructBatchRequestPolicy(perRetryPolicies, perOperationPolicies, newOptions);
 
     m_batchSubrequestPipeline
-        = _detail::ConstructBatchSubrequestPolicy(nullptr, std::move(sharedKeyPolicy), options);
+        = _detail::ConstructBatchSubrequestPolicy(nullptr, sharedKeyPolicy->Clone(), options);
+
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::BlobServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::move(sharedKeyPolicy);
 
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::BlobServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   BlobServiceClient::BlobServiceClient(
@@ -97,14 +102,18 @@ namespace Azure { namespace Storage { namespace Blobs {
         = _detail::ConstructBatchRequestPolicy(perRetryPolicies, perOperationPolicies, options);
 
     m_batchSubrequestPipeline
-        = _detail::ConstructBatchSubrequestPolicy(std::move(tokenAuthPolicy), nullptr, options);
+        = _detail::ConstructBatchSubrequestPolicy(tokenAuthPolicy->Clone(), nullptr, options);
+
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::BlobServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.TokenAuthPolicy = std::move(tokenAuthPolicy);
 
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::BlobServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   BlobServiceClient::BlobServiceClient(
@@ -128,12 +137,15 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     m_batchSubrequestPipeline = _detail::ConstructBatchSubrequestPolicy(nullptr, nullptr, options);
 
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::BlobServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::BlobServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   BlobContainerClient BlobServiceClient::GetBlobContainerClient(

--- a/sdk/storage/azure-storage-common/CMakeLists.txt
+++ b/sdk/storage/azure-storage-common/CMakeLists.txt
@@ -55,6 +55,8 @@ set(
     inc/azure/storage/common/internal/storage_bearer_token_auth.hpp
     inc/azure/storage/common/internal/storage_bearer_token_authentication_policy.hpp
     inc/azure/storage/common/internal/storage_per_retry_policy.hpp
+    inc/azure/storage/common/internal/storage_pipeline.hpp
+    inc/azure/storage/common/internal/storage_retry_policy.hpp
     inc/azure/storage/common/internal/storage_service_version_policy.hpp
     inc/azure/storage/common/internal/storage_switch_to_secondary_policy.hpp
     inc/azure/storage/common/internal/structured_message_decoding_stream.hpp
@@ -80,6 +82,8 @@ set(
     src/storage_credential.cpp
     src/storage_exception.cpp
     src/storage_per_retry_policy.cpp
+    src/storage_pipeline.cpp
+    src/storage_retry_policy.cpp
     src/storage_switch_to_secondary_policy.cpp
     src/structured_message_decoding_stream.cpp
     src/structured_message_encoding_stream.cpp

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/storage_pipeline.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/storage_pipeline.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <azure/core/http/policies/policy.hpp>
+#include <azure/core/internal/client_options.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Azure { namespace Storage { namespace _internal {
+
+  struct BuildStoragePipelineOptions final
+  {
+    std::string PackageName;
+    std::string PackageVersion;
+    std::string PrimaryHost;
+    std::string SecondaryHost;
+    std::string ApiVersion;
+    std::unique_ptr<Core::Http::Policies::HttpPolicy> TokenAuthPolicy;
+    std::unique_ptr<Core::Http::Policies::HttpPolicy> SharedKeyAuthPolicy;
+  };
+
+  std::vector<std::unique_ptr<Core::Http::Policies::HttpPolicy>> BuildHttpPipelinePolicies(
+      const Core::_internal::ClientOptions& clientOptions,
+      BuildStoragePipelineOptions storagePipelineOptions);
+
+}}} // namespace Azure::Storage::_internal

--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/storage_retry_policy.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/storage_retry_policy.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <azure/core/http/policies/policy.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+
+namespace Azure { namespace Storage { namespace _internal {
+
+  class StorageRetryPolicy final : public Core::Http::Policies::_internal::RetryPolicyBase {
+  public:
+    explicit StorageRetryPolicy(Core::Http::Policies::RetryOptions options)
+        : Core::Http::Policies::_internal::RetryPolicyBase(std::move(options))
+    {
+    }
+
+    std::unique_ptr<Core::Http::Policies::HttpPolicy> Clone() const override
+    {
+      return std::make_unique<StorageRetryPolicy>(*this);
+    }
+
+  protected:
+    bool ShouldRetryOnResponse(
+        Core::Http::RawResponse const& response,
+        Core::Http::Policies::RetryOptions const& retryOptions,
+        int32_t attempt,
+        std::chrono::milliseconds& retryAfter,
+        double jitterFactor = -1) const override;
+  };
+
+}}} // namespace Azure::Storage::_internal

--- a/sdk/storage/azure-storage-common/src/storage_pipeline.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_pipeline.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "azure/storage/common/internal/storage_pipeline.hpp"
+
+#include "azure/storage/common/internal/constants.hpp"
+#include "azure/storage/common/internal/storage_per_retry_policy.hpp"
+#include "azure/storage/common/internal/storage_retry_policy.hpp"
+#include "azure/storage/common/internal/storage_service_version_policy.hpp"
+#include "azure/storage/common/internal/storage_switch_to_secondary_policy.hpp"
+
+#include <azure/core/internal/http/http_sanitizer.hpp>
+
+namespace Azure { namespace Storage { namespace _internal {
+
+  std::vector<std::unique_ptr<Core::Http::Policies::HttpPolicy>> BuildHttpPipelinePolicies(
+      const Core::_internal::ClientOptions& clientOptions,
+      BuildStoragePipelineOptions storagePipelineOptions)
+  {
+    using Core::Http::Policies::HttpPolicy;
+
+    std::vector<std::unique_ptr<HttpPolicy>> policies;
+
+    // service per call policies
+    if (!storagePipelineOptions.ApiVersion.empty())
+    {
+      policies.emplace_back(
+          std::make_unique<StorageServiceVersionPolicy>(storagePipelineOptions.ApiVersion));
+    }
+    policies.emplace_back(std::make_unique<Core::Http::Policies::_internal::RequestIdPolicy>());
+    if (!storagePipelineOptions.PackageName.empty())
+    {
+      policies.emplace_back(std::make_unique<Core::Http::Policies::_internal::TelemetryPolicy>(
+          storagePipelineOptions.PackageName,
+          storagePipelineOptions.PackageVersion,
+          clientOptions.Telemetry));
+    }
+
+    // client-options per call policies
+    for (auto& policy : clientOptions.PerOperationPolicies)
+    {
+      policies.emplace_back(policy->Clone());
+    }
+
+    // Retry policy
+    policies.emplace_back(std::make_unique<StorageRetryPolicy>(clientOptions.Retry));
+
+    // service per-retry: switch-to-secondary, storage per-retry
+    if (!storagePipelineOptions.SecondaryHost.empty())
+    {
+      policies.emplace_back(std::make_unique<StorageSwitchToSecondaryPolicy>(
+          storagePipelineOptions.PrimaryHost, storagePipelineOptions.SecondaryHost));
+    }
+    policies.emplace_back(std::make_unique<StoragePerRetryPolicy>());
+
+    // Token/bearer auth runs before user-injected per-retry policies so it sees the
+    // original request URL (e.g. before the test-proxy URL-rewrite policy).
+    if (storagePipelineOptions.TokenAuthPolicy)
+    {
+      policies.emplace_back(std::move(storagePipelineOptions.TokenAuthPolicy));
+    }
+
+    // client options per-retry policies
+    for (auto& policy : clientOptions.PerRetryPolicies)
+    {
+      policies.emplace_back(policy->Clone());
+    }
+
+    // SharedKey/SAS auth runs last among per-retry policies so the signature covers
+    // the final, fully-modified request.
+    if (storagePipelineOptions.SharedKeyAuthPolicy)
+    {
+      policies.emplace_back(std::move(storagePipelineOptions.SharedKeyAuthPolicy));
+    }
+
+    // Request activity policy (distributed tracing)
+    Core::Http::_internal::HttpSanitizer httpSanitizer(
+        clientOptions.Log.AllowedHttpQueryParameters, clientOptions.Log.AllowedHttpHeaders);
+    policies.emplace_back(
+        std::make_unique<Core::Http::Policies::_internal::RequestActivityPolicy>(httpSanitizer));
+
+    // Logging - won't update request
+    policies.emplace_back(
+        std::make_unique<Core::Http::Policies::_internal::LogPolicy>(clientOptions.Log));
+
+    // Transport
+    policies.emplace_back(std::make_unique<Core::Http::Policies::_internal::TransportPolicy>(
+        clientOptions.Transport));
+
+    return policies;
+  }
+
+}}} // namespace Azure::Storage::_internal

--- a/sdk/storage/azure-storage-common/src/storage_retry_policy.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_retry_policy.cpp
@@ -12,7 +12,10 @@ namespace Azure { namespace Storage { namespace _internal {
       std::chrono::milliseconds& retryAfter,
       double jitterFactor) const
   {
-    // Are we out of retry attempts?
+    // Are we out of retry attempts? The base ShouldRetryOnResponse below performs the same check
+    // today, but we guard explicitly here because a `false` return from the base is ambiguous
+    // (retries exhausted vs. non-retryable status code). Once storage-specific retry rules are
+    // added after the base call, we must not fall through to them when retries are exhausted.
     if (attempt > retryOptions.MaxRetries)
     {
       return false;

--- a/sdk/storage/azure-storage-common/src/storage_retry_policy.cpp
+++ b/sdk/storage/azure-storage-common/src/storage_retry_policy.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "azure/storage/common/internal/storage_retry_policy.hpp"
+
+namespace Azure { namespace Storage { namespace _internal {
+
+  bool StorageRetryPolicy::ShouldRetryOnResponse(
+      Core::Http::RawResponse const& response,
+      Core::Http::Policies::RetryOptions const& retryOptions,
+      int32_t attempt,
+      std::chrono::milliseconds& retryAfter,
+      double jitterFactor) const
+  {
+    // Are we out of retry attempts?
+    if (attempt > retryOptions.MaxRetries)
+    {
+      return false;
+    }
+
+    if (Core::Http::Policies::_internal::RetryPolicyBase::ShouldRetryOnResponse(
+            response, retryOptions, attempt, retryAfter, jitterFactor))
+    {
+      return true;
+    }
+
+    // Placeholder for storage-specific retry decisions in the future.
+
+    return false;
+  }
+
+}}} // namespace Azure::Storage::_internal

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
@@ -15,8 +15,7 @@
 #include <azure/storage/common/internal/constants.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
 #include <azure/storage/common/internal/storage_bearer_token_auth.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/internal/storage_switch_to_secondary_policy.hpp>
 #include <azure/storage/common/storage_common.hpp>
 #include <azure/storage/common/storage_exception.hpp>
@@ -59,23 +58,16 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
     m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
 
-    DataLakeClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::DatalakeServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_fileSystemUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_fileSystemUrl.GetHost(), newOptions.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::DatalakeServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   DataLakeFileSystemClient::DataLakeFileSystemClient(
@@ -94,29 +86,25 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
     m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_fileSystemUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::DatalakeServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_fileSystemUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
-              credential, tokenContext, options.EnableTenantDiscovery));
+      pipelineOptions.TokenAuthPolicy
+          = std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
+              credential, tokenContext, options.EnableTenantDiscovery);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::DatalakeServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   DataLakeFileSystemClient::DataLakeFileSystemClient(
@@ -132,19 +120,15 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
     m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_fileSystemUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::DatalakeServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_fileSystemUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::DatalakeServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   DataLakeFileClient DataLakeFileSystemClient::GetFileClient(const std::string& fileName) const

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_path_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_path_client.cpp
@@ -12,8 +12,7 @@
 #include <azure/storage/common/internal/constants.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
 #include <azure/storage/common/internal/storage_bearer_token_auth.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/internal/storage_switch_to_secondary_policy.hpp>
 #include <azure/storage/common/storage_common.hpp>
 #include <azure/storage/common/storage_exception.hpp>
@@ -57,23 +56,16 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
     m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
 
-    DataLakeClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::DatalakeServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_pathUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_pathUrl.GetHost(), newOptions.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::DatalakeServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   DataLakePathClient::DataLakePathClient(
@@ -92,29 +84,25 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
     m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_pathUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::DatalakeServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_pathUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
-              credential, tokenContext, options.EnableTenantDiscovery));
+      pipelineOptions.TokenAuthPolicy
+          = std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
+              credential, tokenContext, options.EnableTenantDiscovery);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::DatalakeServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   DataLakePathClient::DataLakePathClient(
@@ -129,19 +117,15 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
     m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_pathUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::DatalakeServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_pathUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::DatalakeServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   Azure::Response<Models::SetPathAccessControlListResult> DataLakePathClient::SetAccessControlList(

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_service_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_service_client.cpp
@@ -12,9 +12,7 @@
 #include <azure/storage/common/internal/constants.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
 #include <azure/storage/common/internal/storage_bearer_token_auth.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
-#include <azure/storage/common/internal/storage_switch_to_secondary_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/storage_common.hpp>
 #include <azure/storage/common/storage_credential.hpp>
 
@@ -53,23 +51,16 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
     m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
 
-    DataLakeClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::DatalakeServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_serviceUrl.GetHost(), newOptions.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::DatalakeServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   DataLakeServiceClient::DataLakeServiceClient(
@@ -88,29 +79,25 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
     m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_serviceUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::DatalakeServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
-              credential, tokenContext, options.EnableTenantDiscovery));
+      pipelineOptions.TokenAuthPolicy
+          = std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
+              credential, tokenContext, options.EnableTenantDiscovery);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::DatalakeServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   DataLakeServiceClient::DataLakeServiceClient(
@@ -126,19 +113,15 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
     m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_serviceUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::DatalakeServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::DatalakeServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   DataLakeFileSystemClient DataLakeServiceClient::GetFileSystemClient(

--- a/sdk/storage/azure-storage-files-shares/src/share_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_client.cpp
@@ -12,8 +12,7 @@
 #include <azure/storage/common/crypt.hpp>
 #include <azure/storage/common/internal/constants.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/storage_common.hpp>
 #include <azure/storage/common/storage_exception.hpp>
 
@@ -48,21 +47,15 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    ShareClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_shareUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareClient::ShareClient(
@@ -75,29 +68,24 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    ShareClientOptions newOptions = options;
-
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_shareUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
-              credential, tokenContext));
+      pipelineOptions.TokenAuthPolicy = std::make_unique<
+          Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
+          credential, tokenContext);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareClient::ShareClient(const std::string& shareUrl, const ShareClientOptions& options)
@@ -107,17 +95,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_shareUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareDirectoryClient ShareClient::GetRootDirectoryClient() const

--- a/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
@@ -11,8 +11,7 @@
 #include <azure/storage/common/crypt.hpp>
 #include <azure/storage/common/internal/constants.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/storage_common.hpp>
 #include <azure/storage/common/storage_exception.hpp>
 
@@ -50,21 +49,15 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    ShareClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_shareDirectoryUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareDirectoryClient::ShareDirectoryClient(
@@ -77,29 +70,24 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    ShareClientOptions newOptions = options;
-
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_shareDirectoryUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
-              credential, tokenContext));
+      pipelineOptions.TokenAuthPolicy = std::make_unique<
+          Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
+          credential, tokenContext);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareDirectoryClient::ShareDirectoryClient(
@@ -111,17 +99,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_shareDirectoryUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareDirectoryClient ShareDirectoryClient::GetSubdirectoryClient(

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -16,8 +16,7 @@
 #include <azure/storage/common/internal/file_io.hpp>
 #include <azure/storage/common/internal/reliable_stream.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/internal/structured_message_decoding_stream.hpp>
 #include <azure/storage/common/internal/structured_message_encoding_stream.hpp>
 #include <azure/storage/common/storage_common.hpp>
@@ -57,21 +56,15 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    ShareClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_shareFileUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareFileClient::ShareFileClient(
@@ -84,29 +77,24 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    ShareClientOptions newOptions = options;
-
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_shareFileUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
-              credential, tokenContext));
+      pipelineOptions.TokenAuthPolicy = std::make_unique<
+          Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
+          credential, tokenContext);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareFileClient::ShareFileClient(
@@ -118,17 +106,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_shareFileUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareFileClient ShareFileClient::WithShareSnapshot(const std::string& shareSnapshot) const

--- a/sdk/storage/azure-storage-files-shares/src/share_service_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_service_client.cpp
@@ -11,8 +11,7 @@
 #include <azure/storage/common/crypt.hpp>
 #include <azure/storage/common/internal/constants.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/storage_common.hpp>
 #include <azure/storage/common/storage_credential.hpp>
 
@@ -45,21 +44,15 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    ShareClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareServiceClient::ShareServiceClient(
@@ -72,29 +65,24 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    ShareClientOptions newOptions = options;
-
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
-              credential, tokenContext));
+      pipelineOptions.TokenAuthPolicy = std::make_unique<
+          Azure::Core::Http::Policies::_internal::BearerTokenAuthenticationPolicy>(
+          credential, tokenContext);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareServiceClient::ShareServiceClient(
@@ -106,17 +94,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         m_uploadValidationOptions(options.UploadValidationOptions),
         m_downloadValidationOptions(options.DownloadValidationOptions)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::FileServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.ApiVersion = options.ApiVersion;
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::FileServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   ShareClient ShareServiceClient::GetShareClient(const std::string& shareName) const

--- a/sdk/storage/azure-storage-queues/src/queue_client.cpp
+++ b/sdk/storage/azure-storage-queues/src/queue_client.cpp
@@ -9,9 +9,7 @@
 #include <azure/storage/common/crypt.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
 #include <azure/storage/common/internal/storage_bearer_token_auth.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
-#include <azure/storage/common/internal/storage_switch_to_secondary_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/storage_common.hpp>
 #include <azure/storage/common/storage_exception.hpp>
 
@@ -42,23 +40,16 @@ namespace Azure { namespace Storage { namespace Queues {
       const QueueClientOptions& options)
       : QueueClient(queueUrl, options)
   {
-    QueueClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::QueueServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_queueUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion.ToString();
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_queueUrl.GetHost(), newOptions.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion.ToString()));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::QueueServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   QueueClient::QueueClient(
@@ -67,47 +58,39 @@ namespace Azure { namespace Storage { namespace Queues {
       const QueueClientOptions& options)
       : QueueClient(queueUrl, options)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_queueUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::QueueServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_queueUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion.ToString();
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
-              credential, tokenContext, options.EnableTenantDiscovery));
+      pipelineOptions.TokenAuthPolicy
+          = std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
+              credential, tokenContext, options.EnableTenantDiscovery);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion.ToString()));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::QueueServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   QueueClient::QueueClient(const std::string& queueUrl, const QueueClientOptions& options)
       : m_queueUrl(queueUrl)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_queueUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion.ToString()));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::QueueServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_queueUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion.ToString();
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::QueueServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   Azure::Response<Models::CreateQueueResult> QueueClient::Create(

--- a/sdk/storage/azure-storage-queues/src/queue_service_client.cpp
+++ b/sdk/storage/azure-storage-queues/src/queue_service_client.cpp
@@ -9,8 +9,7 @@
 #include <azure/storage/common/crypt.hpp>
 #include <azure/storage/common/internal/shared_key_policy.hpp>
 #include <azure/storage/common/internal/storage_bearer_token_auth.hpp>
-#include <azure/storage/common/internal/storage_per_retry_policy.hpp>
-#include <azure/storage/common/internal/storage_service_version_policy.hpp>
+#include <azure/storage/common/internal/storage_pipeline.hpp>
 #include <azure/storage/common/internal/storage_switch_to_secondary_policy.hpp>
 #include <azure/storage/common/storage_common.hpp>
 
@@ -40,23 +39,16 @@ namespace Azure { namespace Storage { namespace Queues {
       const QueueClientOptions& options)
       : QueueServiceClient(serviceUrl, options)
   {
-    QueueClientOptions newOptions = options;
-    newOptions.PerRetryPolicies.emplace_back(
-        std::make_unique<_internal::SharedKeyPolicy>(credential));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::QueueServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion.ToString();
+    pipelineOptions.SharedKeyAuthPolicy = std::make_unique<_internal::SharedKeyPolicy>(credential);
 
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_serviceUrl.GetHost(), newOptions.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(newOptions.ApiVersion.ToString()));
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        newOptions,
-        _internal::QueueServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   QueueServiceClient::QueueServiceClient(
@@ -65,29 +57,25 @@ namespace Azure { namespace Storage { namespace Queues {
       const QueueClientOptions& options)
       : QueueServiceClient(serviceUrl, options)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_serviceUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::QueueServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion.ToString();
     {
       Azure::Core::Credentials::TokenRequestContext tokenContext;
       tokenContext.Scopes.emplace_back(
           options.Audience.HasValue()
               ? _internal::GetDefaultScopeForAudience(options.Audience.Value().ToString())
               : _internal::StorageScope);
-      perRetryPolicies.emplace_back(
-          std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
-              credential, tokenContext, options.EnableTenantDiscovery));
+      pipelineOptions.TokenAuthPolicy
+          = std::make_unique<_internal::StorageBearerTokenAuthenticationPolicy>(
+              credential, tokenContext, options.EnableTenantDiscovery);
     }
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion.ToString()));
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::QueueServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   QueueServiceClient::QueueServiceClient(
@@ -95,19 +83,15 @@ namespace Azure { namespace Storage { namespace Queues {
       const QueueClientOptions& options)
       : m_serviceUrl(serviceUrl)
   {
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
-    std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
-        m_serviceUrl.GetHost(), options.SecondaryHostForRetryReads));
-    perRetryPolicies.emplace_back(std::make_unique<_internal::StoragePerRetryPolicy>());
-    perOperationPolicies.emplace_back(
-        std::make_unique<_internal::StorageServiceVersionPolicy>(options.ApiVersion.ToString()));
+    _internal::BuildStoragePipelineOptions pipelineOptions;
+    pipelineOptions.PackageName = _internal::QueueServicePackageName;
+    pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
+    pipelineOptions.PrimaryHost = m_serviceUrl.GetHost();
+    pipelineOptions.SecondaryHost = options.SecondaryHostForRetryReads;
+    pipelineOptions.ApiVersion = options.ApiVersion.ToString();
+
     m_pipeline = std::make_shared<Azure::Core::Http::_internal::HttpPipeline>(
-        options,
-        _internal::QueueServicePackageName,
-        _detail::PackageVersion::ToString(),
-        std::move(perRetryPolicies),
-        std::move(perOperationPolicies));
+        _internal::BuildHttpPipelinePolicies(options, std::move(pipelineOptions)));
   }
 
   QueueClient QueueServiceClient::GetQueueClient(const std::string& queueName) const


### PR DESCRIPTION
Refactors storage HTTP pipeline construction:

- Adds `Azure::Storage::_internal::BuildHttpPipelinePolicies` and `BuildStoragePipelineOptions` in `azure-storage-common`, replacing per-client policy assembly across blobs, datalake, files-shares, and queues.
- Switches storage clients to the single-vector `HttpPipeline` constructor; auth policy now runs last among per-retry policies.
- Introduces `StorageRetryPolicy` inheriting from core's `RetryPolicy` with an override of `ShouldRetryOnResponse` as a future extension point.
- Makes core's `RetryPolicy` non-final to enable subclassing.