### PR TITLE
Fix global-buffer-overflow in Base64Decode on bytes >= 0x80

### DIFF
--- a/sdk/core/azure-core/src/base64.cpp
+++ b/sdk/core/azure-core/src/base64.cpp
@@ -346,15 +346,27 @@ std::string Base64Encode(uint8_t const* const data, size_t length)
 
 int32_t Base64Decode(const char* encodedBytes)
 {
-  int32_t i0 = encodedBytes[0];
-  int32_t i1 = encodedBytes[1];
-  int32_t i2 = encodedBytes[2];
-  int32_t i3 = encodedBytes[3];
+  // Read each input byte as unsigned so that bytes >= 0x80 do not sign-extend to a
+  // negative value, which would index Base64DecodeArray out of bounds. Invalid bytes
+  // map to the table's -1 sentinel, handled by the caller's `result < 0` check.
+  int32_t i0 = static_cast<unsigned char>(encodedBytes[0]);
+  int32_t i1 = static_cast<unsigned char>(encodedBytes[1]);
+  int32_t i2 = static_cast<unsigned char>(encodedBytes[2]);
+  int32_t i3 = static_cast<unsigned char>(encodedBytes[3]);
 
   i0 = Base64DecodeArray[i0];
   i1 = Base64DecodeArray[i1];
   i2 = Base64DecodeArray[i2];
   i3 = Base64DecodeArray[i3];
+
+  // An invalid character maps to the -1 sentinel. Bail out before the shifts:
+  // left-shifting a negative value is undefined behavior prior to C++20, which
+  // sanitizer builds (-fsanitize=undefined -fno-sanitize-recover=all) abort on.
+  // The caller rejects the negative return value.
+  if ((i0 | i1 | i2 | i3) < 0)
+  {
+    return -1;
+  }
 
   i0 <<= 18;
   i1 <<= 12;
@@ -418,13 +430,24 @@ std::vector<uint8_t> Base64Decode(const std::string& text)
 
   // We are guaranteed to have an input with at least 4 bytes at this point, with a size that is a
   // multiple of 4.
-  int64_t i0 = inputPtr[inputSize - 4];
-  int64_t i1 = inputPtr[inputSize - 3];
-  int64_t i2 = inputPtr[inputSize - 2];
-  int64_t i3 = inputPtr[inputSize - 1];
+  // Read each input byte as unsigned so that bytes >= 0x80 do not sign-extend to a negative
+  // value, which would index Base64DecodeArray out of bounds. Invalid bytes map to the table's
+  // -1 sentinel, handled by the `i0 < 0` checks below.
+  int64_t i0 = static_cast<unsigned char>(inputPtr[inputSize - 4]);
+  int64_t i1 = static_cast<unsigned char>(inputPtr[inputSize - 3]);
+  int64_t i2 = static_cast<unsigned char>(inputPtr[inputSize - 2]);
+  int64_t i3 = static_cast<unsigned char>(inputPtr[inputSize - 1]);
 
   i0 = Base64DecodeArray[i0];
   i1 = Base64DecodeArray[i1];
+
+  // An invalid character maps to the -1 sentinel. Reject it before the shifts below:
+  // left-shifting a negative value is undefined behavior prior to C++20, which sanitizer
+  // builds (-fsanitize=undefined -fno-sanitize-recover=all) abort on.
+  if ((i0 | i1) < 0)
+  {
+    throw std::runtime_error("Unexpected character in Base64 encoded string");
+  }
 
   i0 <<= 18;
   i1 <<= 12;
@@ -436,15 +459,15 @@ std::vector<uint8_t> Base64Decode(const std::string& text)
     i2 = Base64DecodeArray[i2];
     i3 = Base64DecodeArray[i3];
 
+    if ((i2 | i3) < 0)
+    {
+      throw std::runtime_error("Unexpected character in Base64 encoded string");
+    }
+
     i2 <<= 6;
 
     i0 |= i3;
     i0 |= i2;
-
-    if (i0 < 0)
-    {
-      throw std::runtime_error("Unexpected character in Base64 encoded string");
-    }
 
     Base64WriteThreeLowOrderBytes(destinationPtr, i0);
   }
@@ -452,24 +475,20 @@ std::vector<uint8_t> Base64Decode(const std::string& text)
   {
     i2 = Base64DecodeArray[i2];
 
-    i2 <<= 6;
-
-    i0 |= i2;
-    if (i0 < 0)
+    if (i2 < 0)
     {
       throw std::runtime_error("Unexpected character in Base64 encoded string");
     }
+
+    i2 <<= 6;
+
+    i0 |= i2;
 
     destinationPtr[1] = static_cast<uint8_t>(i0 >> 8);
     destinationPtr[0] = static_cast<uint8_t>(i0 >> 16);
   }
   else
   {
-    if (i0 < 0)
-    {
-      throw std::runtime_error("Unexpected character in Base64 encoded string");
-    }
-
     destinationPtr[0] = static_cast<uint8_t>(i0 >> 16);
   }
 

--- a/sdk/core/azure-core/test/ut/base64_test.cpp
+++ b/sdk/core/azure-core/test/ut/base64_test.cpp
@@ -184,6 +184,48 @@ TEST(Base64, InvalidDecode)
   EXPECT_THROW(Convert::Base64Decode("AD=====EF"), std::runtime_error);
   EXPECT_THROW(Convert::Base64Decode("AD======EF"), std::runtime_error);
 
+  // Invalid bytes map to the decode table's -1 sentinel, which must be rejected before
+  // any left shift: shifting a negative value is undefined behavior prior to C++20, so
+  // sanitizer builds (-fsanitize=undefined -fno-sanitize-recover=all) abort otherwise.
+  // Two distinct defects are covered:
+  //   1. bytes >= 0x80 must not sign-extend to a negative index (out-of-bounds read);
+  //   2. the resulting -1 sentinel must not be left-shifted (undefined behavior).
+  // std::string{...} avoids hex-escape ambiguity in the inputs.
+  for (char invalid : {'\x80', '\xC0', '\xFF', '\x01', '\x7F'})
+  {
+    // Tail path: invalid byte in each of the four positions of a single group.
+    EXPECT_THROW(Convert::Base64Decode(std::string{invalid, 'A', 'A', 'A'}), std::runtime_error);
+    EXPECT_THROW(Convert::Base64Decode(std::string{'A', invalid, 'A', 'A'}), std::runtime_error);
+    EXPECT_THROW(Convert::Base64Decode(std::string{'A', 'A', invalid, 'A'}), std::runtime_error);
+    EXPECT_THROW(Convert::Base64Decode(std::string{'A', 'A', 'A', invalid}), std::runtime_error);
+    // Loop path: invalid byte in each of the eight positions of two groups (the first
+    // group is decoded through the int32_t Base64Decode(const char*) helper).
+    EXPECT_THROW(
+        Convert::Base64Decode(std::string{invalid, 'A', 'A', 'A', 'A', 'A', 'A', 'A'}),
+        std::runtime_error);
+    EXPECT_THROW(
+        Convert::Base64Decode(std::string{'A', invalid, 'A', 'A', 'A', 'A', 'A', 'A'}),
+        std::runtime_error);
+    EXPECT_THROW(
+        Convert::Base64Decode(std::string{'A', 'A', invalid, 'A', 'A', 'A', 'A', 'A'}),
+        std::runtime_error);
+    EXPECT_THROW(
+        Convert::Base64Decode(std::string{'A', 'A', 'A', invalid, 'A', 'A', 'A', 'A'}),
+        std::runtime_error);
+    EXPECT_THROW(
+        Convert::Base64Decode(std::string{'A', 'A', 'A', 'A', invalid, 'A', 'A', 'A'}),
+        std::runtime_error);
+    EXPECT_THROW(
+        Convert::Base64Decode(std::string{'A', 'A', 'A', 'A', 'A', invalid, 'A', 'A'}),
+        std::runtime_error);
+    EXPECT_THROW(
+        Convert::Base64Decode(std::string{'A', 'A', 'A', 'A', 'A', 'A', invalid, 'A'}),
+        std::runtime_error);
+    EXPECT_THROW(
+        Convert::Base64Decode(std::string{'A', 'A', 'A', 'A', 'A', 'A', 'A', invalid}),
+        std::runtime_error);
+  }
+
   // cspell::enable
 }
 


### PR DESCRIPTION
## Bug

`sdk/core/azure-core/src/base64.cpp` mishandles invalid Base64 input in two ways, both before the existing validity check runs:

1. **Out-of-bounds read.** Input bytes are read through `const char*` and used to index `Base64DecodeArray`, an `int8_t[256]` reverse-lookup table. `char` is signed on most platforms, so any byte `>= 0x80` sign-extends to a negative index and reads out of bounds of the global table. AddressSanitizer reports `global-buffer-overflow, READ of size 1`.
2. **Undefined left shift.** The table maps invalid bytes to a `-1` sentinel, but the decoder shifts the looked-up value (`i0 <<= 18`, etc.) before checking for the sentinel. Left-shifting a negative value is undefined behavior prior to C++20 (the standard this library targets); `-fsanitize=undefined` reports `left shift of negative value`.

Both defects are present in two places:
- the 4-byte loop helper `int32_t Base64Decode(const char*)`
- the trailing-group tail of `std::vector<uint8_t> Base64Decode(const std::string&)`

## Fix

- Read each input byte as `unsigned char` before indexing, so the index is always in `[0, 255]`.
- Reject the `-1` sentinel before any shift, in both decode paths.

Malformed input now throws `std::runtime_error("Unexpected character in Base64 encoded string")` cleanly on every code path, instead of reading out of bounds or shifting a negative value. Valid Base64 decodes unchanged.

## Test

Extended `Base64.InvalidDecode` to exercise an invalid byte (high-bit `0x80`/`0xC0`/`0xFF` and low-value `0x01`/`0x7F`) in every position of both the single-group tail path and the multi-group loop path.

Validated with AddressSanitizer + UndefinedBehaviorSanitizer (clang, `-fno-sanitize-recover=all`): pre-fix the inputs read out of bounds and abort on the shift under C++17; post-fix they throw cleanly under C++17/20/23 and all existing valid/invalid decode cases still pass.
