### PR TITLE
[CFS] Fix cargo feed auth for fork builds

### DIFF
--- a/eng/pipelines/templates/steps/cmake-build.yml
+++ b/eng/pipelines/templates/steps/cmake-build.yml
@@ -30,10 +30,33 @@ steps:
       Write-Host "##vso[task.setvariable variable=CargoConfigPath]$configPath"
     displayName: Configure cargo to use the azure-sdk-for-rust feed
 
+  # Workaround issue in public pipelines. Revert when root cause issue is fixed:
+  # https://github.com/microsoft/azure-pipelines-tasks/issues/22421
+  # CargoAuthenticate@0 authenticates with SYSTEM_ACCESSTOKEN, which Azure DevOps does
+  # not deliver to fork builds. The task still "succeeds", but writes the anonymous
+  # identity, and cargo then fails the index fetch with 401 / TF400813 for user
+  # aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa. NuGetAuthenticate@1 authenticates with the
+  # build's service connection, whose token Azure DevOps does deliver to fork builds, and
+  # publishes it as VSS_NUGET_ACCESSTOKEN for later steps. It runs as
+  # `public Build Service (azure-sdk)`, which holds Feed and Upstream Reader on the cargo
+  # feed.
+  #
+  # This is declared here rather than relying on nuget-config.yml because
+  # archetype-sdk-client.yml includes this template without it.
+  - task: NuGetAuthenticate@1
+    displayName: Acquire an Azure Artifacts token that fork builds can use
+
   - task: CargoAuthenticate@0
     displayName: Authenticate cargo to the azure-sdk-for-rust feed
     inputs:
       configFile: $(CargoConfigPath)
+    # Workaround issue in public pipelines. Revert when root cause is fixed:
+    # https://github.com/microsoft/azure-pipelines-tasks/issues/22421
+    #
+    # NuGetAuthenticate@1 above publishes the endpoint token as VSS_NUGET_ACCESSTOKEN,
+    # which is populated in fork builds and useful as SYSTEM_ACCESSTOKEN here.
+    env:
+      SYSTEM_ACCESSTOKEN: $(VSS_NUGET_ACCESSTOKEN)
 
   - script: cmake --version
     workingDirectory: build

--- a/eng/templates/config.toml.template
+++ b/eng/templates/config.toml.template
@@ -6,15 +6,21 @@
 # CMake/Corrosion invokes cargo for the azure-core-amqp rust_wrapper crate.
 #
 # CargoAuthenticate@0 parses the [registries] table below and exports the
-# CARGO_REGISTRIES_AZURE_SDK_FOR_RUST_TOKEN / _CREDENTIAL_PROVIDER variables that cargo
-# needs to authenticate against the feed.
+# CARGO_REGISTRIES_AZURE_SDK_FOR_RUST_PUBLIC_TOKEN / _CREDENTIAL_PROVIDER variables that
+# cargo needs to authenticate against the feed.
+#
+# The feed is the project-scoped `public` one shared with azure-sdk-for-rust, and the
+# `~force-auth` suffix on the feed name is required. Without it Azure DevOps answers the
+# index anonymously, and cargo fails with "token rejected ... got 401" for the anonymous
+# identity aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa. See
+# https://learn.microsoft.com/azure/devops/artifacts/cargo/cargo-upstream-source.
 #
 # The [source] replacement is what actually redirects index.crates.io and
 # static.crates.io to the feed. Cargo does not honor environment variables for the
 # [source] table, so an on-disk config file is required.
 
 [registries]
-azure-sdk-for-rust = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/_packaging/azure-sdk-for-rust/Cargo/index/" }
+azure-sdk-for-rust-public = { index = "sparse+https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-rust-public~force-auth/Cargo/index/" }
 
 [source.crates-io]
-replace-with = "azure-sdk-for-rust"
+replace-with = "azure-sdk-for-rust-public"


### PR DESCRIPTION
`cmake build All` fails in fork PR validation because cargo cannot read the Cargo index. `CargoAuthenticate@0` authenticates with `SYSTEM_ACCESSTOKEN`, which Azure DevOps does not deliver to fork builds; the task still reports success but writes the anonymous identity, so the failure only surfaces later as a 401/TF400813 from the feed.

Both fixes are ported from `azure-sdk-for-rust`.

## Changes
- Point `config.toml.template` at the project-scoped `azure-sdk-for-rust-public~force-auth` feed
- Run `NuGetAuthenticate@1` before `CargoAuthenticate@0` and pass its `VSS_NUGET_ACCESSTOKEN` in as `SYSTEM_ACCESSTOKEN`

Split out of #7214, where this was validated as build 6688949: `cmake build All` 27/27, and CFSClean compliant on every job.
