### PR TITLE
[Storage] Fix download perf test with larger blobs

### DIFF
--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/download_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/download_blob_test.hpp
@@ -17,7 +17,9 @@
 #include <azure/perf/random_stream.hpp>
 
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -64,13 +66,18 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
       BlobsTest::Setup();
 
       m_size = m_options.GetMandatoryOption<int64_t>("Size");
+      if (m_size < 0 || static_cast<uint64_t>(m_size) > (std::numeric_limits<size_t>::max)())
+      {
+        throw std::runtime_error(
+            "--size exceeds the addressable range of this build (size_t max).");
+      }
       m_downloadMethod = m_options.GetOptionOrDefault<std::string>("DownloadMethod", "buffer");
       m_blockSize = m_options.GetOptionOrDefault<int64_t>("BlockSize", 0);
       m_concurrency = m_options.GetOptionOrDefault<int>("Concurrency", 0);
 
       if (m_downloadMethod == "buffer")
       {
-        m_downloadBuffer = std::make_unique<std::vector<uint8_t>>(m_size);
+        m_downloadBuffer = std::make_unique<std::vector<uint8_t>>(static_cast<size_t>(m_size));
       }
       else if (m_downloadMethod != "stream")
       {
@@ -84,7 +91,7 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
 
     void StageInBlocks()
     {
-      auto staging = Azure::Perf::RandomStream::Create(m_size);
+      auto staging = Azure::Perf::RandomStream::Create(static_cast<size_t>(m_size));
 
       std::vector<uint8_t> blockBuffer(StageBlockSize);
       std::vector<std::string> blockIds;

--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/download_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/download_blob_test.hpp
@@ -11,10 +11,12 @@
 
 #include "azure/storage/blobs/test/blob_base_test.hpp"
 
+#include <azure/core/base64.hpp>
 #include <azure/core/io/body_stream.hpp>
 #include <azure/perf.hpp>
 #include <azure/perf/random_stream.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -36,12 +38,18 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
   class DownloadBlob : public Azure::Storage::Blobs::Test::BlobsTest {
   private:
     std::unique_ptr<std::vector<uint8_t>> m_downloadBuffer;
-    long m_size = 0;
+    int64_t m_size = 0;
     std::string m_downloadMethod = "buffer";
-    long m_blockSize = 0;
+    int64_t m_blockSize = 0;
     int m_concurrency = 0;
 
     static constexpr size_t StreamDrainBufferSize = 1024 * 1024;
+
+    // Maximum size of a single staged block. The Put Blob API used by Upload() is limited to
+    // 5 GiB, so blobs are staged in blocks and committed with CommitBlockList(), which supports
+    // much larger blobs. 256 MiB keeps per-block memory bounded while staying well under the
+    // per-block and per-blob (50,000 block) service limits.
+    static constexpr size_t StageBlockSize = 256 * 1024 * 1024;
 
   public:
     /**
@@ -60,9 +68,9 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
       // Call base to create blob client
       BlobsTest::Setup();
 
-      m_size = m_options.GetMandatoryOption<long>("Size");
+      m_size = m_options.GetMandatoryOption<int64_t>("Size");
       m_downloadMethod = m_options.GetOptionOrDefault<std::string>("DownloadMethod", "buffer");
-      m_blockSize = m_options.GetOptionOrDefault<long>("BlockSize", 0);
+      m_blockSize = m_options.GetOptionOrDefault<int64_t>("BlockSize", 0);
       m_concurrency = m_options.GetOptionOrDefault<int>("Concurrency", 0);
 
       if (m_downloadMethod == "buffer")
@@ -76,10 +84,58 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
             + "'. Expected one of: buffer, stream.");
       }
 
-      // Stage the blob with random data. Use the streaming RandomStream so very large
-      // sizes do not materialize a contiguous staging buffer.
+      StageInBlocks();
+    }
+
+    void StageInBlocks()
+    {
       auto staging = Azure::Perf::RandomStream::Create(m_size);
-      m_blobClient->Upload(*staging);
+
+      std::vector<uint8_t> blockBuffer(StageBlockSize);
+      std::vector<std::string> blockIds;
+      uint64_t blockIndex = 0;
+
+      while (true)
+      {
+        size_t offset = 0;
+        while (offset < blockBuffer.size())
+        {
+          auto read = staging->Read(
+              blockBuffer.data() + offset, blockBuffer.size() - offset, Azure::Core::Context());
+          if (read == 0)
+          {
+            break;
+          }
+          offset += read;
+        }
+
+        if (offset == 0)
+        {
+          break;
+        }
+
+        // Block IDs must all be the same length before Base64 encoding; encode the index as
+        // an 8-byte big-endian value to guarantee a fixed length.
+        uint8_t rawBlockId[8];
+        for (int i = 0; i < 8; ++i)
+        {
+          rawBlockId[7 - i] = static_cast<uint8_t>((blockIndex >> (8 * i)) & 0xFF);
+        }
+        std::string blockId = Azure::Core::Convert::Base64Encode(
+            std::vector<uint8_t>(rawBlockId, rawBlockId + sizeof(rawBlockId)));
+
+        Azure::Core::IO::MemoryBodyStream blockContent(blockBuffer.data(), offset);
+        m_blobClient->StageBlock(blockId, blockContent);
+        blockIds.push_back(std::move(blockId));
+        ++blockIndex;
+
+        if (offset < blockBuffer.size())
+        {
+          break;
+        }
+      }
+
+      m_blobClient->CommitBlockList(blockIds);
     }
 
     /**

--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/download_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/download_blob_test.hpp
@@ -44,11 +44,6 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
     int m_concurrency = 0;
 
     static constexpr size_t StreamDrainBufferSize = 1024 * 1024;
-
-    // Maximum size of a single staged block. The Put Blob API used by Upload() is limited to
-    // 5 GiB, so blobs are staged in blocks and committed with CommitBlockList(), which supports
-    // much larger blobs. 256 MiB keeps per-block memory bounded while staying well under the
-    // per-block and per-blob (50,000 block) service limits.
     static constexpr size_t StageBlockSize = 256 * 1024 * 1024;
 
   public:

--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/upload_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/upload_blob_test.hpp
@@ -41,9 +41,10 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
   private:
     // C++ can upload and download from contiguous memory or file only
     std::vector<uint8_t> m_uploadBuffer;
-    long m_size = 0;
+    // 64-bit: on MSVC `long` is 32-bit, so sizes above ~2.14 GB overflow when parsed.
+    int64_t m_size = 0;
     std::string m_uploadMethod = "buffer";
-    long m_blockSize = 0;
+    int64_t m_blockSize = 0;
     int m_concurrency = 0;
 
   public:
@@ -63,9 +64,9 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
       // Call base to create blob client
       BlobsTest::Setup();
 
-      m_size = m_options.GetMandatoryOption<long>("Size");
+      m_size = m_options.GetMandatoryOption<int64_t>("Size");
       m_uploadMethod = m_options.GetOptionOrDefault<std::string>("UploadMethod", "buffer");
-      m_blockSize = m_options.GetOptionOrDefault<long>("BlockSize", 0);
+      m_blockSize = m_options.GetOptionOrDefault<int64_t>("BlockSize", 0);
       m_concurrency = m_options.GetOptionOrDefault<int>("Concurrency", 0);
 
       if (m_uploadMethod == "buffer" || m_uploadMethod == "single")

--- a/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/upload_blob_test.hpp
+++ b/sdk/storage/azure-storage-blobs/test/perf/inc/azure/storage/blobs/test/upload_blob_test.hpp
@@ -15,7 +15,10 @@
 #include <azure/perf.hpp>
 #include <azure/perf/random_stream.hpp>
 
+#include <cstdint>
+#include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -65,14 +68,19 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
       BlobsTest::Setup();
 
       m_size = m_options.GetMandatoryOption<int64_t>("Size");
+      if (m_size < 0 || static_cast<uint64_t>(m_size) > (std::numeric_limits<size_t>::max)())
+      {
+        throw std::runtime_error(
+            "--size exceeds the addressable range of this build (size_t max).");
+      }
       m_uploadMethod = m_options.GetOptionOrDefault<std::string>("UploadMethod", "buffer");
       m_blockSize = m_options.GetOptionOrDefault<int64_t>("BlockSize", 0);
       m_concurrency = m_options.GetOptionOrDefault<int>("Concurrency", 0);
 
       if (m_uploadMethod == "buffer" || m_uploadMethod == "single")
       {
-        m_uploadBuffer
-            = Azure::Perf::RandomStream::Create(m_size)->ReadToEnd(Azure::Core::Context{});
+        m_uploadBuffer = Azure::Perf::RandomStream::Create(static_cast<size_t>(m_size))
+                             ->ReadToEnd(Azure::Core::Context{});
       }
       else if (m_uploadMethod != "stream")
       {
@@ -90,7 +98,7 @@ namespace Azure { namespace Storage { namespace Blobs { namespace Test {
     {
       if (m_uploadMethod == "stream")
       {
-        auto stream = Azure::Perf::RandomStream::Create(m_size);
+        auto stream = Azure::Perf::RandomStream::Create(static_cast<size_t>(m_size));
         m_blobClient->Upload(*stream);
         return;
       }


### PR DESCRIPTION
Fixes the download perf test to support larger blobs.
- Use a partitioned upload during test setup to account for Blobs larger than 5 GiB (the Put Blob limit). This needed to be implemented manually as the SDK does not support this for streams.
- Change sizes to `int64_t` to account for larger values on all platforms.