### PR TITLE
Consolidate Blob and File Share client configuration

### DIFF
--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_client.hpp
@@ -430,30 +430,16 @@ namespace Azure { namespace Storage { namespace Blobs {
     Azure::Core::Url m_blobUrl;
     /** @brief Http Pipeline */
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_pipeline;
-    /** @brief Customer provided encryption key. */
-    Azure::Nullable<EncryptionKey> m_customerProvidedKey;
-    /** @brief Encryption scope. */
-    Azure::Nullable<std::string> m_encryptionScope;
-    /** @brief Upload TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_uploadValidationOptions;
-    /** @brief Download TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_downloadValidationOptions;
+    /** @brief Client configuration */
+    _detail::BlobClientConfiguration m_clientConfiguration;
 
   private:
     explicit BlobClient(
         Azure::Core::Url blobUrl,
         std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> pipeline,
-        Azure::Nullable<EncryptionKey> customerProvidedKey = Azure::Nullable<EncryptionKey>(),
-        Azure::Nullable<std::string> encryptionScope = Azure::Nullable<std::string>(),
-        Azure::Nullable<TransferValidationOptions> uploadValidationOptions
-        = Azure::Nullable<TransferValidationOptions>(),
-        Azure::Nullable<TransferValidationOptions> downloadValidationOptions
-        = Azure::Nullable<TransferValidationOptions>())
+        _detail::BlobClientConfiguration clientConfiguration = _detail::BlobClientConfiguration())
         : m_blobUrl(std::move(blobUrl)), m_pipeline(std::move(pipeline)),
-          m_customerProvidedKey(std::move(customerProvidedKey)),
-          m_encryptionScope(std::move(encryptionScope)),
-          m_uploadValidationOptions(std::move(uploadValidationOptions)),
-          m_downloadValidationOptions(std::move(downloadValidationOptions))
+          m_clientConfiguration(std::move(clientConfiguration))
     {
     }
 

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
@@ -340,10 +340,7 @@ namespace Azure { namespace Storage { namespace Blobs {
   private:
     Azure::Core::Url m_blobContainerUrl;
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_pipeline;
-    Azure::Nullable<EncryptionKey> m_customerProvidedKey;
-    Azure::Nullable<std::string> m_encryptionScope;
-    Azure::Nullable<TransferValidationOptions> m_uploadValidationOptions;
-    Azure::Nullable<TransferValidationOptions> m_downloadValidationOptions;
+    _detail::BlobClientConfiguration m_clientConfiguration;
 
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_batchRequestPipeline;
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_batchSubrequestPipeline;

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
@@ -210,6 +210,31 @@ namespace Azure { namespace Storage { namespace Blobs {
     StorageChecksumAlgorithm Algorithm = StorageChecksumAlgorithm::None;
   };
 
+  namespace _detail {
+    struct BlobClientConfiguration
+    {
+      /**
+       * @brief Holds the customer provided key used when making requests.
+       */
+      Azure::Nullable<EncryptionKey> CustomerProvidedKey;
+
+      /**
+       * @brief Holds the encryption scope used when making requests.
+       */
+      Azure::Nullable<std::string> EncryptionScope;
+
+      /**
+       * @brief Upload TransferValidationOptions
+       */
+      Azure::Nullable<TransferValidationOptions> UploadValidationOptions;
+
+      /**
+       * @brief Download TransferValidationOptions
+       */
+      Azure::Nullable<TransferValidationOptions> DownloadValidationOptions;
+    };
+  } // namespace _detail
+
   /**
    * @brief Client options used to initialize all kinds of blob clients.
    */

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_service_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_service_client.hpp
@@ -271,10 +271,7 @@ namespace Azure { namespace Storage { namespace Blobs {
   private:
     Azure::Core::Url m_serviceUrl;
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_pipeline;
-    Azure::Nullable<EncryptionKey> m_customerProvidedKey;
-    Azure::Nullable<std::string> m_encryptionScope;
-    Azure::Nullable<TransferValidationOptions> m_uploadValidationOptions;
-    Azure::Nullable<TransferValidationOptions> m_downloadValidationOptions;
+    _detail::BlobClientConfiguration m_clientConfiguration;
 
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_batchRequestPipeline;
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_batchSubrequestPipeline;

--- a/sdk/storage/azure-storage-blobs/src/append_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/append_blob_client.cpp
@@ -95,13 +95,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfMatch = options.AccessConditions.IfMatch;
     protocolLayerOptions.IfNoneMatch = options.AccessConditions.IfNoneMatch;
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     if (options.ImmutabilityPolicy.HasValue())
     {
       protocolLayerOptions.ImmutabilityPolicyExpiry = options.ImmutabilityPolicy.Value().ExpiresOn;
@@ -150,13 +152,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfMatch = options.AccessConditions.IfMatch;
     protocolLayerOptions.IfNoneMatch = options.AccessConditions.IfNoneMatch;
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     Nullable<Azure::Response<Models::AppendBlockResult>> responseNullable;
     if (options.TransactionalContentHash.HasValue())
     {
@@ -175,7 +179,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     {
       Azure::Nullable<TransferValidationOptions> validationOptions
           = options.ValidationOptions.HasValue() ? options.ValidationOptions
-                                                 : m_uploadValidationOptions;
+                                                 : m_clientConfiguration.UploadValidationOptions;
       if (validationOptions.HasValue()
           && validationOptions.Value().Algorithm != StorageChecksumAlgorithm::None)
       {
@@ -247,13 +251,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfMatch = options.AccessConditions.IfMatch;
     protocolLayerOptions.IfNoneMatch = options.AccessConditions.IfNoneMatch;
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     if (!options.SourceAuthorization.empty())
     {
       protocolLayerOptions.CopySourceAuthorization = options.SourceAuthorization;

--- a/sdk/storage/azure-storage-blobs/src/blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_client.cpp
@@ -98,11 +98,13 @@ namespace Azure { namespace Storage { namespace Blobs {
   }
 
   BlobClient::BlobClient(const std::string& blobUrl, const BlobClientOptions& options)
-      : m_blobUrl(blobUrl), m_customerProvidedKey(options.CustomerProvidedKey),
-        m_encryptionScope(options.EncryptionScope),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_blobUrl(blobUrl)
   {
+    m_clientConfiguration.CustomerProvidedKey = options.CustomerProvidedKey;
+    m_clientConfiguration.EncryptionScope = options.EncryptionScope;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::BlobServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -181,7 +183,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     {
       Azure::Nullable<TransferValidationOptions> validationOptions
           = options.ValidationOptions.HasValue() ? options.ValidationOptions
-                                                 : m_downloadValidationOptions;
+                                                 : m_clientConfiguration.DownloadValidationOptions;
       if (validationOptions.HasValue()
           && validationOptions.Value().Algorithm != StorageChecksumAlgorithm::None)
       {
@@ -203,11 +205,13 @@ namespace Azure { namespace Storage { namespace Blobs {
         protocolLayerOptions.UserPrincipalName = includeUserPrincipalName;
       }
     }
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
 
     auto downloadResponse = _detail::BlobClient::Download(
@@ -591,11 +595,13 @@ namespace Azure { namespace Storage { namespace Blobs {
         protocolLayerOptions.UserPrincipalName = includeUserPrincipalName;
       }
     }
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
     auto response = _detail::BlobClient::GetProperties(
         *m_pipeline, m_blobUrl, protocolLayerOptions, _internal::WithReplicaStatus(context));
@@ -683,13 +689,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfMatch = options.AccessConditions.IfMatch;
     protocolLayerOptions.IfNoneMatch = options.AccessConditions.IfNoneMatch;
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     return _detail::BlobClient::SetMetadata(*m_pipeline, m_blobUrl, protocolLayerOptions, context);
   }
 
@@ -744,7 +752,7 @@ namespace Azure { namespace Storage { namespace Blobs {
       protocolLayerOptions.ImmutabilityPolicyMode = options.ImmutabilityPolicy.Value().PolicyMode;
     }
     protocolLayerOptions.LegalHold = options.HasLegalHold;
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     protocolLayerOptions.CopySourceTags = options.CopySourceTagsMode;
     if (!options.SourceAuthorization.empty())
     {
@@ -820,13 +828,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfMatch = options.AccessConditions.IfMatch;
     protocolLayerOptions.IfNoneMatch = options.AccessConditions.IfNoneMatch;
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     return _detail::BlobClient::CreateSnapshot(
         *m_pipeline, m_blobUrl, protocolLayerOptions, context);
   }

--- a/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
@@ -1319,11 +1319,13 @@ namespace Azure { namespace Storage { namespace Blobs {
   BlobContainerClient::BlobContainerClient(
       const std::string& blobContainerUrl,
       const BlobClientOptions& options)
-      : m_blobContainerUrl(blobContainerUrl), m_customerProvidedKey(options.CustomerProvidedKey),
-        m_encryptionScope(options.EncryptionScope),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_blobContainerUrl(blobContainerUrl)
   {
+    m_clientConfiguration.CustomerProvidedKey = options.CustomerProvidedKey;
+    m_clientConfiguration.EncryptionScope = options.EncryptionScope;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
     std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
     perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
@@ -1352,13 +1354,7 @@ namespace Azure { namespace Storage { namespace Blobs {
   {
     auto blobUrl = m_blobContainerUrl;
     blobUrl.AppendPath(_internal::UrlEncodePath(blobName));
-    return BlobClient(
-        std::move(blobUrl),
-        m_pipeline,
-        m_customerProvidedKey,
-        m_encryptionScope,
-        m_uploadValidationOptions,
-        m_downloadValidationOptions);
+    return BlobClient(std::move(blobUrl), m_pipeline, m_clientConfiguration);
   }
 
   BlockBlobClient BlobContainerClient::GetBlockBlobClient(const std::string& blobName) const

--- a/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_service_client.cpp
@@ -119,11 +119,13 @@ namespace Azure { namespace Storage { namespace Blobs {
   BlobServiceClient::BlobServiceClient(
       const std::string& serviceUrl,
       const BlobClientOptions& options)
-      : m_serviceUrl(serviceUrl), m_customerProvidedKey(options.CustomerProvidedKey),
-        m_encryptionScope(options.EncryptionScope),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_serviceUrl(serviceUrl)
   {
+    m_clientConfiguration.CustomerProvidedKey = options.CustomerProvidedKey;
+    m_clientConfiguration.EncryptionScope = options.EncryptionScope;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perRetryPolicies;
     std::vector<std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>> perOperationPolicies;
     perRetryPolicies.emplace_back(std::make_unique<_internal::StorageSwitchToSecondaryPolicy>(
@@ -156,10 +158,7 @@ namespace Azure { namespace Storage { namespace Blobs {
 
     BlobContainerClient blobContainerClient(blobContainerUrl.GetAbsoluteUrl());
     blobContainerClient.m_pipeline = m_pipeline;
-    blobContainerClient.m_customerProvidedKey = m_customerProvidedKey;
-    blobContainerClient.m_encryptionScope = m_encryptionScope;
-    blobContainerClient.m_uploadValidationOptions = m_uploadValidationOptions;
-    blobContainerClient.m_downloadValidationOptions = m_downloadValidationOptions;
+    blobContainerClient.m_clientConfiguration = m_clientConfiguration;
     blobContainerClient.m_batchRequestPipeline = m_batchRequestPipeline;
     blobContainerClient.m_batchSubrequestPipeline = m_batchSubrequestPipeline;
     return blobContainerClient;

--- a/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/block_blob_client.cpp
@@ -116,13 +116,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfMatch = options.AccessConditions.IfMatch;
     protocolLayerOptions.IfNoneMatch = options.AccessConditions.IfNoneMatch;
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     if (options.ImmutabilityPolicy.HasValue())
     {
       protocolLayerOptions.ImmutabilityPolicyExpiry = options.ImmutabilityPolicy.Value().ExpiresOn;
@@ -148,7 +150,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     {
       Azure::Nullable<TransferValidationOptions> validationOptions
           = options.ValidationOptions.HasValue() ? options.ValidationOptions
-                                                 : m_uploadValidationOptions;
+                                                 : m_clientConfiguration.UploadValidationOptions;
       if (validationOptions.HasValue()
           && validationOptions.Value().Algorithm != StorageChecksumAlgorithm::None)
       {
@@ -414,13 +416,15 @@ namespace Azure { namespace Storage { namespace Blobs {
         protocolLayerOptions.SourceContentcrc64 = options.TransactionalContentHash.Value().Value;
       }
     }
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     protocolLayerOptions.CopySourceTags = options.CopySourceTagsMode;
     if (!options.SourceAuthorization.empty())
     {
@@ -457,13 +461,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     _detail::BlockBlobClient::StageBlockBlobBlockOptions protocolLayerOptions;
     protocolLayerOptions.BlockId = blockId;
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
 
     Nullable<Azure::Response<Models::StageBlockResult>> responseNullable;
     if (options.TransactionalContentHash.HasValue())
@@ -483,7 +489,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     {
       Azure::Nullable<TransferValidationOptions> validationOptions
           = options.ValidationOptions.HasValue() ? options.ValidationOptions
-                                                 : m_uploadValidationOptions;
+                                                 : m_clientConfiguration.UploadValidationOptions;
       if (validationOptions.HasValue()
           && validationOptions.Value().Algorithm != StorageChecksumAlgorithm::None)
       {
@@ -554,13 +560,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.SourceIfUnmodifiedSince = options.SourceAccessConditions.IfUnmodifiedSince;
     protocolLayerOptions.SourceIfMatch = options.SourceAccessConditions.IfMatch;
     protocolLayerOptions.SourceIfNoneMatch = options.SourceAccessConditions.IfNoneMatch;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     if (!options.SourceAuthorization.empty())
     {
       protocolLayerOptions.CopySourceAuthorization = options.SourceAuthorization;
@@ -610,13 +618,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfMatch = options.AccessConditions.IfMatch;
     protocolLayerOptions.IfNoneMatch = options.AccessConditions.IfNoneMatch;
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     if (options.ImmutabilityPolicy.HasValue())
     {
       protocolLayerOptions.ImmutabilityPolicyExpiry = options.ImmutabilityPolicy.Value().ExpiresOn;
@@ -733,13 +743,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     }
 
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     protocolLayerOptions.IfModifiedSince = options.AccessConditions.IfModifiedSince;
     protocolLayerOptions.IfUnmodifiedSince = options.AccessConditions.IfUnmodifiedSince;
     protocolLayerOptions.IfMatch = options.AccessConditions.IfMatch;

--- a/sdk/storage/azure-storage-blobs/src/page_blob_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/page_blob_client.cpp
@@ -102,13 +102,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfMatch = options.AccessConditions.IfMatch;
     protocolLayerOptions.IfNoneMatch = options.AccessConditions.IfNoneMatch;
     protocolLayerOptions.IfTags = options.AccessConditions.TagConditions;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     if (options.ImmutabilityPolicy.HasValue())
     {
       protocolLayerOptions.ImmutabilityPolicyExpiry = options.ImmutabilityPolicy.Value().ExpiresOn;
@@ -164,13 +166,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfSequenceNumberLessThan
         = options.AccessConditions.IfSequenceNumberLessThan;
     protocolLayerOptions.IfSequenceNumberEqualTo = options.AccessConditions.IfSequenceNumberEqual;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
 
     Nullable<Azure::Response<Models::UploadPagesResult>> responseNullable;
     if (options.TransactionalContentHash.HasValue())
@@ -190,7 +194,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     {
       Azure::Nullable<TransferValidationOptions> validationOptions
           = options.ValidationOptions.HasValue() ? options.ValidationOptions
-                                                 : m_uploadValidationOptions;
+                                                 : m_clientConfiguration.UploadValidationOptions;
       if (validationOptions.HasValue()
           && validationOptions.Value().Algorithm != StorageChecksumAlgorithm::None)
       {
@@ -265,13 +269,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.SourceIfUnmodifiedSince = options.SourceAccessConditions.IfUnmodifiedSince;
     protocolLayerOptions.SourceIfMatch = options.SourceAccessConditions.IfMatch;
     protocolLayerOptions.SourceIfNoneMatch = options.SourceAccessConditions.IfNoneMatch;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     if (!options.SourceAuthorization.empty())
     {
       protocolLayerOptions.CopySourceAuthorization = options.SourceAuthorization;
@@ -317,13 +323,15 @@ namespace Azure { namespace Storage { namespace Blobs {
     protocolLayerOptions.IfSequenceNumberLessThan
         = options.AccessConditions.IfSequenceNumberLessThan;
     protocolLayerOptions.IfSequenceNumberEqualTo = options.AccessConditions.IfSequenceNumberEqual;
-    if (m_customerProvidedKey.HasValue())
+    if (m_clientConfiguration.CustomerProvidedKey.HasValue())
     {
-      protocolLayerOptions.EncryptionKey = m_customerProvidedKey.Value().Key;
-      protocolLayerOptions.EncryptionKeySha256 = m_customerProvidedKey.Value().KeyHash;
-      protocolLayerOptions.EncryptionAlgorithm = m_customerProvidedKey.Value().Algorithm.ToString();
+      protocolLayerOptions.EncryptionKey = m_clientConfiguration.CustomerProvidedKey.Value().Key;
+      protocolLayerOptions.EncryptionKeySha256
+          = m_clientConfiguration.CustomerProvidedKey.Value().KeyHash;
+      protocolLayerOptions.EncryptionAlgorithm
+          = m_clientConfiguration.CustomerProvidedKey.Value().Algorithm.ToString();
     }
-    protocolLayerOptions.EncryptionScope = m_encryptionScope;
+    protocolLayerOptions.EncryptionScope = m_clientConfiguration.EncryptionScope;
     return _detail::PageBlobClient::ClearPages(
         *m_pipeline, m_blobUrl, protocolLayerOptions, context);
   }

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_directory_client.cpp
@@ -136,13 +136,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       blobOptions.Algorithm = m_clientConfiguration.DownloadValidationOptions.Value().Algorithm;
       downloadValidationOptions = blobOptions;
     }
+    Blobs::_detail::BlobClientConfiguration blobClientConfiguration;
+    blobClientConfiguration.CustomerProvidedKey = m_clientConfiguration.CustomerProvidedKey;
+    blobClientConfiguration.UploadValidationOptions = std::move(uploadValidationOptions);
+    blobClientConfiguration.DownloadValidationOptions = std::move(downloadValidationOptions);
+
     auto renamedBlobClient = Blobs::BlobClient(
-        _detail::GetBlobUrlFromUrl(destinationDfsUrl),
-        m_pipeline,
-        m_clientConfiguration.CustomerProvidedKey,
-        Azure::Nullable<std::string>(),
-        std::move(uploadValidationOptions),
-        std::move(downloadValidationOptions));
+        _detail::GetBlobUrlFromUrl(destinationDfsUrl), m_pipeline, blobClientConfiguration);
     auto renamedFileClient = DataLakeFileClient(
         std::move(destinationDfsUrl),
         std::move(renamedBlobClient),
@@ -208,13 +208,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       downloadValidationOptions = blobOptions;
     }
 
+    Blobs::_detail::BlobClientConfiguration blobClientConfiguration;
+    blobClientConfiguration.CustomerProvidedKey = m_clientConfiguration.CustomerProvidedKey;
+    blobClientConfiguration.UploadValidationOptions = std::move(uploadValidationOptions);
+    blobClientConfiguration.DownloadValidationOptions = std::move(downloadValidationOptions);
+
     auto renamedBlobClient = Blobs::BlobClient(
-        _detail::GetBlobUrlFromUrl(destinationDfsUrl),
-        m_pipeline,
-        m_clientConfiguration.CustomerProvidedKey,
-        Azure::Nullable<std::string>(),
-        std::move(uploadValidationOptions),
-        std::move(downloadValidationOptions));
+        _detail::GetBlobUrlFromUrl(destinationDfsUrl), m_pipeline, blobClientConfiguration);
     auto renamedDirectoryClient = DataLakeDirectoryClient(
         std::move(destinationDfsUrl),
         std::move(renamedBlobClient),

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
@@ -402,13 +402,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       downloadValidationOptions = blobOptions;
     }
 
+    Blobs::_detail::BlobClientConfiguration blobClientConfiguration;
+    blobClientConfiguration.CustomerProvidedKey = m_clientConfiguration.CustomerProvidedKey;
+    blobClientConfiguration.UploadValidationOptions = std::move(uploadValidationOptions);
+    blobClientConfiguration.DownloadValidationOptions = std::move(downloadValidationOptions);
+
     auto renamedBlobClient = Blobs::BlobClient(
-        _detail::GetBlobUrlFromUrl(destinationDfsUrl),
-        m_pipeline,
-        m_clientConfiguration.CustomerProvidedKey,
-        Azure::Nullable<std::string>(),
-        std::move(uploadValidationOptions),
-        std::move(downloadValidationOptions));
+        _detail::GetBlobUrlFromUrl(destinationDfsUrl), m_pipeline, blobClientConfiguration);
     auto renamedFileClient = DataLakeFileClient(
         std::move(destinationDfsUrl),
         std::move(renamedBlobClient),
@@ -474,13 +474,13 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
       downloadValidationOptions = blobOptions;
     }
 
+    Blobs::_detail::BlobClientConfiguration blobClientConfiguration;
+    blobClientConfiguration.CustomerProvidedKey = m_clientConfiguration.CustomerProvidedKey;
+    blobClientConfiguration.UploadValidationOptions = std::move(uploadValidationOptions);
+    blobClientConfiguration.DownloadValidationOptions = std::move(downloadValidationOptions);
+
     auto renamedBlobClient = Blobs::BlobClient(
-        _detail::GetBlobUrlFromUrl(destinationDfsUrl),
-        m_pipeline,
-        m_clientConfiguration.CustomerProvidedKey,
-        Azure::Nullable<std::string>(),
-        std::move(uploadValidationOptions),
-        std::move(downloadValidationOptions));
+        _detail::GetBlobUrlFromUrl(destinationDfsUrl), m_pipeline, blobClientConfiguration);
     auto renamedDirectoryClient = DataLakeDirectoryClient(
         std::move(destinationDfsUrl),
         std::move(renamedBlobClient),

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_client.hpp
@@ -245,18 +245,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   private:
     Azure::Core::Url m_shareUrl;
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_pipeline;
-    Nullable<bool> m_allowTrailingDot;
-    Nullable<bool> m_allowSourceTrailingDot;
-    Nullable<Models::ShareTokenIntent> m_shareTokenIntent;
-    /** @brief Upload TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_uploadValidationOptions;
-    /** @brief Download TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_downloadValidationOptions;
+    _detail::ShareClientConfiguration m_clientConfiguration;
 
     explicit ShareClient(
         Azure::Core::Url shareUrl,
-        std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> pipeline)
-        : m_shareUrl(std::move(shareUrl)), m_pipeline(std::move(pipeline))
+        std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> pipeline,
+        _detail::ShareClientConfiguration clientConfiguration)
+        : m_shareUrl(std::move(shareUrl)), m_pipeline(std::move(pipeline)),
+          m_clientConfiguration(std::move(clientConfiguration))
     {
     }
     friend class ShareLeaseClient;

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_directory_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_directory_client.hpp
@@ -275,18 +275,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   private:
     Azure::Core::Url m_shareDirectoryUrl;
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_pipeline;
-    Nullable<bool> m_allowTrailingDot;
-    Nullable<bool> m_allowSourceTrailingDot;
-    Nullable<Models::ShareTokenIntent> m_shareTokenIntent;
-    /** @brief Upload TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_uploadValidationOptions;
-    /** @brief Download TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_downloadValidationOptions;
+    _detail::ShareClientConfiguration m_clientConfiguration;
 
     explicit ShareDirectoryClient(
         Azure::Core::Url shareDirectoryUrl,
-        std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> pipeline)
-        : m_shareDirectoryUrl(std::move(shareDirectoryUrl)), m_pipeline(std::move(pipeline))
+        std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> pipeline,
+        _detail::ShareClientConfiguration clientConfiguration)
+        : m_shareDirectoryUrl(std::move(shareDirectoryUrl)), m_pipeline(std::move(pipeline)),
+          m_clientConfiguration(std::move(clientConfiguration))
     {
     }
 

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_file_client.hpp
@@ -449,18 +449,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   private:
     Azure::Core::Url m_shareFileUrl;
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_pipeline;
-    Nullable<bool> m_allowTrailingDot;
-    Nullable<bool> m_allowSourceTrailingDot;
-    Nullable<Models::ShareTokenIntent> m_shareTokenIntent;
-    /** @brief Upload TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_uploadValidationOptions;
-    /** @brief Download TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_downloadValidationOptions;
+    _detail::ShareClientConfiguration m_clientConfiguration;
 
     explicit ShareFileClient(
         Azure::Core::Url shareFileUrl,
-        std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> pipeline)
-        : m_shareFileUrl(std::move(shareFileUrl)), m_pipeline(std::move(pipeline))
+        std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> pipeline,
+        _detail::ShareClientConfiguration clientConfiguration)
+        : m_shareFileUrl(std::move(shareFileUrl)), m_pipeline(std::move(pipeline)),
+          m_clientConfiguration(std::move(clientConfiguration))
     {
     }
 

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_options.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_options.hpp
@@ -271,6 +271,41 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     StorageChecksumAlgorithm Algorithm = StorageChecksumAlgorithm::None;
   };
 
+  namespace _detail {
+    struct ShareClientConfiguration
+    {
+      /**
+       * If set to true, trailing dot (.) will be allowed to suffix directory and file names.
+       * If false, the trailing dot will be trimmed.
+       * Supported by x-ms-version 2022-11-02 and above.
+       */
+      Nullable<bool> AllowTrailingDot;
+
+      /**
+       * If set to true, trailing dot (.) will be allowed to source file names.
+       * If false, the trailing dot will be trimmed.
+       * Supported by x-ms-version 2022-11-02 and above.
+       */
+      Nullable<bool> AllowSourceTrailingDot;
+
+      /**
+       * Share Token Intent. For use with token authentication. Used to indicate the intent of the
+       * request. This is currently required when using token authentication.
+       */
+      Nullable<Models::ShareTokenIntent> ShareTokenIntent;
+
+      /**
+       * @brief Upload TransferValidationOptions
+       */
+      Azure::Nullable<TransferValidationOptions> UploadValidationOptions;
+
+      /**
+       * @brief Download TransferValidationOptions
+       */
+      Azure::Nullable<TransferValidationOptions> DownloadValidationOptions;
+    };
+  } // namespace _detail
+
   /**
    * @brief Client options used to initialize share clients.
    */

--- a/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_service_client.hpp
+++ b/sdk/storage/azure-storage-files-shares/inc/azure/storage/files/shares/share_service_client.hpp
@@ -132,12 +132,6 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   private:
     Azure::Core::Url m_serviceUrl;
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_pipeline;
-    Nullable<bool> m_allowTrailingDot;
-    Nullable<bool> m_allowSourceTrailingDot;
-    Nullable<Models::ShareTokenIntent> m_shareTokenIntent;
-    /** @brief Upload TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_uploadValidationOptions;
-    /** @brief Download TransferValidationOptions */
-    Azure::Nullable<TransferValidationOptions> m_downloadValidationOptions;
+    _detail::ShareClientConfiguration m_clientConfiguration;
   };
 }}}} // namespace Azure::Storage::Files::Shares

--- a/sdk/storage/azure-storage-files-shares/src/share_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_client.cpp
@@ -41,12 +41,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const std::string& shareUrl,
       std::shared_ptr<StorageSharedKeyCredential> credential,
       const ShareClientOptions& options)
-      : m_shareUrl(shareUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_shareUrl(shareUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -62,12 +64,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const std::string& shareUrl,
       std::shared_ptr<const Core::Credentials::TokenCredential> credential,
       const ShareClientOptions& options)
-      : m_shareUrl(shareUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_shareUrl(shareUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -89,12 +93,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   }
 
   ShareClient::ShareClient(const std::string& shareUrl, const ShareClientOptions& options)
-      : m_shareUrl(shareUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_shareUrl(shareUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -107,13 +113,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
   ShareDirectoryClient ShareClient::GetRootDirectoryClient() const
   {
-    ShareDirectoryClient directoryClient(m_shareUrl, m_pipeline);
-    directoryClient.m_allowTrailingDot = m_allowTrailingDot;
-    directoryClient.m_allowSourceTrailingDot = m_allowSourceTrailingDot;
-    directoryClient.m_shareTokenIntent = m_shareTokenIntent;
-    directoryClient.m_uploadValidationOptions = m_uploadValidationOptions;
-    directoryClient.m_downloadValidationOptions = m_downloadValidationOptions;
-    return directoryClient;
+    return ShareDirectoryClient(m_shareUrl, m_pipeline, m_clientConfiguration);
   }
 
   ShareClient ShareClient::WithSnapshot(const std::string& snapshot) const
@@ -144,7 +144,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.RootSquash = options.RootSquash;
     protocolLayerOptions.EnableSnapshotVirtualDirectoryAccess
         = options.EnableSnapshotVirtualDirectoryAccess;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.PaidBurstingEnabled = options.EnablePaidBursting;
     protocolLayerOptions.PaidBurstingMaxIops = options.PaidBurstingMaxIops;
     protocolLayerOptions.PaidBurstingMaxBandwidthMibps = options.PaidBurstingMaxBandwidthMibps;
@@ -194,7 +194,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       protocolLayerOptions.DeleteSnapshots = Models::DeleteSnapshotsOption::Include;
     }
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto result
         = _detail::ShareClient::Delete(*m_pipeline, m_shareUrl, protocolLayerOptions, context);
     Models::DeleteShareResult ret;
@@ -232,7 +232,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::ShareClient::CreateShareSnapshotOptions();
     protocolLayerOptions.Metadata
         = std::map<std::string, std::string>(options.Metadata.begin(), options.Metadata.end());
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::ShareClient::CreateSnapshot(
         *m_pipeline, m_shareUrl, protocolLayerOptions, context);
   }
@@ -243,7 +243,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     (void)options;
     auto protocolLayerOptions = _detail::ShareClient::GetSharePropertiesOptions();
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::ShareClient::GetProperties(
         *m_pipeline, m_shareUrl, protocolLayerOptions, context);
   }
@@ -258,7 +258,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.RootSquash = options.RootSquash;
     protocolLayerOptions.EnableSnapshotVirtualDirectoryAccess
         = options.EnableSnapshotVirtualDirectoryAccess;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.PaidBurstingEnabled = options.EnablePaidBursting;
     protocolLayerOptions.PaidBurstingMaxIops = options.PaidBurstingMaxIops;
     protocolLayerOptions.PaidBurstingMaxBandwidthMibps = options.PaidBurstingMaxBandwidthMibps;
@@ -277,7 +277,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::ShareClient::SetShareMetadataOptions();
     protocolLayerOptions.Metadata
         = std::map<std::string, std::string>(metadata.begin(), metadata.end());
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::ShareClient::SetMetadata(
         *m_pipeline, m_shareUrl, protocolLayerOptions, context);
   }
@@ -288,7 +288,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     (void)options;
     auto protocolLayerOptions = _detail::ShareClient::GetShareAccessPolicyOptions();
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::ShareClient::GetAccessPolicy(
         *m_pipeline, m_shareUrl, protocolLayerOptions, context);
   }
@@ -301,7 +301,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     (void)options;
     auto protocolLayerOptions = _detail::ShareClient::SetShareAccessPolicyOptions();
     protocolLayerOptions.ShareAcl = accessPolicy;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::ShareClient::SetAccessPolicy(
         *m_pipeline, m_shareUrl, protocolLayerOptions, context);
   }
@@ -312,7 +312,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     (void)options;
     auto protocolLayerOptions = _detail::ShareClient::GetShareStatisticsOptions();
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::ShareClient::GetStatistics(
         *m_pipeline, m_shareUrl, protocolLayerOptions, context);
   }
@@ -326,7 +326,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::ShareClient::CreateSharePermissionOptions();
     protocolLayerOptions.SharePermission.Permission = permission;
     protocolLayerOptions.SharePermission.Format = options.FilePermissionFormat;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::ShareClient::CreatePermission(
         *m_pipeline, m_shareUrl, protocolLayerOptions, context);
   }
@@ -338,7 +338,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     auto protocolLayerOptions = _detail::ShareClient::GetSharePermissionOptions();
     protocolLayerOptions.FilePermissionKey = permissionKey;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.FilePermissionFormat = options.FilePermissionFormat;
     auto result = _detail::ShareClient::GetPermission(
         *m_pipeline, m_shareUrl, protocolLayerOptions, context);

--- a/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_directory_client.cpp
@@ -43,12 +43,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const std::string& shareDirectoryUrl,
       std::shared_ptr<StorageSharedKeyCredential> credential,
       const ShareClientOptions& options)
-      : m_shareDirectoryUrl(shareDirectoryUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_shareDirectoryUrl(shareDirectoryUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -64,12 +66,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const std::string& shareDirectoryUrl,
       std::shared_ptr<const Core::Credentials::TokenCredential> credential,
       const ShareClientOptions& options)
-      : m_shareDirectoryUrl(shareDirectoryUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_shareDirectoryUrl(shareDirectoryUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -93,12 +97,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   ShareDirectoryClient::ShareDirectoryClient(
       const std::string& shareDirectoryUrl,
       const ShareClientOptions& options)
-      : m_shareDirectoryUrl(shareDirectoryUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_shareDirectoryUrl(shareDirectoryUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -114,26 +120,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     auto builder = m_shareDirectoryUrl;
     builder.AppendPath(_internal::UrlEncodePath(subdirectoryName));
-    ShareDirectoryClient subdirectoryClient(builder, m_pipeline);
-    subdirectoryClient.m_allowTrailingDot = m_allowTrailingDot;
-    subdirectoryClient.m_allowSourceTrailingDot = m_allowSourceTrailingDot;
-    subdirectoryClient.m_shareTokenIntent = m_shareTokenIntent;
-    subdirectoryClient.m_uploadValidationOptions = m_uploadValidationOptions;
-    subdirectoryClient.m_downloadValidationOptions = m_downloadValidationOptions;
-    return subdirectoryClient;
+    return ShareDirectoryClient(builder, m_pipeline, m_clientConfiguration);
   }
 
   ShareFileClient ShareDirectoryClient::GetFileClient(const std::string& fileName) const
   {
     auto builder = m_shareDirectoryUrl;
     builder.AppendPath(_internal::UrlEncodePath(fileName));
-    ShareFileClient fileClient(builder, m_pipeline);
-    fileClient.m_allowTrailingDot = m_allowTrailingDot;
-    fileClient.m_allowSourceTrailingDot = m_allowSourceTrailingDot;
-    fileClient.m_shareTokenIntent = m_shareTokenIntent;
-    fileClient.m_uploadValidationOptions = m_uploadValidationOptions;
-    fileClient.m_downloadValidationOptions = m_downloadValidationOptions;
-    return fileClient;
+    return ShareFileClient(builder, m_pipeline, m_clientConfiguration);
   }
 
   ShareDirectoryClient ShareDirectoryClient::WithShareSnapshot(
@@ -187,8 +181,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       protocolLayerOptions.FilePermissionKey = options.SmbProperties.PermissionKey;
     }
 
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.FilePermissionFormat = options.DirectoryPermissionFormat;
     if (options.PosixProperties.FileMode.HasValue())
     {
@@ -286,21 +280,16 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       protocolLayerOptions.FilePermissionKey = options.SmbProperties.PermissionKey;
     }
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.AllowSourceTrailingDot = m_allowSourceTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.AllowSourceTrailingDot = m_clientConfiguration.AllowSourceTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.FileContentType = options.ContentType;
     protocolLayerOptions.FilePermissionFormat = options.FilePermissionFormat;
 
     auto response = _detail::FileClient::Rename(
         *m_pipeline, destinationFileUrl, protocolLayerOptions, context);
 
-    auto renamedFileClient = ShareFileClient(destinationFileUrl, m_pipeline);
-    renamedFileClient.m_allowTrailingDot = m_allowTrailingDot;
-    renamedFileClient.m_allowSourceTrailingDot = m_allowSourceTrailingDot;
-    renamedFileClient.m_shareTokenIntent = m_shareTokenIntent;
-    renamedFileClient.m_uploadValidationOptions = m_uploadValidationOptions;
-    renamedFileClient.m_downloadValidationOptions = m_downloadValidationOptions;
+    auto renamedFileClient = ShareFileClient(destinationFileUrl, m_pipeline, m_clientConfiguration);
     return Azure::Response<ShareFileClient>(
         std::move(renamedFileClient), std::move(response.RawResponse));
   }
@@ -352,20 +341,16 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       protocolLayerOptions.FilePermissionKey = options.SmbProperties.PermissionKey;
     }
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.AllowSourceTrailingDot = m_allowSourceTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.AllowSourceTrailingDot = m_clientConfiguration.AllowSourceTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.FilePermissionFormat = options.FilePermissionFormat;
 
     auto response = _detail::DirectoryClient::Rename(
         *m_pipeline, destinationDirectoryUrl, protocolLayerOptions, context);
 
-    auto renamedSubdirectoryClient = ShareDirectoryClient(destinationDirectoryUrl, m_pipeline);
-    renamedSubdirectoryClient.m_allowTrailingDot = m_allowTrailingDot;
-    renamedSubdirectoryClient.m_allowSourceTrailingDot = m_allowSourceTrailingDot;
-    renamedSubdirectoryClient.m_shareTokenIntent = m_shareTokenIntent;
-    renamedSubdirectoryClient.m_uploadValidationOptions = m_uploadValidationOptions;
-    renamedSubdirectoryClient.m_downloadValidationOptions = m_downloadValidationOptions;
+    auto renamedSubdirectoryClient
+        = ShareDirectoryClient(destinationDirectoryUrl, m_pipeline, m_clientConfiguration);
     return Azure::Response<ShareDirectoryClient>(
         std::move(renamedSubdirectoryClient), std::move(response.RawResponse));
   }
@@ -376,8 +361,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     (void)options;
     auto protocolLayerOptions = _detail::DirectoryClient::DeleteDirectoryOptions();
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto result = _detail::DirectoryClient::Delete(
         *m_pipeline, m_shareDirectoryUrl, protocolLayerOptions, context);
     Models::DeleteDirectoryResult ret;
@@ -414,8 +399,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     (void)options;
     auto protocolLayerOptions = _detail::DirectoryClient::GetDirectoryPropertiesOptions();
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::DirectoryClient::GetProperties(
         *m_pipeline, m_shareDirectoryUrl, protocolLayerOptions, context);
     Models::DirectoryProperties ret;
@@ -466,8 +451,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       protocolLayerOptions.FilePermissionKey = smbProperties.PermissionKey;
     }
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.FilePermissionFormat = options.FilePermissionFormat;
     if (options.PosixProperties.FileMode.HasValue())
     {
@@ -502,8 +487,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::DirectoryClient::SetDirectoryMetadataOptions();
     protocolLayerOptions.Metadata
         = std::map<std::string, std::string>(metadata.begin(), metadata.end());
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::DirectoryClient::SetMetadata(
         *m_pipeline, m_shareDirectoryUrl, protocolLayerOptions, context);
   }
@@ -519,8 +504,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.MaxResults = options.PageSizeHint;
     protocolLayerOptions.Include = options.Include;
     protocolLayerOptions.IncludeExtendedInfo = options.IncludeExtendedInfo;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::DirectoryClient::ListFilesAndDirectoriesSegment(
         *m_pipeline, m_shareDirectoryUrl, protocolLayerOptions, context);
 
@@ -591,8 +576,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.Marker = options.ContinuationToken;
     protocolLayerOptions.MaxResults = options.PageSizeHint;
     protocolLayerOptions.Recursive = options.Recursive;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::DirectoryClient::ListHandles(
         *m_pipeline, m_shareDirectoryUrl, protocolLayerOptions, context);
 
@@ -649,8 +634,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     (void)options;
     auto protocolLayerOptions = _detail::DirectoryClient::ForceDirectoryCloseHandlesOptions();
     protocolLayerOptions.HandleId = handleId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto result = _detail::DirectoryClient::ForceCloseHandles(
         *m_pipeline, m_shareDirectoryUrl, protocolLayerOptions, context);
     Models::ForceCloseDirectoryHandleResult ret;
@@ -666,8 +651,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.HandleId = FileAllHandles;
     protocolLayerOptions.Marker = options.ContinuationToken;
     protocolLayerOptions.Recursive = options.Recursive;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::DirectoryClient::ForceCloseHandles(
         *m_pipeline, m_shareDirectoryUrl, protocolLayerOptions, context);
 

--- a/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_file_client.cpp
@@ -53,12 +53,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const std::string& shareFileUrl,
       std::shared_ptr<StorageSharedKeyCredential> credential,
       const ShareClientOptions& options)
-      : m_shareFileUrl(shareFileUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_shareFileUrl(shareFileUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -74,12 +76,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const std::string& shareFileUrl,
       std::shared_ptr<const Core::Credentials::TokenCredential> credential,
       const ShareClientOptions& options)
-      : m_shareFileUrl(shareFileUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_shareFileUrl(shareFileUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -103,12 +107,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   ShareFileClient::ShareFileClient(
       const std::string& shareFileUrl,
       const ShareClientOptions& options)
-      : m_shareFileUrl(shareFileUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_shareFileUrl(shareFileUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -196,8 +202,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       protocolLayerOptions.FileContentMD5 = options.HttpHeaders.ContentHash.Value;
     }
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.FilePermissionFormat = options.FilePermissionFormat;
     if (options.PosixProperties.FileMode.HasValue())
     {
@@ -213,7 +219,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       Azure::Nullable<TransferValidationOptions> validationOptions
           = options.ValidationOptions.HasValue() ? options.ValidationOptions
-                                                 : m_uploadValidationOptions;
+                                                 : m_clientConfiguration.UploadValidationOptions;
       if (validationOptions.HasValue()
           && validationOptions.Value().Algorithm != StorageChecksumAlgorithm::None)
       {
@@ -279,8 +285,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     auto protocolLayerOptions = _detail::FileClient::DeleteFileOptions();
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto result
         = _detail::FileClient::Delete(*m_pipeline, m_shareFileUrl, protocolLayerOptions, context);
     Models::DeleteFileResult ret;
@@ -345,7 +351,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       Azure::Nullable<TransferValidationOptions> validationOptions
           = options.ValidationOptions.HasValue() ? options.ValidationOptions
-                                                 : m_downloadValidationOptions;
+                                                 : m_clientConfiguration.DownloadValidationOptions;
       if (validationOptions.HasValue()
           && validationOptions.Value().Algorithm != StorageChecksumAlgorithm::None)
       {
@@ -354,8 +360,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       }
     }
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
 
     auto downloadResponse
         = _detail::FileClient::Download(*m_pipeline, m_shareFileUrl, protocolLayerOptions, context);
@@ -629,9 +635,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.IgnoreReadOnly = options.IgnoreReadOnly;
     protocolLayerOptions.SetArchiveAttribute = options.SetArchiveAttribute;
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.AllowSourceTrailingDot = m_allowSourceTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.AllowSourceTrailingDot = m_clientConfiguration.AllowSourceTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     if (options.PosixProperties.FileMode.HasValue())
     {
       protocolLayerOptions.FileMode = options.PosixProperties.FileMode.Value().ToOctalFileMode();
@@ -658,8 +664,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::FileClient::AbortFileCopyOptions();
     protocolLayerOptions.CopyId = std::move(copyId);
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::FileClient::AbortCopy(
         *m_pipeline, m_shareFileUrl, protocolLayerOptions, context);
   }
@@ -670,8 +676,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     auto protocolLayerOptions = _detail::FileClient::GetFilePropertiesOptions();
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::FileClient::GetProperties(
         *m_pipeline, m_shareFileUrl, protocolLayerOptions, context);
     Models::FileProperties ret;
@@ -757,8 +763,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       protocolLayerOptions.FileContentDisposition = httpHeaders.ContentDisposition;
     }
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.FilePermissionFormat = options.FilePermissionFormat;
     if (options.PosixProperties.FileMode.HasValue())
     {
@@ -796,8 +802,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.Metadata
         = std::map<std::string, std::string>(metadata.begin(), metadata.end());
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::FileClient::SetMetadata(
         *m_pipeline, m_shareFileUrl, protocolLayerOptions, context);
   }
@@ -814,8 +820,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
         + std::to_string(offset + content.Length() - 1);
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
     protocolLayerOptions.FileLastWrittenMode = options.FileLastWrittenMode;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     if (options.TransactionalContentHash.HasValue())
     {
       AZURE_ASSERT_MSG(
@@ -827,7 +833,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       Azure::Nullable<TransferValidationOptions> validationOptions
           = options.ValidationOptions.HasValue() ? options.ValidationOptions
-                                                 : m_uploadValidationOptions;
+                                                 : m_clientConfiguration.UploadValidationOptions;
       if (validationOptions.HasValue()
           && validationOptions.Value().Algorithm != StorageChecksumAlgorithm::None)
       {
@@ -864,8 +870,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
     protocolLayerOptions.FileLastWrittenMode = options.FileLastWrittenMode;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::FileClient::UploadRange(
         *m_pipeline,
         m_shareFileUrl,
@@ -902,8 +908,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
 
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.Marker = options.ContinuationToken;
     protocolLayerOptions.MaxResults = options.PageSizeHint;
     auto response = _detail::FileClient::GetRangeList(
@@ -947,8 +953,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     protocolLayerOptions.Prevsharesnapshot = std::move(previousShareSnapshot);
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.SupportRename = options.IncludeRenames;
     protocolLayerOptions.Marker = options.ContinuationToken;
     protocolLayerOptions.MaxResults = options.PageSizeHint;
@@ -991,8 +997,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
 
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.Marker = options.ContinuationToken;
     protocolLayerOptions.MaxResults
         = options.PageSizeHint.ValueOr(DefaultListAllRangesPageSizeHint);
@@ -1041,8 +1047,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
 
     protocolLayerOptions.Prevsharesnapshot = previousShareSnapshot;
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.SupportRename = options.IncludeRenames;
     protocolLayerOptions.Marker = options.ContinuationToken;
     protocolLayerOptions.MaxResults
@@ -1076,8 +1082,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::FileClient::ListFileHandlesOptions();
     protocolLayerOptions.Marker = options.ContinuationToken;
     protocolLayerOptions.MaxResults = options.PageSizeHint;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::FileClient::ListHandles(
         *m_pipeline, m_shareFileUrl, protocolLayerOptions, context);
 
@@ -1134,8 +1140,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     (void)options;
     auto protocolLayerOptions = _detail::FileClient::ForceFileCloseHandlesOptions();
     protocolLayerOptions.HandleId = handleId;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto result = _detail::FileClient::ForceCloseHandles(
         *m_pipeline, m_shareFileUrl, protocolLayerOptions, context);
     return Azure::Response<Models::ForceCloseFileHandleResult>(
@@ -1149,8 +1155,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     auto protocolLayerOptions = _detail::FileClient::ForceFileCloseHandlesOptions();
     protocolLayerOptions.HandleId = FileAllHandles;
     protocolLayerOptions.Marker = options.ContinuationToken;
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::FileClient::ForceCloseHandles(
         *m_pipeline, m_shareFileUrl, protocolLayerOptions, context);
 
@@ -1466,8 +1472,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     protocolLayerOptions.Metadata
         = std::map<std::string, std::string>(options.Metadata.begin(), options.Metadata.end());
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.FilePermissionFormat = options.FilePermissionFormat;
     if (options.PosixProperties.FileMode.HasValue())
     {
@@ -1581,8 +1587,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     protocolLayerOptions.Metadata
         = std::map<std::string, std::string>(options.Metadata.begin(), options.Metadata.end());
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.FilePermissionFormat = options.FilePermissionFormat;
     if (options.PosixProperties.FileMode.HasValue())
     {
@@ -1673,9 +1679,9 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     }
     protocolLayerOptions.SourceRange = std::string("bytes=") + std::to_string(sourceRange.Offset)
         + std::string("-") + std::to_string(sourceRange.Offset + sourceRange.Length.Value() - 1);
-    protocolLayerOptions.AllowTrailingDot = m_allowTrailingDot;
-    protocolLayerOptions.AllowSourceTrailingDot = m_allowSourceTrailingDot;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.AllowTrailingDot = m_clientConfiguration.AllowTrailingDot;
+    protocolLayerOptions.AllowSourceTrailingDot = m_clientConfiguration.AllowSourceTrailingDot;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     if (!options.SourceAuthorization.empty())
     {
       protocolLayerOptions.CopySourceAuthorization = options.SourceAuthorization;
@@ -1704,7 +1710,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
           Azure::DateTime::DateFormat::Rfc3339, DateTime::TimeFractionFormat::AllDigits);
     }
 
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.Owner = options.Owner;
     protocolLayerOptions.Group = options.Group;
     protocolLayerOptions.Metadata
@@ -1732,7 +1738,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     (void)options;
     _detail::FileClient::GetFileSymbolicLinkOptions protocolLayerOptions;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::FileClient::GetSymbolicLink(
         *m_pipeline, m_shareFileUrl, protocolLayerOptions, context);
 
@@ -1751,7 +1757,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     _detail::FileClient::CreateFileHardLinkOptions protocolLayerOptions;
     protocolLayerOptions.TargetFile = targetFile;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     protocolLayerOptions.LeaseId = options.AccessConditions.LeaseId;
 
     auto response = _detail::FileClient::CreateHardLink(

--- a/sdk/storage/azure-storage-files-shares/src/share_lease_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_lease_client.cpp
@@ -25,8 +25,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       _detail::FileClient::AcquireFileLeaseOptions protocolLayerOptions;
       protocolLayerOptions.ProposedLeaseId = GetLeaseId();
       protocolLayerOptions.Duration = static_cast<int32_t>(duration.count());
-      protocolLayerOptions.AllowTrailingDot = m_fileClient.Value().m_allowTrailingDot;
-      protocolLayerOptions.FileRequestIntent = m_fileClient.Value().m_shareTokenIntent;
+      protocolLayerOptions.AllowTrailingDot
+          = m_fileClient.Value().m_clientConfiguration.AllowTrailingDot;
+      protocolLayerOptions.FileRequestIntent
+          = m_fileClient.Value().m_clientConfiguration.ShareTokenIntent;
 
       auto response = _detail::FileClient::AcquireLease(
           *(m_fileClient.Value().m_pipeline),
@@ -47,7 +49,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       _detail::ShareClient::AcquireShareLeaseOptions protocolLayerOptions;
       protocolLayerOptions.ProposedLeaseId = GetLeaseId();
       protocolLayerOptions.Duration = static_cast<int32_t>(duration.count());
-      protocolLayerOptions.FileRequestIntent = m_shareClient.Value().m_shareTokenIntent;
+      protocolLayerOptions.FileRequestIntent
+          = m_shareClient.Value().m_clientConfiguration.ShareTokenIntent;
 
       auto response = _detail::ShareClient::AcquireLease(
           *(m_shareClient.Value().m_pipeline),
@@ -83,7 +86,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       _detail::ShareClient::RenewShareLeaseOptions protocolLayerOptions;
       protocolLayerOptions.LeaseId = GetLeaseId();
-      protocolLayerOptions.FileRequestIntent = m_shareClient.Value().m_shareTokenIntent;
+      protocolLayerOptions.FileRequestIntent
+          = m_shareClient.Value().m_clientConfiguration.ShareTokenIntent;
 
       auto response = _detail::ShareClient::RenewLease(
           *(m_shareClient.Value().m_pipeline),
@@ -114,8 +118,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       _detail::FileClient::ReleaseFileLeaseOptions protocolLayerOptions;
       protocolLayerOptions.LeaseId = GetLeaseId();
-      protocolLayerOptions.AllowTrailingDot = m_fileClient.Value().m_allowTrailingDot;
-      protocolLayerOptions.FileRequestIntent = m_fileClient.Value().m_shareTokenIntent;
+      protocolLayerOptions.AllowTrailingDot
+          = m_fileClient.Value().m_clientConfiguration.AllowTrailingDot;
+      protocolLayerOptions.FileRequestIntent
+          = m_fileClient.Value().m_clientConfiguration.ShareTokenIntent;
 
       auto response = _detail::FileClient::ReleaseLease(
           *(m_fileClient.Value().m_pipeline),
@@ -134,7 +140,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     {
       _detail::ShareClient::ReleaseShareLeaseOptions protocolLayerOptions;
       protocolLayerOptions.LeaseId = GetLeaseId();
-      protocolLayerOptions.FileRequestIntent = m_shareClient.Value().m_shareTokenIntent;
+      protocolLayerOptions.FileRequestIntent
+          = m_shareClient.Value().m_clientConfiguration.ShareTokenIntent;
 
       auto response = _detail::ShareClient::ReleaseLease(
           *(m_shareClient.Value().m_pipeline),
@@ -166,8 +173,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       _detail::FileClient::ChangeFileLeaseOptions protocolLayerOptions;
       protocolLayerOptions.LeaseId = GetLeaseId();
       protocolLayerOptions.ProposedLeaseId = proposedLeaseId;
-      protocolLayerOptions.AllowTrailingDot = m_fileClient.Value().m_allowTrailingDot;
-      protocolLayerOptions.FileRequestIntent = m_fileClient.Value().m_shareTokenIntent;
+      protocolLayerOptions.AllowTrailingDot
+          = m_fileClient.Value().m_clientConfiguration.AllowTrailingDot;
+      protocolLayerOptions.FileRequestIntent
+          = m_fileClient.Value().m_clientConfiguration.ShareTokenIntent;
 
       auto response = _detail::FileClient::ChangeLease(
           *(m_fileClient.Value().m_pipeline),
@@ -193,7 +202,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       _detail::ShareClient::ChangeShareLeaseOptions protocolLayerOptions;
       protocolLayerOptions.LeaseId = GetLeaseId();
       protocolLayerOptions.ProposedLeaseId = proposedLeaseId;
-      protocolLayerOptions.FileRequestIntent = m_shareClient.Value().m_shareTokenIntent;
+      protocolLayerOptions.FileRequestIntent
+          = m_shareClient.Value().m_clientConfiguration.ShareTokenIntent;
 
       auto response = _detail::ShareClient::ChangeLease(
           *(m_shareClient.Value().m_pipeline),
@@ -228,8 +238,10 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     if (m_fileClient.HasValue())
     {
       _detail::FileClient::BreakFileLeaseOptions protocolLayerOptions;
-      protocolLayerOptions.AllowTrailingDot = m_fileClient.Value().m_allowTrailingDot;
-      protocolLayerOptions.FileRequestIntent = m_fileClient.Value().m_shareTokenIntent;
+      protocolLayerOptions.AllowTrailingDot
+          = m_fileClient.Value().m_clientConfiguration.AllowTrailingDot;
+      protocolLayerOptions.FileRequestIntent
+          = m_fileClient.Value().m_clientConfiguration.ShareTokenIntent;
 
       auto response = _detail::FileClient::BreakLease(
           *(m_fileClient.Value().m_pipeline),
@@ -247,7 +259,8 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     else if (m_shareClient.HasValue())
     {
       _detail::ShareClient::BreakShareLeaseOptions protocolLayerOptions;
-      protocolLayerOptions.FileRequestIntent = m_shareClient.Value().m_shareTokenIntent;
+      protocolLayerOptions.FileRequestIntent
+          = m_shareClient.Value().m_clientConfiguration.ShareTokenIntent;
 
       auto response = _detail::ShareClient::BreakLease(
 

--- a/sdk/storage/azure-storage-files-shares/src/share_service_client.cpp
+++ b/sdk/storage/azure-storage-files-shares/src/share_service_client.cpp
@@ -38,12 +38,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const std::string& serviceUrl,
       std::shared_ptr<StorageSharedKeyCredential> credential,
       const ShareClientOptions& options)
-      : m_serviceUrl(serviceUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_serviceUrl(serviceUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -59,12 +61,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
       const std::string& serviceUrl,
       std::shared_ptr<const Core::Credentials::TokenCredential> credential,
       const ShareClientOptions& options)
-      : m_serviceUrl(serviceUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_serviceUrl(serviceUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -88,12 +92,14 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   ShareServiceClient::ShareServiceClient(
       const std::string& serviceUrl,
       const ShareClientOptions& options)
-      : m_serviceUrl(serviceUrl), m_allowTrailingDot(options.AllowTrailingDot),
-        m_allowSourceTrailingDot(options.AllowSourceTrailingDot),
-        m_shareTokenIntent(options.ShareTokenIntent),
-        m_uploadValidationOptions(options.UploadValidationOptions),
-        m_downloadValidationOptions(options.DownloadValidationOptions)
+      : m_serviceUrl(serviceUrl)
   {
+    m_clientConfiguration.AllowTrailingDot = options.AllowTrailingDot;
+    m_clientConfiguration.AllowSourceTrailingDot = options.AllowSourceTrailingDot;
+    m_clientConfiguration.ShareTokenIntent = options.ShareTokenIntent;
+    m_clientConfiguration.UploadValidationOptions = options.UploadValidationOptions;
+    m_clientConfiguration.DownloadValidationOptions = options.DownloadValidationOptions;
+
     _internal::BuildStoragePipelineOptions pipelineOptions;
     pipelineOptions.PackageName = _internal::FileServicePackageName;
     pipelineOptions.PackageVersion = _detail::PackageVersion::ToString();
@@ -108,13 +114,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     auto builder = m_serviceUrl;
     builder.AppendPath(_internal::UrlEncodePath(shareName));
-    ShareClient shareClient(builder, m_pipeline);
-    shareClient.m_allowTrailingDot = m_allowTrailingDot;
-    shareClient.m_allowSourceTrailingDot = m_allowSourceTrailingDot;
-    shareClient.m_shareTokenIntent = m_shareTokenIntent;
-    shareClient.m_uploadValidationOptions = m_uploadValidationOptions;
-    shareClient.m_downloadValidationOptions = m_downloadValidationOptions;
-    return shareClient;
+    return ShareClient(builder, m_pipeline, m_clientConfiguration);
   }
 
   ListSharesPagedResponse ShareServiceClient::ListShares(
@@ -126,7 +126,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     protocolLayerOptions.Marker = options.ContinuationToken;
     protocolLayerOptions.MaxResults = options.PageSizeHint;
     protocolLayerOptions.Prefix = options.Prefix;
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto response = _detail::ServiceClient::ListSharesSegment(
         *m_pipeline, m_serviceUrl, protocolLayerOptions, context);
 
@@ -154,7 +154,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
     (void)options;
     auto protocolLayerOptions = _detail::ServiceClient::SetServicePropertiesOptions();
     protocolLayerOptions.ShareServiceProperties = std::move(properties);
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     return _detail::ServiceClient::SetProperties(
         *m_pipeline, m_serviceUrl, protocolLayerOptions, context);
   }
@@ -165,7 +165,7 @@ namespace Azure { namespace Storage { namespace Files { namespace Shares {
   {
     (void)options;
     auto protocolLayerOptions = _detail::ServiceClient::GetServicePropertiesOptions();
-    protocolLayerOptions.FileRequestIntent = m_shareTokenIntent;
+    protocolLayerOptions.FileRequestIntent = m_clientConfiguration.ShareTokenIntent;
     auto result = _detail::ServiceClient::GetProperties(
         *m_pipeline, m_serviceUrl, protocolLayerOptions, context);
     Models::ShareServiceProperties ret;


### PR DESCRIPTION
## Purpose

- Add internal `BlobClientConfiguration` and `ShareClientConfiguration` value objects, following the existing Data Lake configuration pattern.
- Propagate client-level options through one configuration object instead of passing and storing multiple independent fields.
- Update Data Lake rename paths for the consolidated private Blob client constructor.
- Leave Queue unchanged because its child-client construction already passes only the URL and shared pipeline; it has no duplicated configuration bundle.

## Validation

- Built the Blob, File Share, and Data Lake test targets in Release mode on Windows.
- Blob playback: 131 passed, 20 skipped after excluding shared-key-only tests and one baseline playback failure.
- File Share playback: 93 passed, 4 skipped after excluding shared-key-only tests and one baseline playback failure.
- Data Lake playback: 79 passed, 10 skipped after excluding shared-key-only tests.
- Confirmed the excluded `BlockBlobClientTest.AbortCopy_PLAYBACKONLY_` and `FileShareFileClientTest.DestinationOAuthUploadRangeFromUri_PLAYBACKONLY_` failures reproduce unchanged on the unmodified baseline branch.

Closes #6952