### PR TITLE
Update Storage service READMEs

### DIFF
--- a/sdk/storage/azure-storage-blobs/README.md
+++ b/sdk/storage/azure-storage-blobs/README.md
@@ -1,117 +1,194 @@
-# Azure Storage Blobs Client Library for C++
+# Azure Storage Blobs client library for C++
 
-Azure Blob storage is Microsoft's object storage solution for the cloud. Blob storage is optimized for storing massive amounts of unstructured data. Unstructured data is data that does not adhere to a particular data model or definition, such as text or binary data.
+Azure Blob Storage is Microsoft's object storage solution for the cloud. It is optimized for
+storing massive amounts of unstructured data, such as text, binary data, images, documents,
+streaming media, and application data.
+
+[Source code][source_code] | [Package (vcpkg)][vcpkg_package] | [API reference documentation][api_reference] | [Product documentation][product_documentation] | [Samples][samples]
 
 ## Getting started
 
-### Install the package
-
-The easiest way to acquire the C++ SDK is leveraging vcpkg package manager. See the corresponding [Azure SDK for C++ readme section][azsdk_vcpkg_install].
-
-To install Azure Storage packages via vcpkg:
-
-```batch
-vcpkg install azure-storage-blobs-cpp
-```
-
-Then, use in your CMake file:
-
-```CMake
-find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
-target_link_libraries(<your project name> PRIVATE Azure::azure-storage-blobs)
-```
-
 ### Prerequisites
 
-You need an Azure subscription and a [Storage Account][storage_account_overview] to use this package.
+- [vcpkg](https://learn.microsoft.com/vcpkg/get_started/overview) for package acquisition and dependency management
+- [CMake](https://cmake.org/download/) for project build
+- An [Azure subscription][azure_sub]
+- An existing [Azure Storage account][storage_account_overview]
 
-To create a new Storage Account, you can use the [Azure Portal][create_account_with_azure_portal], [Azure PowerShell][create_account_with_powershell], or the [Azure CLI][create_account_with_azure_cli].
+If you need to create a Storage account, you can use the Azure portal or the [Azure CLI][azure_cli].
+When using the Azure CLI, replace `<your-resource-group-name>` and
+`<your-storage-account-name>` with your own values. Storage account names must be globally unique.
 
-### Build from Source
-
-First, download the repository to your local folder:
-
-```batch
-git clone https://github.com/Azure/azure-sdk-for-cpp.git
+```PowerShell
+az login
+az storage account create `
+  --resource-group <your-resource-group-name> `
+  --name <your-storage-account-name> `
+  --sku Standard_LRS
 ```
 
-Create a new folder under the root directory of local cloned repo, switch into this folder and run below commands:
+### Install the package
 
-Windows:
+The easiest way to acquire the C++ SDK is with the vcpkg package manager and CMake. See the
+[Azure SDK for C++ installation instructions][azsdk_vcpkg_install] for more information.
+The following commands use vcpkg in manifest mode.
 
-```batch
-cmake .. -A x64
-cmake --build . --target azure-storage-blobs
-```
-
-or Unix:
+Create a vcpkg manifest in the root of your project:
 
 ```batch
-cmake .. -DCMAKE_BUILD_TYPE=Debug
-cmake --build . --target azure-storage-blobs
+vcpkg new --application
 ```
+
+Add Azure Storage Blobs and Azure Identity to the manifest:
+
+```batch
+vcpkg add port azure-storage-blobs-cpp azure-identity-cpp
+```
+
+Then add the following to your `CMakeLists.txt` file:
+
+```CMake
+find_package(azure-identity-cpp CONFIG REQUIRED)
+find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
+
+target_link_libraries(
+  <your project name>
+  PRIVATE
+    Azure::azure-identity
+    Azure::azure-storage-blobs)
+```
+
+Set `CMAKE_TOOLCHAIN_FILE` to the path to `vcpkg.cmake` before the `project()` statement in your
+`CMakeLists.txt` file:
+
+```CMake
+set(CMAKE_TOOLCHAIN_FILE "vcpkg-root/scripts/buildsystems/vcpkg.cmake")
+```
+
+You can instead pass the path with the `-DCMAKE_TOOLCHAIN_FILE` argument when configuring CMake.
+For other ways to acquire and install the library, see the
+[Azure C++ project setup samples][project_set_up_examples].
+
+### Create and authenticate clients
+
+`BlobServiceClient` operates on the Blob service at the Storage account level. From it, you can
+create a `BlobContainerClient` for container operations and specialized blob clients for block,
+append, and page blobs.
+
+The following example uses `DefaultAzureCredential`, which supports multiple credential types and
+uses credentials from your development environment. After signing in with `az login`, set
+`AZURE_STORAGE_ACCOUNT_URL` to a URL such as
+`https://<your-storage-account-name>.blob.core.windows.net`.
+
+```cpp
+#include <azure/identity.hpp>
+#include <azure/storage/blobs.hpp>
+
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace Azure::Storage::Blobs;
+
+int main()
+{
+  const char* accountUrl = std::getenv("AZURE_STORAGE_ACCOUNT_URL");
+  if (accountUrl == nullptr)
+  {
+    throw std::runtime_error("AZURE_STORAGE_ACCOUNT_URL is not set.");
+  }
+
+  auto credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+  BlobServiceClient serviceClient(accountUrl, credential);
+
+  BlobContainerClient containerClient
+      = serviceClient.GetBlobContainerClient("sample-container");
+  BlockBlobClient blockBlobClient = containerClient.GetBlockBlobClient("sample-blob");
+}
+```
+
+For more information about credential selection and configuration, see
+[DefaultAzureCredential][default_azure_credential].
 
 ## Key concepts
 
-Blob storage is designed for:
+Blob Storage is designed for:
 
-- Serving images or documents directly to a browser.
-- Storing files for distributed access.
-- Streaming video and audio.
-- Writing to log files.
-- Storing data for backup and restore, disaster recovery, and archiving.
-- Storing data for analysis by an on-premises or Azure-hosted service.
+- Serving images or documents directly to a browser
+- Storing files for distributed access
+- Streaming video and audio
+- Writing to log files
+- Storing data for backup, restore, disaster recovery, and archiving
+- Storing data for analysis by an on-premises or Azure-hosted service
 
-Blob storage offers three types of resources:
+Blob Storage offers three types of resources:
 
-- The storage account used via `BlobServiceClient`
-- A container in the storage account used via `BlobContainerClient`
-- A blob in a container used via `BlobClient`
+- The Storage account, accessed through `BlobServiceClient`
+- A container in the Storage account, accessed through `BlobContainerClient`
+- A blob in a container, accessed through `BlobClient` or a specialized `BlockBlobClient`,
+  `AppendBlobClient`, or `PageBlobClient`
 
-Learn more about options for authentication (including Connection Strings, Shared Key, Shared Key Signatures, Active Directory, and anonymous public access) in our [samples](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs/samples).
+### Authentication
+
+The library supports Microsoft Entra ID credentials, connection strings, shared key credentials,
+shared access signatures, and anonymous public access where enabled. Microsoft Entra ID with
+`DefaultAzureCredential` is recommended for getting started. See the [samples][samples] for other
+authentication options.
 
 ### Thread safety
 
-We guarantee that all client instance methods are thread-safe and independent of each other ([guideline](https://azure.github.io/azure-sdk/cpp_introduction.html#thread-safety)). This ensures that the recommendation of reusing client instances is always safe, even across threads.
+All client instance methods are thread-safe and independent of each other
+([guideline](https://azure.github.io/azure-sdk/cpp_introduction.html#thread-safety)). Reusing client
+instances is safe, even across threads.
 
 ### Additional concepts
 
-Client Options | [Accessing the response](https://github.com/Azure/azure-sdk-for-cpp#response-t-model-types) | [Long-running operations](https://github.com/Azure/azure-sdk-for-cpp#long-running-operations) | Handling failures
+<!-- CLIENT COMMON BAR -->
+[Replaceable HTTP transport adapter](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core#http-transport-adapter) |
+[Response model types](https://github.com/Azure/azure-sdk-for-cpp#response-t-model-types) |
+[Long-running operations](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core#long-running-operations)
+<!-- CLIENT COMMON BAR -->
 
 ## Examples
 
-### Uploading a blob
+### Upload a blob
+
+Create the container if it does not exist, and then upload data to a block blob:
 
 ```cpp
-const std::string connectionString = "<connection_string>";
-const std::string containerName = "sample-container";
-const std::string blobName = "sample-blob";
+const std::string blobContent = "Hello Azure!";
 
-auto containerClient = BlobContainerClient::CreateFromConnectionString(connectionString, containerName);
 containerClient.CreateIfNotExists();
 
-BlockBlobClient blobClient = containerClient.GetBlockBlobClient(blobName);
-// upload from local file
-blobClient.UploadFrom(localFilePath);
-// or upload from memory buffer
-blobClinet.UploadFrom(bufferPtr, bufferLength);
+std::vector<uint8_t> buffer(blobContent.begin(), blobContent.end());
+blockBlobClient.UploadFrom(buffer.data(), buffer.size());
 ```
 
-### Downloading a blob
+### Download a blob
+
+Download the blob into a buffer:
 
 ```cpp
-// download to local file
-blobClient.DownloadTo(localFilePath);
-// or download to memory buffer
-blobClinet.DownloadTo(bufferPtr, bufferLength);
+auto properties = blockBlobClient.GetProperties().Value;
+std::vector<uint8_t> buffer(static_cast<std::size_t>(properties.BlobSize));
+
+blockBlobClient.DownloadTo(buffer.data(), buffer.size());
 ```
 
-### Enumerating blobs
+### List blobs
+
+List the blobs in a container:
 
 ```cpp
-for (auto blobPage = containerClient.ListBlobs(); blobPage.HasPage(); blobPage.MoveToNextPage()) {
-  for (auto& blob : blobPage.Blobs) {
-    // Below is what you want to do with each blob
+for (auto blobPage = containerClient.ListBlobs(); blobPage.HasPage();
+     blobPage.MoveToNextPage())
+{
+  for (const auto& blob : blobPage.Blobs)
+  {
     std::cout << "blob: " << blob.Name << std::endl;
   }
 }
@@ -119,58 +196,94 @@ for (auto blobPage = containerClient.ListBlobs(); blobPage.HasPage(); blobPage.M
 
 ## Troubleshooting
 
-All Blob service operations will throw a [StorageException](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp)
-on failure with helpful [ErrorCode](https://learn.microsoft.com/rest/api/storageservices/blob-service-error-codes)s.
-Many of these errors are recoverable.
+Blob service operations throw an
+[`Azure::Storage::StorageException`](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp)
+on failure. The exception includes the HTTP status code, service error code, request ID, and other
+details that can help diagnose the failure. See the
+[Blob service error codes](https://learn.microsoft.com/rest/api/storageservices/blob-service-error-codes)
+for service-specific errors.
 
 ```cpp
 try
 {
   containerClient.Delete();
 }
-catch (Azure::Storage::StorageException& e)
+catch (const Azure::Storage::StorageException& exception)
 {
-  if (e.ErrorCode == "ContainerNotFound")
+  if (exception.ErrorCode == "ContainerNotFound")
   {
-    // ignore the error if the container does not exist.
+    // The container has already been deleted.
   }
   else
   {
-    // handle other errors here
+    throw;
   }
 }
 ```
 
 ## Next steps
 
-Get started with our [Blob samples](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs/samples):
+The following samples demonstrate common Blob Storage scenarios:
 
-1. [Upload and download blobs](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/samples/blob_getting_started.cpp)
-2. [List operations](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/samples/blob_list_operation.cpp)
+- [Upload and download blobs](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/samples/blob_getting_started.cpp)
+- [List containers and blobs](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/samples/blob_list_operation.cpp)
+- [Set a timeout for list operations](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/samples/blob_list_operation_with_timeout.cpp)
+- [Query blob contents](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/samples/blob_query.cpp)
+- [Create shared access signatures](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/samples/blob_sas.cpp)
+- [Use transactional checksums](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/samples/transactional_checksum.cpp)
 
 ## Contributing
 
-See the [Storage CONTRIBUTING.md][storage_contrib] for details on building,
-testing, and contributing to these libraries.
+For details on contributing to this repository, see the
+[contributing guide][azure_sdk_for_cpp_contributing].
 
-This project welcomes contributions and suggestions.  Most contributions require
-you to agree to a Contributor License Agreement (CLA) declaring that you have
-the right to, and actually do, grant us the rights to use your contribution. For
-details, visit [cla.microsoft.com][cla].
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit the
+[Contributor License Agreement](https://cla.microsoft.com).
 
-This project has adopted the [Microsoft Open Source Code of Conduct][coc].
-For more information see the [Code of Conduct FAQ][coc_faq]
-or contact [opencode@microsoft.com][coc_contact] with any
-additional questions or comments.
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately. Follow the instructions provided by the bot. You only need
+to do this once across all repositories using the CLA.
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any questions or comments.
+
+### Additional helpful links for contributors
+
+- [Good first issues for new contributors](https://github.com/Azure/azure-sdk-for-cpp/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
+- [How to build and test your change][azure_sdk_for_cpp_contributing_developer_guide]
+- [How to submit a pull request][azure_sdk_for_cpp_contributing_pull_requests]
+- [Azure SDK for C++ wiki](https://github.com/Azure/azure-sdk-for-cpp/wiki)
+
+### Reporting security issues and security bugs
+
+Security issues and bugs should be reported privately to the Microsoft Security Response Center
+(MSRC) at <secure@microsoft.com>. You should receive a response within 24 hours. If you do not,
+follow up by email to confirm that your original message was received. For more information,
+including the MSRC PGP key, see the
+[Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue).
+
+### License
+
+Azure SDK for C++ is licensed under the
+[MIT license](https://github.com/Azure/azure-sdk-for-cpp/blob/main/LICENSE.txt).
 
 <!-- LINKS -->
-[azsdk_vcpkg_install]: https://github.com/Azure/azure-sdk-for-cpp#download--install-the-sdk
+[api_reference]: https://learn.microsoft.com/cpp/api/overview/azure/storage-blobs-readme?view=azure-cpp
+[azure_cli]: https://learn.microsoft.com/cli/azure
+[azure_sdk_for_cpp_contributing]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md
+[azure_sdk_for_cpp_contributing_developer_guide]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#developer-guide
+[azure_sdk_for_cpp_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests
+[azure_sub]: https://azure.microsoft.com/free/
+[azsdk_vcpkg_install]: https://github.com/Azure/azure-sdk-for-cpp#getting-started
+[default_azure_credential]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity#defaultazurecredential
+[product_documentation]: https://learn.microsoft.com/azure/storage/blobs/
+[project_set_up_examples]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/samples/integration
+[samples]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs/samples
+[source_code]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs
 [storage_account_overview]: https://learn.microsoft.com/azure/storage/common/storage-account-overview
-[create_account_with_azure_portal]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-portal
-[create_account_with_powershell]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-powershell
-[create_account_with_azure_cli]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-cli
-[storage_contrib]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md
-[cla]: https://cla.microsoft.com
-[coc]: https://opensource.microsoft.com/codeofconduct/
-[coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
-[coc_contact]: mailto:opencode@microsoft.com
+[vcpkg_package]: https://vcpkg.io/en/package/azure-storage-blobs-cpp

--- a/sdk/storage/azure-storage-blobs/README.md
+++ b/sdk/storage/azure-storage-blobs/README.md
@@ -155,6 +155,9 @@ instances is safe, even across threads.
 
 ## Examples
 
+The examples below use the clients created in
+[Create and authenticate clients](#create-and-authenticate-clients).
+
 ### Upload a blob
 
 Create the container if it does not exist, and then upload data to a block blob:

--- a/sdk/storage/azure-storage-files-datalake/README.md
+++ b/sdk/storage/azure-storage-files-datalake/README.md
@@ -1,141 +1,196 @@
-# Azure Storage Files Data Lake Client Library for C++
+# Azure Storage Files Data Lake client library for C++
 
-Azure Data Lake includes all the capabilities required to make it easy for developers, data scientists, and analysts to store data of any size, shape, and speed, and do all types of processing and analytics across platforms and languages. It removes the complexities of ingesting and storing all of your data while making it faster to get up and running with batch, streaming, and interactive analytics.
+Azure Data Lake Storage is a scalable and secure data lake for high-performance analytics
+workloads. It combines the scale and cost benefits of Azure Blob Storage with a hierarchical file
+system that supports directory operations and POSIX access control lists.
+
+[Source code][source_code] | [Package (vcpkg)][vcpkg_package] | [API reference documentation][api_reference] | [Product documentation][product_documentation] | [Samples][samples]
 
 ## Getting started
 
-### Install the package
-
-The easiest way to acquire the C++ SDK is leveraging vcpkg package manager. See the corresponding [Azure SDK for C++ readme section][azsdk_vcpkg_install].
-
-To install Azure Storage packages via vcpkg:
-
-```batch
-vcpkg install azure-storage-files-datalake-cpp
-```
-
-Then, use in your CMake file:
-
-```CMake
-find_package(azure-storage-files-datalake-cpp CONFIG REQUIRED)
-target_link_libraries(<your project name> PRIVATE Azure::azure-storage-files-datalake)
-```
-
 ### Prerequisites
 
-You need an Azure subscription and a [Storage Account][storage_account_overview] to use this package.
+- [vcpkg](https://learn.microsoft.com/vcpkg/get_started/overview) for package acquisition and dependency management
+- [CMake](https://cmake.org/download/) for project build
+- An [Azure subscription][azure_sub]
+- An Azure Storage account with hierarchical namespace enabled
 
-To create a new Storage Account, you can use the [Azure Portal][create_account_with_azure_portal], [Azure PowerShell][create_account_with_powershell], or the [Azure CLI][create_account_with_azure_cli].
+If you need to create a Storage account, you can use the Azure portal or the [Azure CLI][azure_cli].
+When using the Azure CLI, replace `<your-resource-group-name>` and
+`<your-storage-account-name>` with your own values. Storage account names must be globally unique.
 
-### Build from Source
-
-First, download the repository to your local folder:
-
-```batch
-git clone https://github.com/Azure/azure-sdk-for-cpp.git
+```PowerShell
+az login
+az storage account create `
+  --resource-group <your-resource-group-name> `
+  --name <your-storage-account-name> `
+  --sku Standard_LRS `
+  --enable-hierarchical-namespace true
 ```
 
-Create a new folder under the root directory of local cloned repo, switch into this folder and run below commands:
+### Install the package
 
-Windows:
+The easiest way to acquire the C++ SDK is with the vcpkg package manager and CMake. See the
+[Azure SDK for C++ installation instructions][azsdk_vcpkg_install] for more information.
+The following commands use vcpkg in manifest mode.
 
-```batch
-cmake .. -A x64
-cmake --build . --target azure-storage-files-datalake
-```
-
-or Unix:
+Create a vcpkg manifest in the root of your project:
 
 ```batch
-cmake .. -DCMAKE_BUILD_TYPE=Debug
-cmake --build . --target azure-storage-files-datalake
+vcpkg new --application
 ```
+
+Add Azure Storage Files Data Lake and Azure Identity to the manifest:
+
+```batch
+vcpkg add port azure-storage-files-datalake-cpp azure-identity-cpp
+```
+
+Then add the following to your `CMakeLists.txt` file:
+
+```CMake
+find_package(azure-identity-cpp CONFIG REQUIRED)
+find_package(azure-storage-files-datalake-cpp CONFIG REQUIRED)
+
+target_link_libraries(
+  <your project name>
+  PRIVATE
+    Azure::azure-identity
+    Azure::azure-storage-files-datalake)
+```
+
+Set `CMAKE_TOOLCHAIN_FILE` to the path to `vcpkg.cmake` before the `project()` statement in your
+`CMakeLists.txt` file:
+
+```CMake
+set(CMAKE_TOOLCHAIN_FILE "vcpkg-root/scripts/buildsystems/vcpkg.cmake")
+```
+
+You can instead pass the path with the `-DCMAKE_TOOLCHAIN_FILE` argument when configuring CMake.
+For other ways to acquire and install the library, see the
+[Azure C++ project setup samples][project_set_up_examples].
+
+### Create and authenticate clients
+
+`DataLakeServiceClient` operates on the Data Lake service at the Storage account level. From it,
+you can create clients for file systems, directories, and files.
+
+The following example uses `DefaultAzureCredential`, which supports multiple credential types and
+uses credentials from your development environment. After signing in with `az login`, set
+`AZURE_STORAGE_DATALAKE_ACCOUNT_URL` to a URL such as
+`https://<your-storage-account-name>.dfs.core.windows.net`.
+
+```cpp
+#include <azure/identity.hpp>
+#include <azure/storage/files/datalake.hpp>
+
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+
+using namespace Azure::Storage::Files::DataLake;
+
+int main()
+{
+  const char* accountUrl = std::getenv("AZURE_STORAGE_DATALAKE_ACCOUNT_URL");
+  if (accountUrl == nullptr)
+  {
+    throw std::runtime_error("AZURE_STORAGE_DATALAKE_ACCOUNT_URL is not set.");
+  }
+
+  auto credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+  DataLakeServiceClient serviceClient(accountUrl, credential);
+
+  DataLakeFileSystemClient fileSystemClient
+      = serviceClient.GetFileSystemClient("sample-file-system");
+  DataLakeDirectoryClient directoryClient
+      = fileSystemClient.GetDirectoryClient("sample-directory");
+  DataLakeFileClient fileClient = directoryClient.GetFileClient("sample-file");
+}
+```
+
+For more information about credential selection and configuration, see
+[DefaultAzureCredential][default_azure_credential].
 
 ## Key concepts
 
-DataLake Storage Gen2 was designed to:
-- Service multiple petabytes of information while sustaining hundreds of gigabits of throughput
-- Allow you to easily manage massive amounts of data
+Data Lake Storage is designed to:
 
-Key Features of DataLake Storage Gen2 include:
-- Hadoop compatible access
-- A superset of POSIX permissions
-- Cost effective in terms of low-cost storage capacity and transactions
-- Optimized driver for big data analytics
+- Store and analyze data at petabyte scale
+- Provide Hadoop-compatible access
+- Support POSIX-style permissions and access control lists
+- Improve directory management performance with a hierarchical namespace
+- Provide cost-effective storage for batch, streaming, and interactive analytics
 
-A fundamental part of Data Lake Storage Gen2 is the addition of a hierarchical namespace to Blob storage. The hierarchical namespace organizes objects/files into a hierarchy of directories for efficient data access.
+Data Lake Storage offers the following resource hierarchy:
 
-In the past, cloud-based analytics had to compromise in areas of performance, management, and security. Data Lake Storage Gen2 addresses each of these aspects in the following ways:
-- Performance is optimized because you do not need to copy or transform data as a prerequisite for analysis. The hierarchical namespace greatly improves the performance of directory management operations, which improves overall job performance.
-- Management is easier because you can organize and manipulate files through directories and subdirectories.
-- Security is enforceable because you can define POSIX permissions on directories or individual files.
-- Cost effectiveness is made possible as Data Lake Storage Gen2 is built on top of the low-cost Azure Blob storage. The additional features further lower the total cost of ownership for running big data analytics on Azure.
+- The Storage account, accessed through `DataLakeServiceClient`
+- A file system, accessed through `DataLakeFileSystemClient`
+- A directory, accessed through `DataLakeDirectoryClient`
+- A file, accessed through `DataLakeFileClient`
 
-Data Lake Storage Gen2 offers two types of resources:
+A Data Lake file system corresponds to a Blob container, and a Data Lake path corresponds to a
+Blob. This client library requires a Storage account with hierarchical namespace enabled.
 
-- The _filesystem_ used via 'DataLakeFileSystemClient'
-- The _path_ used via 'DataLakeFileClient' or 'DataLakeDirectoryClient'
+### Authentication
 
-|ADLS Gen2 	                | Blob       |
-| --------------------------| ---------- |
-|Filesystem                 | Container  | 
-|Path (File or Directory)   | Blob       |
-
-Note: This client library does not support hierarchical namespace (HNS) disabled storage accounts.
-
-Learn more about options for authentication (including Connection Strings, Shared Key, Shared Key Signatures, Active Directory, and anonymous public access) in our [samples](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake/samples).
+The library supports Microsoft Entra ID credentials, connection strings, shared key credentials,
+and shared access signatures. Microsoft Entra ID with `DefaultAzureCredential` is recommended for
+getting started. See the [sample][samples] for other authentication options.
 
 ### Thread safety
 
-We guarantee that all client instance methods are thread-safe and independent of each other ([guideline](https://azure.github.io/azure-sdk/cpp_introduction.html#thread-safety)). This ensures that the recommendation of reusing client instances is always safe, even across threads.
+All client instance methods are thread-safe and independent of each other
+([guideline](https://azure.github.io/azure-sdk/cpp_introduction.html#thread-safety)). Reusing client
+instances is safe, even across threads.
 
 ### Additional concepts
 
-Client Options | [Accessing the response](https://github.com/Azure/azure-sdk-for-cpp#response-t-model-types) | [Long-running operations](https://github.com/Azure/azure-sdk-for-cpp#long-running-operations) | Handling failures
+<!-- CLIENT COMMON BAR -->
+[Replaceable HTTP transport adapter](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core#http-transport-adapter) |
+[Response model types](https://github.com/Azure/azure-sdk-for-cpp#response-t-model-types) |
+[Long-running operations](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core#long-running-operations)
+<!-- CLIENT COMMON BAR -->
 
 ## Examples
 
-### Appending Data to a DataLake File
+### Create a directory and file
 
 ```cpp
-const std::string connectionString = "<connection_string>";
-const std::string fileSystemName = "sample-filesystem";
-const std::string directoryName = "sample-directory";
-const std::string fileName = "sample-file";
-const std::string localFilePath = "<path_to_local_file>";
-
-// Create DataLakeServiceClient
-DataLakeServiceClient serviceClient = DataLakeServiceClient::CreateFromConnectionString(connectionString);
-
-// Get a reference to a filesystem named "sample-filesystem" and then create it
-DataLakeFileSystemClient filesystemClient = serviceClient.GetFileSystemClient(fileSystemName);
-filesystemClient.CreateIfNotExists();
-
-// Create a DataLake Directory
-DataLakeDirectoryClient directoryClient = filesystemClient.GetDirectoryClient(directoryName);
+fileSystemClient.CreateIfNotExists();
 directoryClient.CreateIfNotExists();
-
-// Create a DataLake File using a DataLake Directory
-DataLakeFileClient fileClient = directoryClient.GetFileClient(fileName);
 fileClient.CreateIfNotExists();
-
-// Append data to the DataLake File
-Azure::Core::IO::FileBodyStream fileStream(localFilePath);
-fileClient.Append(fileStream, 0);
-fileClient.Flush(fileStream.Length());
-```
-### Reading Data from a DataLake File
-```cpp
-Response<DownloadFileResult> fileContents = fileClient.Download();
 ```
 
-### Enumerating DataLake Paths
+### Append data to a file
+
+Data Lake files are updated by appending data and then flushing it:
+
 ```cpp
-for (auto pathPage = client.ListPaths(false); pathPage.HasPage(); pathPage.MoveToNextPage())
+const std::string fileContent = "Hello Azure!";
+std::vector<uint8_t> buffer(fileContent.begin(), fileContent.end());
+Azure::Core::IO::MemoryBodyStream stream(buffer);
+
+fileClient.Append(stream, 0);
+fileClient.Flush(buffer.size());
+```
+
+### Download a file
+
+```cpp
+auto downloadResponse = fileClient.Download();
+Azure::Core::Context context;
+std::vector<uint8_t> downloaded = downloadResponse.Value.Body->ReadToEnd(context);
+```
+
+### List paths
+
+```cpp
+for (auto pathPage = fileSystemClient.ListPaths(false); pathPage.HasPage();
+     pathPage.MoveToNextPage())
 {
-  for (auto& path : pathPage.Paths)
+  for (const auto& path : pathPage.Paths)
   {
-    // Below is what you want to do with each path
     std::cout << "path: " << path.Name << std::endl;
   }
 }
@@ -143,57 +198,87 @@ for (auto pathPage = client.ListPaths(false); pathPage.HasPage(); pathPage.MoveT
 
 ## Troubleshooting
 
-All File DataLake service operations will throw a [StorageException](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp)
-on failure with helpful [ErrorCode](https://learn.microsoft.com/rest/api/storageservices/blob-service-error-codes)s.
-Many of these errors are recoverable.
+Data Lake service operations throw an
+[`Azure::Storage::StorageException`](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp)
+on failure. The exception includes the HTTP status code, service error code, request ID, and other
+details that can help diagnose the failure. See the
+[Blob service error codes](https://learn.microsoft.com/rest/api/storageservices/blob-service-error-codes)
+for service-specific errors.
 
 ```cpp
 try
 {
   fileSystemClient.Delete();
 }
-catch (Azure::Storage::StorageException& e)
+catch (const Azure::Storage::StorageException& exception)
 {
-  if (e.ErrorCode == "ContainerNotFound")
+  if (exception.ErrorCode == "ContainerNotFound")
   {
-    // ignore the error if the file system does not exist.
+    // The file system has already been deleted.
   }
   else
   {
-    // handle other errors here
+    throw;
   }
 }
 ```
 
 ## Next steps
 
-Get started with our [DataLake samples](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake/samples):
-
-1. [Append and read DataLake Files](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-files-datalake/samples/datalake_getting_started.cpp)
+The [Data Lake getting-started sample](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-files-datalake/samples/datalake_getting_started.cpp)
+demonstrates how to create a file system, directory, and file, append data, and download the file.
 
 ## Contributing
 
-See the [Storage CONTRIBUTING.md][storage_contrib] for details on building,
-testing, and contributing to these libraries.
+For details on contributing to this repository, see the
+[contributing guide][azure_sdk_for_cpp_contributing].
 
-This project welcomes contributions and suggestions.  Most contributions require
-you to agree to a Contributor License Agreement (CLA) declaring that you have
-the right to, and actually do, grant us the rights to use your contribution. For
-details, visit [cla.microsoft.com][cla].
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit the
+[Contributor License Agreement](https://cla.microsoft.com).
 
-This project has adopted the [Microsoft Open Source Code of Conduct][coc].
-For more information see the [Code of Conduct FAQ][coc_faq]
-or contact [opencode@microsoft.com][coc_contact] with any
-additional questions or comments.
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately. Follow the instructions provided by the bot. You only need
+to do this once across all repositories using the CLA.
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any questions or comments.
+
+### Additional helpful links for contributors
+
+- [Good first issues for new contributors](https://github.com/Azure/azure-sdk-for-cpp/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
+- [How to build and test your change][azure_sdk_for_cpp_contributing_developer_guide]
+- [How to submit a pull request][azure_sdk_for_cpp_contributing_pull_requests]
+- [Azure SDK for C++ wiki](https://github.com/Azure/azure-sdk-for-cpp/wiki)
+
+### Reporting security issues and security bugs
+
+Security issues and bugs should be reported privately to the Microsoft Security Response Center
+(MSRC) at <secure@microsoft.com>. You should receive a response within 24 hours. If you do not,
+follow up by email to confirm that your original message was received. For more information,
+including the MSRC PGP key, see the
+[Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue).
+
+### License
+
+Azure SDK for C++ is licensed under the
+[MIT license](https://github.com/Azure/azure-sdk-for-cpp/blob/main/LICENSE.txt).
 
 <!-- LINKS -->
-[azsdk_vcpkg_install]: https://github.com/Azure/azure-sdk-for-cpp#download--install-the-sdk
-[storage_account_overview]: https://learn.microsoft.com/azure/storage/common/storage-account-overview
-[create_account_with_azure_portal]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-portal
-[create_account_with_powershell]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-powershell
-[create_account_with_azure_cli]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-cli
-[storage_contrib]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md
-[cla]: https://cla.microsoft.com
-[coc]: https://opensource.microsoft.com/codeofconduct/
-[coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
-[coc_contact]: mailto:opencode@microsoft.com
+[api_reference]: https://learn.microsoft.com/cpp/api/overview/azure/storage-files-datalake-readme?view=azure-cpp
+[azure_cli]: https://learn.microsoft.com/cli/azure
+[azure_sdk_for_cpp_contributing]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md
+[azure_sdk_for_cpp_contributing_developer_guide]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#developer-guide
+[azure_sdk_for_cpp_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests
+[azure_sub]: https://azure.microsoft.com/free/
+[azsdk_vcpkg_install]: https://github.com/Azure/azure-sdk-for-cpp#getting-started
+[default_azure_credential]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity#defaultazurecredential
+[product_documentation]: https://learn.microsoft.com/azure/storage/blobs/data-lake-storage-introduction
+[project_set_up_examples]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/samples/integration
+[samples]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake/samples
+[source_code]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake
+[vcpkg_package]: https://vcpkg.io/en/package/azure-storage-files-datalake-cpp

--- a/sdk/storage/azure-storage-files-datalake/README.md
+++ b/sdk/storage/azure-storage-files-datalake/README.md
@@ -84,9 +84,13 @@ uses credentials from your development environment. After signing in with `az lo
 #include <azure/identity.hpp>
 #include <azure/storage/files/datalake.hpp>
 
+#include <cstdint>
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 using namespace Azure::Storage::Files::DataLake;
 
@@ -136,7 +140,7 @@ Blob. This client library requires a Storage account with hierarchical namespace
 
 The library supports Microsoft Entra ID credentials, connection strings, shared key credentials,
 and shared access signatures. Microsoft Entra ID with `DefaultAzureCredential` is recommended for
-getting started. See the [sample][samples] for other authentication options.
+getting started. See the [samples][samples] for other authentication options.
 
 ### Thread safety
 
@@ -153,6 +157,9 @@ instances is safe, even across threads.
 <!-- CLIENT COMMON BAR -->
 
 ## Examples
+
+The examples below use the clients created in
+[Create and authenticate clients](#create-and-authenticate-clients).
 
 ### Create a directory and file
 

--- a/sdk/storage/azure-storage-files-shares/README.md
+++ b/sdk/storage/azure-storage-files-shares/README.md
@@ -83,9 +83,14 @@ uses credentials from your development environment. After signing in with `az lo
 #include <azure/identity.hpp>
 #include <azure/storage/files/shares.hpp>
 
+#include <cstddef>
+#include <cstdint>
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 using namespace Azure::Storage::Files::Shares;
 
@@ -133,7 +138,7 @@ The library supports Microsoft Entra ID credentials, connection strings, shared 
 and shared access signatures. Microsoft Entra ID with `DefaultAzureCredential` is recommended for
 getting started when the account and operation support OAuth authentication. Token-authenticated
 requests must specify `ShareTokenIntent`; the only currently supported value is
-`Models::ShareTokenIntent::Backup`. See the [sample][samples] for other authentication options.
+`Models::ShareTokenIntent::Backup`. See the [samples][samples] for other authentication options.
 
 ### Thread safety
 
@@ -150,6 +155,9 @@ instances is safe, even across threads.
 <!-- CLIENT COMMON BAR -->
 
 ## Examples
+
+The examples below use the clients created in
+[Create and authenticate clients](#create-and-authenticate-clients).
 
 ### Create a share and upload a file
 

--- a/sdk/storage/azure-storage-files-shares/README.md
+++ b/sdk/storage/azure-storage-files-shares/README.md
@@ -1,187 +1,277 @@
-# Azure Storage Files Shares Client Library for C++
+# Azure Storage Files Shares client library for C++
 
-Azure File Shares offers fully managed file shares in the cloud that are accessible via the industry standard Server Message Block (SMB) protocol. Azure file shares can be mounted concurrently by cloud or on-premises deployments of Windows, Linux, and macOS. Additionally, Azure file shares can be cached on Windows Servers with Azure File Sync for fast access near where the data is being used.
+Azure Files provides fully managed file shares in the cloud that are accessible through the Server
+Message Block (SMB) and Network File System (NFS) protocols. Azure file shares can be mounted
+concurrently by cloud or on-premises deployments and accessed through the Azure Files REST API.
+
+[Source code][source_code] | [Package (vcpkg)][vcpkg_package] | [API reference documentation][api_reference] | [Product documentation][product_documentation] | [Samples][samples]
 
 ## Getting started
 
-### Install the package
-
-The easiest way to acquire the C++ SDK is leveraging vcpkg package manager. See the corresponding [Azure SDK for C++ readme section][azsdk_vcpkg_install].
-
-To install Azure Storage packages via vcpkg:
-
-```batch
-vcpkg install azure-storage-files-shares-cpp
-```
-
-Then, use in your CMake file:
-
-```CMake
-find_package(azure-storage-files-shares-cpp CONFIG REQUIRED)
-target_link_libraries(<your project name> PRIVATE Azure::azure-storage-files-shares)
-```
-
 ### Prerequisites
 
-You need an Azure subscription and a [Storage Account][storage_account_overview] to use this package.
+- [vcpkg](https://learn.microsoft.com/vcpkg/get_started/overview) for package acquisition and dependency management
+- [CMake](https://cmake.org/download/) for project build
+- An [Azure subscription][azure_sub]
+- An existing [Azure Storage account][storage_account_overview]
 
-To create a new Storage Account, you can use the [Azure Portal][create_account_with_azure_portal], [Azure PowerShell][create_account_with_powershell], or the [Azure CLI][create_account_with_azure_cli].
+If you need to create a Storage account, you can use the Azure portal or the [Azure CLI][azure_cli].
+When using the Azure CLI, replace `<your-resource-group-name>` and
+`<your-storage-account-name>` with your own values. Storage account names must be globally unique.
 
-### Build from Source
-
-First, download the repository to your local folder:
-
-```batch
-git clone https://github.com/Azure/azure-sdk-for-cpp.git
+```PowerShell
+az login
+az storage account create `
+  --resource-group <your-resource-group-name> `
+  --name <your-storage-account-name> `
+  --sku Standard_LRS
 ```
 
-Create a new folder under the root directory of local cloned repo, switch into this folder and run below commands:
+### Install the package
 
-Windows:
+The easiest way to acquire the C++ SDK is with the vcpkg package manager and CMake. See the
+[Azure SDK for C++ installation instructions][azsdk_vcpkg_install] for more information.
+The following commands use vcpkg in manifest mode.
 
-```batch
-cmake .. -A x64
-cmake --build . --target azure-storage-files-shares
-```
-
-or Unix:
+Create a vcpkg manifest in the root of your project:
 
 ```batch
-cmake .. -DCMAKE_BUILD_TYPE=Debug
-cmake --build . --target azure-storage-files-shares
+vcpkg new --application
 ```
+
+Add Azure Storage Files Shares and Azure Identity to the manifest:
+
+```batch
+vcpkg add port azure-storage-files-shares-cpp azure-identity-cpp
+```
+
+Then add the following to your `CMakeLists.txt` file:
+
+```CMake
+find_package(azure-identity-cpp CONFIG REQUIRED)
+find_package(azure-storage-files-shares-cpp CONFIG REQUIRED)
+
+target_link_libraries(
+  <your project name>
+  PRIVATE
+    Azure::azure-identity
+    Azure::azure-storage-files-shares)
+```
+
+Set `CMAKE_TOOLCHAIN_FILE` to the path to `vcpkg.cmake` before the `project()` statement in your
+`CMakeLists.txt` file:
+
+```CMake
+set(CMAKE_TOOLCHAIN_FILE "vcpkg-root/scripts/buildsystems/vcpkg.cmake")
+```
+
+You can instead pass the path with the `-DCMAKE_TOOLCHAIN_FILE` argument when configuring CMake.
+For other ways to acquire and install the library, see the
+[Azure C++ project setup samples][project_set_up_examples].
+
+### Create and authenticate clients
+
+`ShareServiceClient` operates on the Azure Files service at the Storage account level. From it,
+you can create clients for shares, directories, and files.
+
+The following example uses `DefaultAzureCredential`, which supports multiple credential types and
+uses credentials from your development environment. After signing in with `az login`, set
+`AZURE_STORAGE_FILE_ACCOUNT_URL` to a URL such as
+`https://<your-storage-account-name>.file.core.windows.net`.
+
+```cpp
+#include <azure/identity.hpp>
+#include <azure/storage/files/shares.hpp>
+
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+
+using namespace Azure::Storage::Files::Shares;
+
+int main()
+{
+  const char* accountUrl = std::getenv("AZURE_STORAGE_FILE_ACCOUNT_URL");
+  if (accountUrl == nullptr)
+  {
+    throw std::runtime_error("AZURE_STORAGE_FILE_ACCOUNT_URL is not set.");
+  }
+
+  auto credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+  ShareClientOptions options;
+  options.ShareTokenIntent = Models::ShareTokenIntent::Backup;
+  ShareServiceClient serviceClient(accountUrl, credential, options);
+
+  ShareClient shareClient = serviceClient.GetShareClient("sample-share");
+  ShareDirectoryClient directoryClient = shareClient.GetRootDirectoryClient();
+  ShareFileClient fileClient = directoryClient.GetFileClient("sample-file");
+}
+```
+
+For more information about credential selection and configuration, see
+[DefaultAzureCredential][default_azure_credential].
 
 ## Key concepts
 
 Azure file shares can be used to:
 
-- Completely replace or supplement traditional on-premises file servers or NAS devices.
-- "Lift and shift" applications to the cloud that expect a file share to store file application or user data.
-- Simplify new cloud development projects with shared application settings, diagnostic shares, and Dev/Test/Debug tool file shares.
+- Replace or supplement on-premises file servers and network-attached storage
+- Lift and shift applications that expect a file share
+- Share application settings, diagnostics, and development tools
+- Provide concurrently mounted storage to cloud and on-premises systems
 
-Learn more about options for authentication (including Connection Strings, Shared Key, Shared Key Signatures, Active Directory, and anonymous public access) in our [samples](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-shares/samples).
+Azure Files offers the following resource hierarchy:
+
+- The Storage account, accessed through `ShareServiceClient`
+- A file share, accessed through `ShareClient`
+- A directory, accessed through `ShareDirectoryClient`
+- A file, accessed through `ShareFileClient`
+
+### Authentication
+
+The library supports Microsoft Entra ID credentials, connection strings, shared key credentials,
+and shared access signatures. Microsoft Entra ID with `DefaultAzureCredential` is recommended for
+getting started when the account and operation support OAuth authentication. Token-authenticated
+requests must specify `ShareTokenIntent`; the only currently supported value is
+`Models::ShareTokenIntent::Backup`. See the [sample][samples] for other authentication options.
 
 ### Thread safety
 
-We guarantee that all client instance methods are thread-safe and independent of each other ([guideline](https://azure.github.io/azure-sdk/cpp_introduction.html#thread-safety)). This ensures that the recommendation of reusing client instances is always safe, even across threads.
+All client instance methods are thread-safe and independent of each other
+([guideline](https://azure.github.io/azure-sdk/cpp_introduction.html#thread-safety)). Reusing client
+instances is safe, even across threads.
 
 ### Additional concepts
 
-Client Options | [Accessing the response](https://github.com/Azure/azure-sdk-for-cpp#response-t-model-types) | [Long-running operations](https://github.com/Azure/azure-sdk-for-cpp#long-running-operations) | Handling failures
+<!-- CLIENT COMMON BAR -->
+[Replaceable HTTP transport adapter](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core#http-transport-adapter) |
+[Response model types](https://github.com/Azure/azure-sdk-for-cpp#response-t-model-types) |
+[Long-running operations](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core#long-running-operations)
+<!-- CLIENT COMMON BAR -->
 
 ## Examples
 
 ### Create a share and upload a file
 
 ```cpp
-const std::string shareName = "sample-share";
-const std::string directoryName = "sample-directory";
-const std::string fileName = "sample-file";
-const std::string localFilePath = "<path_to_local_file>";
+const std::string fileContent = "Hello Azure!";
 
-// Get a reference to a share and then create it
-ShareClient shareClient = ShareClient::CreateFromConnectionString(connectionString, shareName);
 shareClient.CreateIfNotExists();
 
-// Get a reference to a directory and create it
-ShareDirectoryClient directoryClient = shareClient.GetRootDirectoryClient().GetSubdirectoryClient(directoryName);;
-directoryClient.CreateIfNotExists();
-
-// Get a reference to a file and upload it
-ShareFileClient fileClient = directoryClient.GetFileClient(fileName);
-// upload from local file
-fileClient.UploadFrom(localFilePath);
-// or upload from memory buffer
-fileClient.UploadFrom(bufferPtr, bufferLength);
+std::vector<uint8_t> buffer(fileContent.begin(), fileContent.end());
+fileClient.UploadFrom(buffer.data(), buffer.size());
 ```
 
 ### Download a file
 
 ```cpp
-// download to local file
-fileClient.DownloadTo(localFilePath);
-// or download to memory buffer
-fileClient.DownloadTo(bufferPtr, bufferLength);
+auto properties = fileClient.GetProperties().Value;
+std::vector<uint8_t> buffer(static_cast<std::size_t>(properties.FileSize));
+
+fileClient.DownloadTo(buffer.data(), buffer.size());
 ```
 
-### Traverse a share
+### List files and directories
 
 ```cpp
-std::vector<ShareDirectoryClient> remaining;
-remaining.push_back(shareClient.GetRootDirectoryClient());
-while (remaining.size() > 0)
+for (auto page = directoryClient.ListFilesAndDirectories(); page.HasPage();
+     page.MoveToNextPage())
 {
-  auto& directoryClient = remaining.back();
-  remaining.pop_back();
-  for (auto page = directoryClient.ListFilesAndDirectories(); page.HasPage();
-       page.MoveToNextPage())
+  for (const auto& file : page.Files)
   {
-    for (auto& file : page.Files)
-    {
-          std::cout << "file: " << file.Name << std::endl;
-    }
-    for (auto& directory : page.Directories)
-    {
-      std::cout << "directory: " << directory.Name << std::endl;
-      remaining.push_back(directoryClient.GetSubdirectoryClient(directory.Name));
-    }
+    std::cout << "file: " << file.Name << std::endl;
+  }
+  for (const auto& directory : page.Directories)
+  {
+    std::cout << "directory: " << directory.Name << std::endl;
   }
 }
 ```
 
 ## Troubleshooting
 
-All Azure Storage File Shares service operations will throw a [StorageException](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp)
-on failure with helpful [ErrorCode](https://learn.microsoft.com/rest/api/storageservices/file-service-error-codes)s.
-Many of these errors are recoverable.
+Azure Files service operations throw an
+[`Azure::Storage::StorageException`](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp)
+on failure. The exception includes the HTTP status code, service error code, request ID, and other
+details that can help diagnose the failure. See the
+[File service error codes](https://learn.microsoft.com/rest/api/storageservices/file-service-error-codes)
+for service-specific errors.
 
 ```cpp
 try
 {
   shareClient.Delete();
 }
-catch (Azure::Storage::StorageException& e)
+catch (const Azure::Storage::StorageException& exception)
 {
-  if (e.ErrorCode == "ShareNotFound")
+  if (exception.ErrorCode == "ShareNotFound")
   {
-    // ignore the error if the file share does not exist.
+    // The share has already been deleted.
   }
   else
   {
-    // handle other errors here
+    throw;
   }
 }
 ```
 
 ## Next steps
 
-Get started with our [File samples](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-shares/samples):
-
-1. [Upload and download files](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-files-shares/samples/file_share_getting_started.cpp)
+The [Azure Files getting-started sample](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-files-shares/samples/file_share_getting_started.cpp)
+demonstrates how to create a share and upload, download, and inspect a file.
 
 ## Contributing
 
-See the [Storage CONTRIBUTING.md][storage_contrib] for details on building,
-testing, and contributing to these libraries.
+For details on contributing to this repository, see the
+[contributing guide][azure_sdk_for_cpp_contributing].
 
-This project welcomes contributions and suggestions.  Most contributions require
-you to agree to a Contributor License Agreement (CLA) declaring that you have
-the right to, and actually do, grant us the rights to use your contribution. For
-details, visit [cla.microsoft.com][cla].
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit the
+[Contributor License Agreement](https://cla.microsoft.com).
 
-This project has adopted the [Microsoft Open Source Code of Conduct][coc].
-For more information see the [Code of Conduct FAQ][coc_faq]
-or contact [opencode@microsoft.com][coc_contact] with any
-additional questions or comments.
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately. Follow the instructions provided by the bot. You only need
+to do this once across all repositories using the CLA.
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any questions or comments.
+
+### Additional helpful links for contributors
+
+- [Good first issues for new contributors](https://github.com/Azure/azure-sdk-for-cpp/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
+- [How to build and test your change][azure_sdk_for_cpp_contributing_developer_guide]
+- [How to submit a pull request][azure_sdk_for_cpp_contributing_pull_requests]
+- [Azure SDK for C++ wiki](https://github.com/Azure/azure-sdk-for-cpp/wiki)
+
+### Reporting security issues and security bugs
+
+Security issues and bugs should be reported privately to the Microsoft Security Response Center
+(MSRC) at <secure@microsoft.com>. You should receive a response within 24 hours. If you do not,
+follow up by email to confirm that your original message was received. For more information,
+including the MSRC PGP key, see the
+[Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue).
+
+### License
+
+Azure SDK for C++ is licensed under the
+[MIT license](https://github.com/Azure/azure-sdk-for-cpp/blob/main/LICENSE.txt).
 
 <!-- LINKS -->
-[azsdk_vcpkg_install]: https://github.com/Azure/azure-sdk-for-cpp#download--install-the-sdk
+[api_reference]: https://learn.microsoft.com/cpp/api/overview/azure/storage-files-shares-readme?view=azure-cpp
+[azure_cli]: https://learn.microsoft.com/cli/azure
+[azure_sdk_for_cpp_contributing]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md
+[azure_sdk_for_cpp_contributing_developer_guide]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#developer-guide
+[azure_sdk_for_cpp_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests
+[azure_sub]: https://azure.microsoft.com/free/
+[azsdk_vcpkg_install]: https://github.com/Azure/azure-sdk-for-cpp#getting-started
+[default_azure_credential]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity#defaultazurecredential
+[product_documentation]: https://learn.microsoft.com/azure/storage/files/storage-files-introduction
+[project_set_up_examples]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/samples/integration
+[samples]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-shares/samples
+[source_code]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-shares
 [storage_account_overview]: https://learn.microsoft.com/azure/storage/common/storage-account-overview
-[create_account_with_azure_portal]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-portal
-[create_account_with_powershell]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-powershell
-[create_account_with_azure_cli]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-cli
-[storage_contrib]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md
-[cla]: https://cla.microsoft.com
-[coc]: https://opensource.microsoft.com/codeofconduct/
-[coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
-[coc_contact]: mailto:opencode@microsoft.com
+[vcpkg_package]: https://vcpkg.io/en/package/azure-storage-files-shares-cpp

--- a/sdk/storage/azure-storage-queues/README.md
+++ b/sdk/storage/azure-storage-queues/README.md
@@ -84,6 +84,7 @@ uses credentials from your development environment. After signing in with `az lo
 #include <azure/storage/queues.hpp>
 
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 
@@ -146,6 +147,9 @@ instances is safe, even across threads.
 <!-- CLIENT COMMON BAR -->
 
 ## Examples
+
+The examples below use the `queueClient` created in
+[Create and authenticate clients](#create-and-authenticate-clients).
 
 ### Create a queue and send a message
 

--- a/sdk/storage/azure-storage-queues/README.md
+++ b/sdk/storage/azure-storage-queues/README.md
@@ -1,156 +1,274 @@
-# Azure Storage Queues Client Library for C++
+# Azure Storage Queues client library for C++
 
-Azure Queue storage is a service for storing large numbers of messages that can be accessed from anywhere in the world via authenticated calls using HTTP or HTTPS. A single queue message can be up to 64 KB in size, and a queue can contain millions of messages, up to the total capacity limit of a storage account.
+Azure Queue Storage stores large numbers of messages that can be accessed from anywhere through
+authenticated HTTP or HTTPS calls. Queues are commonly used to create a backlog of work for
+asynchronous processing and to exchange messages between components of distributed applications.
+
+[Source code][source_code] | [Package (vcpkg)][vcpkg_package] | [API reference documentation][api_reference] | [Product documentation][product_documentation] | [Samples][samples]
 
 ## Getting started
 
-### Install the package
-
-The easiest way to acquire the C++ SDK is leveraging vcpkg package manager. See the corresponding [Azure SDK for C++ readme section][azsdk_vcpkg_install].
-
-To install Azure Storage packages via vcpkg:
-
-```batch
-vcpkg install azure-storage-queues-cpp
-```
-
-Then, use in your CMake file:
-
-```CMake
-find_package(azure-storage-queues-cpp CONFIG REQUIRED)
-target_link_libraries(<your project name> PRIVATE Azure::azure-storage-queues)
-```
-
 ### Prerequisites
 
-You need an Azure subscription and a [Storage Account][storage_account_overview] to use this package.
+- [vcpkg](https://learn.microsoft.com/vcpkg/get_started/overview) for package acquisition and dependency management
+- [CMake](https://cmake.org/download/) for project build
+- An [Azure subscription][azure_sub]
+- An existing [Azure Storage account][storage_account_overview]
 
-To create a new Storage Account, you can use the [Azure Portal][create_account_with_azure_portal], [Azure PowerShell][create_account_with_powershell], or the [Azure CLI][create_account_with_azure_cli].
+If you need to create a Storage account, you can use the Azure portal or the [Azure CLI][azure_cli].
+When using the Azure CLI, replace `<your-resource-group-name>` and
+`<your-storage-account-name>` with your own values. Storage account names must be globally unique.
 
-### Build from Source
-
-First, download the repository to your local folder:
-
-```batch
-git clone https://github.com/Azure/azure-sdk-for-cpp.git
+```PowerShell
+az login
+az storage account create `
+  --resource-group <your-resource-group-name> `
+  --name <your-storage-account-name> `
+  --sku Standard_LRS
 ```
 
-Create a new folder under the root directory of local cloned repo, switch into this folder and run below commands:
+### Install the package
 
-Windows:
+The easiest way to acquire the C++ SDK is with the vcpkg package manager and CMake. See the
+[Azure SDK for C++ installation instructions][azsdk_vcpkg_install] for more information.
+The following commands use vcpkg in manifest mode.
 
-```batch
-cmake .. -A x64
-cmake --build . --target azure-storage-queues
-```
-
-or Unix:
+Create a vcpkg manifest in the root of your project:
 
 ```batch
-cmake .. -DCMAKE_BUILD_TYPE=Debug
-cmake --build . --target azure-storage-queues
+vcpkg new --application
 ```
+
+Add Azure Storage Queues and Azure Identity to the manifest:
+
+```batch
+vcpkg add port azure-storage-queues-cpp azure-identity-cpp
+```
+
+Then add the following to your `CMakeLists.txt` file:
+
+```CMake
+find_package(azure-identity-cpp CONFIG REQUIRED)
+find_package(azure-storage-queues-cpp CONFIG REQUIRED)
+
+target_link_libraries(
+  <your project name>
+  PRIVATE
+    Azure::azure-identity
+    Azure::azure-storage-queues)
+```
+
+Set `CMAKE_TOOLCHAIN_FILE` to the path to `vcpkg.cmake` before the `project()` statement in your
+`CMakeLists.txt` file:
+
+```CMake
+set(CMAKE_TOOLCHAIN_FILE "vcpkg-root/scripts/buildsystems/vcpkg.cmake")
+```
+
+You can instead pass the path with the `-DCMAKE_TOOLCHAIN_FILE` argument when configuring CMake.
+For other ways to acquire and install the library, see the
+[Azure C++ project setup samples][project_set_up_examples].
+
+### Create and authenticate clients
+
+`QueueServiceClient` operates on the Queue service at the Storage account level. From it, you can
+create a `QueueClient` to manage a queue and its messages.
+
+The following example uses `DefaultAzureCredential`, which supports multiple credential types and
+uses credentials from your development environment. After signing in with `az login`, set
+`AZURE_STORAGE_QUEUE_ACCOUNT_URL` to a URL such as
+`https://<your-storage-account-name>.queue.core.windows.net`.
+
+```cpp
+#include <azure/identity.hpp>
+#include <azure/storage/queues.hpp>
+
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+
+using namespace Azure::Storage::Queues;
+
+int main()
+{
+  const char* accountUrl = std::getenv("AZURE_STORAGE_QUEUE_ACCOUNT_URL");
+  if (accountUrl == nullptr)
+  {
+    throw std::runtime_error("AZURE_STORAGE_QUEUE_ACCOUNT_URL is not set.");
+  }
+
+  auto credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+  QueueServiceClient serviceClient(accountUrl, credential);
+  QueueClient queueClient = serviceClient.GetQueueClient("sample-queue");
+}
+```
+
+For more information about credential selection and configuration, see
+[DefaultAzureCredential][default_azure_credential].
 
 ## Key concepts
 
-Common uses of Queue storage include:
+Queue Storage is designed for:
 
 - Creating a backlog of work to process asynchronously
-- Passing messages between different parts of a distributed application
+- Decoupling components of a distributed application
+- Scheduling work that can be retried independently
+- Scaling producers and consumers separately
 
-Learn more about options for authentication (including Connection Strings, Shared Key, Shared Key Signatures, Active Directory, and anonymous public access) in our [samples](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-queues/samples).
+Queue Storage offers the following resource hierarchy:
+
+- The Storage account, accessed through `QueueServiceClient`
+- A queue, accessed through `QueueClient`
+- Messages within a queue, managed through `QueueClient`
+
+A queue message can be up to 64 KiB and can remain in the queue until it is explicitly deleted or
+its time-to-live expires. Receiving a message makes it temporarily invisible to other consumers;
+the message must be deleted after successful processing.
+
+### Authentication
+
+The library supports Microsoft Entra ID credentials, connection strings, shared key credentials,
+and shared access signatures. Microsoft Entra ID with `DefaultAzureCredential` is recommended for
+getting started. See the [samples][samples] for other authentication options.
 
 ### Thread safety
 
-We guarantee that all client instance methods are thread-safe and independent of each other ([guideline](https://azure.github.io/azure-sdk/cpp_introduction.html#thread-safety)). This ensures that the recommendation of reusing client instances is always safe, even across threads.
+All client instance methods are thread-safe and independent of each other
+([guideline](https://azure.github.io/azure-sdk/cpp_introduction.html#thread-safety)). Reusing client
+instances is safe, even across threads.
 
 ### Additional concepts
 
-Client Options | [Accessing the response](https://github.com/Azure/azure-sdk-for-cpp#response-t-model-types) | [Long-running operations](https://github.com/Azure/azure-sdk-for-cpp#long-running-operations) | Handling failures
+<!-- CLIENT COMMON BAR -->
+[Replaceable HTTP transport adapter](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core#http-transport-adapter) |
+[Response model types](https://github.com/Azure/azure-sdk-for-cpp#response-t-model-types) |
+[Long-running operations](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core#long-running-operations)
+<!-- CLIENT COMMON BAR -->
 
 ## Examples
 
-### Send messages
+### Create a queue and send a message
 
 ```cpp
-const std::string connectionString = "<connection_string>";
-const std::string queueName = "sample-queue";
-
-// Get a reference to a queue and then create it
-QueueClient queueClient = QueueClient(connectionString, queueName);
 queueClient.Create();
-
-// Send a message to our queue
-queueClient.EnqueueMessage("Hello, Azure1!");
-queueClient.EnqueueMessage("Hello, Azure2!");
-queueClient.EnqueueMessage("Hello, Azure3!");
+queueClient.EnqueueMessage("Hello, Azure!");
 ```
-### Receive messages
+
+### Receive and delete messages
+
 ```cpp
-ReceiveMessagesOptions receiveOptions;
-receiveOptions.MaxMessages = 3;
-auto receiveMessagesResult = queueClient.ReceiveMessages(receiveOptions).Value;
-for (auto& msg : receiveMessagesResult.Messages)
+ReceiveMessagesOptions options;
+options.MaxMessages = 5;
+
+auto response = queueClient.ReceiveMessages(options);
+for (const auto& message : response.Value.Messages)
 {
-  std::cout << msg.MessageText << std::endl;
-  queueClient.DeleteMessage(msg.MessageId, updateResponse.Value.PopReceipt);
+  std::cout << message.MessageText << std::endl;
+  queueClient.DeleteMessage(message.MessageId, message.PopReceipt);
+}
+```
+
+### Peek at messages
+
+Peeking returns messages without changing their visibility:
+
+```cpp
+PeekMessagesOptions options;
+options.MaxMessages = 5;
+
+auto response = queueClient.PeekMessages(options);
+for (const auto& message : response.Value.Messages)
+{
+  std::cout << message.MessageText << std::endl;
 }
 ```
 
 ## Troubleshooting
 
-All Azure Storage Queue  service operations will throw a [StorageException](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp)
-on failure with helpful [ErrorCode](https://learn.microsoft.com/rest/api/storageservices/queue-service-error-codes)s.
-Many of these errors are recoverable.
+Queue service operations throw an
+[`Azure::Storage::StorageException`](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/inc/azure/storage/common/storage_exception.hpp)
+on failure. The exception includes the HTTP status code, service error code, request ID, and other
+details that can help diagnose the failure. See the
+[Queue service error codes](https://learn.microsoft.com/rest/api/storageservices/queue-service-error-codes)
+for service-specific errors.
 
 ```cpp
 try
 {
   queueClient.Delete();
 }
-catch (Azure::Storage::StorageException& e)
+catch (const Azure::Storage::StorageException& exception)
 {
-  if (e.ErrorCode == "QueueNotFound")
+  if (exception.ErrorCode == "QueueNotFound")
   {
-    // ignore the error if the queue does not exist.
+    // The queue has already been deleted.
   }
   else
   {
-    // handle other errors here
+    throw;
   }
 }
 ```
 
 ## Next steps
 
-Get started with our [Queue samples](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-queues/samples):
+The following samples demonstrate common Queue Storage scenarios:
 
-1. [Send and receive messages](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-queues/samples/queue_getting_started.cpp)
-2. [Encode and decode messages](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-queues/samples/queue_encode_message.cpp)
+- [Send and receive messages](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-queues/samples/queue_getting_started.cpp)
+- [Encode and decode messages](https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-queues/samples/queue_encode_message.cpp)
 
 ## Contributing
 
-See the [Storage CONTRIBUTING.md][storage_contrib] for details on building,
-testing, and contributing to these libraries.
+For details on contributing to this repository, see the
+[contributing guide][azure_sdk_for_cpp_contributing].
 
-This project welcomes contributions and suggestions.  Most contributions require
-you to agree to a Contributor License Agreement (CLA) declaring that you have
-the right to, and actually do, grant us the rights to use your contribution. For
-details, visit [cla.microsoft.com][cla].
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit the
+[Contributor License Agreement](https://cla.microsoft.com).
 
-This project has adopted the [Microsoft Open Source Code of Conduct][coc].
-For more information see the [Code of Conduct FAQ][coc_faq]
-or contact [opencode@microsoft.com][coc_contact] with any
-additional questions or comments.
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately. Follow the instructions provided by the bot. You only need
+to do this once across all repositories using the CLA.
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any questions or comments.
+
+### Additional helpful links for contributors
+
+- [Good first issues for new contributors](https://github.com/Azure/azure-sdk-for-cpp/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
+- [How to build and test your change][azure_sdk_for_cpp_contributing_developer_guide]
+- [How to submit a pull request][azure_sdk_for_cpp_contributing_pull_requests]
+- [Azure SDK for C++ wiki](https://github.com/Azure/azure-sdk-for-cpp/wiki)
+
+### Reporting security issues and security bugs
+
+Security issues and bugs should be reported privately to the Microsoft Security Response Center
+(MSRC) at <secure@microsoft.com>. You should receive a response within 24 hours. If you do not,
+follow up by email to confirm that your original message was received. For more information,
+including the MSRC PGP key, see the
+[Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue).
+
+### License
+
+Azure SDK for C++ is licensed under the
+[MIT license](https://github.com/Azure/azure-sdk-for-cpp/blob/main/LICENSE.txt).
 
 <!-- LINKS -->
-[azsdk_vcpkg_install]: https://github.com/Azure/azure-sdk-for-cpp#download--install-the-sdk
+[api_reference]: https://learn.microsoft.com/cpp/api/overview/azure/storage-queues-readme?view=azure-cpp
+[azure_cli]: https://learn.microsoft.com/cli/azure
+[azure_sdk_for_cpp_contributing]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md
+[azure_sdk_for_cpp_contributing_developer_guide]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#developer-guide
+[azure_sdk_for_cpp_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md#pull-requests
+[azure_sub]: https://azure.microsoft.com/free/
+[azsdk_vcpkg_install]: https://github.com/Azure/azure-sdk-for-cpp#getting-started
+[default_azure_credential]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity#defaultazurecredential
+[product_documentation]: https://learn.microsoft.com/azure/storage/queues/storage-queues-introduction
+[project_set_up_examples]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/samples/integration
+[samples]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-queues/samples
+[source_code]: https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-queues
 [storage_account_overview]: https://learn.microsoft.com/azure/storage/common/storage-account-overview
-[create_account_with_azure_portal]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-portal
-[create_account_with_powershell]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-powershell
-[create_account_with_azure_cli]: https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-cli
-[storage_contrib]: https://github.com/Azure/azure-sdk-for-cpp/blob/main/CONTRIBUTING.md
-[cla]: https://cla.microsoft.com
-[coc]: https://opensource.microsoft.com/codeofconduct/
-[coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
-[coc_contact]: mailto:opencode@microsoft.com
+[vcpkg_package]: https://vcpkg.io/en/package/azure-storage-queues-cpp


### PR DESCRIPTION
## Purpose

Update the root READMEs for the Azure Storage Blobs, Data Lake, File Shares, and Queues client libraries to follow the common getting-started documentation format.

## Changes

- Add consistent source, package, API reference, product documentation, and sample links.
- Document prerequisites, vcpkg manifest installation, CMake configuration, and Azure CLI resource creation.
- Add service-specific client creation and authentication guidance using `DefaultAzureCredential`.
- Refresh key concepts, examples, troubleshooting guidance, next steps, and contribution information.
- Include the required `ShareTokenIntent::Backup` option for Azure Files token authentication.

Closes #5902
Closes #5903
Closes #5904
Closes #5905