### PR TITLE
fix(eventhubs): honor transient retry classification

### DIFF
--- a/sdk/core/azure-core-amqp/test/ut/amqp_value_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/amqp_value_tests.cpp
@@ -44,6 +44,13 @@ TEST_F(TestValues, SimpleCreateNull)
     TEST_OSTREAM_INSERTER(value, "Null");
   }
 }
+
+TEST_F(TestValues, CustomErrorCondition)
+{
+  _internal::AmqpErrorCondition condition{"test:error"};
+  EXPECT_EQ("test:error", condition.ToString());
+}
+
 TEST_F(TestValues, SimpleCreateBool)
 {
   {

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bugs Fixed
 
+- [[#7254]](https://github.com/Azure/azure-sdk-for-cpp/issues/7254) Updated producer retries to honor `EventHubsException::IsTransient`, retry only allowlisted transient system errors, stop immediately for other failures, and make backoff cancellable through `Azure::Core::Context`. Retry accounting now always performs the initial attempt and treats `MaxRetries` as additional retry attempts.
 - [[#7257]](https://github.com/Azure/azure-sdk-for-cpp/issues/7257) Fixed the partition key on a batch envelope. `EventDataBatch::ToAmqpMessage` wrote the `x-opt-partition-key` value to the AMQP delivery-annotations section. The Event Hubs service ignores that section. The batch also built the envelope from the message before the code applied the partition key annotation. A batch with a partition key thus spread across all partitions. The partition key now goes in the message-annotations section, on the batch envelope and on each message in the batch. A batch that sets `EventDataBatchOptions::PartitionKey` now lands on one partition.
 
 ### Other Changes

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Bugs Fixed
 
-- [[#7254]](https://github.com/Azure/azure-sdk-for-cpp/issues/7254) Updated producer retries to honor `EventHubsException::IsTransient`, retry only allowlisted transient system errors, stop immediately for other failures, and make backoff cancellable through `Azure::Core::Context`. Retry accounting now always performs the initial attempt and treats `MaxRetries` as additional retry attempts.
+- [[#7254]](https://github.com/Azure/azure-sdk-for-cpp/issues/7254) Updated producer retries to honor `EventHubsException::IsTransient`, treat empty AMQP error conditions as transient, stop immediately for unknown and known non-transient failures, preserve bounded retries for AMQP runtime failures, and make backoff cancellable through `Azure::Core::Context`. Retry accounting now always performs the initial attempt and treats `MaxRetries` as additional retry attempts.
 - [[#7257]](https://github.com/Azure/azure-sdk-for-cpp/issues/7257) Fixed the partition key on a batch envelope. `EventDataBatch::ToAmqpMessage` wrote the `x-opt-partition-key` value to the AMQP delivery-annotations section. The Event Hubs service ignores that section. The batch also built the envelope from the message before the code applied the partition key annotation. A batch with a partition key thus spread across all partitions. The partition key now goes in the message-annotations section, on the batch envelope and on each message in the batch. A batch that sets `EventDataBatchOptions::PartitionKey` now lands on one partition.
 
 ### Other Changes

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/eventhubs_utilities.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/eventhubs_utilities.cpp
@@ -127,25 +127,31 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
 
   bool EventHubsExceptionFactory::IsErrorTransient(AmqpErrorCondition const& condition)
   {
-    bool isTransient = false;
-    if ((condition == AmqpErrorCondition::TimeoutError)
-        || (condition == AmqpErrorCondition::ServerBusyError)
-        || (condition == AmqpErrorCondition::InternalError)
-        || (condition == AmqpErrorCondition::LinkDetachForced)
-        || (condition == AmqpErrorCondition::ConnectionForced)
-        || (condition == AmqpErrorCondition::ConnectionFramingError)
-        || (condition == AmqpErrorCondition::ProtonIo))
+    if (condition.ToString().empty())
     {
-      isTransient = true;
+      return true;
     }
-    else if (condition == AmqpErrorCondition::NotFound)
+
+    static AmqpErrorCondition const TransientConditions[]
+        = {AmqpErrorCondition::TimeoutError,
+           AmqpErrorCondition::ServerBusyError,
+           AmqpErrorCondition::InternalError,
+           AmqpErrorCondition::LinkDetachForced,
+           AmqpErrorCondition::ConnectionForced,
+           AmqpErrorCondition::ConnectionFramingError,
+           AmqpErrorCondition::ProtonIo,
+           AmqpErrorCondition::NotFound,
+           AmqpErrorCondition::IllegalState};
+
+    for (auto const& transientCondition : TransientConditions)
     {
-      // Note: Java has additional processing here, it looks for the regex:
-      // "The messaging entity .* could not be found" in the error description and if it is
-      // found it treats the error as not transient. For now, just treat NotFound as transient.
-      isTransient = true;
+      if (condition == transientCondition)
+      {
+        return true;
+      }
     }
-    return isTransient;
+
+    return false;
   }
 
 }}}} // namespace Azure::Messaging::EventHubs::_detail

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/private/retry_operation.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/private/retry_operation.hpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
+#include <azure/core/context.hpp>
 #include <azure/core/http/policies/policy.hpp>
 #include <azure/messaging/eventhubs/eventhubs_exception.hpp>
 
@@ -60,8 +61,8 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
         double jitterFactor = -1);
 
   public:
-    explicit RetryOperation(Azure::Core::Http::Policies::RetryOptions& retryOptions)
-        : m_retryOptions(std::move(retryOptions))
+    explicit RetryOperation(Azure::Core::Http::Policies::RetryOptions const& retryOptions)
+        : m_retryOptions(retryOptions)
     {
     }
 
@@ -76,6 +77,6 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
       return *this;
     }
 
-    bool Execute(std::function<bool()> operation);
+    bool Execute(std::function<bool()> operation, Azure::Core::Context const& context);
   };
 }}}} // namespace Azure::Messaging::EventHubs::_detail

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
@@ -125,26 +125,28 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     // are exhausted, but if the lambda ever returns false directly the batch must not be
     // silently dropped. See issue #7130.
     auto const& partitionId = eventDataBatch.GetPartitionId();
-    if (!retryOp.Execute([&]() -> bool {
-          auto result = GetSender(partitionId).Send(message, context);
+    if (!retryOp.Execute(
+            [&]() -> bool {
+              auto result = GetSender(partitionId).Send(message, context);
 #if ENABLE_UAMQP
-          auto sendStatus = std::get<0>(result);
-          if (sendStatus == Azure::Core::Amqp::_internal::MessageSendStatus::Ok)
-          {
-            return true;
-          }
-          // Throw an exception about the error we just received.
-          throw Azure::Messaging::EventHubs::_detail::EventHubsExceptionFactory::
-              CreateEventHubsException(std::get<1>(result));
+              auto sendStatus = std::get<0>(result);
+              if (sendStatus == Azure::Core::Amqp::_internal::MessageSendStatus::Ok)
+              {
+                return true;
+              }
+              // Throw an exception about the error we just received.
+              throw Azure::Messaging::EventHubs::_detail::EventHubsExceptionFactory::
+                  CreateEventHubsException(std::get<1>(result));
 #elif ENABLE_RUST_AMQP
-          if (result)
-          {
-            throw Azure::Messaging::EventHubs::_detail::EventHubsExceptionFactory::
-                CreateEventHubsException(result);
-          }
-          return true;
+              if (result)
+              {
+                throw Azure::Messaging::EventHubs::_detail::EventHubsExceptionFactory::
+                    CreateEventHubsException(result);
+              }
+              return true;
 #endif
-        }))
+            },
+            context))
     {
       std::string failureDetail = "ProducerClient::Send failed after exhausting "
           + std::to_string(m_producerClientOptions.RetryOptions.MaxRetries)

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
@@ -191,11 +191,10 @@ std::chrono::milliseconds Azure::Messaging::EventHubs::_detail::RetryOperation::
                                           : (std::numeric_limits<int32_t>::max)());
 
   // Multiply exponentialRetryAfter by jitterFactor
-  exponentialRetryAfter = std::chrono::milliseconds(
-      static_cast<std::chrono::milliseconds::rep>(
-          (std::chrono::duration<double, std::chrono::milliseconds::period>(exponentialRetryAfter)
-           * jitterFactor)
-              .count()));
+  exponentialRetryAfter = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(
+      (std::chrono::duration<double, std::chrono::milliseconds::period>(exponentialRetryAfter)
+       * jitterFactor)
+          .count()));
 
   return (std::min)(exponentialRetryAfter, m_retryOptions.MaxRetryDelay);
 }

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
@@ -9,23 +9,10 @@
 #include <algorithm>
 #include <cstdlib>
 #include <limits>
-#include <system_error>
 #include <thread>
 
 namespace {
 constexpr std::chrono::milliseconds CancellationCheckInterval{100};
-
-bool IsRetryableSystemError(std::error_code const& errorCode)
-{
-  return errorCode == std::errc::broken_pipe || errorCode == std::errc::connection_aborted
-      || errorCode == std::errc::connection_refused || errorCode == std::errc::connection_reset
-      || errorCode == std::errc::interrupted || errorCode == std::errc::io_error
-      || errorCode == std::errc::network_down || errorCode == std::errc::network_reset
-      || errorCode == std::errc::network_unreachable || errorCode == std::errc::no_buffer_space
-      || errorCode == std::errc::not_connected || errorCode == std::errc::operation_would_block
-      || errorCode == std::errc::resource_unavailable_try_again
-      || errorCode == std::errc::timed_out;
-}
 
 void WaitForRetryDelay(std::chrono::milliseconds retryAfter, Azure::Core::Context const& context)
 {
@@ -88,19 +75,6 @@ bool Azure::Messaging::EventHubs::_detail::RetryOperation::Execute(
     {
       throw;
     }
-    catch (std::system_error const& e)
-    {
-      context.ThrowIfCancelled();
-      if (Log::ShouldWrite(Logger::Level::Warning))
-      {
-        Log::Write(Logger::Level::Warning, std::string("System error while trying: ") + e.what());
-      }
-      if (!IsRetryableSystemError(e.code()) || !ShouldRetry(false, retryCount, retryAfter))
-      {
-        throw;
-      }
-    }
-#if ENABLE_RUST_AMQP
     catch (std::runtime_error const& e)
     {
       context.ThrowIfCancelled();
@@ -113,7 +87,6 @@ bool Azure::Messaging::EventHubs::_detail::RetryOperation::Execute(
         throw;
       }
     }
-#endif
 
     ++retryCount;
     WaitForRetryDelay(retryAfter, context);

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
@@ -6,94 +6,115 @@
 
 #include <azure/core/internal/diagnostics/log.hpp>
 
-#include <exception>
+#include <algorithm>
+#include <cstdlib>
+#include <limits>
+#include <system_error>
 #include <thread>
 
 namespace {
-// The set of AMQP error conditions that should be treated as fatal conditions.
-constexpr const char* AmqpFatalConditions[] = {"amqp:link:message-size-exceeded"};
+constexpr std::chrono::milliseconds CancellationCheckInterval{100};
 
-bool IsFatalException(Azure::Messaging::EventHubs::EventHubsException const& ex)
+bool IsRetryableSystemError(std::error_code const& errorCode)
 {
-  for (auto const& condition : AmqpFatalConditions)
+  return errorCode == std::errc::broken_pipe || errorCode == std::errc::connection_aborted
+      || errorCode == std::errc::connection_refused || errorCode == std::errc::connection_reset
+      || errorCode == std::errc::interrupted || errorCode == std::errc::io_error
+      || errorCode == std::errc::network_down || errorCode == std::errc::network_reset
+      || errorCode == std::errc::network_unreachable || errorCode == std::errc::no_buffer_space
+      || errorCode == std::errc::not_connected || errorCode == std::errc::operation_would_block
+      || errorCode == std::errc::resource_unavailable_try_again
+      || errorCode == std::errc::timed_out;
+}
+
+void WaitForRetryDelay(std::chrono::milliseconds retryAfter, Azure::Core::Context const& context)
+{
+  auto const deadline = std::chrono::steady_clock::now() + retryAfter;
+  while (true)
   {
-    if (ex.ErrorCondition == condition)
+    context.ThrowIfCancelled();
+
+    auto const now = std::chrono::steady_clock::now();
+    if (now >= deadline)
     {
-      return true;
+      return;
     }
+
+    std::this_thread::sleep_until((std::min)(deadline, now + CancellationCheckInterval));
   }
-  return false;
 }
 } // namespace
-bool Azure::Messaging::EventHubs::_detail::RetryOperation::Execute(std::function<bool()> operation)
+
+bool Azure::Messaging::EventHubs::_detail::RetryOperation::Execute(
+    std::function<bool()> operation,
+    Azure::Core::Context const& context)
 {
   using Azure::Core::Diagnostics::Logger;
   using Azure::Core::Diagnostics::_internal::Log;
-  int retryCount = 0;
-  // Capture the most recent exception so a retries-exhausted fallthrough can
-  // rethrow it instead of silently returning false. See issue #7130.
-  std::exception_ptr lastException;
-  while (retryCount < m_retryOptions.MaxRetries)
+
+  int32_t retryCount = 0;
+  while (true)
   {
+    context.ThrowIfCancelled();
     std::chrono::milliseconds retryAfter{};
 
     try
     {
       bool result = operation();
+      context.ThrowIfCancelled();
 
-      if (ShouldRetry(result, retryCount, retryAfter))
-      {
-        lastException = nullptr;
-        retryCount++;
-        std::this_thread::sleep_for(retryAfter);
-      }
-      else
+      if (!ShouldRetry(result, retryCount, retryAfter))
       {
         return result;
       }
     }
     catch (EventHubsException const& e)
     {
+      context.ThrowIfCancelled();
       if (Log::ShouldWrite(Logger::Level::Warning))
       {
         Log::Stream(Logger::Level::Warning)
             << "Exception thrown. " << e.ErrorCondition << " - " << e.ErrorDescription << std::endl;
       }
-      if (ShouldRetry(IsFatalException(e), retryCount, retryAfter))
-      {
-        lastException = std::current_exception();
-        retryCount++;
-        std::this_thread::sleep_for(retryAfter);
-      }
-      else
+      if (!ShouldRetry(e, retryCount, retryAfter))
       {
         throw;
       }
     }
-    catch (std::exception const& e)
+    catch (Azure::Core::OperationCancelledException const&)
     {
+      throw;
+    }
+    catch (std::system_error const& e)
+    {
+      context.ThrowIfCancelled();
       if (Log::ShouldWrite(Logger::Level::Warning))
       {
-        Log::Write(Logger::Level::Warning, std::string("Exception while trying ") + e.what());
+        Log::Write(Logger::Level::Warning, std::string("System error while trying: ") + e.what());
       }
-      // We assume that all exceptions other than EventHubs exceptions might be retriable.
-      if (ShouldRetry(false, retryCount, retryAfter))
-      {
-        lastException = std::current_exception();
-        retryCount++;
-        std::this_thread::sleep_for(retryAfter);
-      }
-      else
+      if (!IsRetryableSystemError(e.code()) || !ShouldRetry(false, retryCount, retryAfter))
       {
         throw;
       }
     }
+#if ENABLE_RUST_AMQP
+    catch (std::runtime_error const& e)
+    {
+      context.ThrowIfCancelled();
+      if (Log::ShouldWrite(Logger::Level::Warning))
+      {
+        Log::Write(Logger::Level::Warning, std::string("Runtime error while trying: ") + e.what());
+      }
+      if (!ShouldRetry(false, retryCount, retryAfter))
+      {
+        throw;
+      }
+    }
+#endif
+
+    ++retryCount;
+    WaitForRetryDelay(retryAfter, context);
   }
-  if (lastException)
-  {
-    std::rethrow_exception(lastException);
-  }
-  return false;
 }
 
 bool Azure::Messaging::EventHubs::_detail::RetryOperation::ShouldRetry(
@@ -105,23 +126,46 @@ bool Azure::Messaging::EventHubs::_detail::RetryOperation::ShouldRetry(
   using Azure::Core::Diagnostics::Logger;
   using Azure::Core::Diagnostics::_internal::Log;
 
-  // Are we out of retry attempts?
-  if (response || WasLastAttempt(attempt))
+  if (response)
   {
     Log::Write(
         Logger::Level::Informational,
-        std::string("Response was true or last attempt.Operation will not be retried."));
+        std::string("Operation completed successfully and will not be retried."));
     return false;
   }
-  if (response == false)
+
+  if (WasLastAttempt(attempt))
   {
     Log::Write(
-        Logger::Level::Informational, std::string("Response was false.Operation will be retried."));
+        Logger::Level::Informational,
+        std::string("Retry attempts exhausted. Operation will not be retried."));
+    return false;
   }
 
-  retryAfter = CalculateExponentialDelay(attempt, jitterFactor);
+  retryAfter = CalculateExponentialDelay(attempt + 1, jitterFactor);
+  Log::Write(Logger::Level::Informational, std::string("Operation failed and will be retried."));
 
   return true;
+}
+
+bool Azure::Messaging::EventHubs::_detail::RetryOperation::ShouldRetry(
+    Azure::Messaging::EventHubs::EventHubsException const& exception,
+    int32_t attempt,
+    std::chrono::milliseconds& retryAfter,
+    double jitterFactor)
+{
+  using Azure::Core::Diagnostics::Logger;
+  using Azure::Core::Diagnostics::_internal::Log;
+
+  if (!exception.IsTransient)
+  {
+    Log::Write(
+        Logger::Level::Informational,
+        std::string("Event Hubs exception is not transient. Operation will not be retried."));
+    return false;
+  }
+
+  return ShouldRetry(false, attempt, retryAfter, jitterFactor);
 }
 
 std::chrono::milliseconds Azure::Messaging::EventHubs::_detail::RetryOperation::
@@ -144,10 +188,11 @@ std::chrono::milliseconds Azure::Messaging::EventHubs::_detail::RetryOperation::
                                           : (std::numeric_limits<int32_t>::max)());
 
   // Multiply exponentialRetryAfter by jitterFactor
-  exponentialRetryAfter = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(
-      (std::chrono::duration<double, std::chrono::milliseconds::period>(exponentialRetryAfter)
-       * jitterFactor)
-          .count()));
+  exponentialRetryAfter = std::chrono::milliseconds(
+      static_cast<std::chrono::milliseconds::rep>(
+          (std::chrono::duration<double, std::chrono::milliseconds::period>(exponentialRetryAfter)
+           * jitterFactor)
+              .count()));
 
   return (std::min)(exponentialRetryAfter, m_retryOptions.MaxRetryDelay);
 }

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
@@ -61,7 +61,10 @@ bool Azure::Messaging::EventHubs::_detail::RetryOperation::Execute(
     try
     {
       bool result = operation();
-      context.ThrowIfCancelled();
+      if (!result)
+      {
+        context.ThrowIfCancelled();
+      }
 
       if (!ShouldRetry(result, retryCount, retryAfter))
       {

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp
@@ -355,6 +355,42 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _interna
     EXPECT_EQ(1, callCount);
   }
 
+  TEST_F(RetryOperationTest, SuccessfulOperationWinsCancellationRace)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(5);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    int callCount = 0;
+
+    EXPECT_TRUE(retryOp.Execute(
+        [&]() {
+          ++callCount;
+          context.Cancel();
+          return true;
+        },
+        context));
+    EXPECT_EQ(1, callCount);
+  }
+
+  TEST_F(RetryOperationTest, FailedOperationSurfacesCancellationBeforeRetry)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(5);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    int callCount = 0;
+
+    EXPECT_THROW(
+        retryOp.Execute(
+            [&]() {
+              ++callCount;
+              context.Cancel();
+              return false;
+            },
+            context),
+        Azure::Core::OperationCancelledException);
+    EXPECT_EQ(1, callCount);
+  }
+
   TEST_F(RetryOperationTest, CancelledContextDoesNotInvokeOperation)
   {
     auto opts = LocalTest::MakeFastRetryOptions();

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp
@@ -2,25 +2,27 @@
 // Licensed under the MIT License.
 
 #include "eventhubs_test_base.hpp"
+#include "private/eventhubs_utilities.hpp"
 #include "private/retry_operation.hpp"
 
 #include <azure/core/context.hpp>
+#include <azure/core/credentials/credentials.hpp>
 #include <azure/core/http/policies/policy.hpp>
-#include <azure/core/internal/environment.hpp>
-#include <azure/identity.hpp>
 #include <azure/messaging/eventhubs.hpp>
 
+#include <atomic>
+#include <chrono>
+#include <exception>
 #include <functional>
+#include <future>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <thread>
 
 #include <gtest/gtest.h>
 
 namespace LocalTest {
-bool testFunc() { return true; }
-bool testNegative() { return false; }
-Azure::Core::Http::Policies::RetryOptions retryOptions;
-
-// Fast retry options keep regression tests for issue #7130 quick; the production
-// defaults (3 retries, 800ms base delay) would add several seconds of backoff per test.
 Azure::Core::Http::Policies::RetryOptions MakeFastRetryOptions(int32_t maxRetries = 3)
 {
   Azure::Core::Http::Policies::RetryOptions opts;
@@ -29,160 +31,414 @@ Azure::Core::Http::Policies::RetryOptions MakeFastRetryOptions(int32_t maxRetrie
   opts.MaxRetryDelay = std::chrono::milliseconds(2);
   return opts;
 }
+
+Azure::Messaging::EventHubs::EventHubsException MakeEventHubsException(
+    Azure::Core::Amqp::Models::_internal::AmqpErrorCondition const& condition,
+    std::string const& message)
+{
+  Azure::Core::Amqp::Models::_internal::AmqpError error;
+  error.Condition = condition;
+  error.Description = message;
+  return Azure::Messaging::EventHubs::_detail::EventHubsExceptionFactory::CreateEventHubsException(
+      error);
+}
 } // namespace LocalTest
 
 namespace Azure { namespace Messaging { namespace EventHubs { namespace _internal { namespace Test {
-  class RetryOperationTest : public EventHubsTestBase {
-  };
+  class RetryOperationTest : public EventHubsTestBase {};
+
   TEST_F(RetryOperationTest, ExecuteTrue)
   {
-    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(LocalTest::retryOptions);
-    EXPECT_TRUE(retryOp.Execute(LocalTest::testFunc));
+    auto opts = LocalTest::MakeFastRetryOptions();
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+
+    EXPECT_TRUE(retryOp.Execute([]() { return true; }, context));
   }
 
   TEST_F(RetryOperationTest, ExecuteFalse)
   {
-    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(LocalTest::retryOptions);
-    EXPECT_FALSE(retryOp.Execute(LocalTest::testNegative));
+    auto opts = LocalTest::MakeFastRetryOptions(2);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    int callCount = 0;
+
+    EXPECT_FALSE(retryOp.Execute(
+        [&callCount]() {
+          ++callCount;
+          return false;
+        },
+        context));
+    EXPECT_EQ(opts.MaxRetries + 1, callCount);
   }
 
   TEST_F(RetryOperationTest, ShouldRetryTrue1)
   {
+    auto opts = LocalTest::MakeFastRetryOptions();
     std::chrono::milliseconds retryAfter{};
-    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(LocalTest::retryOptions);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+
     EXPECT_FALSE(retryOp.ShouldRetry(true, 0, retryAfter));
   }
 
   TEST_F(RetryOperationTest, ShouldRetryTrue2)
   {
+    auto opts = LocalTest::MakeFastRetryOptions();
     std::chrono::milliseconds retryAfter{};
-    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(LocalTest::retryOptions);
-    EXPECT_FALSE(retryOp.ShouldRetry(true, LocalTest::retryOptions.MaxRetries, retryAfter));
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+
+    EXPECT_FALSE(retryOp.ShouldRetry(true, opts.MaxRetries, retryAfter));
   }
 
   TEST_F(RetryOperationTest, ShouldRetryFalse1)
   {
+    auto opts = LocalTest::MakeFastRetryOptions();
     std::chrono::milliseconds retryAfter{};
-    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(LocalTest::retryOptions);
-    EXPECT_TRUE(retryOp.ShouldRetry(false, 0, retryAfter));
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+
+    EXPECT_TRUE(retryOp.ShouldRetry(false, 0, retryAfter, 1.0));
+    EXPECT_EQ(opts.RetryDelay, retryAfter);
+
+    EXPECT_TRUE(retryOp.ShouldRetry(false, 1, retryAfter, 1.0));
+    EXPECT_EQ(opts.RetryDelay * 2, retryAfter);
   }
 
   TEST_F(RetryOperationTest, ShouldRetryFalse2)
   {
+    auto opts = LocalTest::MakeFastRetryOptions();
     std::chrono::milliseconds retryAfter{};
-    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(LocalTest::retryOptions);
-    EXPECT_FALSE(retryOp.ShouldRetry(false, LocalTest::retryOptions.MaxRetries, retryAfter));
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+
+    EXPECT_FALSE(retryOp.ShouldRetry(false, opts.MaxRetries, retryAfter));
+    EXPECT_EQ(std::chrono::milliseconds::zero(), retryAfter);
   }
 
-  // Regression tests for issue #7130: RetryOperation::Execute must rethrow the last
-  // exception when all retry attempts have been exhausted; previously it returned false
-  // and silently dropped the failure.
   TEST_F(RetryOperationTest, RethrowsLastEventHubsExceptionWhenRetriesExhausted)
   {
     auto opts = LocalTest::MakeFastRetryOptions(3);
     Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
-
+    Azure::Core::Context context;
     int callCount = 0;
+
     auto alwaysThrows = [&callCount]() -> bool {
       ++callCount;
-      throw Azure::Messaging::EventHubs::EventHubsException(
+      throw LocalTest::MakeEventHubsException(
+          Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::TimeoutError,
           "transient failure attempt " + std::to_string(callCount));
     };
 
     try
     {
-      retryOp.Execute(alwaysThrows);
+      retryOp.Execute(alwaysThrows, context);
       FAIL() << "Expected EventHubsException to be rethrown after retries were exhausted.";
     }
     catch (Azure::Messaging::EventHubs::EventHubsException const& e)
     {
-      EXPECT_STREQ("transient failure attempt 3", e.what());
+      EXPECT_STREQ("transient failure attempt 4", e.what());
     }
-    EXPECT_EQ(3, callCount);
+    EXPECT_EQ(opts.MaxRetries + 1, callCount);
   }
 
-  TEST_F(RetryOperationTest, RethrowsLastStdExceptionWhenRetriesExhausted)
+  TEST_F(RetryOperationTest, RethrowsLastSystemErrorWhenRetriesExhausted)
   {
     auto opts = LocalTest::MakeFastRetryOptions(2);
     Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
-
+    Azure::Core::Context context;
+    auto const expectedError = std::make_error_code(std::errc::connection_reset);
     int callCount = 0;
-    auto alwaysThrows = [&callCount]() -> bool {
+
+    auto alwaysThrows = [&callCount, &expectedError]() -> bool {
       ++callCount;
-      throw std::runtime_error("network blip " + std::to_string(callCount));
+      throw std::system_error(expectedError, "network failure");
     };
 
     try
     {
-      retryOp.Execute(alwaysThrows);
-      FAIL() << "Expected std::runtime_error to be rethrown after retries were exhausted.";
+      retryOp.Execute(alwaysThrows, context);
+      FAIL() << "Expected std::system_error to be rethrown after retries were exhausted.";
     }
-    catch (std::runtime_error const& e)
+    catch (std::system_error const& e)
     {
-      EXPECT_STREQ("network blip 2", e.what());
+      EXPECT_EQ(expectedError, e.code());
     }
-    EXPECT_EQ(2, callCount);
+    EXPECT_EQ(opts.MaxRetries + 1, callCount);
   }
 
-  TEST_F(RetryOperationTest, ThrowsImmediatelyOnFatalEventHubsException)
+  TEST_F(RetryOperationTest, DoesNotRetryNonTransientSystemErrors)
   {
     auto opts = LocalTest::MakeFastRetryOptions(5);
     Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    std::errc errorCodes[]
+        = {std::errc::host_unreachable, std::errc::invalid_argument, std::errc::permission_denied};
 
-    int callCount = 0;
-    auto throwsFatal = [&callCount]() -> bool {
-      ++callCount;
-      Azure::Messaging::EventHubs::EventHubsException ex("message too big");
-      ex.ErrorCondition = "amqp:link:message-size-exceeded";
-      throw ex;
-    };
+    for (auto const errorCode : errorCodes)
+    {
+      int callCount = 0;
+      auto throwsSystemError = [&callCount, errorCode]() -> bool {
+        ++callCount;
+        throw std::system_error(std::make_error_code(errorCode), "permanent system error");
+      };
 
-    EXPECT_THROW(retryOp.Execute(throwsFatal), Azure::Messaging::EventHubs::EventHubsException);
-    EXPECT_EQ(1, callCount) << "Fatal exception must not be retried.";
+      EXPECT_THROW(retryOp.Execute(throwsSystemError, context), std::system_error);
+      EXPECT_EQ(1, callCount);
+    }
+  }
+
+  TEST_F(RetryOperationTest, DoesNotRetryNonTransientEventHubsExceptions)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(5);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    Azure::Core::Amqp::Models::_internal::AmqpErrorCondition errorConditions[]
+        = {Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::UnauthorizedAccess,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::PreconditionFailed,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::LinkPayloadSizeExceeded};
+
+    for (auto const& errorCondition : errorConditions)
+    {
+      int callCount = 0;
+      auto throwsNonTransient = [&callCount, errorCondition]() -> bool {
+        ++callCount;
+        throw LocalTest::MakeEventHubsException(errorCondition, "non-transient failure");
+      };
+
+      EXPECT_THROW(
+          retryOp.Execute(throwsNonTransient, context),
+          Azure::Messaging::EventHubs::EventHubsException);
+      EXPECT_EQ(1, callCount) << errorCondition.ToString();
+    }
   }
 
   TEST_F(RetryOperationTest, SucceedsAfterTransientException)
   {
     auto opts = LocalTest::MakeFastRetryOptions(3);
     Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
-
+    Azure::Core::Context context;
     int callCount = 0;
+
     auto eventuallySucceeds = [&callCount]() -> bool {
       ++callCount;
       if (callCount == 1)
       {
-        throw Azure::Messaging::EventHubs::EventHubsException("first attempt fails");
+        throw LocalTest::MakeEventHubsException(
+            Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::TimeoutError,
+            "first attempt fails");
       }
       return true;
     };
 
-    EXPECT_TRUE(retryOp.Execute(eventuallySucceeds));
+    EXPECT_TRUE(retryOp.Execute(eventuallySucceeds, context));
     EXPECT_EQ(2, callCount);
   }
 
   TEST_F(RetryOperationTest, FalseAfterTransientExceptionDoesNotRethrow)
   {
     auto opts = LocalTest::MakeFastRetryOptions(3);
-    // Capture MaxRetries before constructing RetryOperation; the constructor takes
-    // RetryOptions by non-const lvalue ref and moves from it, so reading opts.MaxRetries
-    // afterwards would rely on moved-from state.
-    auto const maxRetries = opts.MaxRetries;
     Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
-
+    Azure::Core::Context context;
     int callCount = 0;
+
     auto throwsThenReturnsFalse = [&callCount]() -> bool {
       ++callCount;
       if (callCount == 1)
       {
-        throw Azure::Messaging::EventHubs::EventHubsException("first attempt fails");
+        throw LocalTest::MakeEventHubsException(
+            Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::TimeoutError,
+            "first attempt fails");
       }
       return false;
     };
 
-    // Second attempt returns false cleanly. ShouldRetry(false=response, retryCount=1)
-    // returns true, so the loop retries; on attempt 3 the loop terminates and Execute
-    // returns false. The exception from attempt 1 must not be rethrown.
-    EXPECT_NO_THROW({ EXPECT_FALSE(retryOp.Execute(throwsThenReturnsFalse)); });
-    EXPECT_EQ(maxRetries, callCount);
+    EXPECT_NO_THROW({ EXPECT_FALSE(retryOp.Execute(throwsThenReturnsFalse, context)); });
+    EXPECT_EQ(opts.MaxRetries + 1, callCount);
+  }
+
+  TEST_F(RetryOperationTest, ZeroRetriesStillExecutesInitialAttempt)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(0);
+    opts.RetryDelay = std::chrono::seconds(5);
+    opts.MaxRetryDelay = std::chrono::seconds(5);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    int callCount = 0;
+
+    auto throwsTransient = [&callCount]() -> bool {
+      ++callCount;
+      throw LocalTest::MakeEventHubsException(
+          Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::TimeoutError,
+          "initial attempt failed");
+    };
+
+    auto const attemptStart = std::chrono::steady_clock::now();
+    EXPECT_THROW(
+        retryOp.Execute(throwsTransient, context), Azure::Messaging::EventHubs::EventHubsException);
+    auto const attemptTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - attemptStart);
+
+    EXPECT_EQ(1, callCount);
+    EXPECT_LT(attemptTime.count(), 1000);
+  }
+
+#if ENABLE_UAMQP
+  TEST_F(RetryOperationTest, DoesNotRetryRuntimeError)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(5);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    int callCount = 0;
+
+    auto throwsRuntimeError = [&callCount]() -> bool {
+      ++callCount;
+      throw std::runtime_error("invalid local state");
+    };
+
+    EXPECT_THROW(retryOp.Execute(throwsRuntimeError, context), std::runtime_error);
+    EXPECT_EQ(1, callCount);
+  }
+#endif
+
+  TEST_F(RetryOperationTest, DoesNotRetryAuthenticationException)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(5);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    int callCount = 0;
+
+    auto throwsAuthenticationException = [&callCount]() -> bool {
+      ++callCount;
+      throw Azure::Core::Credentials::AuthenticationException("authentication failed");
+    };
+
+    EXPECT_THROW(
+        retryOp.Execute(throwsAuthenticationException, context),
+        Azure::Core::Credentials::AuthenticationException);
+    EXPECT_EQ(1, callCount);
+  }
+
+  TEST_F(RetryOperationTest, DoesNotRetryOperationCancelledException)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(5);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    int callCount = 0;
+
+    auto throwsOperationCancelled = [&callCount]() -> bool {
+      ++callCount;
+      throw Azure::Core::OperationCancelledException("operation cancelled");
+    };
+
+    EXPECT_THROW(
+        retryOp.Execute(throwsOperationCancelled, context),
+        Azure::Core::OperationCancelledException);
+    EXPECT_EQ(1, callCount);
+  }
+
+  TEST_F(RetryOperationTest, CancellationDuringOperationSurfacesOperationCancelledException)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(5);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    int callCount = 0;
+
+    auto returnsCancelledAmqpError = [&]() -> bool {
+      ++callCount;
+      context.Cancel();
+      throw LocalTest::MakeEventHubsException(
+          Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::OperationCancelled,
+          "message send operation cancelled");
+    };
+
+    EXPECT_THROW(
+        retryOp.Execute(returnsCancelledAmqpError, context),
+        Azure::Core::OperationCancelledException);
+    EXPECT_EQ(1, callCount);
+  }
+
+  TEST_F(RetryOperationTest, CancelledContextDoesNotInvokeOperation)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions();
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    context.Cancel();
+    int callCount = 0;
+
+    EXPECT_THROW(
+        retryOp.Execute(
+            [&callCount]() {
+              ++callCount;
+              return true;
+            },
+            context),
+        Azure::Core::OperationCancelledException);
+    EXPECT_EQ(0, callCount);
+  }
+
+  TEST_F(RetryOperationTest, CancellingContextInterruptsBackoff)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(3);
+    opts.RetryDelay = std::chrono::seconds(5);
+    opts.MaxRetryDelay = std::chrono::seconds(5);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    std::atomic<int> callCount{0};
+    std::promise<void> firstAttempt;
+    auto firstAttemptFuture = firstAttempt.get_future();
+    std::exception_ptr workerException;
+
+    std::thread worker([&]() {
+      try
+      {
+        retryOp.Execute(
+            [&]() -> bool {
+              auto const attempt = ++callCount;
+              if (attempt == 1)
+              {
+                firstAttempt.set_value();
+              }
+              throw LocalTest::MakeEventHubsException(
+                  Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::TimeoutError,
+                  "transient failure");
+            },
+            context);
+      }
+      catch (...)
+      {
+        workerException = std::current_exception();
+      }
+    });
+
+    if (firstAttemptFuture.wait_for(std::chrono::seconds(2)) != std::future_status::ready)
+    {
+      context.Cancel();
+      worker.join();
+      FAIL() << "The first retry attempt did not start.";
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    auto const cancelStart = std::chrono::steady_clock::now();
+    context.Cancel();
+    worker.join();
+    auto const cancellationTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - cancelStart);
+
+    EXPECT_LT(cancellationTime.count(), 1000);
+    EXPECT_EQ(1, callCount.load());
+    ASSERT_TRUE(workerException != nullptr);
+    EXPECT_THROW(std::rethrow_exception(workerException), Azure::Core::OperationCancelledException);
+  }
+
+  TEST_F(RetryOperationTest, ConstructorCopiesRetryOptions)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(7);
+    auto const expected = opts;
+
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    (void)retryOp;
+
+    EXPECT_EQ(expected.MaxRetries, opts.MaxRetries);
+    EXPECT_EQ(expected.RetryDelay, opts.RetryDelay);
+    EXPECT_EQ(expected.MaxRetryDelay, opts.MaxRetryDelay);
+    EXPECT_EQ(expected.StatusCodes, opts.StatusCodes);
   }
 }}}}} // namespace Azure::Messaging::EventHubs::_internal::Test

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp
@@ -45,7 +45,8 @@ Azure::Messaging::EventHubs::EventHubsException MakeEventHubsException(
 } // namespace LocalTest
 
 namespace Azure { namespace Messaging { namespace EventHubs { namespace _internal { namespace Test {
-  class RetryOperationTest : public EventHubsTestBase {};
+  class RetryOperationTest : public EventHubsTestBase {
+  };
 
   TEST_F(RetryOperationTest, ExecuteTrue)
   {

--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp
@@ -17,7 +17,6 @@
 #include <future>
 #include <stdexcept>
 #include <string>
-#include <system_error>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -140,61 +139,126 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _interna
     EXPECT_EQ(opts.MaxRetries + 1, callCount);
   }
 
-  TEST_F(RetryOperationTest, RethrowsLastSystemErrorWhenRetriesExhausted)
+  TEST_F(RetryOperationTest, RethrowsLastRuntimeErrorWhenRetriesExhausted)
   {
     auto opts = LocalTest::MakeFastRetryOptions(2);
     Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
     Azure::Core::Context context;
-    auto const expectedError = std::make_error_code(std::errc::connection_reset);
     int callCount = 0;
 
-    auto alwaysThrows = [&callCount, &expectedError]() -> bool {
+    auto alwaysThrows = [&callCount]() -> bool {
       ++callCount;
-      throw std::system_error(expectedError, "network failure");
+      throw std::runtime_error("Could not send message attempt " + std::to_string(callCount));
     };
 
     try
     {
       retryOp.Execute(alwaysThrows, context);
-      FAIL() << "Expected std::system_error to be rethrown after retries were exhausted.";
+      FAIL() << "Expected std::runtime_error to be rethrown after retries were exhausted.";
     }
-    catch (std::system_error const& e)
+    catch (std::runtime_error const& e)
     {
-      EXPECT_EQ(expectedError, e.code());
+      EXPECT_STREQ("Could not send message attempt 3", e.what());
     }
     EXPECT_EQ(opts.MaxRetries + 1, callCount);
   }
 
-  TEST_F(RetryOperationTest, DoesNotRetryNonTransientSystemErrors)
+  TEST_F(RetryOperationTest, RetriesEmptyEventHubsCondition)
   {
-    auto opts = LocalTest::MakeFastRetryOptions(5);
+    auto opts = LocalTest::MakeFastRetryOptions(2);
     Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
     Azure::Core::Context context;
-    std::errc errorCodes[]
-        = {std::errc::host_unreachable, std::errc::invalid_argument, std::errc::permission_denied};
+    int callCount = 0;
 
-    for (auto const errorCode : errorCodes)
+    auto succeedsAfterEmptyError = [&callCount]() -> bool {
+      ++callCount;
+      if (callCount == 1)
+      {
+        auto exception = LocalTest::MakeEventHubsException(
+            Azure::Core::Amqp::Models::_internal::AmqpErrorCondition{},
+            "unknown communication failure");
+        EXPECT_TRUE(exception.IsTransient);
+        throw exception;
+      }
+      return true;
+    };
+
+    EXPECT_TRUE(retryOp.Execute(succeedsAfterEmptyError, context));
+    EXPECT_EQ(2, callCount);
+  }
+
+  TEST_F(RetryOperationTest, RetriesAllowlistedEventHubsConditions)
+  {
+    auto opts = LocalTest::MakeFastRetryOptions(2);
+    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
+    Azure::Core::Context context;
+    Azure::Core::Amqp::Models::_internal::AmqpErrorCondition errorConditions[]
+        = {Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::TimeoutError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ServerBusyError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::InternalError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::LinkDetachForced,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ConnectionForced,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ConnectionFramingError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ProtonIo,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::NotFound,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::IllegalState};
+
+    for (auto const& errorCondition : errorConditions)
     {
       int callCount = 0;
-      auto throwsSystemError = [&callCount, errorCode]() -> bool {
+      auto succeedsAfterTransientError = [&callCount, errorCondition]() -> bool {
         ++callCount;
-        throw std::system_error(std::make_error_code(errorCode), "permanent system error");
+        if (callCount == 1)
+        {
+          auto exception = LocalTest::MakeEventHubsException(errorCondition, "transient failure");
+          EXPECT_TRUE(exception.IsTransient);
+          throw exception;
+        }
+        return true;
       };
 
-      EXPECT_THROW(retryOp.Execute(throwsSystemError, context), std::system_error);
-      EXPECT_EQ(1, callCount);
+      EXPECT_TRUE(retryOp.Execute(succeedsAfterTransientError, context));
+      EXPECT_EQ(2, callCount) << errorCondition.ToString();
     }
   }
 
-  TEST_F(RetryOperationTest, DoesNotRetryNonTransientEventHubsExceptions)
+  TEST_F(RetryOperationTest, DoesNotRetryUnknownOrKnownNonTransientEventHubsConditions)
   {
     auto opts = LocalTest::MakeFastRetryOptions(5);
     Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
     Azure::Core::Context context;
     Azure::Core::Amqp::Models::_internal::AmqpErrorCondition errorConditions[]
-        = {Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::UnauthorizedAccess,
+        = {Azure::Core::Amqp::Models::_internal::AmqpErrorCondition{
+               "com.microsoft:future-unknown-error"},
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::UnauthorizedAccess,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::DecodeError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ResourceLimitExceeded,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ResourceLocked,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::NotAllowed,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::InvalidField,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::NotImplemented,
            Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::PreconditionFailed,
-           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::LinkPayloadSizeExceeded};
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ResourceDeleted,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::FrameSizeTooSmall,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::LinkStolen,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::LinkPayloadSizeExceeded,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ArgumentError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ArgumentOutOfRangeError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::EntityDisabledError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::PartitionNotOwnedError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::StoreLockLostError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::PublisherRevokedError,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::TrackingIdProperty,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::OperationCancelled,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::MessageLockLost,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::SessionLockLost,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::SessionCannotBeLocked,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::MessageNotFound,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::SessionNotFound,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::EntityAlreadyExists,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::ConnectionRedirect,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::LinkRedirect,
+           Azure::Core::Amqp::Models::_internal::AmqpErrorCondition::TransferLimitExceeded};
 
     for (auto const& errorCondition : errorConditions)
     {
@@ -280,24 +344,6 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _interna
     EXPECT_EQ(1, callCount);
     EXPECT_LT(attemptTime.count(), 1000);
   }
-
-#if ENABLE_UAMQP
-  TEST_F(RetryOperationTest, DoesNotRetryRuntimeError)
-  {
-    auto opts = LocalTest::MakeFastRetryOptions(5);
-    Azure::Messaging::EventHubs::_detail::RetryOperation retryOp(opts);
-    Azure::Core::Context context;
-    int callCount = 0;
-
-    auto throwsRuntimeError = [&callCount]() -> bool {
-      ++callCount;
-      throw std::runtime_error("invalid local state");
-    };
-
-    EXPECT_THROW(retryOp.Execute(throwsRuntimeError, context), std::runtime_error);
-    EXPECT_EQ(1, callCount);
-  }
-#endif
 
   TEST_F(RetryOperationTest, DoesNotRetryAuthenticationException)
   {


### PR DESCRIPTION
## Summary

Improve the Event Hubs producer retry loop so it uses the transient classification already carried
by `EventHubsException` and allows callers to cancel retry backoff through
`Azure::Core::Context`.

Azure DevOps work item:
[39045656](https://msazure.visualstudio.com/One/_workitems/edit/39045656)

Related GitHub workstream: #7254

## Changes

- Retry `EventHubsException` only when `IsTransient` is `true`.
- Treat empty AMQP error conditions as transient.
- Retry only an explicit allowlist of known transient AMQP conditions.
- Stop arbitrary unknown and known non-transient AMQP conditions, including authorization,
  precondition, message-size, quota, ownership, lock-loss, redirect, and cancellation failures.
- Preserve bounded `std::runtime_error` retries for reachable AMQP send failures on both backends.
- Stop immediately for:
  - Authorization failures.
  - Precondition failures.
  - Message-size failures.
  - Quota/resource-limit failures.
  - Producer/consumer ownership failures.
  - Authentication failures.
  - Cancellation.
- Pass the send operation context into `RetryOperation`.
- Preserve a successful result if cancellation races after the operation has already completed;
  failed results still surface cancellation before retry.
- Replace unconditional backoff sleeps with context-aware waits that check cancellation every
  100 ms.
- Treat `MaxRetries` as retries after the initial attempt:
  - `MaxRetries == 0` still performs the initial attempt.
  - The first backoff uses attempt 1.
  - No backoff occurs after the final failed attempt.
- Copy retry options instead of moving them out of `ProducerClientOptions`.
- Add focused regression coverage for empty/unknown classification, terminal conditions, AMQP
  runtime errors, retry accounting, final exception preservation, and context cancellation.
- Add a Core AMQP unit test that deterministically covers custom `AmqpErrorCondition` construction
  after the coverage counter reset.

## Validation

Configured and built from the repository root with:

```text
CMAKE_BUILD_TYPE=Debug
BUILD_TESTING=ON
DISABLE_RUST_IN_BUILD=ON
DISABLE_AZURE_CORE_OPENTELEMETRY=ON
Generator=Ninja
```

CMake confirmed:

```text
Disabling Rust based functionality in build.
Using vendored uamqp
Using uAMQP.
```

Results:

- `azure-messaging-eventhubs-test` built successfully with MSVC warnings-as-errors.
- Focused retry suite: **22 passed, 0 failed**.
- Complete Event Hubs playback suite: **55 passed, 34 expected live-only skips, 0 failed**.
- Core AMQP value-model suite: **27 passed, 0 failed**.
- Repository `clang-format` applied.
- `git diff --check` passed.
- Final read-only code review reported no significant issues.

## Scope

This PR does not:

- Rebuild producer links after detach.
- Refresh CBS tokens.
- Recover receivers or resume from the last offset.
- Change non-string `x-opt-offset` handling.
- Add per-attempt `TryTimeout`.
- Add the extra server-busy delay.
- Redesign Rust AMQP error classification.
