### PR TITLE
Attestation: Add attestation code owners to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,6 @@
 # PRLabel: %Attestation
 /sdk/attestation/                                                  @Azure/azure-sdk-write-attestation @rickwinter @xirzec
 
-# AzureSdkOwners:                                                  @Azure/azure-sdk-write-attestation
 # ServiceLabel: %Attestation
 # ServiceOwners:                                                   @Azure/azure-sdk-write-attestation
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@
 # ServiceOwners:                                                   @antkmsft @LarryOsterman @RickWinter @xirzec
 
 # PRLabel: %Attestation
-/sdk/attestation/                                                  @Azure/azure-sdk-write-attestation
+/sdk/attestation/                                                  @Azure/azure-sdk-write-attestation @rickwinter @xirzec
 
 # AzureSdkOwners:                                                  @Azure/azure-sdk-write-attestation
 # ServiceLabel: %Attestation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,10 +40,10 @@
 # ServiceOwners:                                                   @antkmsft @LarryOsterman @RickWinter @xirzec
 
 # PRLabel: %Attestation
-/sdk/attestation/                                                  @ahmadmsft @anilba06 @gkostal @LarryOsterman @rickwinter @xirzec
+/sdk/attestation/                                                  @ahmadmsft @alcarasj @anilba06 @deschuma @gkostal @ksapathy @LarryOsterman @olkroshk @rickwinter @xirzec
 
 # ServiceLabel: %Attestation
-# ServiceOwners:                                                   @ahmadmsft @anilba06 @gkostal
+# ServiceOwners:                                                   @ahmadmsft @alcarasj @anilba06 @deschuma @gkostal @ksapathy @olkroshk
 
 # PRLabel: %EngSys
 /sdk/template/                                                     @danieljurek @LarryOsterman @RickWinter @weshaggard

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,10 +40,11 @@
 # ServiceOwners:                                                   @antkmsft @LarryOsterman @RickWinter @xirzec
 
 # PRLabel: %Attestation
-/sdk/attestation/                                                  @ahmadmsft @alcarasj @anilba06 @deschuma @gkostal @ksapathy @LarryOsterman @olkroshk @rickwinter @xirzec
+/sdk/attestation/                                                  @Azure/azure-sdk-write-attestation
 
+# AzureSdkOwners:                                                  @Azure/azure-sdk-write-attestation
 # ServiceLabel: %Attestation
-# ServiceOwners:                                                   @ahmadmsft @alcarasj @anilba06 @deschuma @gkostal @ksapathy @olkroshk
+# ServiceOwners:                                                   @Azure/azure-sdk-write-attestation
 
 # PRLabel: %EngSys
 /sdk/template/                                                     @danieljurek @LarryOsterman @RickWinter @weshaggard


### PR DESCRIPTION
## Description

Updates the %Attestation section of CODEOWNERS to manage attestation ownership via a single write team.

Replaces the individual owner list for attestation with the @Azure/azure-sdk-write-attestation team, and applies the same team to the # AzureSdkOwners: and # ServiceOwners: metadata lines:

```
# PRLabel: %Attestation
/sdk/attestation/                                                  @Azure/azure-sdk-write-attestation

# AzureSdkOwners:                                                  @Azure/azure-sdk-write-attestation
# ServiceLabel: %Attestation
# ServiceOwners:                                                   @Azure/azure-sdk-write-attestation
```

## Pull Request Checklist

- [ ] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html) - n/a
- [ ] Doxygen docs - n/a
- [ ] Unit tests - n/a
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] No related issue listed
- [ ] Comments in source - n/a
- [x] No typos
- [ ] Update changelog - n/a
- [x] Not work-in-progress
- [ ] External references or docs updated - n/a
- [x] Self review of PR done
- [x] Any breaking changes? - no