### PR TITLE
Add CFSClean enforcement

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -91,6 +91,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive, CFSClean
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'cpp - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:


### PR DESCRIPTION
This pull request introduces a configuration update to the pipeline template. The main change is the addition of a `networkIsolationPolicy` parameter to the pipeline settings, which may affect how network access is controlled during pipeline execution.

Pipeline configuration:

* Added `networkIsolationPolicy: Permissive, CFSClean` to the `settings` section in `archetype-sdk-client.yml`, which sets the network isolation policy for the pipeline.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6563192&view=results