### PR TITLE
fix(eventhubs): route batch partition key via message annotations

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -8,7 +8,13 @@
 
 ### Bugs Fixed
 
+- [[#7257]](https://github.com/Azure/azure-sdk-for-cpp/issues/7257) Fixed the partition key on a batch envelope. `EventDataBatch::ToAmqpMessage` wrote the `x-opt-partition-key` value to the AMQP delivery-annotations section. The Event Hubs service ignores that section. The batch also built the envelope from the message before the code applied the partition key annotation. A batch with a partition key thus spread across all partitions. The partition key now goes in the message-annotations section, on the batch envelope and on each message in the batch. A batch that sets `EventDataBatchOptions::PartitionKey` now lands on one partition.
+
 ### Other Changes
+
+- Documented that `EventDataBatch::TryAdd` generates a message ID for a copy of the event when the caller did not set one. The caller's own `EventData` object does not change.
+- The partition key of the batch now replaces a `x-opt-partition-key` annotation that the caller set on a raw AMQP message. The partition key of the batch is the routing key, so the two values must agree.
+- The batch envelope now carries the message ID of the first message in the batch. This includes a message ID that `TryAdd` generated.
 
 ## 1.0.0-beta.13 (2026-06-17)
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/event_data_batch.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/event_data_batch.hpp
@@ -34,8 +34,9 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     Azure::Nullable<std::uint64_t> MaxBytes;
 
     /** @brief PartitionKey is hashed by the Event Hubs service to calculate the partition
-     * assignment. The service applies the partition key to the batch and to every event in the
-     * batch, so all batches with the same PartitionKey go to the same partition.
+     * assignment. The client puts the partition key in the message annotations of the batch
+     * envelope and of every event in the batch. The service then reads that annotation and sends
+     * all batches with the same PartitionKey to the same partition.
      * Note that if you use this option then PartitionId cannot be set.
      */
     std::string PartitionKey;

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/event_data_batch.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/event_data_batch.hpp
@@ -33,8 +33,9 @@ namespace Azure { namespace Messaging { namespace EventHubs {
      */
     Azure::Nullable<std::uint64_t> MaxBytes;
 
-    /** @brief PartitionKey is hashed to calculate the partition assignment.Messages and message
-     * batches with the same PartitionKey are guaranteed to end up in the same partition.
+    /** @brief PartitionKey is hashed by the Event Hubs service to calculate the partition
+     * assignment. The service applies the partition key to the batch and to every event in the
+     * batch, so all batches with the same PartitionKey go to the same partition.
      * Note that if you use this option then PartitionId cannot be set.
      */
     std::string PartitionKey;
@@ -110,6 +111,10 @@ namespace Azure { namespace Messaging { namespace EventHubs {
 
     /** @brief Attempts to add a raw AMQP message to the data batch
      *
+     * @remark The batch stores a copy of the message. If the message has no message ID, the batch
+     * sets a new UUID as the message ID on that copy. If the batch has a partition key, the batch
+     * also sets the partition key annotation on that copy. The message you supply does not change.
+     *
      * @param message The AMQP message to add to the batch
      *
      * @returns true if the message was added to the batch, false otherwise.
@@ -121,6 +126,10 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     }
 
     /** @brief Attempts to add a message to the data batch
+     *
+     * @remark The batch stores a copy of the event. If the event has no message ID, the batch sets
+     * a new UUID as the message ID on that copy. If the batch has a partition key, the batch also
+     * sets the partition key annotation on that copy. The event you supply does not change.
      *
      * @param message The message to add to the batch
      *
@@ -139,6 +148,9 @@ namespace Azure { namespace Messaging { namespace EventHubs {
 
     /** @brief Serializes the EventDataBatch to a single AmqpMessage to be sent to the EventHubs
      * service.
+     *
+     * @remark If the batch has a partition key, the returned message carries the partition key in
+     * its message annotations. The Event Hubs service routes on the message annotations.
      *
      * @return Azure::Core::Amqp::Models::AmqpMessage
      */
@@ -161,11 +173,11 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     }
 
     Azure::Core::Amqp::Models::AmqpMessage CreateBatchEnvelope(
-        std::shared_ptr<Azure::Core::Amqp::Models::AmqpMessage const> const& message) const
+        Azure::Core::Amqp::Models::AmqpMessage const& message) const
     {
       // Create the batch envelope from the prototype message. This copies all the attributes
       // *except* the body attribute to the batch envelope.
-      Azure::Core::Amqp::Models::AmqpMessage batchEnvelope{*message};
+      Azure::Core::Amqp::Models::AmqpMessage batchEnvelope{message};
       batchEnvelope.BodyType = Azure::Core::Amqp::Models::MessageBodyType::None;
       batchEnvelope.MessageFormat = BatchedMessageFormat;
       return batchEnvelope;

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/event_data_batch.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/event_data_batch.cpp
@@ -27,11 +27,14 @@ namespace Azure { namespace Messaging { namespace EventHubs {
       throw std::runtime_error("No messages added to the batch.");
     }
 
-    // Make sure that the partition key in the message is the current partition key.
+    // Make sure that the partition key in the message is the current partition key. The Event Hubs
+    // service routes on the message annotations, so the partition key goes there. The envelope
+    // already carries this same value, because the batch builds the envelope from the annotated
+    // copy of the first message. This assignment keeps the two in agreement.
     if (!m_partitionKey.empty())
     {
-      returnValue.DeliveryAnnotations.emplace(
-          _detail::PartitionKeyAnnotation, Azure::Core::Amqp::Models::AmqpValue(m_partitionKey));
+      returnValue.MessageAnnotations[_detail::PartitionKeyAnnotation]
+          = Azure::Core::Amqp::Models::AmqpValue(m_partitionKey);
     }
 
     std::vector<Azure::Core::Amqp::Models::AmqpBinaryData> messageList;
@@ -57,10 +60,12 @@ namespace Azure { namespace Messaging { namespace EventHubs {
           = Azure::Core::Amqp::Models::AmqpValue(Azure::Core::Uuid::CreateUuid().ToString());
     }
 
+    // Assign instead of emplace, so the batch partition key wins over a partition key annotation
+    // that the caller already put on the message.
     if (!m_partitionKey.empty())
     {
-      messageToSend.MessageAnnotations.emplace(
-          _detail::PartitionKeyAnnotation, Azure::Core::Amqp::Models::AmqpValue(m_partitionKey));
+      messageToSend.MessageAnnotations[_detail::PartitionKeyAnnotation]
+          = Azure::Core::Amqp::Models::AmqpValue(m_partitionKey);
     }
 
     auto serializedMessage = Azure::Core::Amqp::Models::AmqpMessage::Serialize(messageToSend);
@@ -70,8 +75,8 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     if (m_marshalledMessages.empty())
     {
       // The first message is special - we use its properties and annotations on the envelope for
-      // the batch message.
-      m_batchEnvelope = CreateBatchEnvelope(message);
+      // the batch message. Use the annotated copy, so the envelope also carries the partition key.
+      m_batchEnvelope = CreateBatchEnvelope(messageToSend);
       m_currentSize = serializedMessage.size();
     }
     auto actualPayloadSize = CalculateActualSizeForPayload(serializedMessage);

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/event_data_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/event_data_test.cpp
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 #include "../src/private/eventhubs_constants.hpp"
+#include "../src/private/eventhubs_utilities.hpp"
 #include "azure/messaging/eventhubs.hpp"
 #include "eventhubs_test_base.hpp"
+
+#include <limits>
 
 #include <gtest/gtest.h>
 
@@ -11,6 +14,9 @@ using namespace Azure::Core::Amqp::Models;
 using namespace Azure::Messaging::EventHubs::Models;
 
 class EventDataTest : public EventHubsTestBase {
+};
+
+class EventDataBatchTest : public EventHubsTestBase {
 };
 
 // Construct an EventData object and convert it to an AMQP message.
@@ -241,4 +247,136 @@ TEST_F(EventDataTest, ReceivedEventData)
     EXPECT_FALSE(receivedEventData.EnqueuedTime);
     EXPECT_FALSE(receivedEventData.PartitionKey);
   }
+}
+
+// The Event Hubs service routes on the message annotations only. Make sure that the batch envelope
+// and every message in the batch carry the partition key there, and that the delivery annotations
+// stay empty.
+TEST_F(EventDataBatchTest, PartitionKeyIsInMessageAnnotations)
+{
+  constexpr const char* partitionKey = "test-partition-key";
+
+  Azure::Messaging::EventHubs::EventDataBatchOptions options;
+  options.MaxBytes = static_cast<std::uint64_t>((std::numeric_limits<uint16_t>::max)());
+  options.PartitionKey = partitionKey;
+
+  Azure::Messaging::EventHubs::EventDataBatch batch{
+      Azure::Messaging::EventHubs::_detail::EventDataBatchFactory::CreateEventDataBatch(options)};
+
+  EXPECT_TRUE(batch.TryAdd(EventData{"First message."}));
+  EXPECT_TRUE(batch.TryAdd(EventData{"Second message."}));
+
+  auto batchMessage{batch.ToAmqpMessage()};
+
+  AmqpSymbol const partitionKeyAnnotation{
+      Azure::Messaging::EventHubs::_detail::PartitionKeyAnnotation};
+
+  auto envelopeAnnotation = batchMessage.MessageAnnotations.find(partitionKeyAnnotation);
+  ASSERT_NE(envelopeAnnotation, batchMessage.MessageAnnotations.end())
+      << "The batch envelope has no partition key message annotation.";
+  EXPECT_EQ(partitionKey, static_cast<std::string>(envelopeAnnotation->second));
+
+  // Delivery annotations stop at the first hop, so the partition key must not be there.
+  EXPECT_EQ(
+      batchMessage.DeliveryAnnotations.find(partitionKeyAnnotation),
+      batchMessage.DeliveryAnnotations.end());
+
+  EXPECT_EQ(0x80013700u, batchMessage.MessageFormat);
+
+  auto const& batchedMessages = batchMessage.GetBodyAsBinary();
+  ASSERT_EQ(2ul, batchedMessages.size());
+  for (auto const& batchedMessage : batchedMessages)
+  {
+    AmqpMessage innerMessage{
+        AmqpMessage::Deserialize(batchedMessage.data(), batchedMessage.size())};
+    auto innerAnnotation = innerMessage.MessageAnnotations.find(partitionKeyAnnotation);
+    ASSERT_NE(innerAnnotation, innerMessage.MessageAnnotations.end())
+        << "A message in the batch has no partition key message annotation.";
+    EXPECT_EQ(partitionKey, static_cast<std::string>(innerAnnotation->second));
+  }
+
+  // The batch builds the envelope from the annotated copy of the first message. That copy also
+  // carries the generated message ID, so the envelope must carry the same message ID. This pins
+  // the source of the envelope, which the partition key assertions above cannot show on their own.
+  AmqpMessage firstMessage{
+      AmqpMessage::Deserialize(batchedMessages[0].data(), batchedMessages[0].size())};
+  ASSERT_FALSE(batchMessage.Properties.MessageId.IsNull())
+      << "The batch envelope did not come from the annotated copy of the first message.";
+  EXPECT_EQ(firstMessage.Properties.MessageId, batchMessage.Properties.MessageId);
+}
+
+// The partition key of the batch is the routing key for every message in the batch. Make sure that
+// it replaces a partition key annotation that the caller already set on a raw AMQP message.
+TEST_F(EventDataBatchTest, BatchPartitionKeyReplacesCallerAnnotation)
+{
+  constexpr const char* batchPartitionKey = "batch-partition-key";
+
+  Azure::Messaging::EventHubs::EventDataBatchOptions options;
+  options.MaxBytes = static_cast<std::uint64_t>((std::numeric_limits<uint16_t>::max)());
+  options.PartitionKey = batchPartitionKey;
+
+  Azure::Messaging::EventHubs::EventDataBatch batch{
+      Azure::Messaging::EventHubs::_detail::EventDataBatchFactory::CreateEventDataBatch(options)};
+
+  AmqpSymbol const partitionKeyAnnotation{
+      Azure::Messaging::EventHubs::_detail::PartitionKeyAnnotation};
+
+  auto callerMessage{std::make_shared<AmqpMessage>()};
+  callerMessage->SetBody(AmqpBinaryData{'a', 'b', 'c'});
+  callerMessage
+      ->MessageAnnotations[AmqpSymbol{Azure::Messaging::EventHubs::_detail::PartitionKeyAnnotation}]
+      = AmqpValue("caller-partition-key");
+
+  EXPECT_TRUE(batch.TryAdd(callerMessage));
+
+  auto batchMessage{batch.ToAmqpMessage()};
+
+  auto envelopeAnnotation = batchMessage.MessageAnnotations.find(partitionKeyAnnotation);
+  ASSERT_NE(envelopeAnnotation, batchMessage.MessageAnnotations.end());
+  EXPECT_EQ(batchPartitionKey, static_cast<std::string>(envelopeAnnotation->second));
+
+  auto const& batchedMessages = batchMessage.GetBodyAsBinary();
+  ASSERT_EQ(1ul, batchedMessages.size());
+  AmqpMessage innerMessage{
+      AmqpMessage::Deserialize(batchedMessages[0].data(), batchedMessages[0].size())};
+  auto innerAnnotation = innerMessage.MessageAnnotations.find(partitionKeyAnnotation);
+  ASSERT_NE(innerAnnotation, innerMessage.MessageAnnotations.end());
+  EXPECT_EQ(batchPartitionKey, static_cast<std::string>(innerAnnotation->second));
+
+  // The message that the caller supplied must not change.
+  auto callerAnnotation = callerMessage->MessageAnnotations.find(partitionKeyAnnotation);
+  ASSERT_NE(callerAnnotation, callerMessage->MessageAnnotations.end());
+  EXPECT_EQ("caller-partition-key", static_cast<std::string>(callerAnnotation->second));
+}
+
+// A batch without a partition key must not add a partition key annotation anywhere.
+TEST_F(EventDataBatchTest, NoPartitionKeyAddsNoAnnotation)
+{
+  Azure::Messaging::EventHubs::EventDataBatchOptions options;
+  options.MaxBytes = static_cast<std::uint64_t>((std::numeric_limits<uint16_t>::max)());
+
+  Azure::Messaging::EventHubs::EventDataBatch batch{
+      Azure::Messaging::EventHubs::_detail::EventDataBatchFactory::CreateEventDataBatch(options)};
+
+  EXPECT_TRUE(batch.TryAdd(EventData{"First message."}));
+
+  auto batchMessage{batch.ToAmqpMessage()};
+
+  AmqpSymbol const partitionKeyAnnotation{
+      Azure::Messaging::EventHubs::_detail::PartitionKeyAnnotation};
+
+  EXPECT_EQ(
+      batchMessage.MessageAnnotations.find(partitionKeyAnnotation),
+      batchMessage.MessageAnnotations.end());
+  EXPECT_EQ(
+      batchMessage.DeliveryAnnotations.find(partitionKeyAnnotation),
+      batchMessage.DeliveryAnnotations.end());
+
+  auto const& batchedMessages = batchMessage.GetBodyAsBinary();
+  ASSERT_EQ(1ul, batchedMessages.size());
+  AmqpMessage innerMessage{
+      AmqpMessage::Deserialize(batchedMessages[0].data(), batchedMessages[0].size())};
+  EXPECT_EQ(
+      innerMessage.MessageAnnotations.find(partitionKeyAnnotation),
+      innerMessage.MessageAnnotations.end());
 }

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
@@ -6,6 +6,7 @@
 #include "eventhubs_test_base.hpp"
 
 #include <azure/core/context.hpp>
+#include <azure/core/uuid.hpp>
 #include <azure/identity.hpp>
 #include <azure/messaging/eventhubs.hpp>
 
@@ -240,6 +241,102 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
     for (const auto i : iterationsPerThread)
     {
       GTEST_LOG_(INFO) << "Thread iterations: " << i.second;
+    }
+  }
+
+  // Send a batch that has a partition key and make sure that every event in the batch landed on one
+  // partition. The Event Hubs service routes on the partition key annotation in the message
+  // annotations of the batch envelope, so this test fails if the annotation is missing or if it is
+  // in the delivery annotations.
+  TEST_P(ProducerClientTest, SendBatchWithPartitionKey_LIVEONLY_)
+  {
+    constexpr uint32_t eventCount = 20;
+
+    auto client{CreateProducerClient()};
+
+    auto const partitionIds = client->GetEventHubProperties().PartitionIds;
+    ASSERT_GT(partitionIds.size(), 1ul) << "This test needs more than one partition.";
+
+    std::string const partitionKey{"ws5-" + Azure::Core::Uuid::CreateUuid().ToString()};
+
+    std::map<std::string, int64_t> sequenceNumberBeforeSend;
+    for (auto const& partitionId : partitionIds)
+    {
+      sequenceNumberBeforeSend[partitionId]
+          = client->GetPartitionProperties(partitionId).LastEnqueuedSequenceNumber;
+      // Attempt to avoid service throttling.
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    {
+      Azure::Messaging::EventHubs::EventDataBatchOptions batchOptions;
+      batchOptions.MaxBytes = (std::numeric_limits<uint16_t>::max)();
+      batchOptions.PartitionKey = partitionKey;
+      Azure::Messaging::EventHubs::EventDataBatch eventBatch{client->CreateBatch(batchOptions)};
+      for (uint32_t i = 0; i < eventCount; i++)
+      {
+        EXPECT_TRUE(eventBatch.TryAdd(
+            Azure::Messaging::EventHubs::Models::EventData{"Keyed message " + std::to_string(i)}));
+      }
+      // Stop here if the send fails, because the partition counts below would then report a
+      // misleading failure.
+      ASSERT_NO_THROW(client->Send(eventBatch));
+    }
+
+    // Give the service time to report the new sequence numbers.
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+
+    // Count the partitions that grew by the whole batch. Another producer can write to the same
+    // Event Hub while this test runs, so a partition that grew by a smaller amount does not mean
+    // that the routing failed. Before the fix the service spread the batch over every partition,
+    // so no partition grew by the whole batch and the assertion below fails.
+    std::vector<std::string> partitionsWithWholeBatch;
+    for (auto const& partitionId : partitionIds)
+    {
+      auto const sequenceNumberAfterSend
+          = client->GetPartitionProperties(partitionId).LastEnqueuedSequenceNumber;
+      auto const newEvents = sequenceNumberAfterSend - sequenceNumberBeforeSend[partitionId];
+      GTEST_LOG_(INFO) << "Partition " << partitionId << " received " << newEvents << " events.";
+      if (newEvents >= static_cast<int64_t>(eventCount))
+      {
+        partitionsWithWholeBatch.push_back(partitionId);
+      }
+      // Attempt to avoid service throttling.
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    ASSERT_EQ(1ul, partitionsWithWholeBatch.size())
+        << "A batch with a partition key must land on exactly one partition.";
+
+    // Read the events back and make sure that each one carries the partition key.
+    std::string const& targetPartitionId = partitionsWithWholeBatch[0];
+
+    Azure::Messaging::EventHubs::PartitionClientOptions partitionOptions;
+    partitionOptions.StartPosition.SequenceNumber = sequenceNumberBeforeSend[targetPartitionId];
+
+    auto consumer{CreateConsumerClient()};
+    auto receiver = consumer->CreatePartitionClient(targetPartitionId, partitionOptions);
+
+    // ReceiveEvents returns as soon as the receiver queue is empty, so one call can return fewer
+    // events than the batch holds. Collect events until the batch is complete or the time runs out.
+    std::vector<std::shared_ptr<const Azure::Messaging::EventHubs::Models::ReceivedEventData>>
+        receivedEvents;
+    auto const deadline = std::chrono::system_clock::now() + std::chrono::seconds(60);
+    while (receivedEvents.size() < eventCount && std::chrono::system_clock::now() < deadline)
+    {
+      auto batchOfEvents = receiver.ReceiveEvents(eventCount - receivedEvents.size());
+      if (batchOfEvents.empty())
+      {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        continue;
+      }
+      receivedEvents.insert(receivedEvents.end(), batchOfEvents.begin(), batchOfEvents.end());
+    }
+
+    ASSERT_EQ(static_cast<size_t>(eventCount), receivedEvents.size());
+    for (auto const& receivedEvent : receivedEvents)
+    {
+      ASSERT_TRUE(receivedEvent->PartitionKey);
+      EXPECT_EQ(partitionKey, receivedEvent->PartitionKey.Value());
     }
   }
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
@@ -275,67 +275,81 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
       Azure::Messaging::EventHubs::EventDataBatch eventBatch{client->CreateBatch(batchOptions)};
       for (uint32_t i = 0; i < eventCount; i++)
       {
-        EXPECT_TRUE(eventBatch.TryAdd(
-            Azure::Messaging::EventHubs::Models::EventData{"Keyed message " + std::to_string(i)}));
+        // The body starts with the unique marker of this run. The test finds its own events by
+        // that marker, so the check on the partition key below stays independent.
+        EXPECT_TRUE(eventBatch.TryAdd(Azure::Messaging::EventHubs::Models::EventData{
+            partitionKey + " message " + std::to_string(i)}));
       }
       // Stop here if the send fails, because the partition counts below would then report a
       // misleading failure.
       ASSERT_NO_THROW(client->Send(eventBatch));
     }
 
-    // Give the service time to report the new sequence numbers.
+    // Give the service time to report the new events.
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
-    // Count the partitions that grew by the whole batch. Another producer can write to the same
-    // Event Hub while this test runs, so a partition that grew by a smaller amount does not mean
-    // that the routing failed. Before the fix the service spread the batch over every partition,
-    // so no partition grew by the whole batch and the assertion below fails.
-    std::vector<std::string> partitionsWithWholeBatch;
+    // Read every partition from the sequence number that it had before the send, and keep only the
+    // events of this batch. The unique marker in the body identifies them. A count of new events
+    // cannot do this, because another producer can write to the same Event Hub while this test
+    // runs and can add events to any partition.
+    auto consumer{CreateConsumerClient()};
+    std::vector<std::string> partitionsWithBatch;
+    std::vector<std::shared_ptr<const Azure::Messaging::EventHubs::Models::ReceivedEventData>>
+        batchEvents;
+
     for (auto const& partitionId : partitionIds)
     {
-      auto const sequenceNumberAfterSend
-          = client->GetPartitionProperties(partitionId).LastEnqueuedSequenceNumber;
-      auto const newEvents = sequenceNumberAfterSend - sequenceNumberBeforeSend[partitionId];
-      GTEST_LOG_(INFO) << "Partition " << partitionId << " received " << newEvents << " events.";
-      if (newEvents >= static_cast<int64_t>(eventCount))
+      Azure::Messaging::EventHubs::PartitionClientOptions partitionOptions;
+      partitionOptions.StartPosition.SequenceNumber = sequenceNumberBeforeSend[partitionId];
+      auto receiver = consumer->CreatePartitionClient(partitionId, partitionOptions);
+
+      // ReceiveEvents returns as soon as the receiver queue is empty, so one call can return fewer
+      // events than the batch holds. Read until this partition holds the whole batch, or until the
+      // partition stays quiet, or until the time runs out.
+      std::vector<std::shared_ptr<const Azure::Messaging::EventHubs::Models::ReceivedEventData>>
+          eventsOnPartition;
+      auto const deadline = std::chrono::system_clock::now() + std::chrono::seconds(60);
+      int quietReads = 0;
+      while (eventsOnPartition.size() < eventCount && quietReads < 6
+             && std::chrono::system_clock::now() < deadline)
       {
-        partitionsWithWholeBatch.push_back(partitionId);
+        auto batchOfEvents = receiver.ReceiveEvents(eventCount);
+        if (batchOfEvents.empty())
+        {
+          quietReads++;
+          std::this_thread::sleep_for(std::chrono::milliseconds(500));
+          continue;
+        }
+        quietReads = 0;
+        for (auto const& receivedEvent : batchOfEvents)
+        {
+          std::string const body(receivedEvent->Body.begin(), receivedEvent->Body.end());
+          if (body.rfind(partitionKey, 0) == 0)
+          {
+            eventsOnPartition.push_back(receivedEvent);
+          }
+        }
       }
-      // Attempt to avoid service throttling.
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+      GTEST_LOG_(INFO) << "Partition " << partitionId << " holds " << eventsOnPartition.size()
+                       << " events of this batch.";
+      if (!eventsOnPartition.empty())
+      {
+        partitionsWithBatch.push_back(partitionId);
+        batchEvents.insert(batchEvents.end(), eventsOnPartition.begin(), eventsOnPartition.end());
+      }
     }
-    ASSERT_EQ(1ul, partitionsWithWholeBatch.size())
+
+    // Before the fix the service spread the batch over every partition, so more than one partition
+    // holds events of the batch and this assertion fails.
+    ASSERT_EQ(1ul, partitionsWithBatch.size())
         << "A batch with a partition key must land on exactly one partition.";
+    ASSERT_EQ(static_cast<size_t>(eventCount), batchEvents.size())
+        << "The partition must hold every event of the batch.";
 
-    // Read the events back and make sure that each one carries the partition key.
-    std::string const& targetPartitionId = partitionsWithWholeBatch[0];
-
-    Azure::Messaging::EventHubs::PartitionClientOptions partitionOptions;
-    partitionOptions.StartPosition.SequenceNumber = sequenceNumberBeforeSend[targetPartitionId];
-
-    auto consumer{CreateConsumerClient()};
-    auto receiver = consumer->CreatePartitionClient(targetPartitionId, partitionOptions);
-
-    // ReceiveEvents returns as soon as the receiver queue is empty, so one call can return fewer
-    // events than the batch holds. Collect events until the batch is complete or the time runs out.
-    std::vector<std::shared_ptr<const Azure::Messaging::EventHubs::Models::ReceivedEventData>>
-        receivedEvents;
-    auto const deadline = std::chrono::system_clock::now() + std::chrono::seconds(60);
-    while (receivedEvents.size() < eventCount && std::chrono::system_clock::now() < deadline)
-    {
-      // The loop guard keeps the difference below eventCount, so this cast cannot lose data.
-      auto const remaining = static_cast<uint32_t>(eventCount - receivedEvents.size());
-      auto batchOfEvents = receiver.ReceiveEvents(remaining);
-      if (batchOfEvents.empty())
-      {
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        continue;
-      }
-      receivedEvents.insert(receivedEvents.end(), batchOfEvents.begin(), batchOfEvents.end());
-    }
-
-    ASSERT_EQ(static_cast<size_t>(eventCount), receivedEvents.size());
-    for (auto const& receivedEvent : receivedEvents)
+    // The marker in the body found these events, so this check on the partition key does not
+    // depend on the way the test found them.
+    for (auto const& receivedEvent : batchEvents)
     {
       ASSERT_TRUE(receivedEvent->PartitionKey);
       EXPECT_EQ(partitionKey, receivedEvent->PartitionKey.Value());

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
@@ -323,7 +323,9 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
     auto const deadline = std::chrono::system_clock::now() + std::chrono::seconds(60);
     while (receivedEvents.size() < eventCount && std::chrono::system_clock::now() < deadline)
     {
-      auto batchOfEvents = receiver.ReceiveEvents(eventCount - receivedEvents.size());
+      // The loop guard keeps the difference below eventCount, so this cast cannot lose data.
+      auto const remaining = static_cast<uint32_t>(eventCount - receivedEvents.size());
+      auto batchOfEvents = receiver.ReceiveEvents(remaining);
       if (batchOfEvents.empty())
       {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));


### PR DESCRIPTION
## Summary

The C++ Event Hubs library ignored the partition key on every batch send. `EventDataBatch::ToAmqpMessage` wrote the `x-opt-partition-key` value to the AMQP delivery-annotations section of the batch envelope. The Event Hubs service reads only the message-annotations section for routing. A batch with a partition key spread over all partitions, which is the same result as sending no partition key.

Fixes #7257.

## Motivation

OASIS AMQP 1.0 section 3.2.2 states that delivery-annotations "convey information from the sending peer to the receiving peer", and they stop at that hop. Section 3.2.3 states that message-annotations hold properties "aimed at the infrastructure", and that "Intermediaries MUST propagate the annotations unless the annotations are explicitly augmented or modified". The code put a routing key in the one section that no intermediary must forward. See the [OASIS AMQP 1.0 messaging specification](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html).

A second defect made the first one impossible to work around. `TryAddAmqpMessage` built the batch envelope from the original message rather than the annotated copy `messageToSend`, so the envelope inherited no partition key annotation to fall back on.

The service returns no error for the malformed batch. Each consumed event also reports the correct partition key, because the inner messages carried the annotation correctly. A caller therefore read a correct `PartitionKey` on an event that sat on an arbitrary partition. Per-key ordering and partition affinity were broken for every caller that set a partition key on a batch.

C++ was the only Event Hubs SDK that used delivery-annotations. The Go SDK sets the annotation on the envelope and on each message, which is the shape this change adopts.

## Changes

- `ToAmqpMessage` writes the partition key to `MessageAnnotations` instead of `DeliveryAnnotations`.
- `TryAddAmqpMessage` builds the batch envelope from the annotated copy `messageToSend`. `CreateBatchEnvelope` now takes an `AmqpMessage const&`. The method is private and inline, and the package is beta, so this changes no public API.
- Both annotation writes use assignment instead of `emplace`. The partition key of the batch is the routing key, so it must replace a partition key annotation that the caller set on a raw AMQP message. The message that the caller supplies does not change.
- Three offline regression tests in `event_data_test.cpp` cover the envelope annotation, the absence of an annotation when no key is set, and the replacement of a caller-set annotation.
- One live test, `SendBatchWithPartitionKey_LIVEONLY_`, asserts that a keyed batch lands on exactly one partition and that each event carries the key.
- The doc comments record that `TryAdd` applies the generated message ID and the partition key to a copy.

## Test plan

Built with the Rust AMQP stack (the default) and ran the offline suite.

Each test fails when the matching part of the fix is reverted, which is the property that makes the tests worth adding:

| Reverted change | Failing test |
|---|---|
| `MessageAnnotations` back to `DeliveryAnnotations` | `PartitionKeyIsInMessageAnnotations` |
| `CreateBatchEnvelope(messageToSend)` back to the original message | `PartitionKeyIsInMessageAnnotations` |
| assignment back to `emplace` | `BatchPartitionKeyReplacesCallerAnnotation` |

Results:

- The full offline suite passes, 30 of 31 tests. `CheckpointStoreTest.TestCheckpoints` fails before and after this change because the `EVENTHUB_CONSUMER_GROUP` environment variable is absent. It is unrelated to this change.
- `clang-format` reports no difference on all four source files. `cspell` reports zero issues.
- The `_LIVEONLY_` token makes the test framework skip the live test in playback mode.

## Validation not yet done

The live test has not run against a real Event Hub, because this environment has no Event Hubs credentials. Issue #7257 records that the pre-fix behavior is a round-robin spread across every partition, so the live test must fail before this change and pass after it. That run is still outstanding.
