### PR TITLE
Retry large queries with newly uploaded blobs

### DIFF
--- a/sdk/storage/azure-storage-blobs/test/ut/blob_query_test.cpp
+++ b/sdk/storage/azure-storage-blobs/test/ut/blob_query_test.cpp
@@ -314,8 +314,6 @@ xx
 
   TEST_F(BlockBlobClientTest, QueryLargeBlob_LIVEONLY_)
   {
-    auto blobClient = *m_blockBlobClient;
-
     constexpr size_t DataSize = static_cast<size_t>(32_MB);
 
     int recordCounter = 0;
@@ -329,15 +327,16 @@ xx
       jsonData += "{\"_1\":\"" + counter + "\",\"_2\":\"" + record + "\"}\n";
     }
 
-    blobClient.UploadFrom(reinterpret_cast<const uint8_t*>(csvData.data()), csvData.size());
-
     Blobs::QueryBlobOptions queryOptions;
     queryOptions.InputTextConfiguration = Blobs::BlobQueryInputTextOptions::CreateCsvTextOptions();
     queryOptions.OutputTextConfiguration
         = Blobs::BlobQueryOutputTextOptions::CreateJsonTextOptions();
     constexpr int MaxQueryAttempts = 2;
+    const std::string blobNamePrefix = RandomString();
     for (int attempt = 1; attempt <= MaxQueryAttempts; ++attempt)
     {
+      auto blobClient = GetBlockBlobClientForTest(blobNamePrefix + std::to_string(attempt));
+      blobClient.UploadFrom(reinterpret_cast<const uint8_t*>(csvData.data()), csvData.size());
       auto queryResponse = blobClient.Query("SELECT * FROM BlobStorage;", queryOptions);
       try
       {

--- a/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
+++ b/sdk/storage/azure-storage-files-datalake/test/ut/datalake_file_query_test.cpp
@@ -318,8 +318,6 @@ xx
 
   TEST_F(DataLakeFileClientTest, QueryLargeBlob_LIVEONLY_)
   {
-    auto client = m_fileSystemClient->GetFileClient(RandomString());
-
     constexpr size_t DataSize = static_cast<size_t>(32_MB);
 
     int recordCounter = 0;
@@ -333,16 +331,17 @@ xx
       jsonData += "{\"_1\":\"" + counter + "\",\"_2\":\"" + record + "\"}\n";
     }
 
-    client.UploadFrom(reinterpret_cast<const uint8_t*>(csvData.data()), csvData.size());
-
     Files::DataLake::QueryFileOptions queryOptions;
     queryOptions.InputTextConfiguration
         = Files::DataLake::FileQueryInputTextOptions::CreateCsvTextOptions();
     queryOptions.OutputTextConfiguration
         = Files::DataLake::FileQueryOutputTextOptions::CreateJsonTextOptions();
     constexpr int MaxQueryAttempts = 2;
+    const std::string fileNamePrefix = RandomString();
     for (int attempt = 1; attempt <= MaxQueryAttempts; ++attempt)
     {
+      auto client = m_fileSystemClient->GetFileClient(fileNamePrefix + std::to_string(attempt));
+      client.UploadFrom(reinterpret_cast<const uint8_t*>(csvData.data()), csvData.size());
       auto queryResponse = client.Query("SELECT * FROM BlobStorage;", queryOptions);
       try
       {


### PR DESCRIPTION
## Purpose

Retry the large Blob and Data Lake query tests with a newly named, newly uploaded object instead of reusing the object from the failed query attempt.

## Changes

- Generate a stable random name prefix for each test.
- Use distinct `1` and `2` suffixes for the initial query and retry.
- Upload the generated 32 MiB payload before each query attempt.

## Testing

- `BlockBlobClientTest.QueryLargeBlob_LIVEONLY_` (LIVE, curl)
- `DataLakeFileClientTest.QueryLargeBlob_LIVEONLY_` (LIVE, curl)
- Forced first-attempt transport failure locally to verify both separately named objects were uploaded and queried.