### PR TITLE
Fix perf test latency argument, improve list blobs setup

### DIFF
--- a/sdk/core/perf/README.md
+++ b/sdk/core/perf/README.md
@@ -55,7 +55,7 @@ The next options can be used for any test:
 | Insecure   | --insecure       | Allow untrusted SSL certs                        | false | --insecure
 | Iterations | -i, --iterations | Number of iterations of main test loop           | 1     | -d 5
 | Statistics | --statistics     | Print job statistics                             | false | --statistics=true
-| Latency    | -l, --latency    | Track and print per-operation latency statistics | false | -l true
+| Latency    | -l, --latency    | Track and print per-operation latency statistics | false | --latency
 | No Clean   | --noclean        | Disables test clean up                           | false | --nocleanup=true
 | Parallel   | -p, --parallel   | Number of operations to execute in parallel      | 1     | -p 5
 | Port       | --port           | Port to redirect HTTP requests                   | NA    | --port=5000

--- a/sdk/core/perf/src/arg_parser.cpp
+++ b/sdk/core/perf/src/arg_parser.cpp
@@ -72,7 +72,7 @@ Azure::Perf::GlobalTestOptions Azure::Perf::Program::ArgParser::Parse(
   }
   if (parsedArgs["Latency"])
   {
-    options.Latency = parsedArgs["Latency"].as<bool>();
+    options.Latency = true;
   }
   if (parsedArgs["NoCleanup"])
   {

--- a/sdk/core/perf/src/options.cpp
+++ b/sdk/core/perf/src/options.cpp
@@ -77,7 +77,7 @@ std::vector<Azure::Perf::TestOption> Azure::Perf::GlobalTestOptions::GetOptionMe
       {"Latency",
        {"-l", "--latency"},
        "Track and print per-operation latency statistics. Default to false.",
-       1},
+       0},
       {"NoCleanup", {"--noclean"}, "Disables test clean up. Default to false.", 1},
       // .NET-compatible bare-switch alias for --noclean.
       {"NoCleanupSwitch",

--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
@@ -17,7 +17,9 @@
 
 #include <algorithm>
 #include <atomic>
+#include <exception>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -72,15 +74,30 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
           std::min<long>(static_cast<long>(hardwareThreads), std::max<long>(count, 1)));
 
       std::atomic<long> nextBlobIndex(0);
-      auto uploadWorker = [this, count, &nextBlobIndex]() {
-        std::vector<uint8_t> rawData(1);
-        for (long blobCount = nextBlobIndex.fetch_add(1); blobCount < count;
-             blobCount = nextBlobIndex.fetch_add(1))
+      std::mutex exceptionMutex;
+      std::exception_ptr firstException;
+      auto uploadWorker = [this, count, &nextBlobIndex, &exceptionMutex, &firstException]() {
+        try
         {
-          auto content = Azure::Core::IO::MemoryBodyStream(rawData);
-          auto blobName = "Azure.Storage.Blobs.Perf.Scenarios.DownloadBlob-"
-              + Azure::Core::Uuid::CreateUuid().ToString();
-          m_containerClient->GetBlockBlobClient(blobName).Upload(content);
+          std::vector<uint8_t> rawData(1);
+          for (long blobCount = nextBlobIndex.fetch_add(1); blobCount < count;
+               blobCount = nextBlobIndex.fetch_add(1))
+          {
+            auto content = Azure::Core::IO::MemoryBodyStream(rawData);
+            auto blobName = "Azure.Storage.Blobs.Perf.Scenarios.ListBlob-"
+                + Azure::Core::Uuid::CreateUuid().ToString();
+            m_containerClient->GetBlockBlobClient(blobName).Upload(content);
+          }
+        }
+        catch (...)
+        {
+          // Capture the first exception thrown by any worker so it can be rethrown after
+          // joining, avoiding std::terminate from an exception escaping the thread function.
+          std::lock_guard<std::mutex> lock(exceptionMutex);
+          if (!firstException)
+          {
+            firstException = std::current_exception();
+          }
         }
       };
 
@@ -93,6 +110,11 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
       for (auto& thread : threads)
       {
         thread.join();
+      }
+
+      if (firstException)
+      {
+        std::rethrow_exception(firstException);
       }
     }
 

--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/list_blob_test.hpp
@@ -15,8 +15,11 @@
 #include <azure/core/uuid.hpp>
 #include <azure/perf.hpp>
 
+#include <algorithm>
+#include <atomic>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace Azure { namespace Storage { namespace Blobs { namespace Test {
@@ -58,15 +61,38 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
       }
       m_pageSize = m_options.GetOptionOrDefault<int>("PageSize", 0);
 
-      auto rawData = std::make_unique<std::vector<uint8_t>>(1);
-      auto content = Azure::Core::IO::MemoryBodyStream(*rawData);
-
-      // Upload the number of blobs to be listed later in the test
-      for (auto blobCount = 0; blobCount < count; blobCount++)
+      // Upload the number of blobs to be listed later in the test, using multiple
+      // threads to upload the blobs in parallel to speed up setup.
+      unsigned int hardwareThreads = std::thread::hardware_concurrency();
+      if (hardwareThreads == 0)
       {
-        auto blobName = "Azure.Storage.Blobs.Perf.Scenarios.DownloadBlob-"
-            + Azure::Core::Uuid::CreateUuid().ToString();
-        m_containerClient->GetBlockBlobClient(blobName).Upload(content);
+        hardwareThreads = 4;
+      }
+      const unsigned int threadCount = static_cast<unsigned int>(
+          std::min<long>(static_cast<long>(hardwareThreads), std::max<long>(count, 1)));
+
+      std::atomic<long> nextBlobIndex(0);
+      auto uploadWorker = [this, count, &nextBlobIndex]() {
+        std::vector<uint8_t> rawData(1);
+        for (long blobCount = nextBlobIndex.fetch_add(1); blobCount < count;
+             blobCount = nextBlobIndex.fetch_add(1))
+        {
+          auto content = Azure::Core::IO::MemoryBodyStream(rawData);
+          auto blobName = "Azure.Storage.Blobs.Perf.Scenarios.DownloadBlob-"
+              + Azure::Core::Uuid::CreateUuid().ToString();
+          m_containerClient->GetBlockBlobClient(blobName).Upload(content);
+        }
+      };
+
+      std::vector<std::thread> threads;
+      threads.reserve(threadCount);
+      for (unsigned int i = 0; i < threadCount; i++)
+      {
+        threads.emplace_back(uploadWorker);
+      }
+      for (auto& thread : threads)
+      {
+        thread.join();
       }
     }
 


### PR DESCRIPTION
This change includes:
- Change the latency argument from a parsed boolean `--latency 1` to a flag `--latency`. This was done as the PerfAutomation test framework uses the flag and to match other languages.
- Update the setup of the List Blobs perf test to use multiple threads when creating blobs to speed up the setup on very large cotnainers.