### PR TITLE
Core: make RetryPolicy non-final to allow subclassing

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- [[#7196]](https://github.com/Azure/azure-sdk-for-cpp/pull/7196) Added `Azure::Core::Http::Policies::_internal::RetryPolicyBase`, an abstract base class that exposes the retry loop and the protected `ShouldRetryOnResponse`/`ShouldRetryOnTransportFailure` hook points. Service SDKs can derive from `RetryPolicyBase` to customize retry behavior; `RetryPolicy` remains a `final` concrete policy.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/inc/azure/core/http/http.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/http.hpp
@@ -171,7 +171,7 @@ namespace Azure { namespace Core { namespace Http {
   }; // extensible enum HttpMethod
 
   namespace Policies { namespace _internal {
-    class RetryPolicy;
+    class RetryPolicyBase;
   }} // namespace Policies::_internal
 
   /**
@@ -181,7 +181,7 @@ namespace Azure { namespace Core { namespace Http {
    * resource, the URL of the resource, and the protocol version in use.
    */
   class Request final {
-    friend class Azure::Core::Http::Policies::_internal::RetryPolicy;
+    friend class Azure::Core::Http::Policies::_internal::RetryPolicyBase;
 #if defined(_azure_TESTING_BUILD)
     // make tests classes friends to validate set Retry
     friend class Azure::Core::Test::TestHttp_getters_Test;

--- a/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
+++ b/sdk/core/azure-core/inc/azure/core/http/policies/policy.hpp
@@ -388,28 +388,26 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
     };
 
     /**
-     * @brief HTTP retry policy.
+     * @brief Base class for HTTP retry policies.
+     *
+     * @details Provides the retry loop implementation together with the protected hook points
+     * (#ShouldRetryOnResponse, #ShouldRetryOnTransportFailure) that derived classes may override
+     * to customize retry behavior. This class intentionally does not implement `Clone()`, which
+     * keeps it abstract and forces every concrete derived policy to provide its own `Clone()`.
+     * That prevents object slicing when a derived policy adds state of its own.
      */
-    class RetryPolicy
-#if !defined(_azure_TESTING_BUILD)
-        final
-#endif
-        : public HttpPolicy {
+    class RetryPolicyBase : public HttpPolicy {
     private:
       RetryOptions m_retryOptions;
 
     public:
       /**
-       * Constructs HTTP retry policy with the provided #Azure::Core::Http::Policies::RetryOptions.
+       * Constructs an HTTP retry policy base with the provided
+       * #Azure::Core::Http::Policies::RetryOptions.
        *
        * @param options #Azure::Core::Http::Policies::RetryOptions.
        */
-      explicit RetryPolicy(RetryOptions options) : m_retryOptions(std::move(options)) {}
-
-      std::unique_ptr<HttpPolicy> Clone() const override
-      {
-        return std::make_unique<RetryPolicy>(*this);
-      }
+      explicit RetryPolicyBase(RetryOptions options) : m_retryOptions(std::move(options)) {}
 
       std::unique_ptr<RawResponse> Send(
           Request& request,
@@ -420,8 +418,8 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
        * @brief Get the Retry Count from the context.
        *
        * @remark The sentinel `-1` is returned if there is no information in the \p Context about
-       * #RetryPolicy is trying to send a request. Then `0` is returned for the first try of sending
-       * a request by the #RetryPolicy. Any subsequent retry will be referenced with a number
+       * #RetryPolicyBase is trying to send a request. Then `0` is returned for the first try of
+       * sending a request by the policy. Any subsequent retry will be referenced with a number
        * greater than 0.
        *
        * @param context A context to control the request lifetime.
@@ -442,6 +440,24 @@ namespace Azure { namespace Core { namespace Http { namespace Policies {
           int32_t attempt,
           std::chrono::milliseconds& retryAfter,
           double jitterFactor = -1) const;
+    };
+
+    /**
+     * @brief HTTP retry policy.
+     */
+    class RetryPolicy final : public RetryPolicyBase {
+    public:
+      /**
+       * Constructs HTTP retry policy with the provided #Azure::Core::Http::Policies::RetryOptions.
+       *
+       * @param options #Azure::Core::Http::Policies::RetryOptions.
+       */
+      explicit RetryPolicy(RetryOptions options) : RetryPolicyBase(std::move(options)) {}
+
+      std::unique_ptr<HttpPolicy> Clone() const override
+      {
+        return std::make_unique<RetryPolicy>(*this);
+      }
     };
 
     /**

--- a/sdk/core/azure-core/src/http/retry_policy.cpp
+++ b/sdk/core/azure-core/src/http/retry_policy.cpp
@@ -103,7 +103,7 @@ bool WasLastAttempt(RetryOptions const& retryOptions, int32_t attempt)
 Context::Key const RetryKey;
 } // namespace
 
-int32_t RetryPolicy::GetRetryCount(Context const& context)
+int32_t RetryPolicyBase::GetRetryCount(Context const& context)
 {
   int32_t number = -1;
 
@@ -118,7 +118,7 @@ int32_t RetryPolicy::GetRetryCount(Context const& context)
   return *ptr;
 }
 
-std::unique_ptr<RawResponse> RetryPolicy::Send(
+std::unique_ptr<RawResponse> RetryPolicyBase::Send(
     Request& request,
     NextHttpPolicy nextPolicy,
     Context const& context) const
@@ -189,7 +189,7 @@ std::unique_ptr<RawResponse> RetryPolicy::Send(
   }
 }
 
-bool RetryPolicy::ShouldRetryOnTransportFailure(
+bool RetryPolicyBase::ShouldRetryOnTransportFailure(
     RetryOptions const& retryOptions,
     int32_t attempt,
     std::chrono::milliseconds& retryAfter,
@@ -205,7 +205,7 @@ bool RetryPolicy::ShouldRetryOnTransportFailure(
   return true;
 }
 
-bool RetryPolicy::ShouldRetryOnResponse(
+bool RetryPolicyBase::ShouldRetryOnResponse(
     RawResponse const& response,
     RetryOptions const& retryOptions,
     int32_t attempt,

--- a/sdk/core/azure-core/test/ut/retry_policy_test.cpp
+++ b/sdk/core/azure-core/test/ut/retry_policy_test.cpp
@@ -35,7 +35,7 @@ public:
   }
 };
 
-class RetryPolicyTest final : public RetryPolicy {
+class RetryPolicyTest final : public RetryPolicyBase {
 private:
   std::function<bool(RetryOptions const&, int32_t, std::chrono::milliseconds&, double)>
       m_shouldRetryOnTransportFailure;
@@ -51,7 +51,7 @@ public:
       std::chrono::milliseconds& retryAfter,
       double jitterFactor) const
   {
-    return RetryPolicy::ShouldRetryOnTransportFailure(
+    return RetryPolicyBase::ShouldRetryOnTransportFailure(
         retryOptions, attempt, retryAfter, jitterFactor);
   }
 
@@ -62,7 +62,7 @@ public:
       std::chrono::milliseconds& retryAfter,
       double jitterFactor) const
   {
-    return RetryPolicy::ShouldRetryOnResponse(
+    return RetryPolicyBase::ShouldRetryOnResponse(
         response, retryOptions, attempt, retryAfter, jitterFactor);
   }
 
@@ -70,7 +70,7 @@ public:
       RetryOptions const& retryOptions,
       decltype(m_shouldRetryOnTransportFailure) shouldRetryOnTransportFailure,
       decltype(m_shouldRetryOnResponse) shouldRetryOnResponse)
-      : RetryPolicy(retryOptions),
+      : RetryPolicyBase(retryOptions),
         m_shouldRetryOnTransportFailure(
             shouldRetryOnTransportFailure != nullptr //
                 ? shouldRetryOnTransportFailure
@@ -359,9 +359,16 @@ TEST(RetryPolicy, ShouldRetryOnTransportFailure)
 }
 
 namespace {
-class RetryLogic final : private RetryPolicy {
-  RetryLogic() : RetryPolicy(RetryOptions()) {}
+class RetryLogic final : private RetryPolicyBase {
+  RetryLogic() : RetryPolicyBase(RetryOptions()) {}
   ~RetryLogic() {}
+
+  std::unique_ptr<HttpPolicy> Clone() const override
+  {
+    // Not used; RetryLogic is only instantiated as a static helper for invoking the protected
+    // hook methods.
+    std::abort();
+  }
 
   static RetryLogic const g_retryPolicy;
 


### PR DESCRIPTION
Removes the conditional `final` from `RetryPolicy` so service SDKs (e.g. Storage) can derive from it and override hook points such as `ShouldRetryOnResponse`.