### PR TITLE
Preserve Azure CLI user environment on POSIX

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- [[#7316]](https://github.com/Azure/azure-sdk-for-cpp/issues/7316) Preserve Azure CLI user configuration and cache environment variables in spawned POSIX processes.
+
 ### Other Changes
 
 ## 1.13.3 (2026-01-16)

--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -632,18 +632,28 @@ ShellProcess::ShellProcess(std::string const& command, OutputPipe& outputPipe)
   // * Last element is nullptr.
   // * First element (at index 0) is path to a program.
   {
+    std::vector<decltype(m_envpValues)::size_type> envValuePositions;
     auto const actualPathVarValue = Environment::GetVariable("PATH");
     auto const processPathVarStatement = std::string("PATH=") + actualPathVarValue
         + (actualPathVarValue.empty() ? "" : ":") + "/usr/bin:/usr/local/bin";
+    AppendToArgvValues(m_envpValues, envValuePositions, processPathVarStatement);
 
-    m_envpValues.insert(
-        m_envpValues.end(), processPathVarStatement.begin(), processPathVarStatement.end());
-
-    m_envpValues.push_back('\0');
+    // Azure CLI uses these to find the signed-in user's configuration and cache.
+    for (auto const envVarName : {"HOME", "XDG_CACHE_HOME", "AZURE_CONFIG_DIR"})
+    {
+      auto const value = Environment::GetVariable(envVarName);
+      if (!value.empty())
+      {
+        AppendToArgvValues(m_envpValues, envValuePositions, std::string(envVarName) + '=' + value);
+      }
+    }
 
     // We should only grab m_envpValues.data() as we're done appending to it, because appends may
     // reallocate the buffer to a different memory location.
-    m_envp.push_back(m_envpValues.data());
+    for (auto const pos : envValuePositions)
+    {
+      m_envp.push_back(m_envpValues.data() + pos);
+    }
     m_envp.push_back(nullptr);
   }
 

--- a/sdk/identity/azure-identity/src/azure_cli_credential.cpp
+++ b/sdk/identity/azure-identity/src/azure_cli_credential.cpp
@@ -630,7 +630,6 @@ ShellProcess::ShellProcess(std::string const& command, OutputPipe& outputPipe)
   // * An array of pointers to non-const C strings (0-terminated).
   // * Strings are in form key=value (PATH uses ':' as separator)
   // * Last element is nullptr.
-  // * First element (at index 0) is path to a program.
   {
     std::vector<decltype(m_envpValues)::size_type> envValuePositions;
     auto const actualPathVarValue = Environment::GetVariable("PATH");

--- a/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
+++ b/sdk/identity/azure-identity/test/ut/azure_cli_credential_test.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "azure/identity/azure_cli_credential.hpp"
+#include "credential_test_helper.hpp"
 
 #include <azure/core/diagnostics/logger.hpp>
 #include <azure/core/platform.hpp>
@@ -21,6 +22,7 @@ using Azure::Core::Credentials::AuthenticationException;
 using Azure::Core::Credentials::TokenCredentialOptions;
 using Azure::Core::Credentials::TokenRequestContext;
 using Azure::Identity::AzureCliCredentialOptions;
+using Azure::Identity::Test::_detail::CredentialTestHelper;
 
 namespace {
 constexpr auto InfiniteCommand =
@@ -131,6 +133,30 @@ TEST(AzureCliCredential, NotAvailable)
   EXPECT_THROW(static_cast<void>(azCliCred.GetToken(trc, {})), AuthenticationException);
 #endif // UWP
 }
+
+#if !defined(AZ_PLATFORM_WINDOWS)
+TEST(AzureCliCredential, PosixChildEnvironment)
+{
+  CredentialTestHelper::EnvironmentOverride const environment({
+      {"HOME", "/tmp/azure-cli-home"},
+      {"XDG_CACHE_HOME", "/tmp/azure-cli-cache"},
+      {"AZURE_CONFIG_DIR", "/tmp/azure-cli-config"},
+  });
+  constexpr auto Token = "{\"accessToken\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\",\"expiresIn\":30}";
+  AzureCliTestCredential const azCliCred(
+      std::string("if [ \"$HOME\" = /tmp/azure-cli-home ] "
+                  "&& [ \"$XDG_CACHE_HOME\" = /tmp/azure-cli-cache ] "
+                  "&& [ \"$AZURE_CONFIG_DIR\" = /tmp/azure-cli-config ]; "
+                  "then echo '")
+      + Token + "'; else echo 'environment variables not propagated'; fi");
+
+  TokenRequestContext trc;
+  trc.Scopes.push_back("https://storage.azure.com/.default");
+  auto const token = azCliCred.GetToken(trc, {});
+
+  EXPECT_EQ(token.Token, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+}
+#endif
 
 #if !defined(AZ_PLATFORM_WINDOWS) \
     || (!defined(WINAPI_PARTITION_DESKTOP) || WINAPI_PARTITION_DESKTOP) // not UWP


### PR DESCRIPTION
## Summary

- Preserve `HOME`, `XDG_CACHE_HOME`, and `AZURE_CONFIG_DIR` in the restricted POSIX child environment used by `AzureCliCredential`.
- Prevent Azure CLI telemetry from creating `./None/.cache/...` under the caller's working directory and preserve custom Azure CLI config locations.
- Add focused child-environment coverage and an Azure.Identity changelog entry.

Fixes #7316

## Validation

- Regression before implementation: `AzureCliCredential.PosixChildEnvironment` failed with `environment variables not propagated`.
- `ctest --test-dir build --output-on-failure -R 'azure-identity\.AzureCliCredential'`: 31/31 passed.
- `ctest --test-dir build --output-on-failure -E 'LIVEONLY_' -j1`: 192/192 passed; two tests skipped by their own runtime conditions.
- Live `AzureCliCredential` storage-token probe: token acquired; no relative `None` directory created.
- `clang-format-11 --dry-run --Werror` on both changed C++ files.
- `git diff --check`.

# Pull Request Checklist

- [x] C++ Guidelines
- [x] Doxygen docs (no public API or header changes)
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [x] Not work-in-progress
- [x] External references or docs updated (not applicable)
- [x] Self review of PR done
- [x] Any breaking changes? No