### PR TITLE
Stop overriding X_VCPKG_ASSET_SOURCES from a secret variable

### DIFF
--- a/eng/pipelines/templates/steps/cmake-build.yml
+++ b/eng/pipelines/templates/steps/cmake-build.yml
@@ -72,7 +72,6 @@ steps:
     displayName: cmake generate
     env:
       VCPKG_BINARY_SOURCES: $(VCPKG_BINARY_SOURCES_SECRET)
-      X_VCPKG_ASSET_SOURCES: $(X_VCPKG_ASSET_SOURCES_SECRET)
 
 # Core should build all cmake targets
   - ${{ if and(eq(parameters.Build, true), eq(parameters.ServiceDirectory, 'core')) }}:


### PR DESCRIPTION
`X_VCPKG_ASSET_SOURCES` is moving off the azuresdkartifacts storage account and
onto the Microsoft-hosted Terrapin source mirror, which carries no SAS token and
is therefore not a secret. eng/common now sets `X_VCPKG_ASSET_SOURCES` directly
and no longer defines `X_VCPKG_ASSET_SOURCES_SECRET`, so mapping that removed
variable into the step env would shadow the value eng/common sets.

- Dropped the `X_VCPKG_ASSET_SOURCES: $(X_VCPKG_ASSET_SOURCES_SECRET)` env mapping
- `VCPKG_BINARY_SOURCES` still carries a SAS token and keeps its secret mapping

Related: Azure/azure-sdk-tools#16724
