### PR TITLE
[Storage] Clarify AGENTS.md client and rename guidance

### DIFF
--- a/sdk/storage/azure-storage-files-datalake/AGENTS.md
+++ b/sdk/storage/azure-storage-files-datalake/AGENTS.md
@@ -35,7 +35,8 @@ Data Lake builds on Blob Storage primitives; maintain alignment where behavior i
 ## Data Lake-Specific Concepts to Preserve
 
 - **Hierarchical namespace semantics** (directories and path operations).
-- **Path operations:** create, rename (including relocation within a filesystem), delete.
+- **Path operations:** create, rename (including changing the parent path within a filesystem),
+  delete.
 - **File operations:** append + flush workflow (ordering and position semantics matter).
 - **Directory semantics:** recursive operations and path traversal/listing.
 - **Access control:** ACLs, permissions, owner/group where applicable.
@@ -68,7 +69,7 @@ Data Lake builds on Blob Storage primitives; maintain alignment where behavior i
 When modifying datalake code, prioritize tests for:
 
 1. Path create/delete/list operations (including continuation/paging).
-2. Rename/path-relocation behavior and conflict/condition handling.
+2. Rename behavior, including parent-path changes and conflict/condition handling.
 3. Append/flush positional correctness.
 4. ACL/permission operations (where touched).
 5. Deep directory recursive scenarios (if applicable).
@@ -98,7 +99,7 @@ Include edge cases for path encoding and unusual path names when relevant.
 
 Require/flag maintainer review for:
 
-- Rename/path-relocation semantic changes
+- Rename semantics, including parent-path changes
 - Append/flush logic changes
 - ACL/permission handling changes
 - Public API changes across path clients

--- a/sdk/storage/azure-storage-files-datalake/AGENTS.md
+++ b/sdk/storage/azure-storage-files-datalake/AGENTS.md
@@ -23,8 +23,10 @@ The Data Lake client code lives under `azure-storage-files-datalake` in this rep
 Typical hierarchy includes:
 
 - **DataLakeServiceClient** (account/service scope)
-- **FileSystemClient** (filesystem/container scope)
-- **Path clients** (file or directory scope), often with dedicated file/directory operations
+- **DataLakeFileSystemClient** (filesystem/container scope)
+- **DataLakePathClient** (common path operations), with **DataLakeFileClient** and
+  **DataLakeDirectoryClient** specializations
+- **DataLakeLeaseClient** (filesystem/path lease operations)
 
 Data Lake builds on Blob Storage primitives; maintain alignment where behavior intentionally overlaps.
 
@@ -33,7 +35,7 @@ Data Lake builds on Blob Storage primitives; maintain alignment where behavior i
 ## Data Lake-Specific Concepts to Preserve
 
 - **Hierarchical namespace semantics** (directories and path operations).
-- **Path operations:** create, rename, move, delete.
+- **Path operations:** create, rename (including relocation within a filesystem), delete.
 - **File operations:** append + flush workflow (ordering and position semantics matter).
 - **Directory semantics:** recursive operations and path traversal/listing.
 - **Access control:** ACLs, permissions, owner/group where applicable.
@@ -45,7 +47,7 @@ Data Lake builds on Blob Storage primitives; maintain alignment where behavior i
 ## Common Pitfalls (avoid)
 
 - Treating datalake path behavior as identical to flat blob behavior.
-- Breaking rename/move atomicity assumptions or destination-conditions handling.
+- Breaking rename atomicity assumptions or destination-conditions handling.
 - Mis-handling append/flush offsets and finalization semantics.
 - Regressing recursive delete/list behavior with deep trees.
 - Inconsistent URL/path encoding treatment for special characters.
@@ -66,7 +68,7 @@ Data Lake builds on Blob Storage primitives; maintain alignment where behavior i
 When modifying datalake code, prioritize tests for:
 
 1. Path create/delete/list operations (including continuation/paging).
-2. Rename/move behavior and conflict/condition handling.
+2. Rename/path-relocation behavior and conflict/condition handling.
 3. Append/flush positional correctness.
 4. ACL/permission operations (where touched).
 5. Deep directory recursive scenarios (if applicable).
@@ -96,7 +98,7 @@ Include edge cases for path encoding and unusual path names when relevant.
 
 Require/flag maintainer review for:
 
-- Rename/move semantic changes
+- Rename/path-relocation semantic changes
 - Append/flush logic changes
 - ACL/permission handling changes
 - Public API changes across path clients

--- a/sdk/storage/azure-storage-files-shares/AGENTS.md
+++ b/sdk/storage/azure-storage-files-shares/AGENTS.md
@@ -36,7 +36,7 @@ Preserve consistency of this hierarchy and existing naming conventions.
 - **SMB/NFS-relevant properties** (permissions/attributes/protocol-oriented metadata as applicable).
 - **Snapshots** of shares and snapshot-targeted operations.
 - **Quota/provisioning properties** and service/share-level settings.
-- **Rename semantics**, including relocation within the same share, where available.
+- **Rename semantics**, including changing the parent path within the same share, where available.
 
 ---
 
@@ -98,5 +98,5 @@ Flag for maintainer review when changes include:
 - Range write/read logic
 - Snapshot handling
 - Permission/attribute semantics
-- Rename/path-relocation semantics
+- Rename semantics, including parent-path changes
 - Public API changes

--- a/sdk/storage/azure-storage-files-shares/AGENTS.md
+++ b/sdk/storage/azure-storage-files-shares/AGENTS.md
@@ -18,8 +18,11 @@ Typical client hierarchy includes:
 
 - **ShareServiceClient** (service/account scope)
 - **ShareClient** (share scope)
-- **Directory and File clients** (path/item scope)
-- Optional related clients for handles/permissions/snapshots depending on API surface
+- **ShareDirectoryClient** and **ShareFileClient** (path/item scope)
+- **ShareLeaseClient** (share/file lease operations)
+
+Handles, permissions, and snapshots are exposed through these clients rather than separate
+client types.
 
 Preserve consistency of this hierarchy and existing naming conventions.
 
@@ -33,7 +36,7 @@ Preserve consistency of this hierarchy and existing naming conventions.
 - **SMB/NFS-relevant properties** (permissions/attributes/protocol-oriented metadata as applicable).
 - **Snapshots** of shares and snapshot-targeted operations.
 - **Quota/provisioning properties** and service/share-level settings.
-- **Rename/move semantics** where available in API versions.
+- **Rename semantics**, including relocation within the same share, where available.
 
 ---
 
@@ -95,5 +98,5 @@ Flag for maintainer review when changes include:
 - Range write/read logic
 - Snapshot handling
 - Permission/attribute semantics
-- Rename/move/path semantics
+- Rename/path-relocation semantics
 - Public API changes


### PR DESCRIPTION
Clarify the Storage AGENTS.md guidance by naming the exact Data Lake and Files client types, documenting lease clients, and describing path relocation through the existing rename APIs rather than implying separate Move APIs.