### PR TITLE
Add devOps feed as dotnet install source

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -105,6 +105,8 @@ jobs:
     - ${{ each testEnvVar in parameters.TestEnv }}:
       - name: ${{ testEnvVar.Name }}
         value: ${{ testEnvVar.Value }}
+    - name: DotNetDevOpsFeed
+      value: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
 
     steps:
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
@@ -285,8 +287,8 @@ jobs:
       - ${{ if eq(parameters.CoverageEnabled, true) }}:
         - pwsh: |
             $toolsDirectory = "$(Agent.TempDirectory)/coveragetools"
-            dotnet tool install -g dotnet-reportgenerator-globaltool
-            dotnet tool install dotnet-reportgenerator-globaltool --tool-path $toolsDirectory
+            dotnet tool install -g dotnet-reportgenerator-globaltool --add-source "$(DotNetDevOpsFeed)"
+            dotnet tool install dotnet-reportgenerator-globaltool --tool-path $toolsDirectory --add-source "$(DotNetDevOpsFeed)"
             Write-Host "##vso[task.setvariable variable=ToolsDirectory]$toolsDirectory"
           displayName: Install coverage tools
           condition: and(succeeded(), eq(variables['CODE_COVERAGE'], 'enabled'))

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -98,6 +98,8 @@ jobs:
       # Surface the ServiceDirectory parameter as an environment variable so tests can take advantage of it.
     - name: AZURE_SERVICE_DIRECTORY
       value: ${{ parameters.ServiceDirectory }}
+    - name: DotNetDevOpsFeed
+      value: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
 
   steps:
   - checkout: self
@@ -146,8 +148,8 @@ jobs:
     displayName: vcpkg --version
 
   - script: |
-      dotnet tool install -g dotnet-reportgenerator-globaltool
-      dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools
+      dotnet tool install -g --add-source "$(DotNetDevOpsFeed)" dotnet-reportgenerator-globaltool 
+      dotnet tool install --add-source "$(DotNetDevOpsFeed)" dotnet-reportgenerator-globaltool --tool-path tools 
     displayName: Install coverage tools
     # CODE_COVERAGE variable is '' (do-not-generate) in all matrix but linux-gcc
     # It is 'enabled' by default on linux-gcc but it can be opt-out by each pipeline (disabled)

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -148,8 +148,8 @@ jobs:
     displayName: vcpkg --version
 
   - script: |
-      dotnet tool install -g --add-source "$(DotNetDevOpsFeed)" dotnet-reportgenerator-globaltool 
-      dotnet tool install --add-source "$(DotNetDevOpsFeed)" dotnet-reportgenerator-globaltool --tool-path tools 
+      dotnet tool install -g dotnet-reportgenerator-globaltool --add-source "$(DotNetDevOpsFeed)"
+      dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools --add-source "$(DotNetDevOpsFeed)"
     displayName: Install coverage tools
     # CODE_COVERAGE variable is '' (do-not-generate) in all matrix but linux-gcc
     # It is 'enabled' by default on linux-gcc but it can be opt-out by each pipeline (disabled)


### PR DESCRIPTION
This pull request updates the CI and live test pipeline templates to ensure that the .NET coverage tool (`dotnet-reportgenerator-globaltool`) is installed from the Azure DevOps NuGet feed, improving reliability and consistency of tool installation in CI environments.

**Pipeline environment variable additions:**

* Added a new environment variable `DotNetDevOpsFeed` in both `ci.tests.yml` and `live.tests.yml` to specify the Azure DevOps NuGet feed URL for .NET tools. [[1]](diffhunk://#diff-9a817977293f806ff99e282fb84005c9d7d96a314a112fd977f42685fec32edaR108-R109) [[2]](diffhunk://#diff-0ea764226e5dbbb822624683595ddec3033905225c0290d45dcf2c514f677373R101-R102)

**Coverage tool installation improvements:**

* Updated the installation steps for `dotnet-reportgenerator-globaltool` in both `ci.tests.yml` and `live.tests.yml` to use the `--add-source "$(DotNetDevOpsFeed)"` option, ensuring the tool is installed from the specified Azure DevOps feed. [[1]](diffhunk://#diff-9a817977293f806ff99e282fb84005c9d7d96a314a112fd977f42685fec32edaL288-R291) [[2]](diffhunk://#diff-0ea764226e5dbbb822624683595ddec3033905225c0290d45dcf2c514f677373L149-R152)