### PR TITLE
Retry large storage query live tests

### DIFF
--- a/sdk/storage/azure-storage-blobs/test/ut/blob_query_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_query_test.cpp
@@ -4,6 +4,7 @@
 #include "block_blob_client_test.hpp"
 
 #include <future>
+#include <iostream>
 #include <random>
 #include <vector>
 
@@ -335,21 +336,39 @@ xx
     queryOptions.InputTextConfiguration = Blobs::BlobQueryInputTextOptions::CreateCsvTextOptions();
     queryOptions.OutputTextConfiguration
         = Blobs::BlobQueryOutputTextOptions::CreateJsonTextOptions();
-    auto queryResponse = blobClient.Query("SELECT * FROM BlobStorage;", queryOptions);
-
-    size_t comparePos = 0;
-    std::vector<uint8_t> readBuffer(4096);
-    while (true)
+    constexpr int MaxQueryAttempts = 2;
+    for (int attempt = 1; attempt <= MaxQueryAttempts; ++attempt)
     {
-      auto s = queryResponse.Value.BodyStream->Read(readBuffer.data(), readBuffer.size());
-      if (s == 0)
+      auto queryResponse = blobClient.Query("SELECT * FROM BlobStorage;", queryOptions);
+      try
       {
-        break;
+        size_t comparePos = 0;
+        std::vector<uint8_t> readBuffer(4096);
+        while (true)
+        {
+          auto s = queryResponse.Value.BodyStream->Read(readBuffer.data(), readBuffer.size());
+          if (s == 0)
+          {
+            break;
+          }
+          ASSERT_TRUE(comparePos + s <= jsonData.size());
+          ASSERT_EQ(
+              std::string(readBuffer.begin(), readBuffer.begin() + s),
+              jsonData.substr(comparePos, s));
+          comparePos += s;
+        }
+        ASSERT_EQ(comparePos, jsonData.size());
+        return;
       }
-      ASSERT_TRUE(comparePos + s <= jsonData.size());
-      ASSERT_EQ(
-          std::string(readBuffer.begin(), readBuffer.begin() + s), jsonData.substr(comparePos, s));
-      comparePos += s;
+      catch (const Core::Http::TransportException& e)
+      {
+        if (attempt == MaxQueryAttempts)
+        {
+          throw;
+        }
+        std::cout << "Retrying large blob query after response body transport failure: " << e.what()
+                  << std::endl;
+      }
     }
   }
 

--- a/sdk/storage/azure-storage-blobs/test/ut/blob_query_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_query_test.cpp
@@ -4,7 +4,6 @@
 #include "block_blob_client_test.hpp"
 
 #include <future>
-#include <iostream>
 #include <random>
 #include <vector>
 
@@ -366,8 +365,8 @@ xx
         {
           throw;
         }
-        std::cout << "Retrying large blob query after response body transport failure: " << e.what()
-                  << std::endl;
+        SUCCEED() << "Retrying large blob query after response body transport failure: "
+                  << e.what();
       }
     }
   }

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
@@ -4,6 +4,7 @@
 #include "datalake_file_client_test.hpp"
 
 #include <future>
+#include <iostream>
 #include <random>
 #include <vector>
 
@@ -340,21 +341,39 @@ xx
         = Files::DataLake::FileQueryInputTextOptions::CreateCsvTextOptions();
     queryOptions.OutputTextConfiguration
         = Files::DataLake::FileQueryOutputTextOptions::CreateJsonTextOptions();
-    auto queryResponse = client.Query("SELECT * FROM BlobStorage;", queryOptions);
-
-    size_t comparePos = 0;
-    std::vector<uint8_t> readBuffer(4096);
-    while (true)
+    constexpr int MaxQueryAttempts = 2;
+    for (int attempt = 1; attempt <= MaxQueryAttempts; ++attempt)
     {
-      auto s = queryResponse.Value.BodyStream->Read(readBuffer.data(), readBuffer.size());
-      if (s == 0)
+      auto queryResponse = client.Query("SELECT * FROM BlobStorage;", queryOptions);
+      try
       {
-        break;
+        size_t comparePos = 0;
+        std::vector<uint8_t> readBuffer(4096);
+        while (true)
+        {
+          auto s = queryResponse.Value.BodyStream->Read(readBuffer.data(), readBuffer.size());
+          if (s == 0)
+          {
+            break;
+          }
+          ASSERT_TRUE(comparePos + s <= jsonData.size());
+          ASSERT_EQ(
+              std::string(readBuffer.begin(), readBuffer.begin() + s),
+              jsonData.substr(comparePos, s));
+          comparePos += s;
+        }
+        ASSERT_EQ(comparePos, jsonData.size());
+        return;
       }
-      ASSERT_TRUE(comparePos + s <= jsonData.size());
-      ASSERT_EQ(
-          std::string(readBuffer.begin(), readBuffer.begin() + s), jsonData.substr(comparePos, s));
-      comparePos += s;
+      catch (const Core::Http::TransportException& e)
+      {
+        if (attempt == MaxQueryAttempts)
+        {
+          throw;
+        }
+        std::cout << "Retrying large Data Lake query after response body transport failure: "
+                  << e.what() << std::endl;
+      }
     }
   }
 

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
@@ -4,7 +4,6 @@
 #include "datalake_file_client_test.hpp"
 
 #include <future>
-#include <iostream>
 #include <random>
 #include <vector>
 
@@ -371,8 +370,8 @@ xx
         {
           throw;
         }
-        std::cout << "Retrying large Data Lake query after response body transport failure: "
-                  << e.what() << std::endl;
+        SUCCEED() << "Retrying large Data Lake query after response body transport failure: "
+                  << e.what();
       }
     }
   }


### PR DESCRIPTION
## Summary
- retry large Blob and Data Lake query response reads once after a transport failure
- keep request failures and assertion failures immediate
- use the existing GoogleTest logging convention for retry messages
- verify the complete query output length

## Testing
- `BlockBlobClientTest.QueryLargeBlob_LIVEONLY_` (LIVE)
- `DataLakeFileClientTest.QueryLargeBlob_LIVEONLY_` (LIVE)
- built `azure-storage-blobs-test` and `azure-storage-files-datalake-test`

Fixes the macOS nightly flake seen in Azure Pipelines build 6658328 where the streaming query response failed with CURLE 56.