### PR TITLE
Restore durable AMQP test broker setup

### DIFF
--- a/sdk/core/azure-core-amqp/README.md
+++ b/sdk/core/azure-core-amqp/README.md
@@ -1,3 +1,4 @@
+<!-- cspell: ignore cfsclean -->
 # Azure SDK AMQP Library for C++
 
 Azure::Core::Amqp (`azure-core-amqp`) provides an implementation
@@ -126,4 +127,3 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 [c_compiler]: https://visualstudio.microsoft.com/vs/features/cplusplus/
 [cloud_shell]: https://learn.microsoft.com/azure/cloud-shell/overview
 [cloud_shell_bash]: https://shell.azure.com/bash
-

--- a/sdk/core/azure-core-amqp/README.md
+++ b/sdk/core/azure-core-amqp/README.md
@@ -76,6 +76,27 @@ while (messageSendCount < maxMessageSendCount)
 
 You can build and run the tests locally by executing `azure-core-amqp-test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+### Run broker-backed tests
+
+The Rust AMQP tests use the `TestAmqpBroker` from [Azure/azure-amqp][azure_amqp]. The setup script clones commit `239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a`, restores through its checked-in `nuget.cfsclean.config`, builds the `net10.0` target, and waits for the broker to accept TCP connections.
+
+Run the setup from the repository root before starting the tests:
+
+```powershell
+.\sdk\core\azure-core-amqp\Test-Setup.ps1
+```
+
+The default address is `amqp://127.0.0.1:25672`. Set `TEST_BROKER_ADDRESS` before running the script to use another local host or port.
+
+To validate a broker update manually, clone the new commit and run these commands from the clone root:
+
+```powershell
+dotnet restore .\test\TestAmqpBroker\TestAmqpBroker.csproj --configfile .\nuget.cfsclean.config
+dotnet build .\test\TestAmqpBroker\TestAmqpBroker.csproj --configuration Debug --framework net10.0 --no-restore
+```
+
+Update the commit in `Test-Setup.ps1` only after the restore, build, readiness check, and C++ AMQP tests pass. The pinned commit must contain `nuget.cfsclean.config`.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-cpp/issues/new).
@@ -97,6 +118,7 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 [azure_sdk_for_cpp_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests
 [azure_sdk_cpp_development_guidelines]: https://azure.github.io/azure-sdk/cpp_introduction.html
 [azure_cli]: https://learn.microsoft.com/cli/azure
+[azure_amqp]: https://github.com/Azure/azure-amqp
 [azure_pattern_circuit_breaker]: https://learn.microsoft.com/azure/architecture/patterns/circuit-breaker
 [azure_pattern_retry]: https://learn.microsoft.com/azure/architecture/patterns/retry
 [azure_portal]: https://portal.azure.com
@@ -104,5 +126,4 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 [c_compiler]: https://visualstudio.microsoft.com/vs/features/cplusplus/
 [cloud_shell]: https://learn.microsoft.com/azure/cloud-shell/overview
 [cloud_shell_bash]: https://shell.azure.com/bash
-
 

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -1,9 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-# cspell: ignore JOBID depsfile
+# cspell: ignore depsfile
 
-
-# Load common ES scripts
 . "$PSScriptRoot\..\..\..\eng\common\scripts\common.ps1"
 
 if ($IsMacOS) {
@@ -11,74 +9,249 @@ if ($IsMacOS) {
   exit 0
 }
 
-if ($true) {
-  Write-Host "Disabling AMQP Test Broker temporarily"
-  exit 0
+function Invoke-RequiredCommand {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $Description,
+
+    [Parameter(Mandatory = $true)]
+    [string] $FilePath,
+
+    [Parameter(Mandatory = $true)]
+    [string[]] $ArgumentList
+  )
+
+  Write-Host "> $FilePath $($ArgumentList -join ' ')"
+  & $FilePath @ArgumentList
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Description failed with exit code $LASTEXITCODE."
+  }
 }
 
-# Create the test binary *outside* the repo root to avoid polluting the repo.
-$WorkingDirectory = [System.IO.Path]::Combine($RepoRoot, "../TestArtifacts")
+function Write-BrokerLogs {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $StandardOutputPath,
 
-# Create the working directory if it does not exist.
-Write-Host "Using Working Directory $WorkingDirectory"
+    [Parameter(Mandatory = $true)]
+    [string] $StandardErrorPath
+  )
 
-if (-not (Test-Path $WorkingDirectory)) {
-  Write-Host "Working directory does not exist, creating working directory: $WorkingDirectory"
-  New-Item -ItemType Directory -Path $WorkingDirectory
+  foreach ($log in @(
+      @{ Name = "standard output"; Path = $StandardOutputPath },
+      @{ Name = "standard error"; Path = $StandardErrorPath }
+    )) {
+    Write-Host "Test broker $($log.Name):"
+    if (Test-Path $log.Path) {
+      $content = Get-Content -Path $log.Path -Raw
+      if ($content) {
+        Write-Host $content
+      }
+      else {
+        Write-Host "<empty>"
+      }
+    }
+    else {
+      Write-Host "<not created>"
+    }
+  }
 }
 
-Write-Host "Setting current directory to working directory: $WorkingDirectory"
-Push-Location -Path $WorkingDirectory
+function Test-TcpEndpoint {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $HostName,
 
-# Clone and build the Test Amqp Broker.
+    [Parameter(Mandatory = $true)]
+    [int] $Port,
+
+    [int] $TimeoutMilliseconds = 1000
+  )
+
+  $client = [System.Net.Sockets.TcpClient]::new()
+  try {
+    $connection = $client.ConnectAsync($HostName, $Port)
+    return $connection.Wait($TimeoutMilliseconds) -and $client.Connected
+  }
+  catch {
+    return $false
+  }
+  finally {
+    $client.Dispose()
+  }
+}
+
+function Wait-BrokerReady {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Diagnostics.Process] $Process,
+
+    [Parameter(Mandatory = $true)]
+    [System.Uri] $Address,
+
+    [int] $TimeoutSeconds = 30
+  )
+
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  while ((Get-Date) -lt $deadline) {
+    $Process.Refresh()
+    if ($Process.HasExited) {
+      throw "Test broker exited before becoming ready with exit code $($Process.ExitCode)."
+    }
+
+    if (Test-TcpEndpoint -HostName $Address.DnsSafeHost -Port $Address.Port) {
+      Write-Host "Test broker is accepting connections on $($Address.DnsSafeHost):$($Address.Port)."
+      return
+    }
+
+    Start-Sleep -Milliseconds 500
+  }
+
+  throw "Test broker did not accept connections on $($Address.DnsSafeHost):$($Address.Port) within $TimeoutSeconds seconds."
+}
+
+$WorkingDirectory = [System.IO.Path]::GetFullPath(
+  [System.IO.Path]::Combine($RepoRoot, "../TestArtifacts"))
+$repositoryDir = [System.IO.Path]::Combine($WorkingDirectory, "azure-amqp")
+$standardOutputPath = [System.IO.Path]::Combine($WorkingDirectory, "test-broker.log")
+$standardErrorPath = [System.IO.Path]::Combine($WorkingDirectory, "test-broker-error.log")
+$repositoryUrl = "https://github.com/Azure/azure-amqp.git"
+$repositoryHash = "239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a"
+
+$env:TEST_BROKER_ADDRESS = if ($env:TEST_BROKER_ADDRESS) {
+  $env:TEST_BROKER_ADDRESS
+}
+else {
+  "amqp://127.0.0.1:25672"
+}
+
+$brokerAddress = [System.Uri] $env:TEST_BROKER_ADDRESS
+if ($brokerAddress.Port -le 0) {
+  throw "TEST_BROKER_ADDRESS must include a valid port: $($env:TEST_BROKER_ADDRESS)"
+}
+
+Write-Host "Using working directory $WorkingDirectory"
+New-Item -ItemType Directory -Path $WorkingDirectory -Force | Out-Null
+
+if (Test-Path $repositoryDir) {
+  Write-Host "Removing previously cloned repository $repositoryDir"
+  Remove-Item $repositoryDir -Force -Recurse
+}
+Remove-Item $standardOutputPath, $standardErrorPath -Force -ErrorAction SilentlyContinue
+
+$process = $null
 try {
+  # AIDEV-NOTE: Keep the explicit fetch and checkout for agents whose Git does not support
+  # clone --revision.
+  Invoke-RequiredCommand `
+    -Description "Test broker clone" `
+    -FilePath "git" `
+    -ArgumentList @(
+      "clone",
+      "--no-checkout",
+      "--depth", "1",
+      $repositoryUrl,
+      $repositoryDir
+    )
 
-  $repositoryDir = [System.IO.Path]::Combine($WorkingDirectory, "azure-amqp")
-  if (Test-Path $repositoryDir) {
-    Write-Host "Removing previously cloned repository: $repositoryDir"
-    Remove-Item $repositoryDir -Force -Recurse | Out-Null
+  Invoke-RequiredCommand `
+    -Description "Test broker commit fetch" `
+    -FilePath "git" `
+    -ArgumentList @(
+      "-C", $repositoryDir,
+      "fetch",
+      "--depth", "1",
+      "origin",
+      $repositoryHash
+    )
+
+  Invoke-RequiredCommand `
+    -Description "Test broker commit checkout" `
+    -FilePath "git" `
+    -ArgumentList @(
+      "-C", $repositoryDir,
+      "checkout",
+      "--detach",
+      $repositoryHash
+    )
+
+  $actualHash = & git -C $repositoryDir rev-parse HEAD
+  $actualHash = "$actualHash".Trim()
+  if ($LASTEXITCODE -ne 0 -or $actualHash -ne $repositoryHash) {
+    throw "Test broker clone resolved to '$actualHash' instead of '$repositoryHash'."
   }
 
-  $repositoryUrl = "https://github.com/Azure/azure-amqp.git"
-  $repositoryHash = "111de654e170de3ab6cefe150043458c67b6660d"
-  $cloneCommand = "git clone $repositoryUrl --revision $repositoryHash --depth=1"
-  
-  Write-Host "Cloning repository from $repositoryUrl..."
-  Invoke-LoggedCommand $cloneCommand
+  Push-Location $repositoryDir
+  try {
+    Invoke-RequiredCommand `
+      -Description "Test broker restore" `
+      -FilePath "dotnet" `
+      -ArgumentList @(
+        "restore",
+        "./test/TestAmqpBroker/TestAmqpBroker.csproj",
+        "--configfile", "./nuget.cfsclean.config"
+      )
 
-  Set-Location -Path "./azure-amqp/test/TestAmqpBroker"
-
-  Invoke-LoggedCommand "dotnet build --framework net10.0"
-  if (-not $?) {
-    Write-Error "Failed to build TestAmqpBroker."
-    exit 1
+    Invoke-RequiredCommand `
+      -Description "Test broker build" `
+      -FilePath "dotnet" `
+      -ArgumentList @(
+        "build",
+        "./test/TestAmqpBroker/TestAmqpBroker.csproj",
+        "--configuration", "Debug",
+        "--framework", "net10.0",
+        "--no-restore"
+      )
+  }
+  finally {
+    Pop-Location
   }
 
-  Write-Host "Test broker built successfully."
+  $brokerDirectory = [System.IO.Path]::Combine(
+    $repositoryDir, "bin", "Debug", "TestAmqpBroker", "net10.0")
+  $brokerDll = [System.IO.Path]::Combine($brokerDirectory, "TestAmqpBroker.dll")
+  if (-not (Test-Path $brokerDll)) {
+    throw "Test broker build did not produce $brokerDll."
+  }
 
-  # now that the Test broker has been built, launch the broker on a local address.
-  $env:TEST_BROKER_ADDRESS = 'amqp://localhost:25672'
+  if (Test-TcpEndpoint -HostName $brokerAddress.DnsSafeHost -Port $brokerAddress.Port) {
+    throw "The test broker endpoint $($brokerAddress.DnsSafeHost):$($brokerAddress.Port) is already in use."
+  }
 
-  Write-Host "Starting test broker listening on ${env:TEST_BROKER_ADDRESS} ..."
-  
-  # Note that we cannot use `dotnet run -f` here because the TestAmqpBroker relies on args[0] being the broker address.
-  # If we use `dotnet run -f`, the first argument is the csproj file.
-  # Instead, we use `dotnet exec` to run the compiled DLL directly.
-  # This allows us to pass the broker address as the first argument.
-   Set-Location -Path $WorkingDirectory/azure-amqp/bin/Debug/TestAmqpBroker/net10.0
-  $process = Start-Process -FilePath "dotnet" -ArgumentList "exec", "./TestAmqpBroker.dll", "${env:TEST_BROKER_ADDRESS}", "/headless" -PassThru
+  Write-Host "Starting test broker on $($env:TEST_BROKER_ADDRESS)"
+  $process = Start-Process `
+    -FilePath "dotnet" `
+    -ArgumentList @(
+      "exec",
+      "./TestAmqpBroker.dll",
+      $env:TEST_BROKER_ADDRESS,
+      "/headless"
+    ) `
+    -WorkingDirectory $brokerDirectory `
+    -RedirectStandardOutput $standardOutputPath `
+    -RedirectStandardError $standardErrorPath `
+    -PassThru
+
+  if (-not $process) {
+    throw "Start-Process did not return a test broker process."
+  }
 
   $env:TEST_BROKER_JOBID = $process.Id
-
-  Write-Host "Waiting for test broker to start..."
-  Start-Sleep -Seconds 3
-
-  $process = Get-Process -Id $env:TEST_BROKER_JOBID -ErrorAction SilentlyContinue
-  if (-not $process -or $process.HasExited) {
-    Write-Host "Test broker failed to start."
-    exit 1
-  }
+  Write-Host "Test broker process ID: $($process.Id)"
+  Wait-BrokerReady -Process $process -Address $brokerAddress
 }
-finally {
-  Pop-Location
+catch {
+  Write-Error "Test broker setup failed: $_"
+  Write-BrokerLogs `
+    -StandardOutputPath $standardOutputPath `
+    -StandardErrorPath $standardErrorPath
+
+  if ($process) {
+    $process.Refresh()
+    if (-not $process.HasExited) {
+      Stop-Process -Id $process.Id -ErrorAction SilentlyContinue
+    }
+  }
+
+  throw
 }

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-# cspell: ignore depsfile
+# cspell: ignore AIDEV cfsclean depsfile
 
 . "$PSScriptRoot\..\..\..\eng\common\scripts\common.ps1"
 

--- a/sdk/core/azure-core-amqp/test/ut/claim_based_security_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/claim_based_security_tests.cpp
@@ -40,7 +40,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
       if (testBrokerUrl.empty())
       {
-        GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+        GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
       }
       GTEST_LOG_(INFO) << "Use broker address: " << testBrokerUrl;
       Azure::Core::Url brokerUrl(testBrokerUrl);

--- a/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
@@ -190,7 +190,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
     if (testBrokerUrl.empty())
     {
-      GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+      GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
     }
     Azure::Core::Url brokerUrl(testBrokerUrl);
     Azure::Core::Amqp::_internal::ConnectionOptions connectionOptions;

--- a/sdk/core/azure-core-amqp/test/ut/management_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/management_tests.cpp
@@ -37,7 +37,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
       if (testBrokerUrl.empty())
       {
-        GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+        GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
       }
       Azure::Core::Url brokerUrl(testBrokerUrl);
       m_brokerEndpoint = brokerUrl;

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -47,7 +47,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
       if (testBrokerUrl.empty())
       {
-        GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+        GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
       }
       Azure::Core::Url brokerUrl(testBrokerUrl);
       m_brokerEndpoint = brokerUrl;

--- a/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
@@ -56,7 +56,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
       if (testBrokerUrl.empty())
       {
-        GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+        GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
       }
       Azure::Core::Url brokerUrl(testBrokerUrl);
       m_brokerEndpoint = brokerUrl;

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -53,14 +53,14 @@ extends:
     CtestRegex: azure-core.|json-test
     LiveTestCtestRegex: azure-core.|json-test
     LiveTestTimeoutInMinutes: 90 # default is 60 min. We need a little longer on worst case for Win+jsonTests
-    LineCoverageTarget: 75
+    LineCoverageTarget: 81
     BranchCoverageTarget: 62
     PreTestSteps:
       - pwsh: |
           $(Build.SourcesDirectory)/sdk/core/azure-core-amqp/Test-Setup.ps1
         displayName: Test-Setup for azure-core-amqp
-    #          env:
-    #            TEST_BROKER_ADDRESS: "amqp://127.0.0.1:25672"
+        env:
+          TEST_BROKER_ADDRESS: "amqp://127.0.0.1:25672"
 
     #        - pwsh: |
     #            docker build -t squid-local $(Build.SourcesDirectory)/sdk/core/azure-core/test/ut/proxy_tests/localproxy
@@ -107,16 +107,16 @@ extends:
         VcpkgPortName: azure-core-amqp-cpp
 
     # Environment variables for Live tests.
-    # EnvVars:
+    EnvVars:
       # AMQP
-    #        TEST_BROKER_ADDRESS: "amqp://127.0.0.1:25672"
+      TEST_BROKER_ADDRESS: "amqp://127.0.0.1:25672"
 
     # Since Azure Core will run all service's tests, it requires all the expected env vars from services
     # Environment variables for CI tests.
     TestEnv:
       # AMQP
-      #      - Name: TEST_BROKER_ADDRESS
-      #        Value: "amqp://127.0.0.1:25672"
+      - Name: TEST_BROKER_ADDRESS
+        Value: "amqp://127.0.0.1:25672"
       - Name: RUST_BACKTRACE
         Value: "1"
       - Name: RUST_LOG


### PR DESCRIPTION
## Summary

Restores broker-backed `azure-core-amqp` tests after the temporary unblock in [PR 7270](https://github.com/Azure/azure-sdk-for-cpp/pull/7270). Pins `TestAmqpBroker` to commit `239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a` from [Azure/azure-amqp PR 318](https://github.com/Azure/azure-amqp/pull/318), then fails setup when the pinned broker cannot build, start, or accept connections.

## Motivation

[Work item 39130334](https://dev.azure.com/azure-sdk/_workitems/edit/39130334) requires a CFSClean broker build, executed C++ AMQP tests, a fixed broker SHA, and a failing pipeline when broker startup fails.

PR 7270 is merged into `main`. This PR targets `main` as a focused follow-up. Larry's branch is unchanged. The broker commit is currently the head of draft PR 318, and the C++ setup keeps the exact SHA explicit.

## Changes

- Restores `TestAmqpBroker` through its checked-in `nuget.cfsclean.config`, builds `net10.0` with `--no-restore`, captures process logs, and polls the configured TCP endpoint for readiness.
- Restores `TEST_BROKER_ADDRESS` through `TestEnv` and `EnvVars`, fatal missing-broker failures, and the prior 81 percent line coverage gate.
- Documents the broker pin and update validation process.

## Validation

- PowerShell parser and `git diff --check`
- `sdk/core/ci.yml` parsed with `powershell-yaml`
- Pinned broker restore, build, process launch, and readiness check
- Targeted `azure-core-amqp-tests` CMake build
- 146 of 146 `azure-core-amqp` CTest cases passed against the broker
- `TestConnections.ConnectionOpenClose` failed as expected without `TEST_BROKER_ADDRESS`