### PR TITLE
Avoid copying blob client configuration

### DIFF
--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_client.hpp
@@ -437,7 +437,7 @@ namespace Azure { namespace Storage { namespace Blobs {
     explicit BlobClient(
         Azure::Core::Url blobUrl,
         std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> pipeline,
-        _detail::BlobClientConfiguration clientConfiguration = _detail::BlobClientConfiguration())
+        _detail::BlobClientConfiguration clientConfiguration)
         : m_blobUrl(std::move(blobUrl)), m_pipeline(std::move(pipeline)),
           m_clientConfiguration(std::move(clientConfiguration))
     {

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_directory_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_directory_client.cpp
@@ -142,7 +142,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     blobClientConfiguration.DownloadValidationOptions = std::move(downloadValidationOptions);
 
     auto renamedBlobClient = Blobs::BlobClient(
-        _detail::GetBlobUrlFromUrl(destinationDfsUrl), m_pipeline, blobClientConfiguration);
+        _detail::GetBlobUrlFromUrl(destinationDfsUrl),
+        m_pipeline,
+        std::move(blobClientConfiguration));
     auto renamedFileClient = DataLakeFileClient(
         std::move(destinationDfsUrl),
         std::move(renamedBlobClient),
@@ -214,7 +216,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     blobClientConfiguration.DownloadValidationOptions = std::move(downloadValidationOptions);
 
     auto renamedBlobClient = Blobs::BlobClient(
-        _detail::GetBlobUrlFromUrl(destinationDfsUrl), m_pipeline, blobClientConfiguration);
+        _detail::GetBlobUrlFromUrl(destinationDfsUrl),
+        m_pipeline,
+        std::move(blobClientConfiguration));
     auto renamedDirectoryClient = DataLakeDirectoryClient(
         std::move(destinationDfsUrl),
         std::move(renamedBlobClient),

--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
+++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
@@ -408,7 +408,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     blobClientConfiguration.DownloadValidationOptions = std::move(downloadValidationOptions);
 
     auto renamedBlobClient = Blobs::BlobClient(
-        _detail::GetBlobUrlFromUrl(destinationDfsUrl), m_pipeline, blobClientConfiguration);
+        _detail::GetBlobUrlFromUrl(destinationDfsUrl),
+        m_pipeline,
+        std::move(blobClientConfiguration));
     auto renamedFileClient = DataLakeFileClient(
         std::move(destinationDfsUrl),
         std::move(renamedBlobClient),
@@ -480,7 +482,9 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
     blobClientConfiguration.DownloadValidationOptions = std::move(downloadValidationOptions);
 
     auto renamedBlobClient = Blobs::BlobClient(
-        _detail::GetBlobUrlFromUrl(destinationDfsUrl), m_pipeline, blobClientConfiguration);
+        _detail::GetBlobUrlFromUrl(destinationDfsUrl),
+        m_pipeline,
+        std::move(blobClientConfiguration));
     auto renamedDirectoryClient = DataLakeDirectoryClient(
         std::move(destinationDfsUrl),
         std::move(renamedBlobClient),


### PR DESCRIPTION
## Summary
- move temporary blob client configurations into renamed BlobClient instances
- remove the unused default configuration from the private BlobClient constructor

Follow-up to Copilot review comments on #7281.

## Testing
- built azure-storage-blobs and azure-storage-files-datalake (Release)