### PR TITLE
Azure Storage July Beta release

### DIFF
--- a/sdk/storage/azure-storage-blobs/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blobs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.19.0-beta.1 (Unreleased)
+## 12.19.0-beta.1 (2026-07-29)
 
 ### Features Added
 
@@ -11,10 +11,6 @@
 - Added `AdditionalTransactionalContentHash` field in results of write operations
   (`UploadBlockBlob`/`FromUri`, `StageBlock`/`FromUri`, `AppendBlock`/`FromUri`,
   `UploadPages`/`FromUri`).
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 12.15.0-beta.1 (Unreleased)
+## 12.15.0-beta.1 (2026-07-29)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Bumped up Account SAS version to `2026-10-06`.
 
 ## 12.14.0 (2026-06-11)
 

--- a/sdk/storage/azure-storage-common/src/account_sas_builder.cpp
+++ b/sdk/storage/azure-storage-common/src/account_sas_builder.cpp
@@ -9,7 +9,7 @@
 
 namespace Azure { namespace Storage { namespace Sas {
   namespace {
-    constexpr static const char* SasVersion = "2026-06-06";
+    constexpr static const char* SasVersion = "2026-10-06";
   }
 
   void AccountSasBuilder::SetPermissions(AccountSasPermissions permissions)

--- a/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-datalake/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 12.17.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 12.17.0-beta.1 (2026-07-29)
 
 ### Other Changes
 

--- a/sdk/storage/azure-storage-files-shares/CHANGELOG.md
+++ b/sdk/storage/azure-storage-files-shares/CHANGELOG.md
@@ -1,16 +1,12 @@
 # Release History
 
-## 12.19.0-beta.1 (Unreleased)
+## 12.19.0-beta.1 (2026-07-29)
 
 ### Features Added
 
 - Bumped up API version to `2026-10-06`.
 - Added `ShareFileClient::GetAllRangeList` and `ShareFileClient::GetAllRangeListDiff`, paged
   variants of `GetRangeList` / `GetRangeListDiff`.
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 

--- a/sdk/storage/azure-storage-queues/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queues/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 12.8.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 12.8.0-beta.1 (2026-07-29)
 
 ### Other Changes
+
+- No public changes in this release.
 
 ## 12.7.0 (2026-05-12)
 


### PR DESCRIPTION
## Summary

Prepare the Azure Storage C++ packages for the July 2026 beta release on `2026-07-29`.

| Package | Version | Release PBI |
|---|---|---|
| azure-storage-common | `12.15.0-beta.1` | [35449](https://dev.azure.com/azure-sdk/Release/_workitems/edit/35449/) |
| azure-storage-blobs | `12.19.0-beta.1` | [35450](https://dev.azure.com/azure-sdk/Release/_workitems/edit/35450/) |
| azure-storage-files-shares | `12.19.0-beta.1` | [35451](https://dev.azure.com/azure-sdk/Release/_workitems/edit/35451/) |
| azure-storage-files-datalake | `12.17.0-beta.1` | [35452](https://dev.azure.com/azure-sdk/Release/_workitems/edit/35452/) |
| azure-storage-queues | `12.8.0-beta.1` | [35453](https://dev.azure.com/azure-sdk/Release/_workitems/edit/35453/) |


