### PR TITLE
feat(eventhubs): restore connection string authentication

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- [[#7250]](https://github.com/Azure/azure-sdk-for-cpp/issues/7250) Restored the connection string constructors on `ProducerClient` and `ConsumerClient`. Version 1.0.0-beta.11 removed them. This also restores support for the Event Hubs emulator, which accepts a connection string only.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhubs/azure-messaging-eventhubs/README.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/README.md
@@ -133,15 +133,30 @@ That should output something like:
 Event Hub clients are created using a credential from the [Azure Identity package][azure_identity_pkg], like [DefaultAzureCredential][default_azure_credential].
 Alternatively, you can create a client using a connection string.
 
+Use a token credential in production. Use a connection string for local development, for the Event Hubs emulator, or when a shared access key is the only credential you have.
+
 <!-- NOTE: Fix dead Links -->
 #### Using a service principal
  - ConsumerClient: [link][consumer_client]
  - ProducerClient: [link][producer_client]
 
-<!-- NOTE: Fix dead links -->
+Samples: [create_consumer_aad.cpp](samples/basic-operations/create_consumer_aad.cpp) and [create_producer_aad.cpp](samples/basic-operations/create_producer_aad.cpp).
+
 #### Using a connection string
- - ConsumerClient: [link](https://azure.github.io/azure-sdk-for-cpp/storage.html)
- - ProducerClient: [link](https://azure.github.io/azure-sdk-for-cpp/storage.html)
+
+The connection string can be in one of two formats. When it does not carry an `EntityPath` key, name the event hub in the `eventHub` parameter:
+
+```
+Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
+```
+
+When it does carry an `EntityPath` key, leave the `eventHub` parameter empty, or pass the same name. A different name throws `std::invalid_argument`:
+
+```
+Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<event-hub-name>
+```
+
+Samples: [create_consumer.cpp](samples/basic-operations/create_consumer.cpp) and [create_producer.cpp](samples/basic-operations/create_producer.cpp).
 
 # Key concepts
 
@@ -176,22 +191,26 @@ The following example shows how to send events to an event hub:
 std::string connectionString = "<connection_string>";
 std::string eventHubName = "<event_hub_name>";
 
-Azure::Messaging::EventHubs::EventDataBatchOptions batchOptions;
-batchOptions.PartitionId = "1";
-Azure::Messaging::EventHubs::EventDataBatch eventBatch(batchOptions);
-
-Azure::Messaging::EventHubs::Models::EventData message;
-message.Body.Data = {'H', 'e', 'l', 'l', 'o', '2'};
-
-eventBatch.AddMessage(message);
-
 Azure::Messaging::EventHubs::ProducerClientOptions producerOptions;
-producerOptions.Name = "sender-link";
 producerOptions.ApplicationID = "some";
 
-auto client = Azure::Messaging::EventHubs::ProducerClient(
-      connectionString, eventHubName, producerOptions);
-auto result = client.SendEventDataBatch(eventBatch);
+Azure::Messaging::EventHubs::ProducerClient client(
+    connectionString, eventHubName, producerOptions);
+
+// By default the producer sends to all partitions in turn. Name a partition to send to one.
+Azure::Messaging::EventHubs::EventDataBatchOptions batchOptions;
+batchOptions.PartitionId = "1";
+Azure::Messaging::EventHubs::EventDataBatch eventBatch{client.CreateBatch(batchOptions)};
+
+Azure::Messaging::EventHubs::Models::EventData message;
+message.Body = {'H', 'e', 'l', 'l', 'o', '2'};
+
+if (!eventBatch.TryAdd(message))
+{
+  throw std::runtime_error("Failed to add the event to the batch.");
+}
+
+client.Send(eventBatch);
 ```
 
 ## Receive events
@@ -201,16 +220,14 @@ The following example shows how to receive events from partition 1 on an event h
 ```cpp
 #include <azure/messaging/eventhubs.hpp>
 
-
 // Your Event Hubs namespace connection string is available in the Azure portal.
 std::string connectionString = "<connection_string>";
 std::string eventHubName = "<event_hub_name>";
 
-auto client = Azure::Messaging::EventHubs::ConsumerClient(
-	connectionString, eventHubName);
+Azure::Messaging::EventHubs::ConsumerClient client(connectionString, eventHubName);
 
 Azure::Messaging::EventHubs::PartitionClient partitionClient
-        = client.CreatePartitionClient("1");
+    = client.CreatePartitionClient("1");
 
 auto events = partitionClient.ReceiveEvents(1);
 ```

--- a/sdk/eventhubs/azure-messaging-eventhubs/README.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/README.md
@@ -140,7 +140,7 @@ Use a token credential in production. Use a connection string for local developm
  - ConsumerClient: [link][consumer_client]
  - ProducerClient: [link][producer_client]
 
-Samples: [create_consumer_aad.cpp](samples/basic-operations/create_consumer_aad.cpp) and [create_producer_aad.cpp](samples/basic-operations/create_producer_aad.cpp).
+Samples: [create_consumer_aad.cpp](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer_aad.cpp) and [create_producer_aad.cpp](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer_aad.cpp).
 
 #### Using a connection string
 
@@ -156,7 +156,7 @@ When it does carry an `EntityPath` key, leave the `eventHub` parameter empty, or
 Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<event-hub-name>
 ```
 
-Samples: [create_consumer.cpp](samples/basic-operations/create_consumer.cpp) and [create_producer.cpp](samples/basic-operations/create_producer.cpp).
+Samples: [create_consumer.cpp](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp) and [create_producer.cpp](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp).
 
 # Key concepts
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
@@ -142,6 +142,28 @@ namespace Azure { namespace Messaging { namespace EventHubs {
       return m_consumerClientOptions.RetryOptions;
     }
 
+    /** @brief creates a ConsumerClient from a connection string.
+     *
+     * @param connectionString connection string to resource
+     * @param eventHub event hub name
+     * @param consumerGroup consumer group name
+     * @param options client options
+     *
+     * @remark The connection string can be in one of two formats, with or without an EntityPath
+     *  key. When the connection string does not have an entity path, as shown below, the eventHub
+     *  parameter cannot be empty and must contain the name of your event hub.
+     *  Endpoint=sb://\<your-namespace\>.servicebus.windows.net/;SharedAccessKeyName=\<key-name\>;SharedAccessKey=\<key\>
+     *  When the connection string does have an entity path, as shown below, the eventHub parameter
+     *  must be empty or must match the entity path. A different value throws.
+     *  Endpoint=sb://\<your-namespace\>.servicebus.windows.net/;
+     *  SharedAccessKeyName=\<key-name\>;SharedAccessKey=\<key\>;EntityPath=\<entitypath\>;
+     */
+    ConsumerClient(
+        std::string const& connectionString,
+        std::string const& eventHub = {},
+        std::string const& consumerGroup = DefaultConsumerGroup,
+        ConsumerClientOptions const& options = {});
+
     /** @brief Create new Partition client
      *
      * @param partitionId targeted partition

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
@@ -98,6 +98,26 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     /** Default Constructor for a ProducerClient */
     ProducerClient() = default;
 
+    /**@brief Constructs a new ProducerClient instance from a connection string.
+     *
+     * @param connectionString Event hubs connection string
+     * @param eventHub Event hub name
+     * @param options Additional options for creating the client
+     *
+     * @remark The connection string can be in one of two formats, with or without an EntityPath
+     *  key. When the connection string does not have an entity path, as shown below, the eventHub
+     *  parameter cannot be empty and must contain the name of your event hub.
+     *  Endpoint=sb://\<your-namespace\>.servicebus.windows.net/;SharedAccessKeyName=\<key-name\>;SharedAccessKey=\<key\>
+     *  When the connection string does have an entity path, as shown below, the eventHub parameter
+     *  must be empty or must match the entity path. A different value throws.
+     *  Endpoint=sb://\<your-namespace\>.servicebus.windows.net/;
+     *  SharedAccessKeyName=\<key-name\>;SharedAccessKey=\<key\>;EntityPath=\<entitypath\>;
+     */
+    ProducerClient(
+        std::string const& connectionString,
+        std::string const& eventHub,
+        ProducerClientOptions options = {});
+
     ~ProducerClient();
 
     /** @brief Close all the connections and sessions.

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/README.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/README.md
@@ -7,7 +7,7 @@ This repository contains samples for the Azure Event Hubs service.
 These samples are written with the assumption that the following environment
 variables have been set by the user:
 
-* EVENTHUBS_CONNECTION_STRING - The service connection string for the eventhubs instance.
+* EVENTHUB_CONNECTION_STRING - The service connection string for the eventhubs instance.
 * EVENTHUB_NAME - Name of the eventhubs instance to communicate with.
 * EVENTHUBS_HOST - Fully qualified domain name for the eventhubs instance.
 
@@ -32,7 +32,7 @@ az eventhubs namespace authorization-rule keys list --resource-group <your resou
 }
 ```
 
-The value of the `primaryConnectionString` property should be used as the `EVENTHUBS_CONNECTION_STRING` environment variable.
+The value of the `primaryConnectionString` property should be used as the `EVENTHUB_CONNECTION_STRING` environment variable.
 
 
 ## Samples

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/CMakeLists.txt
@@ -18,5 +18,7 @@ target_link_libraries(eventhubs-${samplename} PRIVATE azure-messaging-eventhubs 
 target_compile_definitions(eventhubs-${samplename} PRIVATE _azure_BUILDING_SAMPLES)
 endmacro()
 
+define_sample(create_consumer)
 define_sample(create_consumer_aad)
+define_sample(create_producer)
 define_sample(create_producer_aad)

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Minimal sample showing how to create an Event Hubs consumer from a connection string. It then
+// gets the properties of the Event Hub instance.
+
+// This sample expects that the following environment variables exist:
+// * EVENTHUB_CONNECTION_STRING - the connection string to an Event Hubs namespace.
+// * EVENTHUB_NAME - the name of the Event Hub instance.
+//
+// Both of these are available from the Azure portal.
+//
+// When the connection string carries an EntityPath key, the EVENTHUB_NAME value must be empty or
+// must match that entity path. A different value throws std::invalid_argument.
+//
+
+#include <azure/messaging/eventhubs.hpp>
+
+#include <iostream>
+
+int main()
+{
+  char const* const connectionString{std::getenv("EVENTHUB_CONNECTION_STRING")};
+  char const* const eventhubName{std::getenv("EVENTHUB_NAME")};
+  if (connectionString == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    return 1;
+  }
+  if (eventhubName == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    return 1;
+  }
+
+  Azure::Messaging::EventHubs::ConsumerClient consumerClient(connectionString, eventhubName);
+
+  Azure::Messaging::EventHubs::Models::EventHubProperties eventhubProperties
+      = consumerClient.GetEventHubProperties();
+
+  std::cout << "Created consumer for event hub, properties: " << eventhubProperties << std::endl;
+}

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Minimal sample showing how to create an Event Hubs producer from a connection string. It then
+// gets the properties of the Event Hub instance.
+
+// This sample expects that the following environment variables exist:
+// * EVENTHUB_CONNECTION_STRING - the connection string to an Event Hubs namespace.
+// * EVENTHUB_NAME - the name of the Event Hub instance.
+//
+// Both of these are available from the Azure portal.
+//
+// When the connection string carries an EntityPath key, the EVENTHUB_NAME value must be empty or
+// must match that entity path. A different value throws std::invalid_argument.
+//
+
+#include <azure/messaging/eventhubs.hpp>
+
+#include <iostream>
+
+int main()
+{
+  char const* const connectionString{std::getenv("EVENTHUB_CONNECTION_STRING")};
+  char const* const eventhubName{std::getenv("EVENTHUB_NAME")};
+  if (connectionString == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    return 1;
+  }
+  if (eventhubName == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    return 1;
+  }
+
+  Azure::Messaging::EventHubs::ProducerClient producerClient(connectionString, eventhubName);
+
+  Azure::Messaging::EventHubs::Models::EventHubProperties eventhubProperties
+      = producerClient.GetEventHubProperties();
+
+  std::cout << "Created producer for event hub, properties: " << eventhubProperties << std::endl;
+}

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/CMakeLists.txt
@@ -18,4 +18,5 @@ target_link_libraries(eventhubs-${samplename} PRIVATE azure-messaging-eventhubs 
 target_compile_definitions(eventhubs-${samplename} PRIVATE _azure_BUILDING_SAMPLES)
 endmacro()
 
+define_sample(consume_events)
 define_sample(consume_events_aad)

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Minimal sample showing how to create an Event Hubs consumer from a connection string. It then
+// consumes events from the first partition of the Event Hub instance.
+
+// This sample expects that the following environment variables exist:
+// * EVENTHUB_CONNECTION_STRING - the connection string to an Event Hubs namespace.
+// * EVENTHUB_NAME - the name of the Event Hub instance.
+//
+// Both of these are available from the Azure portal.
+//
+
+#include <azure/messaging/eventhubs.hpp>
+
+#include <iostream>
+
+int main()
+{
+  char const* const connectionString{std::getenv("EVENTHUB_CONNECTION_STRING")};
+  char const* const eventhubName{std::getenv("EVENTHUB_NAME")};
+  if (connectionString == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    return 1;
+  }
+  if (eventhubName == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    return 1;
+  }
+
+  Azure::Messaging::EventHubs::ConsumerClient consumerClient(connectionString, eventhubName);
+
+  auto eventhubProperties{consumerClient.GetEventHubProperties()};
+  std::cout << "Event hub properties: " << eventhubProperties << std::endl;
+
+  // Create a PartitionClient to read events from one partition, in this case the first one.
+  //
+  // This partition client reads events from the start of the partition. The default is to read
+  // new events only.
+  Azure::Messaging::EventHubs::PartitionClientOptions partitionClientOptions;
+  partitionClientOptions.StartPosition.Earliest = true;
+  partitionClientOptions.StartPosition.Inclusive = true;
+
+  Azure::Messaging::EventHubs::PartitionClient partitionClient{consumerClient.CreatePartitionClient(
+      eventhubProperties.PartitionIds[0], partitionClientOptions)};
+
+  std::vector<std::shared_ptr<const Azure::Messaging::EventHubs::Models::ReceivedEventData>> events
+      = partitionClient.ReceiveEvents(2);
+
+  for (const auto& event : events)
+  {
+    std::cout << "Event: " << *event << std::endl;
+  }
+}

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/CMakeLists.txt
@@ -18,4 +18,5 @@ target_link_libraries(eventhubs-${samplename} PRIVATE azure-messaging-eventhubs 
 target_compile_definitions(eventhubs-${samplename} PRIVATE _azure_BUILDING_SAMPLES)
 endmacro()
 
+define_sample(produce_events)
 define_sample(produce_events_aad)

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Minimal sample showing how to create an Event Hubs producer from a connection string. It then
+// creates 2 events in a single batch and sends those events to the first partition.
+
+// This sample expects that the following environment variables exist:
+// * EVENTHUB_CONNECTION_STRING - the connection string to an Event Hubs namespace.
+// * EVENTHUB_NAME - the name of the Event Hub instance.
+//
+// Both of these are available from the Azure portal.
+//
+
+#include <azure/messaging/eventhubs.hpp>
+
+#include <iostream>
+
+int main()
+{
+  char const* const connectionString{std::getenv("EVENTHUB_CONNECTION_STRING")};
+  char const* const eventhubName{std::getenv("EVENTHUB_NAME")};
+  if (connectionString == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    return 1;
+  }
+  if (eventhubName == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_NAME" << std::endl;
+    return 1;
+  }
+
+  Azure::Messaging::EventHubs::ProducerClient producerClient(connectionString, eventhubName);
+
+  Azure::Messaging::EventHubs::Models::EventHubProperties eventhubProperties
+      = producerClient.GetEventHubProperties();
+
+  // By default, the producer sends to all available partitions in turn. Name a partition in the
+  // batch options to send to one partition. The consume-events sample reads from the first
+  // partition, so send to that one.
+  Azure::Messaging::EventHubs::EventDataBatchOptions batchOptions;
+  batchOptions.PartitionId = eventhubProperties.PartitionIds[0];
+  Azure::Messaging::EventHubs::EventDataBatch batch{producerClient.CreateBatch(batchOptions)};
+
+  // Send an event with a simple binary body.
+  {
+    Azure::Messaging::EventHubs::Models::EventData event;
+    event.Body = {1, 3, 5, 7};
+    event.MessageId = "connection-string-message-id-1";
+    if (!batch.TryAdd(event))
+    {
+      std::cerr << "Failed to add the event to the batch" << std::endl;
+      return 1;
+    }
+  }
+
+  // Send an event with a string body.
+  {
+    Azure::Messaging::EventHubs::Models::EventData event{"Hello Eventhubs via connection string!"};
+    event.MessageId = "connection-string-message-id-2";
+    if (!batch.TryAdd(event))
+    {
+      std::cerr << "Failed to add the event to the batch" << std::endl;
+      return 1;
+    }
+  }
+
+  producerClient.Send(batch);
+
+  std::cout << "Sent the batch to partition " << batchOptions.PartitionId.Value() << std::endl;
+}

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp
@@ -67,5 +67,5 @@ int main()
 
   producerClient.Send(batch);
 
-  std::cout << "Sent the batch to partition " << batchOptions.PartitionId.Value() << std::endl;
+  std::cout << "Sent the batch to partition " << batchOptions.PartitionId << std::endl;
 }

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
@@ -5,6 +5,7 @@
 #include "private/eventhubs_utilities.hpp"
 #include "private/package_version.hpp"
 
+#include <azure/core/amqp/internal/connection_string_credential.hpp>
 #include <azure/core/amqp/internal/message_receiver.hpp>
 #include <azure/messaging/eventhubs.hpp>
 
@@ -14,6 +15,35 @@ using namespace Azure::Messaging::EventHubs::Models;
 using namespace Azure::Core::Amqp::_internal;
 
 namespace Azure { namespace Messaging { namespace EventHubs {
+
+  ConsumerClient::ConsumerClient(
+      std::string const& connectionString,
+      std::string const& eventHub,
+      std::string const& consumerGroup,
+      ConsumerClientOptions const& options)
+      : m_connectionString{connectionString}, m_eventHub{eventHub}, m_consumerGroup{consumerGroup},
+        m_consumerClientOptions(options)
+  {
+    auto sasCredential
+        = std::make_shared<ServiceBusSasConnectionStringCredential>(m_connectionString, eventHub);
+
+    m_credential = sasCredential;
+    if (!sasCredential->GetEntityPath().empty())
+    {
+      m_eventHub = sasCredential->GetEntityPath();
+    }
+    m_fullyQualifiedNamespace = sasCredential->GetHostName();
+    std::string serviceScheme = _detail::EventHubsServiceScheme;
+    if (sasCredential->UseDevelopmentEmulator())
+    {
+      serviceScheme = _detail::EventHubsServiceScheme_Emulator;
+      m_targetPort = Azure::Core::Amqp::_internal::AmqpPort; // When using the emulator, use the
+                                                             // non-TLS endpoint by default.
+    }
+
+    m_hostUrl = serviceScheme + m_fullyQualifiedNamespace + "/" + m_eventHub
+        + _detail::EventHubsConsumerGroupsPath + m_consumerGroup;
+  }
 
   ConsumerClient::ConsumerClient(
       std::string const& fullyQualifiedNamespace,

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
@@ -10,6 +10,7 @@
 #include "private/retry_operation.hpp"
 
 #include <azure/core/amqp.hpp>
+#include <azure/core/amqp/internal/connection_string_credential.hpp>
 #include <azure/core/amqp/internal/message_sender.hpp>
 #include <azure/core/diagnostics/logger.hpp>
 #include <azure/core/internal/diagnostics/log.hpp>
@@ -21,6 +22,32 @@ const std::string DefaultAuthScope = "https://eventhubs.azure.net/.default";
 }
 
 namespace Azure { namespace Messaging { namespace EventHubs {
+
+  ProducerClient::ProducerClient(
+      std::string const& connectionString,
+      std::string const& eventHub,
+      Azure::Messaging::EventHubs::ProducerClientOptions options)
+      : m_connectionString{connectionString}, m_eventHub{eventHub}, m_producerClientOptions(options)
+  {
+    auto sasCredential
+        = std::make_shared<Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential>(
+            connectionString, eventHub);
+
+    m_credential = sasCredential;
+
+    m_eventHub
+        = (sasCredential->GetEntityPath().empty() ? eventHub : sasCredential->GetEntityPath());
+    m_fullyQualifiedNamespace = sasCredential->GetHostName();
+    std::string serviceScheme = _detail::EventHubsServiceScheme;
+    if (sasCredential->UseDevelopmentEmulator())
+    {
+      serviceScheme = _detail::EventHubsServiceScheme_Emulator;
+      m_targetPort = Azure::Core::Amqp::_internal::AmqpPort; // When using the emulator, use the
+                                                             // non-TLS endpoint by default.
+    }
+    m_targetUrl = serviceScheme + m_fullyQualifiedNamespace + ":"
+        + std::to_string(sasCredential->GetPort()) + "/" + m_eventHub;
+  }
 
   ProducerClient::ProducerClient(
       std::string const& fullyQualifiedNamespace,

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/consumer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/consumer_client_test.cpp
@@ -344,6 +344,9 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   }
 
   namespace {
+    // The keys below are fake base64 text. cspell tokenizes base64 into fragments that are not
+    // words, so spell checking is disabled across this block.
+    // cspell: disable
     // A connection string without an EntityPath key. The caller must name the event hub.
     constexpr const char* ConnectionStringNoEntityPath
         = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=FakeKey;"
@@ -356,6 +359,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
     constexpr const char* ConnectionStringEmulator
         = "Endpoint=sb://localhost:5672/;SharedAccessKeyName=RootManageSharedAccessKey;"
           "SharedAccessKey=abcdefabcdef;UseDevelopmentEmulator=true";
+    // cspell: enable
   } // namespace
 
   // These tests construct a client only. A client makes no network connection until the caller

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/consumer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/consumer_client_test.cpp
@@ -344,6 +344,64 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   }
 
   namespace {
+    // A connection string without an EntityPath key. The caller must name the event hub.
+    constexpr const char* ConnectionStringNoEntityPath
+        = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=FakeKey;"
+          "SharedAccessKey=ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleQ==";
+    // A connection string that names the event hub in its EntityPath key.
+    constexpr const char* ConnectionStringWithEntityPath
+        = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=FakeKey;"
+          "SharedAccessKey=ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleQ==;EntityPath=eventhub1";
+    // The connection string shape that the Event Hubs emulator uses.
+    constexpr const char* ConnectionStringEmulator
+        = "Endpoint=sb://localhost:5672/;SharedAccessKeyName=RootManageSharedAccessKey;"
+          "SharedAccessKey=abcdefabcdef;UseDevelopmentEmulator=true";
+  } // namespace
+
+  // These tests construct a client only. A client makes no network connection until the caller
+  // sends or receives, so these tests need no live Event Hub.
+  class ConsumerClientConnectionStringTest : public EventHubsTestBase {
+  };
+
+  TEST_F(ConsumerClientConnectionStringTest, EntityPathSuppliesEventHubName)
+  {
+    ConsumerClient client(ConnectionStringWithEntityPath);
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+  }
+
+  TEST_F(ConsumerClientConnectionStringTest, EntityPathMatchesEventHubName)
+  {
+    ConsumerClient client(ConnectionStringWithEntityPath, "eventhub1");
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+  }
+
+  TEST_F(ConsumerClientConnectionStringTest, EntityPathMismatchThrows)
+  {
+    EXPECT_THROW(
+        { ConsumerClient client(ConnectionStringWithEntityPath, "otherhub"); },
+        std::invalid_argument);
+  }
+
+  TEST_F(ConsumerClientConnectionStringTest, CallerSuppliesEventHubName)
+  {
+    ConsumerClient client(ConnectionStringNoEntityPath, "eventhub2");
+    EXPECT_EQ("eventhub2", client.GetEventHubName());
+    EXPECT_EQ("fake.servicebus.windows.net", client.GetDetails().FullyQualifiedNamespace);
+  }
+
+  TEST_F(ConsumerClientConnectionStringTest, DefaultConsumerGroup)
+  {
+    ConsumerClient client(ConnectionStringWithEntityPath);
+    EXPECT_EQ("$Default", client.GetDetails().ConsumerGroup);
+  }
+
+  TEST_F(ConsumerClientConnectionStringTest, EmulatorConnectionString)
+  {
+    ConsumerClient client(ConnectionStringEmulator, "eh1");
+    EXPECT_EQ("eh1", client.GetEventHubName());
+  }
+
+  namespace {
     static std::string GetSuffix(const testing::TestParamInfo<AuthType>& info)
     {
       std::string stringValue = "";
@@ -351,6 +409,9 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
       {
         case AuthType::Key:
           stringValue = "Key_LIVEONLY_";
+          break;
+        case AuthType::ConnectionString:
+          stringValue = "ConnectionString_LIVEONLY_";
           break;
         case AuthType::Emulator:
           stringValue = "Emulator";
@@ -362,6 +423,6 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   INSTANTIATE_TEST_SUITE_P(
       EventHubs,
       ConsumerClientTest,
-      ::testing::Values(AuthType::Key /*, AuthType::Emulator*/),
+      ::testing::Values(AuthType::Key, AuthType::ConnectionString /*, AuthType::Emulator*/),
       GetSuffix);
 }}}} // namespace Azure::Messaging::EventHubs::Test

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/eventhubs_test_base.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/eventhubs_test_base.hpp
@@ -12,7 +12,7 @@
 enum class AuthType
 {
   Key,
-  //  ConnectionString,
+  ConnectionString,
   Emulator,
 };
 
@@ -48,14 +48,19 @@ protected:
         return std::make_unique<Azure::Messaging::EventHubs::ConsumerClient>(
             eventHubNamespace, eventHubName, GetTestCredential(), eventConsumerGroup, options);
       }
+      case AuthType::ConnectionString: {
+        std::string connectionString = GetEnv("EVENTHUB_CONNECTION_STRING");
+        return std::make_unique<Azure::Messaging::EventHubs::ConsumerClient>(
+            connectionString, eventHubName, eventConsumerGroup, options);
+      }
       case AuthType::Emulator: {
-        //   return std::make_unique<Azure::Messaging::EventHubs::ConsumerClient>(
-        //       "Endpoint=sb://localhost:5672/"
-        //       ";SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abcdefabcdef;"
-        //       "UseDevelopmentEmulator=true",
-        //       "eh1",
-        //       "$default",
-        //       options);
+        return std::make_unique<Azure::Messaging::EventHubs::ConsumerClient>(
+            "Endpoint=sb://localhost:5672/"
+            ";SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abcdefabcdef;"
+            "UseDevelopmentEmulator=true",
+            "eh1",
+            "$default",
+            options);
       }
     }
     return nullptr;
@@ -79,13 +84,20 @@ protected:
             eventHubNamespace, eventHubName, GetTestCredential(), options);
         break;
       }
+      case AuthType::ConnectionString: {
+        std::string connectionString = GetEnv("EVENTHUB_CONNECTION_STRING");
+        producer = std::make_unique<Azure::Messaging::EventHubs::ProducerClient>(
+            connectionString, eventHubName, options);
+        break;
+      }
       case AuthType::Emulator: {
-        //   producer = std::make_unique<Azure::Messaging::EventHubs::ProducerClient>(
-        //       "Endpoint=sb://localhost:5672/"
-        //       ";SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abcdefabcdef;"
-        //       "UseDevelopmentEmulator=true",
-        //       "eh1",
-        //       options);
+        producer = std::make_unique<Azure::Messaging::EventHubs::ProducerClient>(
+            "Endpoint=sb://localhost:5672/"
+            ";SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abcdefabcdef;"
+            "UseDevelopmentEmulator=true",
+            "eh1",
+            options);
+        break;
       }
     }
     return producer;

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/processor_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/processor_test.cpp
@@ -656,6 +656,9 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
         case AuthType::Key:
           stringValue = "Key_LIVEONLY_";
           break;
+        case AuthType::ConnectionString:
+          stringValue = "ConnectionString_LIVEONLY_";
+          break;
         case AuthType::Emulator:
           stringValue = "Emulator";
           break;
@@ -666,7 +669,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   INSTANTIATE_TEST_SUITE_P(
       EventHubs,
       ProcessorTest,
-      ::testing::Values(AuthType::Key /*, AuthType::Emulator*/),
+      ::testing::Values(AuthType::Key, AuthType::ConnectionString /*, AuthType::Emulator*/),
       GetSuffix);
 
 }}}} // namespace Azure::Messaging::EventHubs::Test

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
@@ -244,6 +244,57 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   }
 
   namespace {
+    // A connection string without an EntityPath key. The caller must name the event hub.
+    constexpr const char* ConnectionStringNoEntityPath
+        = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=FakeKey;"
+          "SharedAccessKey=ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleQ==";
+    // A connection string that names the event hub in its EntityPath key.
+    constexpr const char* ConnectionStringWithEntityPath
+        = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=FakeKey;"
+          "SharedAccessKey=ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleQ==;EntityPath=eventhub1";
+    // The connection string shape that the Event Hubs emulator uses.
+    constexpr const char* ConnectionStringEmulator
+        = "Endpoint=sb://localhost:5672/;SharedAccessKeyName=RootManageSharedAccessKey;"
+          "SharedAccessKey=abcdefabcdef;UseDevelopmentEmulator=true";
+  } // namespace
+
+  // These tests construct a client only. A client makes no network connection until the caller
+  // sends or receives, so these tests need no live Event Hub.
+  class ProducerClientConnectionStringTest : public EventHubsTestBase {
+  };
+
+  TEST_F(ProducerClientConnectionStringTest, EntityPathSuppliesEventHubName)
+  {
+    ProducerClient client(ConnectionStringWithEntityPath, "");
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+  }
+
+  TEST_F(ProducerClientConnectionStringTest, EntityPathMatchesEventHubName)
+  {
+    ProducerClient client(ConnectionStringWithEntityPath, "eventhub1");
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+  }
+
+  TEST_F(ProducerClientConnectionStringTest, EntityPathMismatchThrows)
+  {
+    EXPECT_THROW(
+        { ProducerClient client(ConnectionStringWithEntityPath, "otherhub"); },
+        std::invalid_argument);
+  }
+
+  TEST_F(ProducerClientConnectionStringTest, CallerSuppliesEventHubName)
+  {
+    ProducerClient client(ConnectionStringNoEntityPath, "eventhub2");
+    EXPECT_EQ("eventhub2", client.GetEventHubName());
+  }
+
+  TEST_F(ProducerClientConnectionStringTest, EmulatorConnectionString)
+  {
+    ProducerClient client(ConnectionStringEmulator, "eh1");
+    EXPECT_EQ("eh1", client.GetEventHubName());
+  }
+
+  namespace {
     static std::string GetSuffix(const testing::TestParamInfo<AuthType>& info)
     {
       std::string stringValue = "";
@@ -251,6 +302,9 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
       {
         case AuthType::Key:
           stringValue = "Key_LIVEONLY_";
+          break;
+        case AuthType::ConnectionString:
+          stringValue = "ConnectionString_LIVEONLY_";
           break;
         case AuthType::Emulator:
           stringValue = "Emulator";
@@ -264,13 +318,13 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   INSTANTIATE_TEST_SUITE_P(
       EventHubs,
       ProducerClientTest,
-      ::testing::Values(AuthType::Key),
+      ::testing::Values(AuthType::Key, AuthType::ConnectionString),
       GetSuffix);
 #else
   INSTANTIATE_TEST_SUITE_P(
       EventHubs,
       ProducerClientTest,
-      ::testing::Values(AuthType::Key),
+      ::testing::Values(AuthType::Key, AuthType::ConnectionString),
       GetSuffix);
 #endif
 }}}} // namespace Azure::Messaging::EventHubs::Test

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
@@ -244,6 +244,9 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   }
 
   namespace {
+    // The keys below are fake base64 text. cspell tokenizes base64 into fragments that are not
+    // words, so spell checking is disabled across this block.
+    // cspell: disable
     // A connection string without an EntityPath key. The caller must name the event hub.
     constexpr const char* ConnectionStringNoEntityPath
         = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=FakeKey;"
@@ -256,6 +259,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
     constexpr const char* ConnectionStringEmulator
         = "Endpoint=sb://localhost:5672/;SharedAccessKeyName=RootManageSharedAccessKey;"
           "SharedAccessKey=abcdefabcdef;UseDevelopmentEmulator=true";
+    // cspell: enable
   } // namespace
 
   // These tests construct a client only. A client makes no network connection until the caller

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/round_trip_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/round_trip_test.cpp
@@ -148,6 +148,9 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
         case AuthType::Key:
           stringValue = "Key_LIVEONLY_";
           break;
+        case AuthType::ConnectionString:
+          stringValue = "ConnectionString_LIVEONLY_";
+          break;
         case AuthType::Emulator:
           stringValue = "Emulator";
           break;
@@ -159,7 +162,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
   INSTANTIATE_TEST_SUITE_P(
       EventHubs,
       RoundTripTests,
-      ::testing::Values(AuthType::Key /*, AuthType::Emulator*/),
+      ::testing::Values(AuthType::Key, AuthType::ConnectionString /*, AuthType::Emulator*/),
       GetSuffix);
 
 }}}} // namespace Azure::Messaging::EventHubs::Test


### PR DESCRIPTION
## Summary

This change restores the connection string constructors on `ProducerClient` and `ConsumerClient`. Version `1.0.0-beta.11` removed them, which made the C++ library the only Event Hubs SDK without a connection string entry point. The change also restores Event Hubs emulator support, which depended on those constructors.

Fixes #7250.

## Motivation

The removal arrived with commit `e04e96cf8` ("Merged Rust AMQP stack with main.", #6442), a large merge that rebuilt the AMQP layer. The `CHANGELOG.md` records the removal as a breaking change, and neither the entry nor the commit message states a rationale.

The Azure SDK guidelines permit the restoration. `general-auth-connection-strings` states "DO NOT support constructing a service client with a connection string unless such connection string is available within tooling (for copy/paste operations)." Event Hubs publishes connection strings in the Azure portal under the shared access policies of a namespace, so the exception applies.

The supporting code was never deleted. `ConnectionStringParser` and `ServiceBusSasConnectionStringCredential` still live in `azure-core-amqp`, still build for both the uAMQP and the Rust AMQP backends, and still have unit tests. `ServiceBusSasConnectionStringCredential` derives from `Azure::Core::Credentials::TokenCredential`, so the restored constructors parse the string, build the credential, and delegate to the existing token credential path. The AMQP connection layer already branches on `IsSasCredential()` to select the CBS token type, so the transport needs no change.

Two effects of the removal made this worth fixing. Every sibling Event Hubs SDK exposes a connection string entry point: .NET, Go, Java, Python, and Rust. And the Event Hubs emulator does not support Microsoft Entra ID, so a connection string is its only credential. The dead constant `EventHubsServiceScheme_Emulator` still sat in `eventhubs_constants.hpp` with no code path able to reach it.

## Changes

- Restored `ProducerClient(connectionString, eventHub, options)` and `ConsumerClient(connectionString, eventHub, consumerGroup, options)` with their pre-removal signatures.
- Restored the emulator path. When the connection string sets `UseDevelopmentEmulator=true`, the constructor selects the `amqp://` scheme and sets the target port to `AmqpPort`. Both AMQP backends derive the transport from the port, so that one assignment disables TLS.
- Kept `ServiceBusSasConnectionStringCredential` inside the `.cpp` files. The public headers gain no `azure/core/amqp/internal/*` include, so this change does not add to the internal header leakage in the public surface.
- Restored the `ConnectionString` authentication type in the test base, and restored the `ConnectionString` parameterization in the producer, consumer, processor, and round trip suites. The `ConnectionString_LIVEONLY_` suffix gates them to live runs.
- Added 11 offline constructor tests that need no live Event Hub. They cover `EntityPath` adoption, a matching event hub name, the mismatch throw, a caller supplied name, namespace extraction, the default consumer group, and the emulator connection string.
- Restored the four deleted connection string samples. `samples/README.md` still listed all four.
- Corrected the package `README.md`. It documented the removed constructors, and its examples used `EventDataBatch` direct construction, `AddMessage`, and `SendEventDataBatch`, none of which exist on the current surface.
- Corrected the connection string environment variable name in `samples/README.md` from `EVENTHUBS_CONNECTION_STRING` to `EVENTHUB_CONNECTION_STRING`, which is the name that the sample code and `ci.yml` use.

### EntityPath precedence

The behavior matches .NET. An empty `eventHub` parameter adopts the `EntityPath` value, a matching value passes, and a different value throws `std::invalid_argument`. `ServiceBusSasConnectionStringCredential` already implements this rule, so the clients inherit it by delegation.

One deviation from .NET: the C++ credential compares the two names exactly, and .NET compares them without case. This change keeps the exact compare, because changing the shared credential would also change Service Bus behavior.

## Validation

Built and tested on macOS arm64 with the uAMQP backend.

```
cmake -B build-uamqp -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
  -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DDISABLE_RUST_IN_BUILD=ON
make azure-messaging-eventhubs azure-messaging-eventhubs-test -j8
AZURE_TEST_MODE=PLAYBACK EVENTHUB_CONSUMER_GROUP='$Default' ./azure-messaging-eventhubs-test
```

Results: the library and the test binary build clean. The full suite reports 97 tests, 39 passed, 0 failed, and 117 live only cases skipped. All 11 new offline tests pass.

Note on `CheckpointStoreTest.TestCheckpoints`: it fails without the `EVENTHUB_CONSUMER_GROUP` environment variable, on this branch and on `main`. That behavior predates this change, and this change does not touch the checkpoint store.

## Work not done in this pull request

- **Live connection string tests cannot pass yet.** `test-resources.json` sets `"disableLocalAuth": true` on the test namespace, and the outputs block exports no connection string. Enabling shared access key authentication on the test subscription needs engineering system sign off, so this change leaves the resource template alone. The restored `ConnectionString` parameterizations stay dormant until the environment variable exists.
- **The emulator path has no automated coverage.** CI provisions no emulator. The analysis is that the port assignment is the whole TLS story on both backends, and the offline test makes sure the emulator connection string constructs. A manual run against the Docker emulator is still the only end to end proof.
- **The Rust AMQP backend build is unverified here.** Only the uAMQP backend was built locally. The new code calls no backend specific API, and `connection_string_credential.cpp` builds for both backends, so CI should cover this.
- **`BlobCheckpointStore` keeps its current surface.** It takes a `BlobContainerClient`, and Azure Storage already ships `BlobContainerClient::CreateFromConnectionString`, so a connection string user has a path with no new API.
- **The performance test still misuses `EVENTHUB_CONNECTION_STRING`.** It reads that variable into a host name field and passes it with a token credential (`test/perf/inc/azure/messaging/eventhubs/test/eventhubs_batch_perf_test.hpp`). That is a separate latent defect from the removal, and it is a natural follow up.

