### PR TITLE
Build the uAMQP AMQP stack in CI beside the Rust stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,19 +7,7 @@ cmake_minimum_required (VERSION 3.13)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 
 # Disable Rust based APIs in C++ SDK.
-#
-# EXPERIMENT. DO NOT MERGE. The default below reads OFF in main.
-#
-# No pipeline sets this option, so each pipeline gets the Rust AMQP stack, and
-# CI has not compiled the uAMQP stack since 2025-03-11, when #6442 forced the
-# Rust stack on. This branch turns the option on by default, so the pipelines
-# build uAMQP and run its tests. The purpose is to measure what that time did to
-# the uAMQP build on gcc, on clang, and on MSVC, with WARNINGS_AS_ERRORS on.
-#
-# This option is the supported switch, so the UWP jobs stay correct: the block
-# below that tests BUILD_WINDOWS_UWP sets DISABLE_AMQP when this option is on,
-# because uAMQP does not build for UWP.
-set(DISABLE_RUST_IN_BUILD ON CACHE BOOL "Disable Rust based APIs in package")
+set(DISABLE_RUST_IN_BUILD OFF CACHE BOOL "Disable Rust based APIs in package")
 set(DISABLE_AMQP OFF CACHE BOOL "Disable AMQP based functionality")
 set(DISABLE_AZURE_CORE_OPENTELEMETRY OFF CACHE BOOL "Disable OpenTelemetry based functionality")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,19 @@ cmake_minimum_required (VERSION 3.13)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 
 # Disable Rust based APIs in C++ SDK.
-set(DISABLE_RUST_IN_BUILD OFF CACHE BOOL "Disable Rust based APIs in package")
+#
+# EXPERIMENT. DO NOT MERGE. The default below reads OFF in main.
+#
+# No pipeline sets this option, so each pipeline gets the Rust AMQP stack, and
+# CI has not compiled the uAMQP stack since 2025-03-11, when #6442 forced the
+# Rust stack on. This branch turns the option on by default, so the pipelines
+# build uAMQP and run its tests. The purpose is to measure what that time did to
+# the uAMQP build on gcc, on clang, and on MSVC, with WARNINGS_AS_ERRORS on.
+#
+# This option is the supported switch, so the UWP jobs stay correct: the block
+# below that tests BUILD_WINDOWS_UWP sets DISABLE_AMQP when this option is on,
+# because uAMQP does not build for UWP.
+set(DISABLE_RUST_IN_BUILD ON CACHE BOOL "Disable Rust based APIs in package")
 set(DISABLE_AMQP OFF CACHE BOOL "Disable AMQP based functionality")
 set(DISABLE_AZURE_CORE_OPENTELEMETRY OFF CACHE BOOL "Disable OpenTelemetry based functionality")
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -44,6 +44,10 @@ parameters:
   - name: MatrixFile
     type: string
     default: eng/pipelines/templates/stages/platform-matrix.json
+  # A second matrix file, built beside MatrixFile. Empty means no second job set.
+  - name: AdditionalMatrixFile
+    type: string
+    default: ''
   - name: JobName
     type: string
     default: Validate 
@@ -77,6 +81,38 @@ jobs:
         TestEnv: ${{ parameters.TestEnv }}
         PreTestSteps: ${{ parameters.PreTestSteps }}
         PostTestSteps: ${{ parameters.PostTestSteps }}
+
+  # A separate call, not a second MatrixConfigs entry above: generate-job-matrix
+  # passes one AdditionalParameters object to every config, and ci.tests.yml
+  # names each job "<DisplayName>_<OSName>", so two configs in one call would
+  # declare the same job identifier twice.
+  - ${{ if ne(parameters.AdditionalMatrixFile, '') }}:
+    - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+      parameters:
+        GenerateJobName: ${{ parameters.JobName }}_uamqp_generate_matrix
+        MatrixConfigs:
+          - Name: uamqp
+            Path: ${{ parameters.AdditionalMatrixFile }}
+            Selection: all
+            GenerateVMJobs: true
+        JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
+        OsVmImage: $(LINUXVMIMAGE)
+        Pool: $(LINUXPOOL)
+        AdditionalParameters:
+          DisplayName: ${{ parameters.JobName }}_uamqp
+          Artifacts: ${{ parameters.Artifacts }}
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          TestPipeline: ${{ parameters.TestPipeline }}
+          CtestRegex: ${{ parameters.CtestRegex }}
+          CtestExcludeRegex: ${{ parameters.CtestExcludeRegex }}
+          CoverageReportPath: ${{ parameters.CoverageReportPath }}
+          # The coverage targets are calibrated against the Rust build.
+          CoverageEnabled: false
+          LineCoverageTarget: ${{ parameters.LineCoverageTarget }}
+          BranchCoverageTarget: ${{ parameters.BranchCoverageTarget }}
+          TestEnv: ${{ parameters.TestEnv }}
+          PreTestSteps: ${{ parameters.PreTestSteps }}
+          PostTestSteps: ${{ parameters.PostTestSteps }}
 
   # Disable build for cpp - client
   - ${{ if and(eq(parameters.RunMetaJobs, 'true'), ne(parameters.ServiceDirectory, 'not-specified' )) }}:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -82,6 +82,11 @@ parameters:
   - name: UseFederatedAuth
     type: boolean
     default: true
+  # A second matrix file. The Build stage passes it; PrePublishBuild does not,
+  # so pull request feedback stays fast.
+  - name: AdditionalMatrixFile
+    type: string
+    default: ''
 
 extends:
   ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -172,6 +177,7 @@ extends:
             # Code coverage is enabled by default for live tests
             parameters:
               MatrixFile: eng/pipelines/templates/stages/platform-matrix.json
+              AdditionalMatrixFile: ${{ parameters.AdditionalMatrixFile }}
               JobName: Validate
               ServiceDirectory: ${{ parameters.ServiceDirectory }}
               Artifacts: ${{ parameters.Artifacts }}

--- a/eng/pipelines/templates/stages/platform-matrix-uamqp.json
+++ b/eng/pipelines/templates/stages/platform-matrix-uamqp.json
@@ -1,0 +1,48 @@
+{
+  "displayNames": {
+    "_": ""
+  },
+  "include": [
+    {
+      "StaticConfigs": {
+        "Ubuntu22": {
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL",
+          "VCPKG_DEFAULT_TRIPLET": "x64-linux",
+          "BuildArgs": "-j 10",
+          "CMAKE_BUILD_TYPE": "Debug",
+          "CmakeArgs": " -DBUILD_TESTING=ON -DDISABLE_RUST_IN_BUILD=ON"
+        }
+      },
+      "BuildSettings": {
+        "gpp-9": {
+          "AptDependencies": "g++-9",
+          "CC": "/usr/bin/gcc-9",
+          "CXX": "/usr/bin/g++-9"
+        },
+        "clang-15": {
+          "AptDependencies": "clang-15",
+          "CC": "/usr/bin/clang-15",
+          "CXX": "/usr/bin/clang++-15"
+        }
+      }
+    },
+    {
+      "StaticConfigs": {
+        "Win2022": {
+          "OSVmImage": "env:WINDOWSVMIMAGE",
+          "Pool": "env:WINDOWSPOOL",
+          "CMAKE_GENERATOR": "Visual Studio 17 2022",
+          "BuildArgs": "--parallel 8 --config Debug"
+        }
+      },
+      "TargetArchitecture": {
+        "x64": {
+          "CMAKE_GENERATOR_PLATFORM": "x64",
+          "VCPKG_DEFAULT_TRIPLET": "x64-windows-static",
+          "CmakeArgs": " -DBUILD_TESTING=ON -DMSVC_USE_STATIC_CRT=ON -DDISABLE_RUST_IN_BUILD=ON"
+        }
+      }
+    }
+  ]
+}

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/vendor/azure-uamqp-c/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/vendor/azure-uamqp-c/CMakeLists.txt
@@ -1,7 +1,9 @@
 #Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.5)
+if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
+    cmake_minimum_required(VERSION 3.18)
+endif()
 project(uamqp)
 
 FILE(READ ${CMAKE_CURRENT_LIST_DIR}/version.txt UAMQP_VERSION)

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -47,6 +47,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: core
+    AdditionalMatrixFile: eng/pipelines/templates/stages/platform-matrix-uamqp.json
     # CI has static code analysis disabled, while LiveTest will have it enabled
     # In the case of changes to core we want to re-run all CI tests for all
     # libraries to check for potential regressions everywhere.

--- a/sdk/eventhubs/ci.yml
+++ b/sdk/eventhubs/ci.yml
@@ -27,6 +27,7 @@ extends:
     template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
     parameters:
       ServiceDirectory: eventhubs
+      AdditionalMatrixFile: eng/pipelines/templates/stages/platform-matrix-uamqp.json
       CtestRegex: "azure-messaging-eventhubs.*"
       LiveTestCtestRegex: "azure-messaging-eventhubs.*"
       LiveTestTimeoutInMinutes: 120


### PR DESCRIPTION
## Summary

Continuous integration builds only the Rust AMQP stack. The uAMQP transport has no automated test coverage.

This change adds a three-leg matrix for uAMQP builds and tests. Each continuous integration run now covers both stacks. The Rust stack remains the default for all other consumers.

## Motivation

No pipeline sets `DISABLE_RUST_IN_BUILD`. On 2025-03-11, #6442 forced `USE_RUST_AMQP` on. Continuous integration then compiled only the Rust AMQP stack.

The guards are symmetric. One stack alone leaves the other stack's test bodies empty. `sdk/core/azure-core-amqp/test/ut` contains 45 `ENABLE_UAMQP` guards across 9 files and 21 `ENABLE_RUST_AMQP` guards across 6 files.

Build 6707791 passed all 605 tests. The uAMQP run contained 225 `azure-core-amqp` entries; the Rust run contained 170.

The uAMQP build used `WARNINGS_AS_ERRORS` and produced no compiler warning or error in a uAMQP source. uAMQP needs no repair phase before continuous integration uses it.

## Changes

- Adds `eng/pipelines/templates/stages/platform-matrix-uamqp.json` with three legs: `Ubuntu22_gpp9`, `Ubuntu22_clang15`, and `Win2022_x64`. Each leg passes `-DDISABLE_RUST_IN_BUILD=ON` and `-DBUILD_TESTING=ON`.
- Adds an `AdditionalMatrixFile` parameter with an empty default to the client job and stage templates. All other pipelines remain unchanged.
- Uses a separate `generate-job-matrix.yml` call for the second matrix. One call gives each configuration the same `AdditionalParameters` object. Two configurations in one call declare the same job identifier twice.
- Passes the parameter only to the `Build` stage, so pull request feedback keeps its current speed.
- Adds the matrix to `sdk/core/ci.yml` and `sdk/eventhubs/ci.yml`. These two pipelines are the only pipelines that use AMQP.
- Disables coverage for the uAMQP legs. The Rust build sets the baseline for `LineCoverageTarget`.
- Changes the vendored uAMQP CMake floor to the guarded form on the upstream `azure-uamqp-c` `master` branch. The subdirectory uses the root CMake floor of 3.13.

## Test plan

- `Create-JobMatrix.ps1` produced exactly the three expected legs. Each leg contained both flags.
- The real pool filters routed two legs to Linux, one to Windows, and zero to macOS. The literal `env:` pool names passed the filter before variable resolution.
- The base matrix still produced its current 26 legs.
- The final continuous integration run must show a Rust leg set and a uAMQP leg set.

## Related work

#7342 covers the sync of two upstream decoder fixes into the vendored copy.
