### PR TITLE
Restore durable AMQP test broker setup

### DIFF
--- a/sdk/core/azure-core-amqp/README.md
+++ b/sdk/core/azure-core-amqp/README.md
@@ -107,7 +107,7 @@ These environment variables change the setup:
 
 The setup script asks the GitHub compare API whether the pinned commit is reachable from `master`. When that request fails, for example because the anonymous rate limit of 60 requests per hour is exhausted, the script warns and continues. It continues even when `TEST_BROKER_REQUIRE_MERGED` is set, because a request that did not run says nothing about the pin.
 
-The current pin is `239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a`. That commit is the head of a pull request in Azure/azure-amqp, so it is not reachable from `master` and the setup script warns. Azure/azure-amqp squash-merges its pull requests, so the head commit of a pull request never lands on `master`. After that pull request merges, set the pin to its `merge_commit_sha`, which is the squash commit on `master`. Do not use the `merge_commit_sha` of an open pull request, because that commit is a temporary test merge.
+The current pin is `111de654e170de3ab6cefe150043458c67b6660d`, the head of `master` in Azure/azure-amqp. Set the pin to any commit that builds the broker. Azure/azure-amqp squash-merges its pull requests, so the commit that lands on `master` is the `merge_commit_sha` of a merged pull request and never the head commit of that pull request.
 
 To validate a broker update manually, clone the new commit and run these commands from the clone root:
 

--- a/sdk/core/azure-core-amqp/README.md
+++ b/sdk/core/azure-core-amqp/README.md
@@ -1,3 +1,4 @@
+<!-- cspell: ignore cfsclean -->
 # Azure SDK AMQP Library for C++
 
 Azure::Core::Amqp (`azure-core-amqp`) provides an implementation
@@ -126,4 +127,3 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 [c_compiler]: https://visualstudio.microsoft.com/vs/features/cplusplus/
 [cloud_shell]: https://learn.microsoft.com/azure/cloud-shell/overview
 [cloud_shell_bash]: https://shell.azure.com/bash
-

--- a/sdk/core/azure-core-amqp/README.md
+++ b/sdk/core/azure-core-amqp/README.md
@@ -76,6 +76,27 @@ while (messageSendCount < maxMessageSendCount)
 
 You can build and run the tests locally by executing `azure-core-amqp-test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+### Run broker-backed tests
+
+The Rust AMQP tests use the `TestAmqpBroker` from [Azure/azure-amqp][azure_amqp]. The setup script clones commit `239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a`, restores through its checked-in `nuget.cfsclean.config`, builds the `net10.0` target, and waits for the broker to accept TCP connections.
+
+Run the setup from the repository root before starting the tests:
+
+```powershell
+.\sdk\core\azure-core-amqp\Test-Setup.ps1
+```
+
+The default address is `amqp://127.0.0.1:25672`. Set `TEST_BROKER_ADDRESS` before running the script to use another local host or port.
+
+To validate a broker update manually, clone the new commit and run these commands from the clone root:
+
+```powershell
+dotnet restore .\test\TestAmqpBroker\TestAmqpBroker.csproj --configfile .\nuget.cfsclean.config
+dotnet build .\test\TestAmqpBroker\TestAmqpBroker.csproj --configuration Debug --framework net10.0 --no-restore
+```
+
+Update the commit in `Test-Setup.ps1` only after the restore, build, readiness check, and C++ AMQP tests pass. The pinned commit must contain `nuget.cfsclean.config`.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-cpp/issues/new).
@@ -97,6 +118,7 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 [azure_sdk_for_cpp_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests
 [azure_sdk_cpp_development_guidelines]: https://azure.github.io/azure-sdk/cpp_introduction.html
 [azure_cli]: https://learn.microsoft.com/cli/azure
+[azure_amqp]: https://github.com/Azure/azure-amqp
 [azure_pattern_circuit_breaker]: https://learn.microsoft.com/azure/architecture/patterns/circuit-breaker
 [azure_pattern_retry]: https://learn.microsoft.com/azure/architecture/patterns/retry
 [azure_portal]: https://portal.azure.com
@@ -104,5 +126,4 @@ Azure SDK for C++ is licensed under the [MIT](https://github.com/Azure/azure-sdk
 [c_compiler]: https://visualstudio.microsoft.com/vs/features/cplusplus/
 [cloud_shell]: https://learn.microsoft.com/azure/cloud-shell/overview
 [cloud_shell_bash]: https://shell.azure.com/bash
-
 

--- a/sdk/core/azure-core-amqp/README.md
+++ b/sdk/core/azure-core-amqp/README.md
@@ -79,7 +79,7 @@ You can build and run the tests locally by executing `azure-core-amqp-test`. Exp
 
 ### Run broker-backed tests
 
-Some tests in this package need a live AMQP broker. They use the `TestAmqpBroker` from [Azure/azure-amqp][azure_amqp]. The default build sets `USE_RUST_AMQP`, so these tests exercise the Rust AMQP stack. The setup script clones the commit that `Test-Setup.ps1` pins, restores through the clone's checked-in `nuget.cfsclean.config`, builds the `net10.0` target, and waits for the broker to accept TCP connections.
+Some tests in this package need a live AMQP broker. They use the `TestAmqpBroker` from [Azure/azure-amqp][azure_amqp]. The default build sets `USE_RUST_AMQP`, so these tests exercise the Rust AMQP stack. The setup script clones the commit that `Test-Setup.ps1` pins, restores through the `nuget.cfsclean.config` in this directory, builds the `net10.0` target, and waits for the broker to accept TCP connections.
 
 Run the setup from the repository root before starting the tests:
 
@@ -112,11 +112,11 @@ The current pin is `111de654e170de3ab6cefe150043458c67b6660d`, the head of `mast
 To validate a broker update manually, clone the new commit and run these commands from the clone root:
 
 ```powershell
-dotnet restore .\test\TestAmqpBroker\TestAmqpBroker.csproj --configfile .\nuget.cfsclean.config
+dotnet restore .\test\TestAmqpBroker\TestAmqpBroker.csproj --configfile <this directory>\nuget.cfsclean.config
 dotnet build .\test\TestAmqpBroker\TestAmqpBroker.csproj --configuration Debug --framework net10.0 --no-restore
 ```
 
-Update the commit in `Test-Setup.ps1` and in this file only after the restore, build, readiness check, and C++ AMQP tests pass. The pinned commit must contain `nuget.cfsclean.config`. Prefer a commit that is reachable from `master`.
+Update the commit in `Test-Setup.ps1` and in this file only after the restore, build, readiness check, and C++ AMQP tests pass. Any commit that builds the broker works, because the restore configuration lives in this repository and not in the clone. Prefer a commit that is reachable from `master`.
 
 ## Troubleshooting
 

--- a/sdk/core/azure-core-amqp/README.md
+++ b/sdk/core/azure-core-amqp/README.md
@@ -79,7 +79,7 @@ You can build and run the tests locally by executing `azure-core-amqp-test`. Exp
 
 ### Run broker-backed tests
 
-The Rust AMQP tests use the `TestAmqpBroker` from [Azure/azure-amqp][azure_amqp]. The setup script clones commit `239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a`, restores through its checked-in `nuget.cfsclean.config`, builds the `net10.0` target, and waits for the broker to accept TCP connections.
+Some tests in this package need a live AMQP broker. They use the `TestAmqpBroker` from [Azure/azure-amqp][azure_amqp]. The default build sets `USE_RUST_AMQP`, so these tests exercise the Rust AMQP stack. The setup script clones the commit that `Test-Setup.ps1` pins, restores through the clone's checked-in `nuget.cfsclean.config`, builds the `net10.0` target, and waits for the broker to accept TCP connections.
 
 Run the setup from the repository root before starting the tests:
 
@@ -87,7 +87,27 @@ Run the setup from the repository root before starting the tests:
 .\sdk\core\azure-core-amqp\Test-Setup.ps1
 ```
 
-The default address is `amqp://127.0.0.1:25672`. Set `TEST_BROKER_ADDRESS` before running the script to use another local host or port.
+Stop the broker when the tests finish:
+
+```powershell
+.\sdk\core\azure-core-amqp\Test-Cleanup.ps1
+```
+
+`Test-Setup.ps1` writes the broker process ID to `TestArtifacts\test-broker.pid`, next to the broker logs. `Test-Cleanup.ps1` reads that file to stop the right process. The cleanup script reports success when the broker has already exited.
+
+The default address is `amqp://127.0.0.1:25672`. Set `TEST_BROKER_ADDRESS` before running the script to use another local host or port. When another process already holds that port, the setup script keeps that process and runs the tests against it.
+
+These environment variables change the setup:
+
+| Variable | Effect |
+| --- | --- |
+| `TEST_BROKER_ADDRESS` | Sets the broker address. The default is `amqp://127.0.0.1:25672`. |
+| `TEST_BROKER_COMMIT` | Overrides the pinned broker commit. The value must be a full 40 character commit SHA. |
+| `TEST_BROKER_REQUIRE_MERGED` | Turns the pin reachability warning into an error. Set this to make the run fail when the pinned commit is not reachable from `master` in Azure/azure-amqp. |
+
+The setup script asks the GitHub compare API whether the pinned commit is reachable from `master`. When that request fails, for example because the anonymous rate limit of 60 requests per hour is exhausted, the script warns and continues. It continues even when `TEST_BROKER_REQUIRE_MERGED` is set, because a request that did not run says nothing about the pin.
+
+The current pin is `239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a`. That commit is the head of a pull request in Azure/azure-amqp, so it is not reachable from `master` and the setup script warns. Azure/azure-amqp squash-merges its pull requests, so the head commit of a pull request never lands on `master`. After that pull request merges, set the pin to its `merge_commit_sha`, which is the squash commit on `master`. Do not use the `merge_commit_sha` of an open pull request, because that commit is a temporary test merge.
 
 To validate a broker update manually, clone the new commit and run these commands from the clone root:
 
@@ -96,7 +116,7 @@ dotnet restore .\test\TestAmqpBroker\TestAmqpBroker.csproj --configfile .\nuget.
 dotnet build .\test\TestAmqpBroker\TestAmqpBroker.csproj --configuration Debug --framework net10.0 --no-restore
 ```
 
-Update the commit in `Test-Setup.ps1` only after the restore, build, readiness check, and C++ AMQP tests pass. The pinned commit must contain `nuget.cfsclean.config`.
+Update the commit in `Test-Setup.ps1` and in this file only after the restore, build, readiness check, and C++ AMQP tests pass. The pinned commit must contain `nuget.cfsclean.config`. Prefer a commit that is reachable from `master`.
 
 ## Troubleshooting
 

--- a/sdk/core/azure-core-amqp/Test-Broker-Common.ps1
+++ b/sdk/core/azure-core-amqp/Test-Broker-Common.ps1
@@ -71,13 +71,25 @@ function Stop-TestBroker {
     return
   }
 
-  $recordedId = (Get-Content -Path $ProcessIdPath -Raw).Trim()
+  # The file holds the process ID on the first line, and the start time in ticks on the second.
+  # Older files hold the ID alone, and those still work with the name check below.
+  $recorded = @(Get-Content -Path $ProcessIdPath -ErrorAction SilentlyContinue)
   Remove-Item $ProcessIdPath -Force -ErrorAction SilentlyContinue
 
   $processId = 0
-  if (-not [int]::TryParse($recordedId, [ref] $processId) -or $processId -le 0) {
-    Write-Host "The test broker process ID file held '$recordedId', which is not a process ID."
+  if ($recorded.Count -lt 1 -or
+    -not [int]::TryParse(("" + $recorded[0]).Trim(), [ref] $processId) -or
+    $processId -le 0) {
+    Write-Host "The test broker process ID file did not hold a process ID."
     return
+  }
+
+  $recordedTicks = $null
+  if ($recorded.Count -ge 2) {
+    $parsedTicks = [long] 0
+    if ([long]::TryParse(("" + $recorded[1]).Trim(), [ref] $parsedTicks)) {
+      $recordedTicks = $parsedTicks
+    }
   }
 
   $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
@@ -92,6 +104,23 @@ function Stop-TestBroker {
     Write-Host ("Process $processId is '$($process.ProcessName)', not the test broker. " +
       "This script leaves it alone.")
     return
+  }
+
+  # A recycled process ID can belong to another dotnet process. Compare the start time, which
+  # makes the pair unique. A start time that cannot be read falls back to the name check above,
+  # because a broker that keeps running holds the port and breaks every later run.
+  if ($null -ne $recordedTicks) {
+    $actualTicks = $null
+    try { $actualTicks = $process.StartTime.Ticks } catch { $actualTicks = $null }
+
+    if ($null -eq $actualTicks) {
+      Write-Host "The start time of process $processId is not readable. Stopping it on the name alone."
+    }
+    elseif ($actualTicks -ne $recordedTicks) {
+      Write-Host ("Process $processId started at a different time than the recorded broker, so " +
+        "the operating system gave this ID to another process. This script leaves it alone.")
+      return
+    }
   }
 
   Write-Host "Stopping test broker process $processId."

--- a/sdk/core/azure-core-amqp/Test-Broker-Common.ps1
+++ b/sdk/core/azure-core-amqp/Test-Broker-Common.ps1
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Shared state for the AMQP test broker.
+#
+# Test-Setup.ps1 starts the broker and writes its process ID to a file. Test-Cleanup.ps1
+# reads that file and stops the process. The two scripts run in separate pwsh steps, so an
+# environment variable does not carry the process ID between them. A file in the working
+# directory does, and it also works for a developer who runs the scripts by hand.
+#
+# Both scripts must agree on these paths, so the paths live here.
+
+function Get-TestBrokerPaths {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $RepositoryRoot
+  )
+
+  $workingDirectory = [System.IO.Path]::GetFullPath(
+    [System.IO.Path]::Combine($RepositoryRoot, "../TestArtifacts"))
+
+  return [pscustomobject]@{
+    WorkingDirectory   = $workingDirectory
+    RepositoryDir      = [System.IO.Path]::Combine($workingDirectory, "azure-amqp")
+    StandardOutputPath = [System.IO.Path]::Combine($workingDirectory, "test-broker.log")
+    StandardErrorPath  = [System.IO.Path]::Combine($workingDirectory, "test-broker-error.log")
+    ProcessIdPath      = [System.IO.Path]::Combine($workingDirectory, "test-broker.pid")
+  }
+}
+
+function Write-BrokerLogs {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $StandardOutputPath,
+
+    [Parameter(Mandatory = $true)]
+    [string] $StandardErrorPath
+  )
+
+  foreach ($log in @(
+      @{ Name = "standard output"; Path = $StandardOutputPath },
+      @{ Name = "standard error"; Path = $StandardErrorPath }
+    )) {
+    Write-Host "Test broker $($log.Name):"
+    if (Test-Path $log.Path) {
+      $content = Get-Content -Path $log.Path -Raw
+      if ($content) {
+        Write-Host $content
+      }
+      else {
+        Write-Host "<empty>"
+      }
+    }
+    else {
+      Write-Host "<not created>"
+    }
+  }
+}
+
+function Stop-TestBroker {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $ProcessIdPath
+  )
+
+  # This function must be idempotent and must never throw. Test-Setup.ps1 calls it to clear a
+  # broker that an earlier run left behind, and Test-Cleanup.ps1 calls it after the tests. A
+  # broker that already exited is a normal state, not an error.
+  if (-not (Test-Path $ProcessIdPath)) {
+    Write-Host "No test broker process ID file at $ProcessIdPath. There is nothing to stop."
+    return
+  }
+
+  $recordedId = (Get-Content -Path $ProcessIdPath -Raw).Trim()
+  Remove-Item $ProcessIdPath -Force -ErrorAction SilentlyContinue
+
+  $processId = 0
+  if (-not [int]::TryParse($recordedId, [ref] $processId) -or $processId -le 0) {
+    Write-Host "The test broker process ID file held '$recordedId', which is not a process ID."
+    return
+  }
+
+  $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+  if (-not $process) {
+    Write-Host "Test broker process $processId already exited."
+    return
+  }
+
+  # The operating system reuses process IDs. Make sure that this process is still the broker
+  # before you stop it. Test-Setup.ps1 starts the broker with the dotnet host.
+  if ($process.ProcessName -ne "dotnet") {
+    Write-Host ("Process $processId is '$($process.ProcessName)', not the test broker. " +
+      "This script leaves it alone.")
+    return
+  }
+
+  Write-Host "Stopping test broker process $processId."
+  Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
+  if ($process.WaitForExit(10000)) {
+    Write-Host "Test broker stopped."
+  }
+  else {
+    Write-Host "Test broker process $processId did not exit within 10 seconds."
+  }
+}

--- a/sdk/core/azure-core-amqp/Test-Cleanup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Cleanup.ps1
@@ -1,21 +1,21 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-# cspell: ignore JOBID
 
 . "$PSScriptRoot\..\..\..\eng\common\scripts\common.ps1"
+. "$PSScriptRoot\Test-Broker-Common.ps1"
 
-Write-Host "Test Broker output:"
-Receive-Job -Id $env:TEST_BROKER_JOBID
-
-# Check if the test broker job is still running
-$job = Get-Job -Id $env:TEST_BROKER_JOBID
-if ($job.State -ne "Running") {
-  Write-Host "Test broker terminated unexpectedly."
-  exit 1
+if ($IsMacOS) {
+  Write-Host "AMQP tests are not supported on macOS. Skipping test cleanup."
+  exit 0
 }
 
-# Stop the test broker job started in Test-Setup.ps1
-Write-Host "Stopping test broker"
-Stop-Job -Id $env:TEST_BROKER_JOBID
-Remove-Job -Id $env:TEST_BROKER_JOBID
-Write-Host "Test broker stopped."
+$paths = Get-TestBrokerPaths -RepositoryRoot $RepoRoot
+
+Write-BrokerLogs `
+  -StandardOutputPath $paths.StandardOutputPath `
+  -StandardErrorPath $paths.StandardErrorPath
+
+# This step runs after the tests, and it runs even when the tests fail. It must not turn a
+# test failure into a cleanup failure, so it always reports success.
+Stop-TestBroker -ProcessIdPath $paths.ProcessIdPath
+exit 0

--- a/sdk/core/azure-core-amqp/Test-Cleanup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Cleanup.ps1
@@ -11,11 +11,13 @@ if ($IsMacOS) {
 
 $paths = Get-TestBrokerPaths -RepositoryRoot $RepoRoot
 
+# Stop the broker first. It holds the log files open while it runs, and a read of an open file
+# can fail on Windows. This step also runs after the tests, and it runs even when the tests
+# fail, so it must not turn a test failure into a cleanup failure. It always reports success.
+Stop-TestBroker -ProcessIdPath $paths.ProcessIdPath
+
 Write-BrokerLogs `
   -StandardOutputPath $paths.StandardOutputPath `
   -StandardErrorPath $paths.StandardErrorPath
 
-# This step runs after the tests, and it runs even when the tests fail. It must not turn a
-# test failure into a cleanup failure, so it always reports success.
-Stop-TestBroker -ProcessIdPath $paths.ProcessIdPath
 exit 0

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -161,8 +161,8 @@ $repositoryBranch = "master"
 # A tag is not a safe substitute, because azure-amqp uses lightweight tags that a maintainer
 # can move.
 #
-# This SHA comes from refs/pull/318/head of Azure/azure-amqp. It is not on master yet, and
-# that is intentional for now. The reachability test below reports this as a warning.
+# This SHA is the head of master in Azure/azure-amqp. The reachability test below stays
+# quiet while the pin sits on master.
 #
 # To update the pin:
 #   1. Pick the new commit from Azure/azure-amqp. Prefer a commit on master.
@@ -174,7 +174,7 @@ $repositoryBranch = "master"
 #   5. Replace the SHA below with the full 40 character SHA, and update README.md.
 #
 # Set TEST_BROKER_COMMIT to point a pipeline at a different broker commit without a code change.
-$defaultRepositoryHash = "239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a"
+$defaultRepositoryHash = "111de654e170de3ab6cefe150043458c67b6660d"
 
 $repositoryHash = if ($env:TEST_BROKER_COMMIT) {
   $env:TEST_BROKER_COMMIT.Trim().ToLowerInvariant()

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -301,6 +301,14 @@ try {
     }
   }
 
+  # The restore config belongs to this repository, and not to the broker clone. The restricted
+  # feed policy is this pipeline's requirement, so the file that satisfies it sits next to this
+  # script. Pass an absolute path, because the dotnet calls run from the clone root.
+  $nugetConfig = [System.IO.Path]::Combine($PSScriptRoot, "nuget.cfsclean.config")
+  if (-not (Test-Path $nugetConfig)) {
+    throw "This repository does not contain $nugetConfig."
+  }
+
   # Push-Location is load-bearing. The dotnet calls below must run from the clone root, because
   # the clone root holds the global.json that selects the .NET SDK, and because the paths below
   # are relative to it. Do not replace these paths with absolute paths and drop the location
@@ -317,7 +325,7 @@ try {
       -ArgumentList @(
         "restore",
         "./test/TestAmqpBroker/TestAmqpBroker.csproj",
-        "--configfile", "./nuget.cfsclean.config"
+        "--configfile", $nugetConfig
       )
 
     Invoke-RequiredCommand `

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -1,9 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-# cspell: ignore JOBID depsfile
+# cspell: ignore depsfile
 
-
-# Load common ES scripts
 . "$PSScriptRoot\..\..\..\eng\common\scripts\common.ps1"
 
 if ($IsMacOS) {
@@ -11,74 +9,249 @@ if ($IsMacOS) {
   exit 0
 }
 
-if ($true) {
-  Write-Host "Disabling AMQP Test Broker temporarily"
-  exit 0
+function Invoke-RequiredCommand {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $Description,
+
+    [Parameter(Mandatory = $true)]
+    [string] $FilePath,
+
+    [Parameter(Mandatory = $true)]
+    [string[]] $ArgumentList
+  )
+
+  Write-Host "> $FilePath $($ArgumentList -join ' ')"
+  & $FilePath @ArgumentList
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Description failed with exit code $LASTEXITCODE."
+  }
 }
 
-# Create the test binary *outside* the repo root to avoid polluting the repo.
-$WorkingDirectory = [System.IO.Path]::Combine($RepoRoot, "../TestArtifacts")
+function Write-BrokerLogs {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $StandardOutputPath,
 
-# Create the working directory if it does not exist.
-Write-Host "Using Working Directory $WorkingDirectory"
+    [Parameter(Mandatory = $true)]
+    [string] $StandardErrorPath
+  )
 
-if (-not (Test-Path $WorkingDirectory)) {
-  Write-Host "Working directory does not exist, creating working directory: $WorkingDirectory"
-  New-Item -ItemType Directory -Path $WorkingDirectory
+  foreach ($log in @(
+      @{ Name = "standard output"; Path = $StandardOutputPath },
+      @{ Name = "standard error"; Path = $StandardErrorPath }
+    )) {
+    Write-Host "Test broker $($log.Name):"
+    if (Test-Path $log.Path) {
+      $content = Get-Content -Path $log.Path -Raw
+      if ($content) {
+        Write-Host $content
+      }
+      else {
+        Write-Host "<empty>"
+      }
+    }
+    else {
+      Write-Host "<not created>"
+    }
+  }
 }
 
-Write-Host "Setting current directory to working directory: $WorkingDirectory"
-Push-Location -Path $WorkingDirectory
+function Test-TcpEndpoint {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $HostName,
 
-# Clone and build the Test Amqp Broker.
+    [Parameter(Mandatory = $true)]
+    [int] $Port,
+
+    [int] $TimeoutMilliseconds = 1000
+  )
+
+  $client = [System.Net.Sockets.TcpClient]::new()
+  try {
+    $connection = $client.ConnectAsync($HostName, $Port)
+    return $connection.Wait($TimeoutMilliseconds) -and $client.Connected
+  }
+  catch {
+    return $false
+  }
+  finally {
+    $client.Dispose()
+  }
+}
+
+function Wait-BrokerReady {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Diagnostics.Process] $Process,
+
+    [Parameter(Mandatory = $true)]
+    [System.Uri] $Address,
+
+    [int] $TimeoutSeconds = 30
+  )
+
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  while ((Get-Date) -lt $deadline) {
+    $Process.Refresh()
+    if ($Process.HasExited) {
+      throw "Test broker exited before becoming ready with exit code $($Process.ExitCode)."
+    }
+
+    if (Test-TcpEndpoint -HostName $Address.DnsSafeHost -Port $Address.Port) {
+      Write-Host "Test broker is accepting connections on $($Address.DnsSafeHost):$($Address.Port)."
+      return
+    }
+
+    Start-Sleep -Milliseconds 500
+  }
+
+  throw "Test broker did not accept connections on $($Address.DnsSafeHost):$($Address.Port) within $TimeoutSeconds seconds."
+}
+
+$WorkingDirectory = [System.IO.Path]::GetFullPath(
+  [System.IO.Path]::Combine($RepoRoot, "../TestArtifacts"))
+$repositoryDir = [System.IO.Path]::Combine($WorkingDirectory, "azure-amqp")
+$standardOutputPath = [System.IO.Path]::Combine($WorkingDirectory, "test-broker.log")
+$standardErrorPath = [System.IO.Path]::Combine($WorkingDirectory, "test-broker-error.log")
+$repositoryUrl = "https://github.com/Azure/azure-amqp.git"
+$repositoryHash = "239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a"
+
+$env:TEST_BROKER_ADDRESS = if ($env:TEST_BROKER_ADDRESS) {
+  $env:TEST_BROKER_ADDRESS
+}
+else {
+  "amqp://127.0.0.1:25672"
+}
+
+$brokerAddress = [System.Uri] $env:TEST_BROKER_ADDRESS
+if ($brokerAddress.Port -le 0) {
+  throw "TEST_BROKER_ADDRESS must include a valid port: $($env:TEST_BROKER_ADDRESS)"
+}
+
+Write-Host "Using working directory $WorkingDirectory"
+New-Item -ItemType Directory -Path $WorkingDirectory -Force | Out-Null
+
+if (Test-Path $repositoryDir) {
+  Write-Host "Removing previously cloned repository $repositoryDir"
+  Remove-Item $repositoryDir -Force -Recurse
+}
+Remove-Item $standardOutputPath, $standardErrorPath -Force -ErrorAction SilentlyContinue
+
+$process = $null
 try {
+  # AIDEV-NOTE: Keep the explicit fetch and checkout for agents whose Git does not support
+  # clone --revision.
+  Invoke-RequiredCommand `
+    -Description "Test broker clone" `
+    -FilePath "git" `
+    -ArgumentList @(
+      "clone",
+      "--no-checkout",
+      "--depth", "1",
+      $repositoryUrl,
+      $repositoryDir
+    )
 
-  $repositoryDir = [System.IO.Path]::Combine($WorkingDirectory, "azure-amqp")
-  if (Test-Path $repositoryDir) {
-    Write-Host "Removing previously cloned repository: $repositoryDir"
-    Remove-Item $repositoryDir -Force -Recurse | Out-Null
+  Invoke-RequiredCommand `
+    -Description "Test broker commit fetch" `
+    -FilePath "git" `
+    -ArgumentList @(
+      "-C", $repositoryDir,
+      "fetch",
+      "--depth", "1",
+      "origin",
+      $repositoryHash
+    )
+
+  Invoke-RequiredCommand `
+    -Description "Test broker commit checkout" `
+    -FilePath "git" `
+    -ArgumentList @(
+      "-C", $repositoryDir,
+      "checkout",
+      "--detach",
+      $repositoryHash
+    )
+
+  $actualHash = & git -C $repositoryDir rev-parse HEAD
+  $actualHash = "$actualHash".Trim()
+  if ($LASTEXITCODE -ne 0 -or $actualHash -ne $repositoryHash) {
+    throw "Test broker clone resolved to '$actualHash' instead of '$repositoryHash'."
   }
 
-  $repositoryUrl = "https://github.com/Azure/azure-amqp.git"
-  $repositoryHash = "111de654e170de3ab6cefe150043458c67b6660d"
-  $cloneCommand = "git clone $repositoryUrl --revision $repositoryHash --depth=1"
-  
-  Write-Host "Cloning repository from $repositoryUrl..."
-  Invoke-LoggedCommand $cloneCommand
+  Push-Location $repositoryDir
+  try {
+    Invoke-RequiredCommand `
+      -Description "Test broker restore" `
+      -FilePath "dotnet" `
+      -ArgumentList @(
+        "restore",
+        "./test/TestAmqpBroker/TestAmqpBroker.csproj",
+        "--configfile", "./nuget.cfsclean.config"
+      )
 
-  Set-Location -Path "./azure-amqp/test/TestAmqpBroker"
-
-  Invoke-LoggedCommand "dotnet build --framework net10.0"
-  if (-not $?) {
-    Write-Error "Failed to build TestAmqpBroker."
-    exit 1
+    Invoke-RequiredCommand `
+      -Description "Test broker build" `
+      -FilePath "dotnet" `
+      -ArgumentList @(
+        "build",
+        "./test/TestAmqpBroker/TestAmqpBroker.csproj",
+        "--configuration", "Debug",
+        "--framework", "net10.0",
+        "--no-restore"
+      )
+  }
+  finally {
+    Pop-Location
   }
 
-  Write-Host "Test broker built successfully."
+  $brokerDirectory = [System.IO.Path]::Combine(
+    $repositoryDir, "bin", "Debug", "TestAmqpBroker", "net10.0")
+  $brokerDll = [System.IO.Path]::Combine($brokerDirectory, "TestAmqpBroker.dll")
+  if (-not (Test-Path $brokerDll)) {
+    throw "Test broker build did not produce $brokerDll."
+  }
 
-  # now that the Test broker has been built, launch the broker on a local address.
-  $env:TEST_BROKER_ADDRESS = 'amqp://localhost:25672'
+  if (Test-TcpEndpoint -HostName $brokerAddress.DnsSafeHost -Port $brokerAddress.Port) {
+    throw "The test broker endpoint $($brokerAddress.DnsSafeHost):$($brokerAddress.Port) is already in use."
+  }
 
-  Write-Host "Starting test broker listening on ${env:TEST_BROKER_ADDRESS} ..."
-  
-  # Note that we cannot use `dotnet run -f` here because the TestAmqpBroker relies on args[0] being the broker address.
-  # If we use `dotnet run -f`, the first argument is the csproj file.
-  # Instead, we use `dotnet exec` to run the compiled DLL directly.
-  # This allows us to pass the broker address as the first argument.
-   Set-Location -Path $WorkingDirectory/azure-amqp/bin/Debug/TestAmqpBroker/net10.0
-  $process = Start-Process -FilePath "dotnet" -ArgumentList "exec", "./TestAmqpBroker.dll", "${env:TEST_BROKER_ADDRESS}", "/headless" -PassThru
+  Write-Host "Starting test broker on $($env:TEST_BROKER_ADDRESS)"
+  $process = Start-Process `
+    -FilePath "dotnet" `
+    -ArgumentList @(
+      "exec",
+      "./TestAmqpBroker.dll",
+      $env:TEST_BROKER_ADDRESS,
+      "/headless"
+    ) `
+    -WorkingDirectory $brokerDirectory `
+    -RedirectStandardOutput $standardOutputPath `
+    -RedirectStandardError $standardErrorPath `
+    -PassThru
+
+  if (-not $process) {
+    throw "Start-Process did not return a test broker process."
+  }
 
   $env:TEST_BROKER_JOBID = $process.Id
-
-  Write-Host "Waiting for test broker to start..."
-  Start-Sleep -Seconds 3
-
-  $process = Get-Process -Id $env:TEST_BROKER_JOBID -ErrorAction SilentlyContinue
-  if (-not $process -or $process.HasExited) {
-    Write-Host "Test broker failed to start."
-    exit 1
-  }
+  Write-Host "Test broker process ID: $($process.Id)"
+  Wait-BrokerReady -Process $process -Address $brokerAddress
 }
-finally {
-  Pop-Location
+catch {
+  Write-Error "Test broker setup failed: $_"
+  Write-BrokerLogs `
+    -StandardOutputPath $standardOutputPath `
+    -StandardErrorPath $standardErrorPath
+
+  if ($process) {
+    $process.Refresh()
+    if (-not $process.HasExited) {
+      Stop-Process -Id $process.Id -ErrorAction SilentlyContinue
+    }
+  }
+
+  throw
 }

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -170,8 +170,10 @@ $repositoryBranch = "master"
 #      merged pull request, not the head commit of that pull request.
 #   2. Run the manual restore and build steps in README.md against that commit.
 #   3. Run the C++ AMQP tests against the broker that the commit builds.
-#   4. Make sure that the commit contains nuget.cfsclean.config.
-#   5. Replace the SHA below with the full 40 character SHA, and update README.md.
+#   4. Replace the SHA below with the full 40 character SHA, and update README.md.
+#
+# The commit does not need to carry a restore configuration. This repository owns that file,
+# and the restore names it by an absolute path.
 #
 # Set TEST_BROKER_COMMIT to point a pipeline at a different broker commit without a code change.
 $defaultRepositoryHash = "111de654e170de3ab6cefe150043458c67b6660d"
@@ -380,9 +382,11 @@ try {
     throw "Start-Process did not return a test broker process."
   }
 
-  # Record the process ID for Test-Cleanup.ps1. That script runs in a separate pwsh step, so an
-  # environment variable set here does not reach it.
-  Set-Content -Path $processIdPath -Value $process.Id -NoNewline
+  # Record the process ID and the start time for Test-Cleanup.ps1. That script runs in a
+  # separate pwsh step, so an environment variable set here does not reach it. The operating
+  # system reuses process IDs, and the pair of ID and start time identifies one process, so the
+  # cleanup can tell this broker apart from a later process that inherited the same ID.
+  Set-Content -Path $processIdPath -Value @($process.Id, $process.StartTime.Ticks)
   Write-Host "Test broker process ID: $($process.Id) (recorded in $processIdPath)"
   Wait-BrokerReady -Process $process -Address $brokerAddress
 }

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-# cspell: ignore depsfile
+# cspell: ignore AIDEV cfsclean depsfile
 
 . "$PSScriptRoot\..\..\..\eng\common\scripts\common.ps1"
 

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -71,13 +71,23 @@ function Test-BrokerPinReachable {
     return "unknown"
   }
 
+  # Test the raw field for absence FIRST. `$null -as [int]` gives 0, not $null, so a coercion
+  # on its own would turn a missing field into 0 and read as "reachable".
   if ($null -eq $comparison -or $null -eq $comparison.ahead_by) {
     Write-Host "The compare answer held no ahead_by field."
     return "unknown"
   }
 
-  Write-Host "Compare answer: status=$($comparison.status) ahead_by=$($comparison.ahead_by)"
-  if ($comparison.ahead_by -eq 0) {
+  # Then coerce. A non-numeric ahead_by must count as "the test did not run", and must not
+  # read as "not reachable" and fail a build.
+  $aheadBy = $comparison.ahead_by -as [int]
+  if ($null -eq $aheadBy) {
+    Write-Host "The compare answer held a non-numeric ahead_by field."
+    return "unknown"
+  }
+
+  Write-Host "Compare answer: status=$($comparison.status) ahead_by=$aheadBy"
+  if ($aheadBy -eq 0) {
     return "reachable"
   }
 
@@ -369,11 +379,11 @@ try {
   Wait-BrokerReady -Process $process -Address $brokerAddress
 }
 catch {
-  Write-Error "Test broker setup failed: $_"
-  Write-BrokerLogs `
-    -StandardOutputPath $standardOutputPath `
-    -StandardErrorPath $standardErrorPath
-
+  # Stop the broker and drop its record BEFORE anything that can terminate this block. The
+  # pipeline pwsh task sets $ErrorActionPreference to "stop", which makes Write-Error a
+  # terminating error, so a Write-Error here would skip every line after it and leave a broker
+  # running that no later step can find. `throw` at the end reports the original error, so no
+  # Write-Error is needed.
   if ($process) {
     $process.Refresh()
     if (-not $process.HasExited) {
@@ -384,6 +394,11 @@ catch {
   # This run owns no broker now, so the record must go. Otherwise Test-Cleanup.ps1 or the next
   # run reads a stale process ID.
   Remove-Item $processIdPath -Force -ErrorAction SilentlyContinue
+
+  # Read the logs after the stop, so the broker no longer holds the files open.
+  Write-BrokerLogs `
+    -StandardOutputPath $standardOutputPath `
+    -StandardErrorPath $standardErrorPath
 
   throw
 }

--- a/sdk/core/azure-core-amqp/Test-Setup.ps1
+++ b/sdk/core/azure-core-amqp/Test-Setup.ps1
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-# cspell: ignore AIDEV cfsclean depsfile
+# cspell: ignore cfsclean NETSDK
 
 . "$PSScriptRoot\..\..\..\eng\common\scripts\common.ps1"
+. "$PSScriptRoot\Test-Broker-Common.ps1"
 
 if ($IsMacOS) {
   Write-Host "AMQP tests are not supported on macOS. Skipping test setup."
@@ -28,33 +29,59 @@ function Invoke-RequiredCommand {
   }
 }
 
-function Write-BrokerLogs {
+function Test-BrokerPinReachable {
   param(
     [Parameter(Mandatory = $true)]
-    [string] $StandardOutputPath,
+    [string] $RepositorySlug,
 
     [Parameter(Mandatory = $true)]
-    [string] $StandardErrorPath
+    [string] $CommitHash,
+
+    [Parameter(Mandatory = $true)]
+    [string] $BranchName,
+
+    [int] $TimeoutSeconds = 15
   )
 
-  foreach ($log in @(
-      @{ Name = "standard output"; Path = $StandardOutputPath },
-      @{ Name = "standard error"; Path = $StandardErrorPath }
-    )) {
-    Write-Host "Test broker $($log.Name):"
-    if (Test-Path $log.Path) {
-      $content = Get-Content -Path $log.Path -Raw
-      if ($content) {
-        Write-Host $content
+  # Returns "reachable", "unreachable", or "unknown".
+  #
+  # This script makes a --depth 1 clone, which holds no commit graph, so
+  # git merge-base --is-ancestor cannot answer this question. The GitHub compare API answers it
+  # in one request, and that request works without a token on a public repository.
+  #
+  # Read ahead_by, not status. A reachable commit gives status "identical" or "behind", and both
+  # of those give ahead_by 0. A commit that is not on the branch gives ahead_by above 0.
+  $uri = "https://api.github.com/repos/$RepositorySlug/compare/$BranchName...$CommitHash"
+  Write-Host "> GET $uri"
+
+  try {
+    $comparison = Invoke-RestMethod `
+      -Uri $uri `
+      -Method Get `
+      -TimeoutSec $TimeoutSeconds `
+      -Headers @{
+        "Accept"     = "application/vnd.github+json"
+        "User-Agent" = "azure-sdk-for-cpp-test-setup"
       }
-      else {
-        Write-Host "<empty>"
-      }
-    }
-    else {
-      Write-Host "<not created>"
-    }
   }
+  catch {
+    # A network error, a non-200 answer, and the 60 request per hour anonymous rate limit all
+    # arrive here. None of them says anything about the pin.
+    Write-Host "The compare request failed: $($_.Exception.Message)"
+    return "unknown"
+  }
+
+  if ($null -eq $comparison -or $null -eq $comparison.ahead_by) {
+    Write-Host "The compare answer held no ahead_by field."
+    return "unknown"
+  }
+
+  Write-Host "Compare answer: status=$($comparison.status) ahead_by=$($comparison.ahead_by)"
+  if ($comparison.ahead_by -eq 0) {
+    return "reachable"
+  }
+
+  return "unreachable"
 }
 
 function Test-TcpEndpoint {
@@ -110,13 +137,49 @@ function Wait-BrokerReady {
   throw "Test broker did not accept connections on $($Address.DnsSafeHost):$($Address.Port) within $TimeoutSeconds seconds."
 }
 
-$WorkingDirectory = [System.IO.Path]::GetFullPath(
-  [System.IO.Path]::Combine($RepoRoot, "../TestArtifacts"))
-$repositoryDir = [System.IO.Path]::Combine($WorkingDirectory, "azure-amqp")
-$standardOutputPath = [System.IO.Path]::Combine($WorkingDirectory, "test-broker.log")
-$standardErrorPath = [System.IO.Path]::Combine($WorkingDirectory, "test-broker-error.log")
-$repositoryUrl = "https://github.com/Azure/azure-amqp.git"
-$repositoryHash = "239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a"
+$paths = Get-TestBrokerPaths -RepositoryRoot $RepoRoot
+$WorkingDirectory = $paths.WorkingDirectory
+$repositoryDir = $paths.RepositoryDir
+$standardOutputPath = $paths.StandardOutputPath
+$standardErrorPath = $paths.StandardErrorPath
+$processIdPath = $paths.ProcessIdPath
+$repositorySlug = "Azure/azure-amqp"
+$repositoryUrl = "https://github.com/${repositorySlug}.git"
+$repositoryBranch = "master"
+
+# The broker pin. This is a full 40 character commit SHA, so the build stays reproducible.
+# A tag is not a safe substitute, because azure-amqp uses lightweight tags that a maintainer
+# can move.
+#
+# This SHA comes from refs/pull/318/head of Azure/azure-amqp. It is not on master yet, and
+# that is intentional for now. The reachability test below reports this as a warning.
+#
+# To update the pin:
+#   1. Pick the new commit from Azure/azure-amqp. Prefer a commit on master.
+#      Azure/azure-amqp squash-merges, so the commit on master is the merge_commit_sha of the
+#      merged pull request, not the head commit of that pull request.
+#   2. Run the manual restore and build steps in README.md against that commit.
+#   3. Run the C++ AMQP tests against the broker that the commit builds.
+#   4. Make sure that the commit contains nuget.cfsclean.config.
+#   5. Replace the SHA below with the full 40 character SHA, and update README.md.
+#
+# Set TEST_BROKER_COMMIT to point a pipeline at a different broker commit without a code change.
+$defaultRepositoryHash = "239aff0d87b2c19e1fa91636e0fc0f6ee6e9999a"
+
+$repositoryHash = if ($env:TEST_BROKER_COMMIT) {
+  $env:TEST_BROKER_COMMIT.Trim().ToLowerInvariant()
+}
+else {
+  $defaultRepositoryHash
+}
+
+if ($repositoryHash -notmatch '^[0-9a-f]{40}$') {
+  throw "TEST_BROKER_COMMIT must be a full 40 character commit SHA: '$repositoryHash'"
+}
+
+if ($repositoryHash -ne $defaultRepositoryHash) {
+  Write-Host "TEST_BROKER_COMMIT overrides the broker pin with $repositoryHash."
+}
 
 $env:TEST_BROKER_ADDRESS = if ($env:TEST_BROKER_ADDRESS) {
   $env:TEST_BROKER_ADDRESS
@@ -133,6 +196,11 @@ if ($brokerAddress.Port -le 0) {
 Write-Host "Using working directory $WorkingDirectory"
 New-Item -ItemType Directory -Path $WorkingDirectory -Force | Out-Null
 
+# Stop a broker that an earlier run left behind. A pipeline agent can be reused, and a stage
+# re-run starts this script again on the same machine. Without this step the old broker keeps
+# the port, and this run cannot start its own broker.
+Stop-TestBroker -ProcessIdPath $processIdPath
+
 if (Test-Path $repositoryDir) {
   Write-Host "Removing previously cloned repository $repositoryDir"
   Remove-Item $repositoryDir -Force -Recurse
@@ -141,8 +209,9 @@ Remove-Item $standardOutputPath, $standardErrorPath -Force -ErrorAction Silently
 
 $process = $null
 try {
-  # AIDEV-NOTE: Keep the explicit fetch and checkout for agents whose Git does not support
-  # clone --revision.
+  # Keep the clone, the fetch, and the checkout as three steps. A single clone --revision call
+  # would do the same work, but that option needs Git 2.49 or later, and some pipeline agents
+  # carry an older Git.
   Invoke-RequiredCommand `
     -Description "Test broker clone" `
     -FilePath "git" `
@@ -181,8 +250,57 @@ try {
     throw "Test broker clone resolved to '$actualHash' instead of '$repositoryHash'."
   }
 
+  # Report a pin that does not sit on the upstream branch. A pull request head can disappear,
+  # and a pin that is only on a pull request head cannot be rebuilt after the branch is deleted.
+  $pinState = Test-BrokerPinReachable `
+    -RepositorySlug $repositorySlug `
+    -CommitHash $repositoryHash `
+    -BranchName $repositoryBranch
+
+  switch ($pinState) {
+    "reachable" {
+      Write-Host "Broker pin $repositoryHash is reachable from $repositorySlug $repositoryBranch."
+    }
+
+    "unreachable" {
+      $pinMessage = @(
+        "Broker pin $repositoryHash is not reachable from $repositorySlug $repositoryBranch.",
+        "$repositorySlug squash-merges its pull requests, so the head commit of a pull request",
+        "never lands on $repositoryBranch.",
+        "If the source pull request has merged, set the pin to its merge_commit_sha, which is",
+        "the squash commit on $repositoryBranch.",
+        "Do not use the merge_commit_sha of an open pull request, because that commit is a",
+        "temporary test merge."
+      ) -join " "
+
+      if ($env:TEST_BROKER_REQUIRE_MERGED) {
+        throw "$pinMessage TEST_BROKER_REQUIRE_MERGED is set, so this is an error."
+      }
+
+      Write-Warning ("$pinMessage The setup continues. Set TEST_BROKER_REQUIRE_MERGED to make " +
+        "this an error.")
+    }
+
+    default {
+      # "unknown" means the test itself did not run. Continue always, even when
+      # TEST_BROKER_REQUIRE_MERGED is set. A shared CI address can exhaust the 60 request per
+      # hour anonymous rate limit, and that says nothing about the pin. A failure to test must
+      # never become a new source of flaky builds.
+      Write-Warning ("The script could not test whether broker pin $repositoryHash is reachable " +
+        "from $repositorySlug $repositoryBranch. The setup continues.")
+    }
+  }
+
+  # Push-Location is load-bearing. The dotnet calls below must run from the clone root, because
+  # the clone root holds the global.json that selects the .NET SDK, and because the paths below
+  # are relative to it. Do not replace these paths with absolute paths and drop the location
+  # change. That silently loses the SDK pin.
   Push-Location $repositoryDir
   try {
+    # The restore covers every target framework, and the build below covers only net10.0. That
+    # is intentional. A -p:TargetFramework argument is an MSBuild global property, so it flows
+    # into the netstandard2.0 Microsoft.Azure.Amqp project reference, and the build then fails
+    # with NETSDK1005. Do not add a framework filter here.
     Invoke-RequiredCommand `
       -Description "Test broker restore" `
       -FilePath "dotnet" `
@@ -214,8 +332,16 @@ try {
     throw "Test broker build did not produce $brokerDll."
   }
 
+  # A broker from an earlier run of this script is already gone, because Stop-TestBroker ran
+  # above. A process that still holds the port belongs to somebody else. This script did not
+  # start it, so this script does not stop it. Run the tests against it and report the reuse.
+  # A busy port is not a reason to fail the run.
   if (Test-TcpEndpoint -HostName $brokerAddress.DnsSafeHost -Port $brokerAddress.Port) {
-    throw "The test broker endpoint $($brokerAddress.DnsSafeHost):$($brokerAddress.Port) is already in use."
+    Write-Warning ("A process already listens on " +
+      "$($brokerAddress.DnsSafeHost):$($brokerAddress.Port). This script did not start it, so " +
+      "this script will not stop it. The tests will use that endpoint. Stop that process and " +
+      "run this script again if the tests fail in an unexpected way.")
+    exit 0
   }
 
   Write-Host "Starting test broker on $($env:TEST_BROKER_ADDRESS)"
@@ -236,8 +362,10 @@ try {
     throw "Start-Process did not return a test broker process."
   }
 
-  $env:TEST_BROKER_JOBID = $process.Id
-  Write-Host "Test broker process ID: $($process.Id)"
+  # Record the process ID for Test-Cleanup.ps1. That script runs in a separate pwsh step, so an
+  # environment variable set here does not reach it.
+  Set-Content -Path $processIdPath -Value $process.Id -NoNewline
+  Write-Host "Test broker process ID: $($process.Id) (recorded in $processIdPath)"
   Wait-BrokerReady -Process $process -Address $brokerAddress
 }
 catch {
@@ -252,6 +380,10 @@ catch {
       Stop-Process -Id $process.Id -ErrorAction SilentlyContinue
     }
   }
+
+  # This run owns no broker now, so the record must go. Otherwise Test-Cleanup.ps1 or the next
+  # run reads a stale process ID.
+  Remove-Item $processIdPath -Force -ErrorAction SilentlyContinue
 
   throw
 }

--- a/sdk/core/azure-core-amqp/nuget.cfsclean.config
+++ b/sdk/core/azure-core-amqp/nuget.cfsclean.config
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  NuGet configuration for the AMQP test broker build on a restricted agent.
+
+  Test-Setup.ps1 clones Azure/azure-amqp and builds TestAmqpBroker from source.
+  This pipeline must not restore from a direct public endpoint, so the restore
+  passes this file through the configfile option.
+
+  The clear entries are the point of this file. Without them NuGet merges the
+  sources it finds in parent directories and in the user and machine
+  configuration. With them, the restore uses the one feed below and nothing
+  else.
+
+  This file belongs to this repository, and not to the broker clone. The policy
+  is this pipeline's requirement, so the configuration that satisfies it lives
+  next to the pipeline that enforces it.
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="azure-sdk-for-net" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/sdk/core/azure-core-amqp/nuget.cfsclean.config
+++ b/sdk/core/azure-core-amqp/nuget.cfsclean.config
@@ -4,7 +4,7 @@
 
   Test-Setup.ps1 clones Azure/azure-amqp and builds TestAmqpBroker from source.
   This pipeline must not restore from a direct public endpoint, so the restore
-  passes this file through the configfile option.
+  names this file explicitly.
 
   The clear entries are the point of this file. Without them NuGet merges the
   sources it finds in parent directories and in the user and machine

--- a/sdk/core/azure-core-amqp/test/ut/claim_based_security_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/claim_based_security_tests.cpp
@@ -40,7 +40,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
       if (testBrokerUrl.empty())
       {
-        GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+        GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
       }
       GTEST_LOG_(INFO) << "Use broker address: " << testBrokerUrl;
       Azure::Core::Url brokerUrl(testBrokerUrl);

--- a/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
@@ -190,7 +190,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
     if (testBrokerUrl.empty())
     {
-      GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+      GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
     }
     Azure::Core::Url brokerUrl(testBrokerUrl);
     Azure::Core::Amqp::_internal::ConnectionOptions connectionOptions;

--- a/sdk/core/azure-core-amqp/test/ut/management_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/management_tests.cpp
@@ -37,7 +37,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
       if (testBrokerUrl.empty())
       {
-        GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+        GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
       }
       Azure::Core::Url brokerUrl(testBrokerUrl);
       m_brokerEndpoint = brokerUrl;

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -47,7 +47,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
       if (testBrokerUrl.empty())
       {
-        GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+        GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
       }
       Azure::Core::Url brokerUrl(testBrokerUrl);
       m_brokerEndpoint = brokerUrl;

--- a/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/session_tests.cpp
@@ -56,7 +56,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       auto testBrokerUrl = Azure::Core::_internal::Environment::GetVariable("TEST_BROKER_ADDRESS");
       if (testBrokerUrl.empty())
       {
-        GTEST_SKIP_("Could not find required environment variable TEST_BROKER_ADDRESS");
+        GTEST_FATAL_FAILURE_("Could not find required environment variable TEST_BROKER_ADDRESS");
       }
       Azure::Core::Url brokerUrl(testBrokerUrl);
       m_brokerEndpoint = brokerUrl;

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -85,9 +85,15 @@ extends:
     #          displayName: Verify Proxy Server Working Correctly.
     #          condition: and(succeeded(), variables.RunProxyTests, contains(variables.CmakeArgs, 'BUILD_TESTING=ON'))
 
-    #      PostTestSteps:
-    #        - pwsh: |
-    #            $(Build.SourcesDirectory)/sdk/core/azure-core-amqp//Test-Cleanup.ps1
+    PostTestSteps:
+      - pwsh: |
+          $(Build.SourcesDirectory)/sdk/core/azure-core-amqp/Test-Cleanup.ps1
+        displayName: Test-Cleanup for azure-core-amqp
+        # The broker must stop even when the tests fail, so this step always runs.
+        condition: always()
+        env:
+          TEST_BROKER_ADDRESS: "amqp://127.0.0.1:25672"
+
     #        - pwsh: |
     #            docker ps -q -f ancestor=azsdkengsys.azurecr.io/mirror/ubuntu/squid | ForEach-Object { `
     #                docker stop $_ `

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -53,14 +53,14 @@ extends:
     CtestRegex: azure-core.|json-test
     LiveTestCtestRegex: azure-core.|json-test
     LiveTestTimeoutInMinutes: 90 # default is 60 min. We need a little longer on worst case for Win+jsonTests
-    LineCoverageTarget: 75
+    LineCoverageTarget: 81
     BranchCoverageTarget: 62
     PreTestSteps:
       - pwsh: |
           $(Build.SourcesDirectory)/sdk/core/azure-core-amqp/Test-Setup.ps1
         displayName: Test-Setup for azure-core-amqp
-    #          env:
-    #            TEST_BROKER_ADDRESS: "amqp://127.0.0.1:25672"
+        env:
+          TEST_BROKER_ADDRESS: "amqp://127.0.0.1:25672"
 
     #        - pwsh: |
     #            docker build -t squid-local $(Build.SourcesDirectory)/sdk/core/azure-core/test/ut/proxy_tests/localproxy
@@ -107,16 +107,16 @@ extends:
         VcpkgPortName: azure-core-amqp-cpp
 
     # Environment variables for Live tests.
-    # EnvVars:
+    EnvVars:
       # AMQP
-    #        TEST_BROKER_ADDRESS: "amqp://127.0.0.1:25672"
+      TEST_BROKER_ADDRESS: "amqp://127.0.0.1:25672"
 
     # Since Azure Core will run all service's tests, it requires all the expected env vars from services
     # Environment variables for CI tests.
     TestEnv:
       # AMQP
-      #      - Name: TEST_BROKER_ADDRESS
-      #        Value: "amqp://127.0.0.1:25672"
+      - Name: TEST_BROKER_ADDRESS
+        Value: "amqp://127.0.0.1:25672"
       - Name: RUST_BACKTRACE
         Value: "1"
       - Name: RUST_LOG


### PR DESCRIPTION
## Summary

Restores the broker backed `azure-core-amqp` tests that [PR 7270](https://github.com/Azure/azure-sdk-for-cpp/pull/7270) turned off, and stops them going quiet again.

## Motivation

[Work item 39130334](https://dev.azure.com/azure-sdk/_workitems/edit/39130334) requires a restricted feed broker build, executed C++ AMQP tests, a fixed broker commit, and a failing pipeline when the broker does not start.

PR 7270 turned the tests off because the broker could not restore after the pipelines moved to Azure DevOps feeds. Three separate faults then let the tests decay quietly. The tests skipped instead of failing, so a missing broker kept the build green. Nothing stopped the broker, so a reused agent found the port busy. The pin gave no signal when it went stale.

## Changes

- Adds `nuget.cfsclean.config` to this repository and restores the broker through it. The feed policy is this pipeline's requirement, so the configuration that satisfies it lives with the pipeline and not in the broker clone.
- Builds `net10.0` with `--no-restore` from the clone root, because the .NET SDK reads `global.json` from the current directory and not from the project directory.
- Returns the five broker test sites to fatal failures, and restores the 81 percent line coverage gate.
- Records the broker process id in a file, rewrites `Test-Cleanup.ps1` to stop that process, and enables `PostTestSteps` with a condition of `always()`. The old cleanup used job commands, which cannot stop a process that `Start-Process` started.
- Reuses a foreign process that holds the broker port instead of failing the run, and checks the process name before any stop, because the operating system reuses process ids.
- Adds `TEST_BROKER_COMMIT` to retarget the broker, and a GitHub compare API check that warns when the pin is not reachable from `master`. `TEST_BROKER_REQUIRE_MERGED` makes that an error. A check that cannot run always continues.

## Validation

- 146 of 146 `azure-core-amqp` CTest cases passed against a running broker. `TestConnections.ConnectionOpenClose` failed as expected with no `TEST_BROKER_ADDRESS`.
- Restore and build from a clean broker clone using this repository's config, from an empty package cache. The clone stayed unchanged.
- A separate PowerShell process stopped a real broker through the process id file and released the port. A missing file, a garbage file, a dead process id, and a live process of another name all completed without an error.
- The pin check answers correctly for a reachable commit, an unreachable commit, and a squash commit. A 404, a timeout, an empty answer, and a non-numeric field all report that the check did not run, and none fails the build.
