### PR TITLE
[CFS] Route NuGet and Cargo restores through Azure DevOps feeds

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -135,6 +135,10 @@ jobs:
           )
         displayName: Xcode version
 
+      # Must precede every NuGet consumer in this job: test-proxy, the coverage tools
+      # install, and any PreTestSteps that restore packages (e.g. TestAmqpBroker).
+      - template: /eng/pipelines/templates/steps/nuget-config.yml
+
       - template: /eng/common/pipelines/templates/steps/set-vcpkg-cache-vars.yml
 
       - script: vcpkg --version
@@ -283,10 +287,6 @@ jobs:
         condition: succeededOrFailed()
 
       - ${{ if eq(parameters.CoverageEnabled, true) }}:
-        - task: NuGetAuthenticate@1
-          displayName: Authenticate NuGet for coverage tools
-          condition: and(succeeded(), eq(variables['CODE_COVERAGE'], 'enabled'))
-
         - pwsh: |
             $toolsDirectory = "$(Agent.TempDirectory)/coveragetools"
             dotnet tool install -g dotnet-reportgenerator-globaltool

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -283,6 +283,10 @@ jobs:
         condition: succeededOrFailed()
 
       - ${{ if eq(parameters.CoverageEnabled, true) }}:
+        - task: NuGetAuthenticate@1
+          displayName: Authenticate NuGet for coverage tools
+          condition: and(succeeded(), eq(variables['CODE_COVERAGE'], 'enabled'))
+
         - pwsh: |
             $toolsDirectory = "$(Agent.TempDirectory)/coveragetools"
             dotnet tool install -g dotnet-reportgenerator-globaltool

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -145,11 +145,9 @@ jobs:
         )
     displayName: vcpkg --version
 
-  - task: NuGetAuthenticate@1
-    displayName: Authenticate NuGet for coverage tools
-    # Matches the condition on "Install coverage tools" below so the credentials are
-    # available whenever the dotnet tool install actually runs.
-    condition: and(succeededOrFailed(), ne(variables['CODE_COVERAGE'], 'disabled'), ne(variables['CODE_COVERAGE'], ''))
+  # Must precede every NuGet consumer in this job: the coverage tools install below,
+  # test-proxy, and any PreTestSteps that restore packages.
+  - template: /eng/pipelines/templates/steps/nuget-config.yml
 
   - script: |
       dotnet tool install -g dotnet-reportgenerator-globaltool

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -145,6 +145,12 @@ jobs:
         )
     displayName: vcpkg --version
 
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet for coverage tools
+    # Matches the condition on "Install coverage tools" below so the credentials are
+    # available whenever the dotnet tool install actually runs.
+    condition: and(succeededOrFailed(), ne(variables['CODE_COVERAGE'], 'disabled'), ne(variables['CODE_COVERAGE'], ''))
+
   - script: |
       dotnet tool install -g dotnet-reportgenerator-globaltool
       dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -91,6 +91,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive, CFSClean
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'cpp - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/steps/cmake-build.yml
+++ b/eng/pipelines/templates/steps/cmake-build.yml
@@ -11,6 +11,30 @@ steps:
   - script: mkdir build
     displayName: create working directory
 
+  # Cargo only reads config files from $CARGO_HOME or from ancestors of its working
+  # directory, and it ignores environment variables for [source] replacement, so the
+  # config has to be written to disk before cargo runs.
+  - pwsh: |
+      $cargoHome = $env:CARGO_HOME
+      if (-not $cargoHome) { $cargoHome = Join-Path $HOME '.cargo' }
+      New-Item -ItemType Directory -Force -Path $cargoHome | Out-Null
+
+      $configPath = Join-Path $cargoHome 'config.toml'
+      Copy-Item `
+        -Path '$(Build.SourcesDirectory)/eng/templates/config.toml.template' `
+        -Destination $configPath `
+        -Force
+
+      Write-Host "Wrote cargo config to $configPath"
+      Get-Content $configPath
+      Write-Host "##vso[task.setvariable variable=CargoConfigPath]$configPath"
+    displayName: Configure cargo to use the azure-sdk-for-rust feed
+
+  - task: CargoAuthenticate@0
+    displayName: Authenticate cargo to the azure-sdk-for-rust feed
+    inputs:
+      configFile: $(CargoConfigPath)
+
   - script: cmake --version
     workingDirectory: build
     displayName: cmake --version

--- a/eng/pipelines/templates/steps/nuget-config.yml
+++ b/eng/pipelines/templates/steps/nuget-config.yml
@@ -1,0 +1,31 @@
+steps:
+  # NuGet only reads package sources from the machine-wide config, the user (global)
+  # config, and NuGet.config files at or above the working directory. The CI consumers
+  # (reportgenerator, test-proxy, TestAmqpBroker) each restore from a different working
+  # directory, so the config has to be installed at the user level to cover all of them.
+  - pwsh: |
+      $nugetConfigDir = if ($env:APPDATA) {
+        Join-Path $env:APPDATA 'NuGet'
+      } else {
+        Join-Path (Join-Path $HOME '.nuget') 'NuGet'
+      }
+      New-Item -ItemType Directory -Force -Path $nugetConfigDir | Out-Null
+
+      $configPath = Join-Path $nugetConfigDir 'NuGet.Config'
+      Copy-Item `
+        -Path '$(Build.SourcesDirectory)/eng/templates/NuGet.config.template' `
+        -Destination $configPath `
+        -Force
+
+      Write-Host "Wrote NuGet config to $configPath"
+      Get-Content $configPath
+
+      if (Get-Command dotnet -ErrorAction SilentlyContinue) {
+        dotnet nuget list source
+      }
+    displayName: Configure NuGet to use the azure-sdk-for-net feed
+
+  # Runs after the config is in place so the credential provider is installed for the
+  # feed that is actually configured above.
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet to Azure Artifacts feeds

--- a/eng/templates/NuGet.config.template
+++ b/eng/templates/NuGet.config.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  NuGet configuration used by CI builds to route package restores through the
+  Centralized Feed Service (CFS) instead of the public internet.
+
+  Under the CFSClean network isolation policy, api.nuget.org is blocked. NuGet resolves
+  its package sources by merging the machine-wide config, the user (global) config, and
+  any NuGet.config found in or above the working directory. Because the CI consumers
+  here run from unrelated working directories (a global tool install for reportgenerator,
+  a tool-path install for test-proxy, and a build of TestAmqpBroker in a temporary
+  clone), a repo-local config would not apply. This file is therefore copied over the
+  user-level config by eng/pipelines/templates/steps/nuget-config.yml.
+
+  <clear /> discards nuget.org and anything else inherited from machine-wide config, and
+  the single <add> below makes the azure-sdk-for-net Azure Artifacts feed the only
+  source. That feed has an upstream to nuget.org, so third-party packages still resolve.
+
+  NuGetAuthenticate@1 does not add package sources - it only installs the Azure Artifacts
+  Credential Provider and binds it to feeds under pkgs.dev.azure.com/azure-sdk. Clearing
+  without adding a replacement would fail every restore with NU1100, so the <add> here is
+  required rather than optional.
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="azure-sdk-for-net" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/eng/templates/config.toml.template
+++ b/eng/templates/config.toml.template
@@ -1,0 +1,20 @@
+# Cargo configuration used by CI builds to route crates.io traffic through the
+# Centralized Feed Service (CFS) instead of the public internet.
+#
+# This file is copied to $CARGO_HOME/config.toml (which defaults to ~/.cargo/config.toml
+# when CARGO_HOME is not set) by eng/pipelines/templates/steps/cmake-build.yml, before
+# CMake/Corrosion invokes cargo for the azure-core-amqp rust_wrapper crate.
+#
+# CargoAuthenticate@0 parses the [registries] table below and exports the
+# CARGO_REGISTRIES_AZURE_SDK_FOR_RUST_TOKEN / _CREDENTIAL_PROVIDER variables that cargo
+# needs to authenticate against the feed.
+#
+# The [source] replacement is what actually redirects index.crates.io and
+# static.crates.io to the feed. Cargo does not honor environment variables for the
+# [source] table, so an on-disk config file is required.
+
+[registries]
+azure-sdk-for-rust = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/_packaging/azure-sdk-for-rust/Cargo/index/" }
+
+[source.crates-io]
+replace-with = "azure-sdk-for-rust"

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -30,18 +30,6 @@ try {
   Write-Host "Cloning repository from $repositoryUrl..."
   Invoke-LoggedCommand $cloneCommand
 
-  # The cloned repository's nuget.config adds api.nuget.org, which the CFSClean network
-  # isolation policy blocks, and a repository level config takes precedence over the
-  # agent's user level config. Swap that source for the Azure SDK public feed and leave
-  # the dotnet-public feed in place, so restores stay on Azure Artifacts.
-  $clonedNuGetConfig = Join-Path $WorkingDirectory "azure-amqp/nuget.config"
-  $azureSdkFeed = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
-
-  Write-Host "Updating package sources in $clonedNuGetConfig"
-  dotnet nuget remove source "NuGet official package source" --configfile $clonedNuGetConfig
-  dotnet nuget add source $azureSdkFeed --name azure-sdk-for-net --configfile $clonedNuGetConfig
-  dotnet nuget list source --configfile $clonedNuGetConfig
-
   Set-Location -Path "./azure-amqp/test/TestAmqpBroker"
 
   Invoke-LoggedCommand "dotnet build -p RollForward=LatestMajor --framework net8.0"

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -44,12 +44,7 @@ try {
 
   Set-Location -Path "./azure-amqp/test/TestAmqpBroker"
 
-  # TODO: Revert before merge. Temporary unblock for CFS/network-isolation validation.
-  # Azure/azure-amqp master now targets <TargetFrameworks>net48;net10.0</TargetFrameworks>,
-  # so the previous net8.0 target no longer exists and both the build and the launch path
-  # below were failing. Bumping to net10.0 here (and at the Set-Location below) keeps CI
-  # moving; the real fix belongs to whoever owns the azure-amqp dependency uptake.
-  Invoke-LoggedCommand "dotnet build -p RollForward=LatestMajor --framework net10.0"
+  Invoke-LoggedCommand "dotnet build -p RollForward=LatestMajor --framework net8.0"
   if (!$? -ne 0) {
     Write-Error "Failed to build TestAmqpBroker."
     exit 1
@@ -60,8 +55,7 @@ try {
   # now that the Test broker has been built, launch the broker on a local address.
   Write-Host "Starting test broker listening on ${env:TEST_BROKER_ADDRESS} ..."
 
-  # TODO: Revert before merge. Must match the --framework used in the build above.
-  Set-Location -Path $WorkingDirectory/azure-amqp/bin/Debug/TestAmqpBroker/net10.0
+  Set-Location -Path $WorkingDirectory/azure-amqp/bin/Debug/TestAmqpBroker/net8.0
 
 #  $job = dotnet exec ./TestAmqpBroker.dll ${env:TEST_BROKER_ADDRESS} /headless &
   $Process = Start-Process -NoNewWindow -FilePath "dotnet" -ArgumentList "exec ./TestAmqpBroker.dll ${env:TEST_BROKER_ADDRESS} /headless" -PassThru  -RedirectStandardOutput $WorkingDirectory/test-broker.log -RedirectStandardError $WorkingDirectory/test-broker-error.log

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -30,18 +30,17 @@ try {
   Write-Host "Cloning repository from $repositoryUrl..."
   Invoke-LoggedCommand $cloneCommand
 
-  # The cloned repository ships its own nuget.config which adds api.nuget.org. A
-  # repository level config takes precedence over the agent's user level config, so the
-  # clone reintroduces a source that the CFSClean network isolation policy blocks.
-  # Replace it with the same Azure Artifacts feed config the rest of the pipeline uses.
+  # The cloned repository's nuget.config adds api.nuget.org, which the CFSClean network
+  # isolation policy blocks, and a repository level config takes precedence over the
+  # agent's user level config. Swap that source for the Azure SDK public feed and leave
+  # the dotnet-public feed in place, so restores stay on Azure Artifacts.
   $clonedNuGetConfig = Join-Path $WorkingDirectory "azure-amqp/nuget.config"
-  Copy-Item `
-    -Path (Join-Path $RepoRoot "eng/templates/NuGet.config.template") `
-    -Destination $clonedNuGetConfig `
-    -Force
+  $azureSdkFeed = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
 
-  Write-Host "Replaced $clonedNuGetConfig with the Azure Artifacts feed config:"
-  Get-Content $clonedNuGetConfig
+  Write-Host "Updating package sources in $clonedNuGetConfig"
+  dotnet nuget remove source "NuGet official package source" --configfile $clonedNuGetConfig
+  dotnet nuget add source $azureSdkFeed --name azure-sdk-for-net --configfile $clonedNuGetConfig
+  dotnet nuget list source --configfile $clonedNuGetConfig
 
   Set-Location -Path "./azure-amqp/test/TestAmqpBroker"
 

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -32,7 +32,7 @@ try {
 
   Set-Location -Path "./azure-amqp/test/TestAmqpBroker"
 
-  Invoke-LoggedCommand "dotnet build -p RollForward=LatestMajor --framework net8.0"
+  Invoke-LoggedCommand "dotnet build -p RollForward=LatestMajor --framework net10.0"
   if (!$? -ne 0) {
     Write-Error "Failed to build TestAmqpBroker."
     exit 1

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -32,6 +32,11 @@ try {
 
   Set-Location -Path "./azure-amqp/test/TestAmqpBroker"
 
+  # TODO: Revert before merge. Temporary unblock for CFS/network-isolation validation.
+  # Azure/azure-amqp master now targets <TargetFrameworks>net48;net10.0</TargetFrameworks>,
+  # so the previous net8.0 target no longer exists and both the build and the launch path
+  # below were failing. Bumping to net10.0 here (and at the Set-Location below) keeps CI
+  # moving; the real fix belongs to whoever owns the azure-amqp dependency uptake.
   Invoke-LoggedCommand "dotnet build -p RollForward=LatestMajor --framework net10.0"
   if (!$? -ne 0) {
     Write-Error "Failed to build TestAmqpBroker."
@@ -43,7 +48,8 @@ try {
   # now that the Test broker has been built, launch the broker on a local address.
   Write-Host "Starting test broker listening on ${env:TEST_BROKER_ADDRESS} ..."
 
-  Set-Location -Path $WorkingDirectory/azure-amqp/bin/Debug/TestAmqpBroker/net8.0
+  # TODO: Revert before merge. Must match the --framework used in the build above.
+  Set-Location -Path $WorkingDirectory/azure-amqp/bin/Debug/TestAmqpBroker/net10.0
 
 #  $job = dotnet exec ./TestAmqpBroker.dll ${env:TEST_BROKER_ADDRESS} /headless &
   $Process = Start-Process -NoNewWindow -FilePath "dotnet" -ArgumentList "exec ./TestAmqpBroker.dll ${env:TEST_BROKER_ADDRESS} /headless" -PassThru  -RedirectStandardOutput $WorkingDirectory/test-broker.log -RedirectStandardError $WorkingDirectory/test-broker-error.log

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -30,6 +30,19 @@ try {
   Write-Host "Cloning repository from $repositoryUrl..."
   Invoke-LoggedCommand $cloneCommand
 
+  # The cloned repository ships its own nuget.config which adds api.nuget.org. A
+  # repository level config takes precedence over the agent's user level config, so the
+  # clone reintroduces a source that the CFSClean network isolation policy blocks.
+  # Replace it with the same Azure Artifacts feed config the rest of the pipeline uses.
+  $clonedNuGetConfig = Join-Path $WorkingDirectory "azure-amqp/nuget.config"
+  Copy-Item `
+    -Path (Join-Path $RepoRoot "eng/templates/NuGet.config.template") `
+    -Destination $clonedNuGetConfig `
+    -Force
+
+  Write-Host "Replaced $clonedNuGetConfig with the Azure Artifacts feed config:"
+  Get-Content $clonedNuGetConfig
+
   Set-Location -Path "./azure-amqp/test/TestAmqpBroker"
 
   # TODO: Revert before merge. Temporary unblock for CFS/network-isolation validation.


### PR DESCRIPTION
## Summary

Routes CI package restores through Azure DevOps feeds so builds satisfy the **CFSClean** 1ES Network Isolation policy, instead of reaching the public internet at `api.nuget.org` and `crates.io`.

`networkIsolationPolicy` is also set to `Permissive, CFSClean` in `archetype-sdk-client.yml` so the policy is actually applied.

## Result

**CFSClean is compliant in aggregate across all jobs**, verified on three full pipeline runs (162 jobs total):

| Definition | Build | Jobs | Blocked connections | Non-compliant policies |
|---|---|---:|---:|---|
| cpp - core | 6647208 | 54 | 0 | Default Deny(58), CFSClean2(48), CFSClean3(8) |
| cpp - keyvault | 6647120 | 54 | 0 | CFSClean2(48), Default Deny(10) |
| cpp - storage | 6647119 | 54 | 0 | CFSClean2(48), Default Deny(10) |

CFSClean does not appear for any build, and every one of the 141 measured jobs reports `CFSClean=PASS`.

| Domain | Policy | Before | After |
|---|---|---:|---:|
| `api.nuget.org` | CFSClean | 3175 hits / 37 jobs | **0** |
| `index.crates.io` | CFSClean | 364 hits / 34 jobs | **0** |
| `static.crates.io` | CFSClean | (same cluster) | **0** |
| `static.rust-lang.org` | CFSClean | (same cluster) | **0** |

`static.rust-lang.org` needed no separate fix. It only ever appeared because it shares Fastly IPs with crates.io, so redirecting crates.io removed it. Confirmed by a run where the rustup toolchain download still occurred and the domain reported zero violations.

> Note: those measurements were collected with a temporary local workaround applied to `sdk/core/azure-core-amqp/Test-Setup.ps1`, described under Known issues below. That workaround is **not** part of this PR.

## Changes

### Cargo

- **`eng/templates/config.toml.template`** — declares the `azure-sdk-for-rust` registry and a `[source.crates-io] replace-with` entry pointing at it.
- **`eng/pipelines/templates/steps/cmake-build.yml`** — copies that template to `$CARGO_HOME/config.toml` before CMake/Corrosion invokes cargo, then runs `CargoAuthenticate@0` against it.

An on-disk config is required because cargo does not honor environment variables for the `[source]` table, and only reads config from `$CARGO_HOME` or ancestors of its working directory.

### NuGet

- **`eng/templates/NuGet.config.template`** — clears inherited package sources and adds the `azure-sdk-for-net` Azure Artifacts feed.
- **`eng/pipelines/templates/steps/nuget-config.yml`** — installs that config at the user level (`%APPDATA%\NuGet` on Windows, `~/.nuget/NuGet` otherwise), prints the resulting source list, then runs `NuGetAuthenticate@1`.
- **`eng/pipelines/templates/jobs/ci.tests.yml`, `live.tests.yml`** — invoke the step early, ahead of every NuGet consumer. This replaces the previous standalone `NuGetAuthenticate@1` tasks, which were scoped to code coverage only.

Two details worth calling out for review:

- The config is installed at the **user level** rather than in the repo because each consumer restores from a different working directory. Coverage tools install globally, test-proxy installs to a tool path, and TestAmqpBroker builds from a temporary clone, so a repo-local `NuGet.config` would not apply to any of them.
- `NuGetAuthenticate@1` does **not** register package sources. It only installs the Azure Artifacts Credential Provider and binds it to feeds under `pkgs.dev.azure.com/azure-sdk`. Clearing sources without adding a replacement fails every restore with `NU1100`, so the explicit `<add>` is required rather than optional.

## Known issues owned by azure-core-amqp

`sdk/core/azure-core-amqp/Test-Setup.ps1` is intentionally **not modified** by this PR. It has two problems that should be resolved by the owners of the azure-amqp dependency uptake.

**1. The step is already failing in the pipelines, independently of this PR.** `Azure/azure-amqp` master now declares `<TargetFrameworks>net48;net10.0</TargetFrameworks>`. The `net8.0` target that `Test-Setup.ps1` builds and launches no longer exists, so the step fails regardless of network isolation. Targeting `net10.0` was used as a temporary local workaround to get a fully green core run for the compliance measurements above; it has been reverted and is not proposed here, because which framework to target should be a deliberate decision by the owners.

**2. It will still reach `api.nuget.org` once that is fixed.** The cloned `Azure/azure-amqp` repository ships its own `nuget.config` listing `api.nuget.org` and `dotnet-public`. A repository level config takes precedence over the user level config installed by this PR, so the clone reintroduces the blocked source and the restore fails under CFSClean with:

```
error NU1301: Unable to load the service index for source https://api.nuget.org/v3/index.json.
error NU1301:   Permission denied (api.nuget.org:443)
```

A verified fix is to rewrite the cloned config after `git clone`, swapping the nuget.org source for the Azure SDK feed while leaving `dotnet-public` in place:

```powershell
$clonedNuGetConfig = Join-Path $WorkingDirectory "azure-amqp/nuget.config"
$azureSdkFeed = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"

dotnet nuget remove source "NuGet official package source" --configfile $clonedNuGetConfig
dotnet nuget add source $azureSdkFeed --name azure-sdk-for-net --configfile $clonedNuGetConfig
```

Keeping `dotnet-public` matters: it supplies `Microsoft.CodeAnalysis.PublicApiAnalyzers` and `Microsoft.NETFramework.ReferenceAssemblies.net48`, which the `azure-sdk-for-net` feed has not cached and would otherwise require an authenticated upstream pull. This was validated from a clean clone with an empty package cache, where `TestAmqpBroker` builds with no credentials.

## Out of scope

These remain non-compliant. All are `blocked=0` (audit only) and none are addressable by feed redirection:

| Domain | Policy | Hits / Jobs | Source |
|---|---|---:|---|
| `www.powershellgallery.com` | CFSClean2 | 48 / 16 | shared `eng/common` PowerShell bootstrap; identical in all three pipelines, so one fix covers all |
| `anglesharp.azurewebsites.net` | Default Deny | 26 / 26 | an azure-core **unit test** calling a live internet endpoint; needs a test-proxy recording or local fixture |
| `docs.oasis-open.org`, `curl.se`, `en.cppreference.com`, `www.doxygen.org`, `datatracker.ietf.org` | Default Deny / CFSClean3 | 34 / 1 | documentation links fetched by `GenerateReleaseArtifacts` |

macOS jobs run on Microsoft-hosted agents rather than `azsdk-pool`, so they are not instrumented by 1ES Network Isolation and could not be assessed.
