### PR TITLE
chore: add @meetamitbhatia to CODEOWNERS alongside @j7nw4r

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,10 +53,10 @@
 # ServiceOwners:                                                   @danieljurek @LarryOsterman @RickWinter @weshaggard
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/                                                    @axisc @hmlam @sjkwak @j7nw4r @SwayGom @sagar0207
+/sdk/eventhubs/                                                    @axisc @hmlam @sjkwak @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 # ServiceLabel: %Event Hubs
-# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @SwayGom @sagar0207
+# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 # PRLabel: %KeyVault
 /sdk/keyvault/                                                     @Azure/azure-sdk-write-keyvault


### PR DESCRIPTION
## Summary

@meetamitbhatia (Amit Bhatia) is not in the CODEOWNERS file. He works on the messaging libraries and must get review requests on the same paths as @j7nw4r.

## Motivation

@meetamitbhatia joined the messaging team. Without a CODEOWNERS entry, GitHub does not add him to pull requests that touch the messaging paths. The team then loses a reviewer, and review latency goes up.

## Changes

This change adds `@meetamitbhatia` next to `@j7nw4r` on every line that already lists `@j7nw4r`. It changes 1 owner path and 1 `ServiceOwners` comment. It removes no owner and adds no new path.

Owner paths:

- `/sdk/eventhubs/`

## Validation

@meetamitbhatia is a member of the `Azure` organization, so the CODEOWNERS linter can resolve the handle.
