### PR TITLE
[Storage] Add missing include of constants.hpp in storage_service_version_policy.hpp

### DIFF
--- a/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/storage_service_version_policy.hpp
+++ b/sdk/storage/azure-storage-common/inc/azure/storage/common/internal/storage_service_version_policy.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <azure/core/http/policies/policy.hpp>
+#include <azure/storage/common/internal/constants.hpp>
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
### Summary

`sdk/storage/azure-storage-common/inc/azure/storage/common/internal/storage_service_version_policy.hpp` uses `HttpHeaderXMsVersion`, which is declared in `azure/storage/common/internal/constants.hpp`. The header did not `#include` that file and only compiled because of a transitive include. This adds the direct include (include-what-you-use).

No behavioral change.

### Credits

Original author of this fix: @mahmood-openai. It was surfaced in Jinming-Hu/azure-sdk-for-cpp#2 (a private branch PR) and is being upstreamed here since it applies cleanly to `main`.

### Testing

Header-only change; existing storage builds/tests continue to compile.