### PR TITLE
feat(eventhubs): restore connection string authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1016,6 +1017,15 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1907,9 +1917,12 @@ dependencies = [
  "azure_core",
  "azure_core_amqp",
  "azure_identity",
+ "base64 0.22.1",
  "cbindgen",
  "fe2o3-amqp-types",
+ "hmac",
  "serde_amqp",
+ "sha2",
  "time",
  "tokio",
  "tracing",
@@ -2211,6 +2224,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- The Rust AMQP backend now generates SAS tokens from a shared access key. It sends CBS put-token requests with the `servicebus.windows.net:sastoken` token type.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection_string_credential.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/connection_string_credential.hpp
@@ -12,6 +12,13 @@
 #include <stdexcept>
 #include <string>
 
+#if defined(_azure_TESTING_BUILD)
+// Define the test classes dependant on this class here.
+namespace Azure { namespace Core { namespace Amqp { namespace Tests {
+  class ConnectionStringTest_GenerateSasTokenFixedVector_Test;
+}}}} // namespace Azure::Core::Amqp::Tests
+#endif // _azure_TESTING_BUILD
+
 namespace Azure { namespace Core { namespace Amqp { namespace _internal {
   //
   // A ServiceBus connection string has the following format:
@@ -179,6 +186,13 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     // * @param expiresOn The expiration time for the SAS token.
     // */
     std::string GenerateSasToken(std::chrono::system_clock::time_point const& expiresOn) const;
+
+#if defined(_azure_TESTING_BUILD)
+    // The token test needs a fixed expiration time, so it calls GenerateSasToken directly.
+    // GetToken derives the expiration time from the clock, which cannot produce a stable
+    // token to compare against.
+    friend class Azure::Core::Amqp::Tests::ConnectionStringTest_GenerateSasTokenFixedVector_Test;
+#endif // _azure_TESTING_BUILD
   };
 
 }}}} // namespace Azure::Core::Amqp::_internal

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/claim_based_security.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/claim_based_security.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-// cspell: words amqpclaimsbasedsecurity
+// cspell: words amqpclaimsbasedsecurity sastoken servicebus
 #include "azure/core/amqp/internal/claims_based_security.hpp"
 #include "azure/core/amqp/internal/common/global_state.hpp"
 #include "azure/core/amqp/internal/common/runtime_context.hpp"
@@ -76,16 +76,25 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     Common::_detail::CallContext callContext(
         Common::_detail::GlobalStateHolder::GlobalStateInstance()->GetRuntimeContext(), context);
 
-    // The Rust AMQP implementation only supports JWT tokens.
-    if (tokenType != CbsTokenType::Jwt)
+    // These are the same token type strings the uAMQP backend sends.
+    char const* tokenTypeString;
+    switch (tokenType)
     {
-      throw std::runtime_error("Unsupported Token Type");
+      case CbsTokenType::Jwt:
+        tokenTypeString = "jwt";
+        break;
+      case CbsTokenType::Sas:
+        tokenTypeString = "servicebus.windows.net:sastoken";
+        break;
+      default:
+        throw std::runtime_error("Unsupported CBS token type.");
     }
 
     if (amqpclaimsbasedsecurity_authorize_path(
             callContext.GetCallContext(),
             m_claimsBasedSecurity.get(),
             audience.c_str(),
+            tokenTypeString,
             token.c_str(),
             std::chrono::duration_cast<std::chrono::seconds>(expirationTime.time_since_epoch())
                 .count()))

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/connection_string_credential.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/connection_string_credential.cpp
@@ -3,6 +3,14 @@
 
 #include "azure/core/amqp/internal/connection_string_credential.hpp"
 
+#include "azure/core/amqp/internal/common/global_state.hpp"
+#include "azure/core/amqp/internal/common/runtime_context.hpp"
+
+#include <azure/core/url.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+
 namespace Azure { namespace Core { namespace Amqp { namespace _internal {
 
   // Generate a Shared Access Signature token for a ServiceBus client.
@@ -15,7 +23,35 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
   std::string ServiceBusSasConnectionStringCredential::GenerateSasToken(
       std::chrono::system_clock::time_point const& expirationTime) const
   {
-    (void)expirationTime;
-    return std::string();
+    // These two lines are duplicated from the uAMQP backend on purpose. Azure::Core::Url
+    // lowercases the scheme and drops a trailing slash, so both backends must build the
+    // resource URI the same way to produce the same token.
+    Azure::Core::Url resourceUri{GetEndpoint()};
+    resourceUri.AppendPath(GetEntityPath());
+    std::string const absoluteUri{resourceUri.GetAbsoluteUrl()};
+
+    auto const expiresOn{
+        std::chrono::duration_cast<std::chrono::seconds>(expirationTime.time_since_epoch())
+            .count()};
+
+    Common::_detail::CallContext callContext(
+        Common::_detail::GlobalStateHolder::GlobalStateInstance()->GetRuntimeContext(), {});
+
+    // The Rust implementation percent-encodes the resource URI, so pass it unencoded.
+    char* token = Azure::Core::Amqp::RustInterop::_detail::sastoken_create(
+        callContext.GetCallContext(),
+        absoluteUri.c_str(),
+        GetSharedAccessKeyName().c_str(),
+        GetSharedAccessKey().c_str(),
+        static_cast<uint64_t>(expiresOn));
+    if (token == nullptr)
+    {
+      // Never return an empty token. An empty token must not reach the CBS layer.
+      throw std::runtime_error("Could not create SAS token: " + callContext.GetError());
+    }
+
+    std::string tokenString{token};
+    Azure::Core::Amqp::RustInterop::_detail::rust_string_delete(token);
+    return tokenString;
   }
 }}}} // namespace Azure::Core::Amqp::_internal

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/Cargo.toml
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/Cargo.toml
@@ -22,6 +22,9 @@ tracing-subscriber.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 url.workspace = true
 time.workspace = true
+base64.workspace = true
+hmac.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 serde_amqp = { workspace = true }

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/cbs.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/cbs.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License.
-// cspell: words amqp amqpclaimsbasedsecurity amqpsession
+// cspell: words amqp amqpclaimsbasedsecurity amqpsession sastoken servicebus
 
 use crate::{
     amqp::session::RustAmqpSession,
@@ -121,6 +121,7 @@ pub unsafe extern "C" fn amqpclaimsbasedsecurity_authorize_path(
     call_context: *mut RustCallContext,
     cbs: *mut RustAmqpClaimsBasedSecurity,
     path: *const c_char,
+    token_type: *const c_char,
     secret: *const c_char,
     expires_on: u64,
 ) -> i32 {
@@ -128,13 +129,28 @@ pub unsafe extern "C" fn amqpclaimsbasedsecurity_authorize_path(
     let cbs = &mut (*cbs).inner;
     let path = std::ffi::CStr::from_ptr(path).to_str().unwrap();
     let secret = std::ffi::CStr::from_ptr(secret).to_str().unwrap();
+
+    // A null token type keeps the previous behaviour, because the AMQP crate treats a
+    // missing token type as "jwt".
+    let token_type = if token_type.is_null() {
+        None
+    } else {
+        match std::ffi::CStr::from_ptr(token_type).to_str() {
+            Ok(value) => Some(value.to_string()),
+            Err(_) => {
+                call_context.set_error(crate::error_from_str("Token type is not valid UTF-8"));
+                return -1;
+            }
+        }
+    };
+
     let expires_on = UNIX_EPOCH + Duration::from_secs(expires_on);
     let expires_on = time::OffsetDateTime::from(expires_on);
 
     let result = call_context
         .runtime_context()
         .runtime()
-        .block_on(cbs.authorize_path(path.to_string(), None, secret.to_string(), expires_on));
+        .block_on(cbs.authorize_path(path.to_string(), token_type, secret.to_string(), expires_on));
     if let Err(e) = result {
         error!("Failed to authorize path: {:?}", e);
         call_context.set_error(Box::new(e));
@@ -189,10 +205,25 @@ mod tests {
             let secret = CString::new("test_secret").unwrap();
             let expires_on = UNIX_EPOCH + Duration::from_secs(1000);
 
+            // A null token type means the default, which the AMQP crate treats as "jwt".
             let result = amqpclaimsbasedsecurity_authorize_path(
                 call_context,
                 claims_based_security,
                 path.as_ptr(),
+                std::ptr::null(),
+                secret.as_ptr(),
+                expires_on.duration_since(UNIX_EPOCH).unwrap().as_secs(),
+            );
+
+            assert_eq!(result, 0);
+
+            // A SAS token uses an explicit token type.
+            let token_type = CString::new("servicebus.windows.net:sastoken").unwrap();
+            let result = amqpclaimsbasedsecurity_authorize_path(
+                call_context,
+                claims_based_security,
+                path.as_ptr(),
+                token_type.as_ptr(),
                 secret.as_ptr(),
                 expires_on.duration_since(UNIX_EPOCH).unwrap().as_secs(),
             );

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/mod.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/mod.rs
@@ -6,4 +6,5 @@ pub mod connection;
 pub mod management;
 pub mod message_receiver;
 pub mod message_sender;
+pub mod sas;
 pub mod session;

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/sas.rs
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/rust_amqp/rust_wrapper/src/amqp/sas.rs
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation. All Rights Reserved.
+// Licensed under the MIT License.
+// cspell: words sastoken servicebus
+
+use crate::{
+    call_context::{call_context_from_ptr_mut, RustCallContext},
+    error_from_str,
+};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::ffi::{c_char, CStr, CString};
+
+/// Percent-encode a string the way `URL_EncodeString` from azure-c-shared-utility does.
+///
+/// The uAMQP backend builds its SAS tokens with that encoder, so this backend must
+/// produce the same bytes. The character set is not RFC 3986. It escapes `~`, which
+/// RFC 3986 lists as unreserved, and it passes `!`, `(`, `)`, and `*` through, which
+/// RFC 3986 lists as sub-delimiters. The hex digits are lowercase, so the output is
+/// `%3a` and not `%3A`.
+///
+/// One difference is deliberate. azure-c-shared-utility treats each byte at or above
+/// 0x80 as a Latin-1 code point and emits the percent-encoded UTF-8 of that code
+/// point, which garbles UTF-8 input. This function percent-encodes the raw UTF-8
+/// bytes instead. Event Hubs and Service Bus entity names are ASCII, so the two
+/// encoders agree in practice.
+fn url_encode(value: &str) -> String {
+    const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        let is_printable = matches!(byte, b'!' | b'(' | b')' | b'*' | b'-' | b'.' | b'_')
+            || byte.is_ascii_digit()
+            || byte.is_ascii_uppercase()
+            || byte.is_ascii_lowercase();
+
+        if is_printable {
+            encoded.push(*byte as char);
+        } else {
+            encoded.push('%');
+            encoded.push(HEX_DIGITS[(byte >> 4) as usize] as char);
+            encoded.push(HEX_DIGITS[(byte & 0x0f) as usize] as char);
+        }
+    }
+    encoded
+}
+
+/// Generate a Shared Access Signature token for a Service Bus or Event Hubs resource.
+///
+/// The fields appear in the order `sr`, `sig`, `se`, `skn`, which mirrors
+/// `SASToken_Create` in azure-c-shared-utility. The Microsoft documentation shows a
+/// different order. Both orders work, because the service reads the fields by name.
+/// Matching the uAMQP order lets one expected token cover both backends in a test.
+pub fn generate_sas_token(
+    resource_uri: &str,
+    key_name: &str,
+    key: &str,
+    expires_on_secs: u64,
+) -> String {
+    let scope = url_encode(resource_uri);
+    let to_sign = format!("{}\n{}", scope, expires_on_secs);
+
+    // The shared access key is a plain text string that looks like base64. The Service
+    // Bus specification says not to decode it, so the HMAC key is its raw UTF-8 bytes.
+    // The uAMQP path reaches the same result by base64-encoding the key so that
+    // SASToken_Create can base64-decode it again.
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(key.as_bytes()).expect("HMAC accepts a key of any length");
+    mac.update(to_sign.as_bytes());
+    let signature = STANDARD.encode(mac.finalize().into_bytes());
+
+    // The key name is never percent-encoded.
+    format!(
+        "SharedAccessSignature sr={}&sig={}&se={}&skn={}",
+        scope,
+        url_encode(&signature),
+        expires_on_secs,
+        key_name
+    )
+}
+
+/// Create a Shared Access Signature token.
+///
+/// On success this returns an owned C string. The caller must release it with
+/// `rust_string_delete`. On failure this records the reason in the call context and
+/// returns null.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. Every string
+/// argument must be a valid, null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn sastoken_create(
+    call_context: *mut RustCallContext,
+    resource_uri: *const c_char,
+    key_name: *const c_char,
+    key: *const c_char,
+    expires_on: u64,
+) -> *mut c_char {
+    let call_context = call_context_from_ptr_mut(call_context);
+
+    if resource_uri.is_null() || key_name.is_null() || key.is_null() {
+        call_context.set_error(error_from_str("SAS token arguments must not be null"));
+        return std::ptr::null_mut();
+    }
+
+    let resource_uri = match CStr::from_ptr(resource_uri).to_str() {
+        Ok(value) => value,
+        Err(_) => {
+            call_context.set_error(error_from_str("Resource URI is not valid UTF-8"));
+            return std::ptr::null_mut();
+        }
+    };
+    let key_name = match CStr::from_ptr(key_name).to_str() {
+        Ok(value) => value,
+        Err(_) => {
+            call_context.set_error(error_from_str("Shared access key name is not valid UTF-8"));
+            return std::ptr::null_mut();
+        }
+    };
+    let key = match CStr::from_ptr(key).to_str() {
+        Ok(value) => value,
+        Err(_) => {
+            call_context.set_error(error_from_str("Shared access key is not valid UTF-8"));
+            return std::ptr::null_mut();
+        }
+    };
+
+    let token = generate_sas_token(resource_uri, key_name, key, expires_on);
+    match CString::new(token) {
+        Ok(token) => token.into_raw(),
+        Err(_) => {
+            call_context.set_error(error_from_str("SAS token contains an interior null byte"));
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // This pins the three ways the encoder departs from RFC 3986: the hex digits are
+    // lowercase, `~` is escaped, and `!` is not.
+    #[test]
+    fn url_encode_matches_azure_c_shared_utility() {
+        assert_eq!(url_encode("sb://a.b/c~d!e"), "sb%3a%2f%2fa.b%2fc%7ed!e");
+    }
+
+    // The same expected token appears in the C++ test
+    // ConnectionStringTest.GenerateSasTokenFixedVector, which runs on both the Rust
+    // and the uAMQP backend. The key is fake.
+    // cspell: disable
+    #[test]
+    fn generate_sas_token_matches_golden_vector() {
+        let token = generate_sas_token(
+            "sb://fake.servicebus.windows.net/eventhub1",
+            "FakeKeyName",
+            "ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleQ==",
+            1735689600,
+        );
+
+        assert_eq!(
+            token,
+            "SharedAccessSignature sr=sb%3a%2f%2ffake.servicebus.windows.net%2feventhub1\
+             &sig=166yHuTCCC7xv5eXWn%2fzAaC%2fRlB8GsmwNyKJpMehFp0%3d\
+             &se=1735689600&skn=FakeKeyName"
+        );
+    }
+    // cspell: enable
+}

--- a/sdk/core/azure-core-amqp/test/ut/connection_string_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/connection_string_tests.cpp
@@ -9,100 +9,135 @@
 
 #include <gtest/gtest.h>
 
-class ConnectionStringTest : public testing::Test {
-protected:
-  void SetUp() override {}
-  void TearDown() override {}
-};
+namespace Azure { namespace Core { namespace Amqp { namespace Tests {
+  class ConnectionStringTest : public testing::Test {
+  protected:
+    void SetUp() override {}
+    void TearDown() override {}
+  };
 
-// EventHubs connection strings look like:
-// Endpoint=sb://{NAMESPACE}.servicebus.windows.net/{EVENT_HUB_NAME};EntityPath={EVENT_HUB_NAME};SharedAccessKeyName={ACCESS_KEY_NAME};SharedAccessKey={ACCESS_KEY}
+  // EventHubs connection strings look like:
+  // Endpoint=sb://{NAMESPACE}.servicebus.windows.net/{EVENT_HUB_NAME};EntityPath={EVENT_HUB_NAME};SharedAccessKeyName={ACCESS_KEY_NAME};SharedAccessKey={ACCESS_KEY}
 
-TEST_F(ConnectionStringTest, SaslPlainConnectionGood)
-{
+  TEST_F(ConnectionStringTest, SaslPlainConnectionGood)
   {
-    std::string connectionString
-        = "Endpoint=sb://{NAMESPACE}.servicebus.windows.net/"
-          "{EVENT_HUB_NAME};EntityPath={EVENT_HUB_NAME};SharedAccessKeyName={ACCESS_KEY_NAME};"
-          "SharedAccessKey={ACCESS_KEY}";
-    Azure::Core::Amqp::_internal::ConnectionStringParser credential(connectionString);
-    EXPECT_EQ("sb://{NAMESPACE}.servicebus.windows.net/{EVENT_HUB_NAME}", credential.GetEndpoint());
-    EXPECT_EQ("{EVENT_HUB_NAME}", credential.GetEntityPath());
-    EXPECT_EQ("{ACCESS_KEY_NAME}", credential.GetSharedAccessKeyName());
-    EXPECT_EQ("{ACCESS_KEY}", credential.GetSharedAccessKey());
-  }
-}
-
-TEST_F(ConnectionStringTest, ServiceBusSasConnectionGood)
-{
-  {
-    std::string connectionString
-        = "Endpoint=sb://{NAMESPACE}.servicebus.windows.net/"
-          "{EVENT_HUB_NAME};EntityPath={EVENT_HUB_NAME};SharedAccessKeyName={ACCESS_KEY_NAME}=;"
-          "SharedAccessKey={ACCESS_KEY}=";
-    Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential credential(
-        connectionString);
-    EXPECT_EQ("sb://{NAMESPACE}.servicebus.windows.net/{EVENT_HUB_NAME}", credential.GetEndpoint());
-    EXPECT_EQ("{EVENT_HUB_NAME}", credential.GetEntityPath());
-    EXPECT_EQ("{ACCESS_KEY_NAME}=", credential.GetSharedAccessKeyName());
-    EXPECT_EQ("{ACCESS_KEY}=", credential.GetSharedAccessKey());
     {
+      std::string connectionString
+          = "Endpoint=sb://{NAMESPACE}.servicebus.windows.net/"
+            "{EVENT_HUB_NAME};EntityPath={EVENT_HUB_NAME};SharedAccessKeyName={ACCESS_KEY_NAME};"
+            "SharedAccessKey={ACCESS_KEY}";
+      Azure::Core::Amqp::_internal::ConnectionStringParser credential(connectionString);
+      EXPECT_EQ(
+          "sb://{NAMESPACE}.servicebus.windows.net/{EVENT_HUB_NAME}", credential.GetEndpoint());
+      EXPECT_EQ("{EVENT_HUB_NAME}", credential.GetEntityPath());
+      EXPECT_EQ("{ACCESS_KEY_NAME}", credential.GetSharedAccessKeyName());
+      EXPECT_EQ("{ACCESS_KEY}", credential.GetSharedAccessKey());
+    }
+  }
+
+  TEST_F(ConnectionStringTest, ServiceBusSasConnectionGood)
+  {
+    {
+      std::string connectionString
+          = "Endpoint=sb://{NAMESPACE}.servicebus.windows.net/"
+            "{EVENT_HUB_NAME};EntityPath={EVENT_HUB_NAME};SharedAccessKeyName={ACCESS_KEY_NAME}=;"
+            "SharedAccessKey={ACCESS_KEY}=";
+      Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential credential(
+          connectionString);
+      EXPECT_EQ(
+          "sb://{NAMESPACE}.servicebus.windows.net/{EVENT_HUB_NAME}", credential.GetEndpoint());
+      EXPECT_EQ("{EVENT_HUB_NAME}", credential.GetEntityPath());
+      EXPECT_EQ("{ACCESS_KEY_NAME}=", credential.GetSharedAccessKeyName());
+      EXPECT_EQ("{ACCESS_KEY}=", credential.GetSharedAccessKey());
+      {
 #if !defined(AZ_PLATFORM_MAC)
 #if ENABLE_UAMQP
-      auto xport = credential.GetTransport();
+        auto xport = credential.GetTransport();
 #endif
 #endif // !defined(AZ_PLATFORM_MAC)
 
-      // Generate a SAS token which expires in 60 seconds.
-      Azure::Core::Credentials::TokenRequestContext trc;
-      auto token = credential.GetToken(trc, {});
+        // Generate a SAS token which expires in 60 seconds.
+        Azure::Core::Credentials::TokenRequestContext trc;
+        auto token = credential.GetToken(trc, {});
+      }
     }
-  }
-  EXPECT_NO_THROW([]() {
-    Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential zz(
-        "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey=Bar", "entityPath");
-  }());
-  EXPECT_NO_THROW([]() {
-    Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential zz(
-        "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey=Foo;EntityPath=otherPath",
-        "otherPath");
-  }());
-}
-
-TEST_F(ConnectionStringTest, ConnectionStringParserBad)
-{
-  {
-    EXPECT_ANY_THROW([]() { Azure::Core::Amqp::_internal::ConnectionStringParser xx(""); }());
-    EXPECT_ANY_THROW([]() {
-      Azure::Core::Amqp::_internal::ConnectionStringParser yy("Foo=Bar;Boo=Eek;Yoiks=Blang!");
-    }());
-    EXPECT_ANY_THROW([]() {
-      Azure::Core::Amqp::_internal::ConnectionStringParser zz(
-          "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey");
-    }());
-    EXPECT_ANY_THROW([]() {
-      Azure::Core::Amqp::_internal::ConnectionStringParser zz(
-          "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey");
-    }());
-  }
-}
-TEST_F(ConnectionStringTest, ServiceBusSasBad)
-{
-  {
-    EXPECT_ANY_THROW(
-        []() { Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential xx(""); }());
-    EXPECT_ANY_THROW([]() {
-      Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential yy(
-          "Foo=Bar;Boo=Eek;Yoiks=Blang!");
-    }());
-    EXPECT_ANY_THROW([]() {
+    EXPECT_NO_THROW([]() {
       Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential zz(
-          "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey");
+          "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey=Bar", "entityPath");
     }());
-    EXPECT_ANY_THROW([]() {
+    EXPECT_NO_THROW([]() {
       Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential zz(
           "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey=Foo;EntityPath=otherPath",
-          "entityPath");
+          "otherPath");
     }());
   }
-}
+
+  // The uAMQP backend builds its tokens with SASToken_Create and URL_EncodeString from
+  // azure-c-shared-utility, and the Rust backend builds them in Rust. Both must produce
+  // the same bytes, so this test runs unchanged on both backends.
+  //
+  // Two details of the expected value are worth knowing. The fields appear in the order
+  // sr, sig, se, skn, which is the order SASToken_Create uses and not the order the
+  // Microsoft documentation shows. The percent-encoded hex digits are lowercase.
+  //
+  // The shared access key is fake.
+  TEST_F(ConnectionStringTest, GenerateSasTokenFixedVector)
+  {
+    // cspell: disable
+    std::string const connectionString
+        = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=FakeKeyName;"
+          "SharedAccessKey=ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleQ==;EntityPath=eventhub1";
+
+    Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential credential(
+        connectionString);
+
+    // A fixed expiration time. GetToken derives its own from the clock, so it cannot
+    // produce a stable token to compare against.
+    auto const expiresOn{std::chrono::system_clock::from_time_t(1735689600)};
+
+    EXPECT_EQ(
+        "SharedAccessSignature sr=sb%3a%2f%2ffake.servicebus.windows.net%2feventhub1"
+        "&sig=166yHuTCCC7xv5eXWn%2fzAaC%2fRlB8GsmwNyKJpMehFp0%3d"
+        "&se=1735689600&skn=FakeKeyName",
+        credential.GenerateSasToken(expiresOn));
+    // cspell: enable
+  }
+
+  TEST_F(ConnectionStringTest, ConnectionStringParserBad)
+  {
+    {
+      EXPECT_ANY_THROW([]() { Azure::Core::Amqp::_internal::ConnectionStringParser xx(""); }());
+      EXPECT_ANY_THROW([]() {
+        Azure::Core::Amqp::_internal::ConnectionStringParser yy("Foo=Bar;Boo=Eek;Yoiks=Blang!");
+      }());
+      EXPECT_ANY_THROW([]() {
+        Azure::Core::Amqp::_internal::ConnectionStringParser zz(
+            "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey");
+      }());
+      EXPECT_ANY_THROW([]() {
+        Azure::Core::Amqp::_internal::ConnectionStringParser zz(
+            "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey");
+      }());
+    }
+  }
+  TEST_F(ConnectionStringTest, ServiceBusSasBad)
+  {
+    {
+      EXPECT_ANY_THROW(
+          []() { Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential xx(""); }());
+      EXPECT_ANY_THROW([]() {
+        Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential yy(
+            "Foo=Bar;Boo=Eek;Yoiks=Blang!");
+      }());
+      EXPECT_ANY_THROW([]() {
+        Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential zz(
+            "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey");
+      }());
+      EXPECT_ANY_THROW([]() {
+        Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential zz(
+            "Endpoint=Bar;SharedAccessKeyName=Eek;SharedAccessKey=Foo;EntityPath=otherPath",
+            "entityPath");
+      }());
+    }
+  }
+}}}} // namespace Azure::Core::Amqp::Tests

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features Added
 
-- [[#7250]](https://github.com/Azure/azure-sdk-for-cpp/issues/7250) Restored connection-string authentication for `ProducerClient` and `ConsumerClient`, including support for the Event Hubs emulator when using the uAMQP backend.
+- [[#7250]](https://github.com/Azure/azure-sdk-for-cpp/issues/7250) Restored connection-string authentication for `ProducerClient` and `ConsumerClient`, including support for the Event Hubs emulator.
+- [[#7295]](https://github.com/Azure/azure-sdk-for-cpp/issues/7295) Connection-string authentication now works on the Rust AMQP backend. `ProducerClient` and `ConsumerClient` no longer throw when the caller passes a connection string.
 
 ### Breaking Changes
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- [[#7250]](https://github.com/Azure/azure-sdk-for-cpp/issues/7250) Restored connection-string authentication for `ProducerClient` and `ConsumerClient`, including support for the Event Hubs emulator when using the uAMQP backend.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhubs/azure-messaging-eventhubs/README.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/README.md
@@ -159,8 +159,6 @@ Samples: [create_consumer_aad.cpp](https://github.com/Azure/azure-sdk-for-cpp/bl
 
 Use a token credential for production applications when possible. A connection string is useful for local development, for the Event Hubs emulator, or when a shared access key is required.
 
-Connection-string authentication currently requires the uAMQP backend.
-
 A namespace connection string does not contain an `EntityPath`. Pass the Event Hub name separately:
 
 ```text

--- a/sdk/eventhubs/azure-messaging-eventhubs/README.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/README.md
@@ -133,15 +133,49 @@ That should output something like:
 Event Hub clients are created using a credential from the [Azure Identity package][azure_identity_pkg], like [DefaultAzureCredential][default_azure_credential].
 Alternatively, you can create a client using a connection string.
 
-<!-- NOTE: Fix dead Links -->
-#### Using a service principal
+#### Using Microsoft Entra ID
+
+```cpp
+#include <azure/identity.hpp>
+#include <azure/messaging/eventhubs.hpp>
+
+std::string fullyQualifiedNamespace = "<namespace>.servicebus.windows.net";
+std::string eventHubName = "<event_hub_name>";
+
+auto credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+
+Azure::Messaging::EventHubs::ProducerClient producer(
+    fullyQualifiedNamespace, eventHubName, credential);
+Azure::Messaging::EventHubs::ConsumerClient consumer(
+    fullyQualifiedNamespace, eventHubName, credential);
+```
+
  - ConsumerClient: [link][consumer_client]
  - ProducerClient: [link][producer_client]
 
-<!-- NOTE: Fix dead links -->
+Samples: [create_consumer_aad.cpp](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer_aad.cpp) and [create_producer_aad.cpp](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer_aad.cpp).
+
 #### Using a connection string
- - ConsumerClient: [link](https://azure.github.io/azure-sdk-for-cpp/storage.html)
- - ProducerClient: [link](https://azure.github.io/azure-sdk-for-cpp/storage.html)
+
+Use a token credential for production applications when possible. A connection string is useful for local development, for the Event Hubs emulator, or when a shared access key is required.
+
+Connection-string authentication currently requires the uAMQP backend.
+
+A namespace connection string does not contain an `EntityPath`. Pass the Event Hub name separately:
+
+```text
+Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>
+```
+
+An Event Hub connection string contains an `EntityPath`. The Event Hub argument can be empty or must match that value:
+
+```text
+Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=<key-name>;SharedAccessKey=<key>;EntityPath=<event-hub-name>
+```
+
+A different Event Hub argument throws `std::invalid_argument`.
+
+Samples: [create_consumer.cpp](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp) and [create_producer.cpp](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp).
 
 # Key concepts
 
@@ -172,26 +206,26 @@ The following example shows how to send events to an event hub:
 ```cpp
 #include <azure/messaging/eventhubs.hpp>
 
+#include <stdexcept>
+
 // Your Event Hubs namespace connection string is available in the Azure portal.
 std::string connectionString = "<connection_string>";
 std::string eventHubName = "<event_hub_name>";
 
+Azure::Messaging::EventHubs::ProducerClient client(connectionString, eventHubName);
+
 Azure::Messaging::EventHubs::EventDataBatchOptions batchOptions;
 batchOptions.PartitionId = "1";
-Azure::Messaging::EventHubs::EventDataBatch eventBatch(batchOptions);
+Azure::Messaging::EventHubs::EventDataBatch eventBatch{client.CreateBatch(batchOptions)};
 
-Azure::Messaging::EventHubs::Models::EventData message;
-message.Body.Data = {'H', 'e', 'l', 'l', 'o', '2'};
+Azure::Messaging::EventHubs::Models::EventData message{"Hello Event Hubs"};
 
-eventBatch.AddMessage(message);
+if (!eventBatch.TryAdd(message))
+{
+  throw std::runtime_error("Failed to add the event to the batch.");
+}
 
-Azure::Messaging::EventHubs::ProducerClientOptions producerOptions;
-producerOptions.Name = "sender-link";
-producerOptions.ApplicationID = "some";
-
-auto client = Azure::Messaging::EventHubs::ProducerClient(
-      connectionString, eventHubName, producerOptions);
-auto result = client.SendEventDataBatch(eventBatch);
+client.Send(eventBatch);
 ```
 
 ## Receive events
@@ -206,11 +240,10 @@ The following example shows how to receive events from partition 1 on an event h
 std::string connectionString = "<connection_string>";
 std::string eventHubName = "<event_hub_name>";
 
-auto client = Azure::Messaging::EventHubs::ConsumerClient(
-	connectionString, eventHubName);
+Azure::Messaging::EventHubs::ConsumerClient client(connectionString, eventHubName);
 
 Azure::Messaging::EventHubs::PartitionClient partitionClient
-        = client.CreatePartitionClient("1");
+    = client.CreatePartitionClient("1");
 
 auto events = partitionClient.ReceiveEvents(1);
 ```
@@ -270,5 +303,3 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 
 [cppdoc]: https://azuresdkdocs.z19.web.core.windows.net/cpp/azure-messaging-eventhubs/latest/index.html
 [cppdoc_examples]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/eventhubs/azure-messaging-eventhubs/samples
-
-

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
@@ -142,6 +142,27 @@ namespace Azure { namespace Messaging { namespace EventHubs {
       return m_consumerClientOptions.RetryOptions;
     }
 
+    /** @brief Constructs a ConsumerClient from a connection string.
+     *
+     * @param connectionString The Event Hubs namespace or Event Hub connection string.
+     * @param eventHub The Event Hub name. This can be empty when the connection string contains an
+     * EntityPath value.
+     * @param consumerGroup The consumer group name.
+     * @param options Additional options for creating the client.
+     *
+     * @remark When the connection string contains an EntityPath value, eventHub must be empty or
+     * match that value.
+     *
+     * @throw std::invalid_argument When eventHub conflicts with the connection string EntityPath,
+     * or when neither value supplies an Event Hub name.
+     * @throw std::runtime_error When the client is built with the Rust AMQP backend.
+     */
+    ConsumerClient(
+        std::string const& connectionString,
+        std::string const& eventHub = {},
+        std::string const& consumerGroup = DefaultConsumerGroup,
+        ConsumerClientOptions const& options = {});
+
     /** @brief Create new Partition client
      *
      * @param partitionId targeted partition

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
@@ -98,6 +98,25 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     /** Default Constructor for a ProducerClient */
     ProducerClient() = default;
 
+    /** @brief Constructs a ProducerClient from a connection string.
+     *
+     * @param connectionString The Event Hubs namespace or Event Hub connection string.
+     * @param eventHub The Event Hub name. This can be empty when the connection string contains an
+     * EntityPath value.
+     * @param options Additional options for creating the client.
+     *
+     * @remark When the connection string contains an EntityPath value, eventHub must be empty or
+     * match that value.
+     *
+     * @throw std::invalid_argument When eventHub conflicts with the connection string EntityPath,
+     * or when neither value supplies an Event Hub name.
+     * @throw std::runtime_error When the client is built with the Rust AMQP backend.
+     */
+    ProducerClient(
+        std::string const& connectionString,
+        std::string const& eventHub,
+        ProducerClientOptions options = {});
+
     ~ProducerClient();
 
     /** @brief Close all the connections and sessions.

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/README.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/README.md
@@ -7,9 +7,9 @@ This repository contains samples for the Azure Event Hubs service.
 These samples are written with the assumption that the following environment
 variables have been set by the user:
 
-* EVENTHUBS_CONNECTION_STRING - The service connection string for the eventhubs instance.
-* EVENTHUB_NAME - Name of the eventhubs instance to communicate with.
-* EVENTHUBS_HOST - Fully qualified domain name for the eventhubs instance.
+* EVENTHUB_CONNECTION_STRING - The Event Hubs namespace or Event Hub connection string.
+* EVENTHUB_NAME - The Event Hub name. This is optional when the connection string contains `EntityPath`.
+* EVENTHUBS_HOST - Fully qualified namespace used by the Microsoft Entra ID samples.
 
 The tests also assume that the currently logged on user is authorized to call
 into the Event Hubs service instance because they use [Azure::Core::Credentials::TokenCredential](https://azuresdkdocs.z19.web.core.windows.net/cpp/azure-core/latest/class_azure_1_1_core_1_1_credentials_1_1_token_credential.html) for authorization.
@@ -32,20 +32,19 @@ az eventhubs namespace authorization-rule keys list --resource-group <your resou
 }
 ```
 
-The value of the `primaryConnectionString` property should be used as the `EVENTHUBS_CONNECTION_STRING` environment variable.
+The value of the `primaryConnectionString` property should be used as the `EVENTHUB_CONNECTION_STRING` environment variable.
 
 
 ## Samples
 
 | Sample | Description |
 |--------|-------------|
-| basic-operations/create_producer.cpp | This sample demonstrates how to create an `EventHubProducerClient` using a connection string. |
-| basic-operation/create_consumer.cpp | This sample demonstrates how to create an `EventHubConsumerClient` using a connection string. |
-| basic-operations/create_producer-aad.cpp | This sample demonstrates how to create an `EventHubProducerClient` using an Azure Active Directory account. |
-| basic-operation/create_consumer-aad.cpp | This sample demonstrates how to create an `EventHubConsumerClient` using an Azure Active Directory account. |
+| basic-operations/create_producer.cpp | Create a `ProducerClient` using a connection string. |
+| basic-operations/create_consumer.cpp | Create a `ConsumerClient` using a connection string. |
+| basic-operations/create_producer_aad.cpp | Create a `ProducerClient` using a Microsoft Entra ID credential. |
+| basic-operations/create_consumer_aad.cpp | Create a `ConsumerClient` using a Microsoft Entra ID credential. |
 | | |
-| produce-events/produce_events.cpp | This sample demonstrates how to send events to an Event Hub using the `EventHubProducerClient`. |
-| produce-events/produce_events_aad.cpp | This sample demonstrates how to send events to an Event Hub using the `EventHubProducerClient` using an Azure Active Directory account. |
-| consume-events/consume_events.cpp | This sample demonstrates how to receive events from an Event Hub using the `EventHubConsumerClient`. |
-| consume-events/consume_events_aad.cpp | This sample demonstrates how to receive events from an Event Hub using the `EventHubConsumerClient` using an Azure Active Directory account. |
-
+| produce-events/produce_events.cpp | Send events using a connection string. |
+| produce-events/produce_events_aad.cpp | Send events using a Microsoft Entra ID credential. |
+| consume-events/consume_events.cpp | Receive events using a connection string. |
+| consume-events/consume_events_aad.cpp | Receive events using a Microsoft Entra ID credential. |

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/CMakeLists.txt
@@ -12,11 +12,13 @@ add_executable (
   eventhubs-${samplename}
   ${samplename}.cpp)
 
-CREATE_PER_SERVICE_TARGET_BUILD_FOR_SAMPLE(eventhubs eventhubs-${samplename})
+CREATE_PER_SERVICE_TARGET_BUILD_FOR_SAMPLE(eventhubs eventhubs-${samplename} ${ARGN})
 
 target_link_libraries(eventhubs-${samplename} PRIVATE azure-messaging-eventhubs azure-identity)
 target_compile_definitions(eventhubs-${samplename} PRIVATE _azure_BUILDING_SAMPLES)
 endmacro()
 
+define_sample(create_consumer DISABLE_RUN)
 define_sample(create_consumer_aad)
+define_sample(create_producer DISABLE_RUN)
 define_sample(create_producer_aad)

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Creates an Event Hubs consumer from a connection string and gets Event Hub properties.
+//
+// Required environment variable:
+// * EVENTHUB_CONNECTION_STRING - an Event Hubs namespace or Event Hub connection string.
+//
+// Optional environment variable:
+// * EVENTHUB_NAME - required when the connection string does not contain EntityPath.
+
+#include <azure/messaging/eventhubs.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main()
+{
+  char const* const connectionStringValue{std::getenv("EVENTHUB_CONNECTION_STRING")};
+  if (connectionStringValue == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    return 1;
+  }
+
+  char const* const eventHubNameValue{std::getenv("EVENTHUB_NAME")};
+  std::string const eventHubName{eventHubNameValue == nullptr ? "" : eventHubNameValue};
+
+  Azure::Messaging::EventHubs::ConsumerClient consumerClient(connectionStringValue, eventHubName);
+
+  auto eventHubProperties = consumerClient.GetEventHubProperties();
+  std::cout << "Event Hub properties: " << eventHubProperties << std::endl;
+}

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Creates an Event Hubs producer from a connection string and gets Event Hub properties.
+//
+// Required environment variable:
+// * EVENTHUB_CONNECTION_STRING - an Event Hubs namespace or Event Hub connection string.
+//
+// Optional environment variable:
+// * EVENTHUB_NAME - required when the connection string does not contain EntityPath.
+
+#include <azure/messaging/eventhubs.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main()
+{
+  char const* const connectionStringValue{std::getenv("EVENTHUB_CONNECTION_STRING")};
+  if (connectionStringValue == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    return 1;
+  }
+
+  char const* const eventHubNameValue{std::getenv("EVENTHUB_NAME")};
+  std::string const eventHubName{eventHubNameValue == nullptr ? "" : eventHubNameValue};
+
+  Azure::Messaging::EventHubs::ProducerClient producerClient(connectionStringValue, eventHubName);
+
+  auto eventHubProperties = producerClient.GetEventHubProperties();
+  std::cout << "Event Hub properties: " << eventHubProperties << std::endl;
+}

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/CMakeLists.txt
@@ -12,10 +12,11 @@ add_executable (
   eventhubs-${samplename}
   ${samplename}.cpp)
 
-CREATE_PER_SERVICE_TARGET_BUILD_FOR_SAMPLE(eventhubs eventhubs-${samplename})
+CREATE_PER_SERVICE_TARGET_BUILD_FOR_SAMPLE(eventhubs eventhubs-${samplename} ${ARGN})
 
 target_link_libraries(eventhubs-${samplename} PRIVATE azure-messaging-eventhubs azure-identity)
 target_compile_definitions(eventhubs-${samplename} PRIVATE _azure_BUILDING_SAMPLES)
 endmacro()
 
+define_sample(consume_events DISABLE_RUN)
 define_sample(consume_events_aad)

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Receives events from the first partition using connection-string authentication.
+//
+// Required environment variable:
+// * EVENTHUB_CONNECTION_STRING - an Event Hubs namespace or Event Hub connection string.
+//
+// Optional environment variable:
+// * EVENTHUB_NAME - required when the connection string does not contain EntityPath.
+
+#include <azure/messaging/eventhubs.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main()
+{
+  char const* const connectionStringValue{std::getenv("EVENTHUB_CONNECTION_STRING")};
+  if (connectionStringValue == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    return 1;
+  }
+
+  char const* const eventHubNameValue{std::getenv("EVENTHUB_NAME")};
+  std::string const eventHubName{eventHubNameValue == nullptr ? "" : eventHubNameValue};
+
+  Azure::Messaging::EventHubs::ConsumerClient consumerClient(connectionStringValue, eventHubName);
+  auto eventHubProperties = consumerClient.GetEventHubProperties();
+
+  Azure::Messaging::EventHubs::PartitionClientOptions partitionOptions;
+  partitionOptions.StartPosition.Earliest = true;
+  partitionOptions.StartPosition.Inclusive = true;
+
+  auto partitionClient
+      = consumerClient.CreatePartitionClient(eventHubProperties.PartitionIds[0], partitionOptions);
+  auto events = partitionClient.ReceiveEvents(2);
+
+  for (auto const& event : events)
+  {
+    std::cout << "Received event: " << *event << std::endl;
+  }
+}

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/CMakeLists.txt
@@ -12,10 +12,11 @@ add_executable (
   eventhubs-${samplename}
   ${samplename}.cpp)
 
-CREATE_PER_SERVICE_TARGET_BUILD_FOR_SAMPLE(eventhubs eventhubs-${samplename})
+CREATE_PER_SERVICE_TARGET_BUILD_FOR_SAMPLE(eventhubs eventhubs-${samplename} ${ARGN})
 
 target_link_libraries(eventhubs-${samplename} PRIVATE azure-messaging-eventhubs azure-identity)
 target_compile_definitions(eventhubs-${samplename} PRIVATE _azure_BUILDING_SAMPLES)
 endmacro()
 
+define_sample(produce_events DISABLE_RUN)
 define_sample(produce_events_aad)

--- a/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Sends two events to the first partition using connection-string authentication.
+//
+// Required environment variable:
+// * EVENTHUB_CONNECTION_STRING - an Event Hubs namespace or Event Hub connection string.
+//
+// Optional environment variable:
+// * EVENTHUB_NAME - required when the connection string does not contain EntityPath.
+
+#include <azure/messaging/eventhubs.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main()
+{
+  char const* const connectionStringValue{std::getenv("EVENTHUB_CONNECTION_STRING")};
+  if (connectionStringValue == nullptr)
+  {
+    std::cerr << "Missing environment variable EVENTHUB_CONNECTION_STRING" << std::endl;
+    return 1;
+  }
+
+  char const* const eventHubNameValue{std::getenv("EVENTHUB_NAME")};
+  std::string const eventHubName{eventHubNameValue == nullptr ? "" : eventHubNameValue};
+
+  Azure::Messaging::EventHubs::ProducerClient producerClient(connectionStringValue, eventHubName);
+  auto eventHubProperties = producerClient.GetEventHubProperties();
+
+  Azure::Messaging::EventHubs::EventDataBatchOptions batchOptions;
+  batchOptions.PartitionId = eventHubProperties.PartitionIds[0];
+  Azure::Messaging::EventHubs::EventDataBatch batch{producerClient.CreateBatch(batchOptions)};
+
+  Azure::Messaging::EventHubs::Models::EventData firstEvent{"First connection-string event"};
+  firstEvent.MessageId = "connection-string-message-1";
+  if (!batch.TryAdd(firstEvent))
+  {
+    std::cerr << "Failed to add the first event to the batch" << std::endl;
+    return 1;
+  }
+
+  Azure::Messaging::EventHubs::Models::EventData secondEvent{"Second connection-string event"};
+  secondEvent.MessageId = "connection-string-message-2";
+  if (!batch.TryAdd(secondEvent))
+  {
+    std::cerr << "Failed to add the second event to the batch" << std::endl;
+    return 1;
+  }
+
+  producerClient.Send(batch);
+  std::cout << "Sent two events to partition " << batchOptions.PartitionId << std::endl;
+}

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
@@ -27,10 +27,6 @@ namespace Azure { namespace Messaging { namespace EventHubs {
       : m_connectionString{connectionString}, m_eventHub{eventHub}, m_consumerGroup{consumerGroup},
         m_consumerClientOptions(options)
   {
-#if ENABLE_RUST_AMQP
-    throw std::runtime_error(
-        "Connection-string authentication is supported only with the uAMQP backend.");
-#else
     auto sasCredential
         = std::make_shared<ServiceBusSasConnectionStringCredential>(connectionString, eventHub);
 
@@ -59,7 +55,6 @@ namespace Azure { namespace Messaging { namespace EventHubs {
 
     m_hostUrl = serviceScheme + m_fullyQualifiedNamespace + "/" + m_eventHub
         + _detail::EventHubsConsumerGroupsPath + m_consumerGroup;
-#endif
   }
 
   ConsumerClient::ConsumerClient(

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
@@ -5,8 +5,12 @@
 #include "private/eventhubs_utilities.hpp"
 #include "private/package_version.hpp"
 
+#include <azure/core/amqp/internal/connection_string_credential.hpp>
 #include <azure/core/amqp/internal/message_receiver.hpp>
+#include <azure/core/url.hpp>
 #include <azure/messaging/eventhubs.hpp>
+
+#include <stdexcept>
 
 using namespace Azure::Core::Diagnostics::_internal;
 using namespace Azure::Core::Diagnostics;
@@ -14,6 +18,49 @@ using namespace Azure::Messaging::EventHubs::Models;
 using namespace Azure::Core::Amqp::_internal;
 
 namespace Azure { namespace Messaging { namespace EventHubs {
+
+  ConsumerClient::ConsumerClient(
+      std::string const& connectionString,
+      std::string const& eventHub,
+      std::string const& consumerGroup,
+      ConsumerClientOptions const& options)
+      : m_connectionString{connectionString}, m_eventHub{eventHub}, m_consumerGroup{consumerGroup},
+        m_consumerClientOptions(options)
+  {
+#if ENABLE_RUST_AMQP
+    throw std::runtime_error(
+        "Connection-string authentication is supported only with the uAMQP backend.");
+#else
+    auto sasCredential
+        = std::make_shared<ServiceBusSasConnectionStringCredential>(connectionString, eventHub);
+
+    m_credential = sasCredential;
+    m_eventHub = sasCredential->GetEntityPath().empty() ? eventHub : sasCredential->GetEntityPath();
+    if (m_eventHub.empty())
+    {
+      throw std::invalid_argument(
+          "An Event Hub name is required when the connection string does not contain EntityPath.");
+    }
+
+    m_fullyQualifiedNamespace = sasCredential->GetHostName();
+    m_targetPort = sasCredential->GetPort();
+
+    std::string serviceScheme = _detail::EventHubsServiceScheme;
+    if (sasCredential->UseDevelopmentEmulator())
+    {
+      serviceScheme = _detail::EventHubsServiceScheme_Emulator;
+      uint16_t const endpointPort{Azure::Core::Url(sasCredential->GetEndpoint()).GetPort()};
+      if (endpointPort == Azure::Core::Amqp::_internal::AmqpTlsPort)
+      {
+        throw std::invalid_argument("The Event Hubs emulator cannot use the TLS AMQP port 5671.");
+      }
+      m_targetPort = endpointPort == 0 ? Azure::Core::Amqp::_internal::AmqpPort : endpointPort;
+    }
+
+    m_hostUrl = serviceScheme + m_fullyQualifiedNamespace + "/" + m_eventHub
+        + _detail::EventHubsConsumerGroupsPath + m_consumerGroup;
+#endif
+  }
 
   ConsumerClient::ConsumerClient(
       std::string const& fullyQualifiedNamespace,

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
@@ -10,9 +10,13 @@
 #include "private/retry_operation.hpp"
 
 #include <azure/core/amqp.hpp>
+#include <azure/core/amqp/internal/connection_string_credential.hpp>
 #include <azure/core/amqp/internal/message_sender.hpp>
 #include <azure/core/diagnostics/logger.hpp>
 #include <azure/core/internal/diagnostics/log.hpp>
+#include <azure/core/url.hpp>
+
+#include <stdexcept>
 
 using namespace Azure::Core::Diagnostics::_internal;
 using namespace Azure::Core::Diagnostics;
@@ -21,6 +25,48 @@ const std::string DefaultAuthScope = "https://eventhubs.azure.net/.default";
 }
 
 namespace Azure { namespace Messaging { namespace EventHubs {
+
+  ProducerClient::ProducerClient(
+      std::string const& connectionString,
+      std::string const& eventHub,
+      Azure::Messaging::EventHubs::ProducerClientOptions options)
+      : m_connectionString{connectionString}, m_eventHub{eventHub}, m_producerClientOptions(options)
+  {
+#if ENABLE_RUST_AMQP
+    throw std::runtime_error(
+        "Connection-string authentication is supported only with the uAMQP backend.");
+#else
+    auto sasCredential
+        = std::make_shared<Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential>(
+            connectionString, eventHub);
+
+    m_credential = sasCredential;
+    m_eventHub = sasCredential->GetEntityPath().empty() ? eventHub : sasCredential->GetEntityPath();
+    if (m_eventHub.empty())
+    {
+      throw std::invalid_argument(
+          "An Event Hub name is required when the connection string does not contain EntityPath.");
+    }
+
+    m_fullyQualifiedNamespace = sasCredential->GetHostName();
+    m_targetPort = sasCredential->GetPort();
+
+    std::string serviceScheme = _detail::EventHubsServiceScheme;
+    if (sasCredential->UseDevelopmentEmulator())
+    {
+      serviceScheme = _detail::EventHubsServiceScheme_Emulator;
+      uint16_t const endpointPort{Azure::Core::Url(sasCredential->GetEndpoint()).GetPort()};
+      if (endpointPort == Azure::Core::Amqp::_internal::AmqpTlsPort)
+      {
+        throw std::invalid_argument("The Event Hubs emulator cannot use the TLS AMQP port 5671.");
+      }
+      m_targetPort = endpointPort == 0 ? Azure::Core::Amqp::_internal::AmqpPort : endpointPort;
+    }
+
+    m_targetUrl = serviceScheme + m_fullyQualifiedNamespace + ":" + std::to_string(m_targetPort)
+        + "/" + m_eventHub;
+#endif
+  }
 
   ProducerClient::ProducerClient(
       std::string const& fullyQualifiedNamespace,

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
@@ -32,10 +32,6 @@ namespace Azure { namespace Messaging { namespace EventHubs {
       Azure::Messaging::EventHubs::ProducerClientOptions options)
       : m_connectionString{connectionString}, m_eventHub{eventHub}, m_producerClientOptions(options)
   {
-#if ENABLE_RUST_AMQP
-    throw std::runtime_error(
-        "Connection-string authentication is supported only with the uAMQP backend.");
-#else
     auto sasCredential
         = std::make_shared<Azure::Core::Amqp::_internal::ServiceBusSasConnectionStringCredential>(
             connectionString, eventHub);
@@ -65,7 +61,6 @@ namespace Azure { namespace Messaging { namespace EventHubs {
 
     m_targetUrl = serviceScheme + m_fullyQualifiedNamespace + ":" + std::to_string(m_targetPort)
         + "/" + m_eventHub;
-#endif
   }
 
   ProducerClient::ProducerClient(

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/CMakeLists.txt
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable (
   azure-messaging-eventhubs-test
     azure_messaging_eventhubs_test.cpp
     checkpoint_store_test.cpp
+    connection_string_test.cpp
     consumer_client_test.cpp
     event_data_test.cpp
     eventhubs_admin_client_test.cpp

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/connection_string_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/connection_string_test.cpp
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "eventhubs_test_base.hpp"
+
+#include <azure/core/internal/environment.hpp>
+#include <azure/messaging/eventhubs.hpp>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
+
+  namespace {
+    // The keys below are fake base64 text. cspell tokenizes base64 into fragments that are not
+    // words, so spell checking is disabled across this block.
+    // cspell: disable
+    constexpr const char* ConnectionStringNoEntityPath
+        = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=FakeKey;"
+          "SharedAccessKey=ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleQ==";
+    constexpr const char* ConnectionStringWithEntityPath
+        = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=FakeKey;"
+          "SharedAccessKey=ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleQ==;EntityPath=eventhub1";
+    constexpr const char* EmulatorConnectionString
+        = "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;"
+          "SharedAccessKey=U0FTX0tFWV9WQUxVRQ==;UseDevelopmentEmulator=true;";
+    constexpr const char* EmulatorTlsPortConnectionString
+        = "Endpoint=sb://localhost:5671;SharedAccessKeyName=RootManageSharedAccessKey;"
+          "SharedAccessKey=U0FTX0tFWV9WQUxVRQ==;UseDevelopmentEmulator=true;";
+    // cspell: enable
+  } // namespace
+
+#if ENABLE_UAMQP
+  TEST(ConnectionStringClientTest, ProducerUsesExplicitEventHubWithoutEntityPath)
+  {
+    ProducerClient client(ConnectionStringNoEntityPath, "eventhub1");
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+  }
+
+  TEST(ConnectionStringClientTest, ProducerUsesEntityPathWhenEventHubIsEmpty)
+  {
+    ProducerClient client(ConnectionStringWithEntityPath, "");
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+  }
+
+  TEST(ConnectionStringClientTest, ProducerAcceptsMatchingEntityPath)
+  {
+    ProducerClient client(ConnectionStringWithEntityPath, "eventhub1");
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+  }
+
+  TEST(ConnectionStringClientTest, ProducerRejectsMismatchedEntityPath)
+  {
+    EXPECT_THROW(
+        { ProducerClient client(ConnectionStringWithEntityPath, "eventhub2"); },
+        std::invalid_argument);
+  }
+
+  TEST(ConnectionStringClientTest, ProducerRejectsMissingEventHub)
+  {
+    EXPECT_THROW(
+        { ProducerClient client(ConnectionStringNoEntityPath, ""); }, std::invalid_argument);
+  }
+
+  TEST(ConnectionStringClientTest, ConsumerUsesExplicitEventHubWithoutEntityPath)
+  {
+    ConsumerClient client(ConnectionStringNoEntityPath, "eventhub1", "consumer-group");
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+    EXPECT_EQ("consumer-group", client.GetConsumerGroup());
+    EXPECT_EQ("fake.servicebus.windows.net", client.GetDetails().FullyQualifiedNamespace);
+  }
+
+  TEST(ConnectionStringClientTest, ConsumerUsesEntityPathAndDefaultConsumerGroup)
+  {
+    ConsumerClient client(ConnectionStringWithEntityPath);
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+    EXPECT_EQ(DefaultConsumerGroup, client.GetConsumerGroup());
+  }
+
+  TEST(ConnectionStringClientTest, ConsumerAcceptsMatchingEntityPath)
+  {
+    ConsumerClient client(ConnectionStringWithEntityPath, "eventhub1");
+    EXPECT_EQ("eventhub1", client.GetEventHubName());
+  }
+
+  TEST(ConnectionStringClientTest, ConsumerRejectsMismatchedEntityPath)
+  {
+    EXPECT_THROW(
+        { ConsumerClient client(ConnectionStringWithEntityPath, "eventhub2"); },
+        std::invalid_argument);
+  }
+
+  TEST(ConnectionStringClientTest, ConsumerRejectsMissingEventHub)
+  {
+    EXPECT_THROW({ ConsumerClient client(ConnectionStringNoEntityPath); }, std::invalid_argument);
+  }
+
+  TEST(ConnectionStringClientTest, EmulatorConnectionStringConstructsClients)
+  {
+    ProducerClient producer(EmulatorConnectionString, "eh1");
+    ConsumerClient consumer(EmulatorConnectionString, "eh1", "cg1");
+
+    EXPECT_EQ("eh1", producer.GetEventHubName());
+    EXPECT_EQ("eh1", consumer.GetEventHubName());
+    EXPECT_EQ("localhost", consumer.GetDetails().FullyQualifiedNamespace);
+  }
+
+  TEST(ConnectionStringClientTest, MissingEndpointThrows)
+  {
+    EXPECT_THROW(
+        { ProducerClient client("SharedAccessKeyName=FakeKey;SharedAccessKey=FakeKey", "eh1"); },
+        std::runtime_error);
+  }
+
+  TEST(ConnectionStringClientTest, EmulatorRejectsTlsPort)
+  {
+    EXPECT_THROW(
+        { ProducerClient client(EmulatorTlsPortConnectionString, "eh1"); }, std::invalid_argument);
+    EXPECT_THROW(
+        { ConsumerClient client(EmulatorTlsPortConnectionString, "eh1"); }, std::invalid_argument);
+  }
+
+  // Standard live-test resources disable local authentication. This test runs only when a
+  // dedicated SAS-enabled resource supplies the required environment variables.
+  class ConnectionStringLiveTest : public EventHubsTestBase {};
+
+  TEST_F(ConnectionStringLiveTest, RoundTrip_LIVEONLY_)
+  {
+    std::string const connectionString
+        = Azure::Core::_internal::Environment::GetVariable("EVENTHUB_CONNECTION_STRING");
+    std::string const eventHubName
+        = Azure::Core::_internal::Environment::GetVariable("EVENTHUB_NAME");
+    if (connectionString.empty() || eventHubName.empty())
+    {
+      GTEST_SKIP() << "EVENTHUB_CONNECTION_STRING and EVENTHUB_NAME are required.";
+    }
+
+    std::string consumerGroup
+        = Azure::Core::_internal::Environment::GetVariable("EVENTHUB_CONSUMER_GROUP");
+    if (consumerGroup.empty())
+    {
+      consumerGroup = DefaultConsumerGroup;
+    }
+
+    std::string partitionId
+        = Azure::Core::_internal::Environment::GetVariable("EVENTHUB_PARTITION_ID");
+    if (partitionId.empty())
+    {
+      partitionId = "0";
+    }
+
+    std::vector<uint8_t> const expectedBody{
+        'c', 'o', 'n', 'n', 'e', 'c', 't', 'i', 'o', 'n', '-', 's', 't', 'r', 'i', 'n', 'g'};
+
+    Azure::Core::Context rootContext;
+    auto context
+        = rootContext.WithDeadline(Azure::DateTime::clock::now() + std::chrono::seconds(30));
+
+    ConsumerClient consumer(connectionString, eventHubName, consumerGroup);
+    auto partitionClient = consumer.CreatePartitionClient(partitionId, {}, context);
+
+    ProducerClient producer(connectionString, eventHubName);
+    EventDataBatchOptions batchOptions;
+    batchOptions.PartitionId = partitionId;
+    EventDataBatch batch{producer.CreateBatch(batchOptions, context)};
+    ASSERT_TRUE(batch.TryAdd(Models::EventData(expectedBody)));
+    producer.Send(batch, context);
+
+    auto events = partitionClient.ReceiveEvents(1, context);
+
+    ASSERT_EQ(1ul, events.size());
+    EXPECT_EQ(expectedBody, events[0]->Body);
+  }
+#elif ENABLE_RUST_AMQP
+  TEST(ConnectionStringClientTest, ProducerRejectsRustBackend)
+  {
+    EXPECT_THROW(
+        { ProducerClient client(ConnectionStringNoEntityPath, "eventhub1"); }, std::runtime_error);
+  }
+
+  TEST(ConnectionStringClientTest, ConsumerRejectsRustBackend)
+  {
+    EXPECT_THROW(
+        { ConsumerClient client(ConnectionStringNoEntityPath, "eventhub1"); }, std::runtime_error);
+  }
+#endif
+
+}}}} // namespace Azure::Messaging::EventHubs::Test

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/connection_string_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/connection_string_test.cpp
@@ -35,7 +35,6 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
     // cspell: enable
   } // namespace
 
-#if ENABLE_UAMQP
   TEST(ConnectionStringClientTest, ProducerUsesExplicitEventHubWithoutEntityPath)
   {
     ProducerClient client(ConnectionStringNoEntityPath, "eventhub1");
@@ -177,18 +176,5 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
     ASSERT_EQ(std::size_t{1}, events.size());
     EXPECT_EQ(expectedBody, events[0]->Body);
   }
-#elif ENABLE_RUST_AMQP
-  TEST(ConnectionStringClientTest, ProducerRejectsRustBackend)
-  {
-    EXPECT_THROW(
-        { ProducerClient client(ConnectionStringNoEntityPath, "eventhub1"); }, std::runtime_error);
-  }
-
-  TEST(ConnectionStringClientTest, ConsumerRejectsRustBackend)
-  {
-    EXPECT_THROW(
-        { ConsumerClient client(ConnectionStringNoEntityPath, "eventhub1"); }, std::runtime_error);
-  }
-#endif
 
 }}}} // namespace Azure::Messaging::EventHubs::Test

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/connection_string_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/connection_string_test.cpp
@@ -126,7 +126,8 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
 
   // Standard live-test resources disable local authentication. This test runs only when a
   // dedicated SAS-enabled resource supplies the required environment variables.
-  class ConnectionStringLiveTest : public EventHubsTestBase {};
+  class ConnectionStringLiveTest : public EventHubsTestBase {
+  };
 
   TEST_F(ConnectionStringLiveTest, RoundTrip_LIVEONLY_)
   {

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/connection_string_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/connection_string_test.cpp
@@ -7,6 +7,7 @@
 #include <azure/messaging/eventhubs.hpp>
 
 #include <chrono>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -173,7 +174,7 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
 
     auto events = partitionClient.ReceiveEvents(1, context);
 
-    ASSERT_EQ(1ul, events.size());
+    ASSERT_EQ(std::size_t{1}, events.size());
     EXPECT_EQ(expectedBody, events[0]->Body);
   }
 #elif ENABLE_RUST_AMQP


### PR DESCRIPTION
## Summary

Restore connection-string authentication for the Event Hubs `ProducerClient` and `ConsumerClient`.

The constructors were available through `1.0.0-beta.10` and were removed in `1.0.0-beta.11` during the Rust AMQP merge. The connection-string parser and SAS credential remained, but the Rust backend's token generation and CBS SAS-token handling were incomplete.

Fixes #7250 and #7295.

Azure DevOps work item: [39045651](https://msazure.visualstudio.com/One/_workitems/edit/39045651)

Related earlier draft: #7251.

## Changes

- Restored the previous public constructor signatures:

  ```cpp
  ProducerClient(
      std::string const& connectionString,
      std::string const& eventHub,
      ProducerClientOptions options = {});

  ConsumerClient(
      std::string const& connectionString,
      std::string const& eventHub = {},
      std::string const& consumerGroup = DefaultConsumerGroup,
      ConsumerClientOptions const& options = {});
  ```

- Reused `ServiceBusSasConnectionStringCredential` and the existing uAMQP CBS SAS-token path.
- Added SAS support to the default Rust AMQP backend:
  - Generates HMAC-SHA256 SAS tokens through the Rust wrapper.
  - Matches the existing uAMQP token bytes and URL encoding.
  - Sends `servicebus.windows.net:sastoken` through the Rust CBS path.
  - Preserves JWT behavior for Microsoft Entra ID credentials.
- Restored `EntityPath` behavior:
  - An empty Event Hub argument uses the connection string `EntityPath`.
  - A matching Event Hub argument is accepted.
  - A different Event Hub argument throws `std::invalid_argument`.
  - An Event Hub name is required when the connection string has no `EntityPath`.
- Restored Event Hubs emulator support:
  - Uses AMQP without TLS.
  - Defaults to port 5672 when the emulator endpoint has no port.
  - Preserves an explicitly configured non-TLS port.
  - Rejects emulator port 5671 because the current AMQP transport maps that port to TLS.
- Added focused offline tests, a shared fixed-vector token test, and an opt-in live round-trip test.
- Restored and updated four connection-string samples:
  - `create_producer.cpp`
  - `create_consumer.cpp`
  - `produce_events.cpp`
  - `consume_events.cpp`
- Kept those samples in compile coverage but excluded them from automatic live sample execution because the standard live resources do not expose a connection string.
- Updated the package README with:
  - An inline Microsoft Entra ID example.
  - Connection-string formats with and without `EntityPath`.
  - Support on both AMQP backends.
  - Current send and receive APIs.
- Updated the samples README and changelog.

## Validation

The branch was rebased onto current `main` at `5270d5ae7`.

### uAMQP

- Event Hubs library built successfully.
- Azure Core AMQP connection-string tests built successfully.
- Event Hubs test executable built successfully.
- All four restored samples compiled and linked successfully.
- The fixed-vector SAS token test passed.
- 13 focused offline connection-string tests passed.
- The live-only test correctly skipped in playback mode.

### Event Hubs emulator

The focused round-trip test passed on both uAMQP and Rust AMQP against the Docker Event Hubs emulator using the official connection-string shape without an explicit port.

The test opened the receiver, sent one event, received it, and compared the event body.

### Azure Event Hubs

The focused round-trip test passed on both uAMQP and Rust AMQP against:

- Namespace: `cpp-connscale-ns`
- Event Hub: `eh-connscale-testing`
- Consumer group: `$Default`

The connection string was held only in process memory and removed after the test.

### Rust AMQP

- Rust SAS token unit tests passed.
- Azure Core AMQP and Event Hubs C++ tests built successfully.
- The fixed-vector test produced the same literal SAS token on both backends.
- 13 focused Event Hubs connection-string tests passed.
- Live Azure Event Hubs and emulator round trips passed.

## Scope

This PR does not:

- Change CBS token refresh behavior.
- Change retry or link recovery behavior.
- Change the standard live-test resources to enable local authentication.
- Add a new `BlobCheckpointStore` constructor.
- Fix the separate Event Hubs performance-test connection-string configuration issue.

## Security

- No real connection strings, shared keys, or SAS tokens are stored in the repository.
- Connection-string samples are not automatically executed by the standard live sample job.
- Live SAS validation requires an explicitly supplied SAS-enabled resource.
