### PR TITLE
Remove link verification from GenerateReleaseArtifacts job

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -111,15 +111,6 @@ jobs:
             SourceDirectory: $(Build.SourcesDirectory)
             BasePathLength: 75
 
-        - template: /eng/common/pipelines/templates/steps/verify-links.yml
-          parameters:
-            ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-              Directory: ''
-              Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-            ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-              Directory: sdk/${{ parameters.ServiceDirectory }}
-            CheckLinkGuidance: $true
-
         - ${{ each artifact in parameters.Artifacts }}:
           - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
             parameters:


### PR DESCRIPTION
This pull request removes the link verification step from the `archetype-sdk-client.yml` pipeline template. The step that ran `/eng/common/pipelines/templates/steps/verify-links.yml` to check for broken links in markdown files is no longer included.

* Pipeline simplification:
  * Removed the `verify-links.yml` template step, which previously checked for broken links in markdown files during builds and pull requests.