### PR TITLE
fix(core-amqp): leave an object closed when its close fails

### DIFF
--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- A close that fails now leaves the object closed. `ManagementClient`, `MessageSender`, and `MessageReceiver` kept the open flag when the close threw, and the destructor then stopped the process. [[#7323]](https://github.com/Azure/azure-sdk-for-cpp/issues/7323)
+
 ### Other Changes
 
 ## 1.0.0-beta.12 (2026-05-14)

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/management.cpp
@@ -140,11 +140,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     Common::_detail::CallContext callContext(
         Common::_detail::GlobalStateHolder::GlobalStateInstance()->GetRuntimeContext(), context);
 
+    // Even if the detach fails, the management client is closed. A client that failed to detach is
+    // not usable again, and a client that keeps the open flag stops the process in its destructor.
+    m_isOpen = false;
+
     if (amqpmanagement_detach_and_release(callContext.GetCallContext(), m_management.release()))
     {
       throw std::runtime_error("Could not close management client: " + callContext.GetError());
     }
-    m_isOpen = false;
     Log::Stream(Logger::Level::Verbose) << "ManagementClient::Close completed." << std::endl;
   }
 

--- a/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/rust_amqp/amqp/message_sender.cpp
@@ -174,12 +174,15 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       Common::_detail::CallContext callContext(
           Common::_detail::GlobalStateHolder::GlobalStateInstance()->GetRuntimeContext(), context);
 
+      // Even if the detach fails, the sender is closed. A sender that failed to detach is not
+      // usable again, and a sender that keeps the open flag stops the process in its destructor.
+      m_senderOpen = false;
+
       if (amqpmessagesender_detach_and_release(
               callContext.GetCallContext(), m_messageSender.release()))
       {
         throw std::runtime_error("Could not close Message Sender: " + callContext.GetError());
       }
-      m_senderOpen = false;
     }
     else
     {

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/management.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/management.cpp
@@ -11,6 +11,7 @@
 #include <azure/core/diagnostics/logger.hpp>
 #include <azure/core/internal/diagnostics/log.hpp>
 
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -280,13 +281,26 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     }
 
     SetState(ManagementState::Closing);
+
+    // Close the message sender and the message receiver, even if one of the two closes fails. An
+    // object that stays open stops the process in its own destructor. Keep the first exception and
+    // give it to the caller after both objects are closed.
+    std::exception_ptr firstException;
+
     if (m_messageSender && m_messageSenderOpen)
     {
       if (m_options.EnableTrace)
       {
         Log::Stream(Logger::Level::Verbose) << "ManagementClient::Close Sender" << std::endl;
       }
-      m_messageSender->Close(context);
+      try
+      {
+        m_messageSender->Close(context);
+      }
+      catch (...)
+      {
+        firstException = std::current_exception();
+      }
       m_messageSenderOpen = false;
     }
     if (m_messageReceiver && m_messageReceiverOpen)
@@ -295,10 +309,28 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       {
         Log::Stream(Logger::Level::Verbose) << "ManagementClient::Close Receiver" << std::endl;
       }
-      m_messageReceiver->Close(context);
+      try
+      {
+        m_messageReceiver->Close(context);
+      }
+      catch (...)
+      {
+        if (!firstException)
+        {
+          firstException = std::current_exception();
+        }
+      }
       m_messageReceiverOpen = false;
     }
+
+    // The management client is closed, even if a close failed. An object that failed to detach is
+    // not usable again.
     m_isOpen = false;
+
+    if (firstException)
+    {
+      std::rethrow_exception(firstException);
+    }
   }
 
   void ManagementClientImpl::OnMessageSenderStateChanged(

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_receiver.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_receiver.cpp
@@ -448,58 +448,78 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (m_receiverOpen)
     {
-      if (m_options.EnableTrace)
+      // The teardown must run on every path, because a close that fails leaves the receiver
+      // unusable. CompleteClose() does the teardown. The caller gets the exception after the
+      // teardown.
+      try
       {
-        Log::Stream(Logger::Level::Verbose) << "Lock for Closing message receiver.";
-      }
-
-      AZURE_ASSERT(m_link);
-
-      bool shouldWaitForClose = m_currentState == _internal::MessageReceiverState::Closing
-          || m_currentState == _internal::MessageReceiverState::Open;
-
-      {
-        std::unique_lock<std::mutex> lock{m_mutableState};
-        if (m_linkPollingEnabled)
+        if (m_options.EnableTrace)
         {
-          Common::_detail::GlobalStateHolder::GlobalStateInstance()->RemovePollable(
-              m_link); // This will ensure that the link is cleaned up on the next poll()
-          m_linkPollingEnabled = false;
+          Log::Stream(Logger::Level::Verbose) << "Lock for Closing message receiver.";
+        }
+
+        AZURE_ASSERT(m_link);
+
+        bool shouldWaitForClose = m_currentState == _internal::MessageReceiverState::Closing
+            || m_currentState == _internal::MessageReceiverState::Open;
+
+        {
+          std::unique_lock<std::mutex> lock{m_mutableState};
+          if (m_linkPollingEnabled)
+          {
+            Common::_detail::GlobalStateHolder::GlobalStateInstance()->RemovePollable(
+                m_link); // This will ensure that the link is cleaned up on the next poll()
+            m_linkPollingEnabled = false;
+          }
+        }
+        {
+          auto lock{m_session->GetConnection()->Lock()};
+
+          // Clear messages from the queue.
+          m_messageQueue.Clear();
+          if (messagereceiver_close(m_messageReceiver.get()))
+          {
+            throw std::runtime_error("Could not close message receiver");
+          }
+        }
+
+        // Release the lock so that the polling thread can make forward progress delivering the
+        // detach notification.
+        if (m_options.EnableTrace)
+        {
+          Log::Stream(Logger::Level::Verbose)
+              << "Wait for receiver detach to complete. Current state: " << m_currentState;
+        }
+
+        if (shouldWaitForClose)
+        {
+          // At this point, the underlying link is in the "half closed" state.
+          // We need to wait for the link to be fully closed before we can destroy it.
+          auto closeResult = m_closeQueue.WaitForResult(context);
+          if (!closeResult)
+          {
+            throw Azure::Core::OperationCancelledException(
+                "MessageReceiver close operation was cancelled.");
+          }
         }
       }
+      catch (...)
       {
-        auto lock{m_session->GetConnection()->Lock()};
-
-        // Clear messages from the queue.
-        m_messageQueue.Clear();
-        if (messagereceiver_close(m_messageReceiver.get()))
-        {
-          throw std::runtime_error("Could not close message receiver");
-        }
+        CompleteClose();
+        throw;
       }
 
-      // Release the lock so that the polling thread can make forward progress delivering the
-      // detach notification.
-      if (m_options.EnableTrace)
-      {
-        Log::Stream(Logger::Level::Verbose)
-            << "Wait for receiver detach to complete. Current state: " << m_currentState;
-      }
+      CompleteClose();
+    }
+  }
 
-      if (shouldWaitForClose)
-      {
-        // At this point, the underlying link is in the "half closed" state.
-        // We need to wait for the link to be fully closed before we can destroy it.
-        auto closeResult = m_closeQueue.WaitForResult(context);
-        if (!closeResult)
-        {
-          throw Azure::Core::OperationCancelledException(
-              "MessageReceiver close operation was cancelled.");
-        }
-      }
-      {
-        auto lock{m_session->GetConnection()->Lock()};
+  void MessageReceiverImpl::CompleteClose() noexcept
+  {
+    {
+      auto lock{m_session->GetConnection()->Lock()};
 
+      if (m_link)
+      {
         // We've received the close, we don't care about the detach event any more.
         if (m_options.EnableTrace)
         {
@@ -511,14 +531,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         // Now that the connection is closed, the link is no longer needed. This will free the link
         m_link.reset();
       }
-      if (m_options.EnableTrace)
-      {
-        Log::Stream(Logger::Level::Verbose) << "Closing message receiver. Stop async";
-      }
-      m_session->GetConnection()->EnableAsyncOperation(false);
-
-      m_receiverOpen = false;
     }
+    if (m_options.EnableTrace)
+    {
+      Log::Stream(Logger::Level::Verbose) << "Closing message receiver. Stop async";
+    }
+    m_session->GetConnection()->EnableAsyncOperation(false);
+
+    m_receiverOpen = false;
   }
 
   std::string MessageReceiverImpl::GetLinkName() const

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
@@ -381,59 +381,78 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
   {
     if (m_senderOpen)
     {
-      if (m_options.EnableTrace)
-      {
-        Log::Stream(Logger::Level::Verbose) << "Closing message sender.";
-      }
-      Common::_detail::GlobalStateHolder::GlobalStateInstance()->RemovePollable(
-          m_link); // This will ensure that the link is cleaned up on the next poll()
-      bool shouldWaitForClose = m_currentState == _internal::MessageSenderState::Closing
-          || m_currentState == _internal::MessageSenderState::Open;
-
+      // The teardown must run on every path, because a close that fails leaves the sender
+      // unusable. CompleteClose() does the teardown. The caller gets the exception after the
+      // teardown.
+      try
       {
         if (m_options.EnableTrace)
         {
-          Log::Stream(Logger::Level::Verbose) << "Lock for Closing message sender.";
+          Log::Stream(Logger::Level::Verbose) << "Closing message sender.";
         }
+        Common::_detail::GlobalStateHolder::GlobalStateInstance()->RemovePollable(
+            m_link); // This will ensure that the link is cleaned up on the next poll()
+        bool shouldWaitForClose = m_currentState == _internal::MessageSenderState::Closing
+            || m_currentState == _internal::MessageSenderState::Open;
 
-        auto lock{m_session->GetConnection()->Lock()};
-
-        if (messagesender_close(m_messageSender.get()))
         {
-          throw std::runtime_error("Could not close message sender");
-        }
-      }
-      // The message sender (and it's underlying link) is in the half open state. Wait until the
-      // link has fully closed.
-      if (shouldWaitForClose)
-      {
-        if (m_options.EnableTrace)
-        {
-          Log::Stream(Logger::Level::Verbose)
-              << "Wait for sender detach to complete. Current state: " << m_currentState;
-        }
-
-        auto result = m_closeQueue.WaitForResult(context);
-        if (!result)
-        {
-          throw Azure::Core::OperationCancelledException(
-              "Message sender close operation cancelled.");
-        }
-        if (std::get<0>(*result))
-        {
-          auto rv = std::move(std::get<0>(*result));
-          if (rv)
+          if (m_options.EnableTrace)
           {
-            throw std::runtime_error(
-                "Message sender close operation failed: " + rv.Condition.ToString()
-                + " description: " + rv.Description);
+            Log::Stream(Logger::Level::Verbose) << "Lock for Closing message sender.";
+          }
+
+          auto lock{m_session->GetConnection()->Lock()};
+
+          if (messagesender_close(m_messageSender.get()))
+          {
+            throw std::runtime_error("Could not close message sender");
+          }
+        }
+        // The message sender (and it's underlying link) is in the half open state. Wait until the
+        // link has fully closed.
+        if (shouldWaitForClose)
+        {
+          if (m_options.EnableTrace)
+          {
+            Log::Stream(Logger::Level::Verbose)
+                << "Wait for sender detach to complete. Current state: " << m_currentState;
+          }
+
+          auto result = m_closeQueue.WaitForResult(context);
+          if (!result)
+          {
+            throw Azure::Core::OperationCancelledException(
+                "Message sender close operation cancelled.");
+          }
+          if (std::get<0>(*result))
+          {
+            auto rv = std::move(std::get<0>(*result));
+            if (rv)
+            {
+              throw std::runtime_error(
+                  "Message sender close operation failed: " + rv.Condition.ToString()
+                  + " description: " + rv.Description);
+            }
           }
         }
       }
-
+      catch (...)
       {
-        auto lock{m_session->GetConnection()->Lock()};
+        CompleteClose();
+        throw;
+      }
 
+      CompleteClose();
+    }
+  }
+
+  void MessageSenderImpl::CompleteClose() noexcept
+  {
+    {
+      auto lock{m_session->GetConnection()->Lock()};
+
+      if (m_link)
+      {
         if (m_options.EnableTrace)
 
         {
@@ -446,10 +465,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         // Now that the connection is closed, the link is no longer needed. This will free the link
         m_link.reset();
       }
-      m_session->GetConnection()->EnableAsyncOperation(false);
-
-      m_senderOpen = false;
     }
+    m_session->GetConnection()->EnableAsyncOperation(false);
+
+    m_senderOpen = false;
   }
 
   void MessageSenderImpl::OnLinkDetached(Models::_internal::AmqpError const& error)

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/message_receiver_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/message_receiver_impl.hpp
@@ -108,5 +108,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     void CreateLink();
     void CreateLink(_internal::LinkEndpoint& endpoint);
     void PopulateLinkProperties();
+
+    /** @brief Release the link and the async operation on the connection, then mark the receiver
+     * as closed.
+     *
+     * Close() calls this on every path, including the paths that throw. A receiver that keeps the
+     * async operation on the connection stops the process in ~ConnectionImpl, and a receiver that
+     * keeps the open flag stops the process in ~MessageReceiverImpl.
+     */
+    void CompleteClose() noexcept;
   };
 }}}} // namespace Azure::Core::Amqp::_detail

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/message_sender_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/message_sender_impl.hpp
@@ -74,6 +74,15 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         Context const& context);
     void OnLinkDetached(Models::_internal::AmqpError const& error);
 
+    /** @brief Release the link and the async operation on the connection, then mark the sender as
+     * closed.
+     *
+     * Close() calls this on every path, including the paths that throw. A sender that keeps the
+     * async operation on the connection stops the process in ~ConnectionImpl, and a sender that
+     * keeps the open flag stops the process in ~MessageSenderImpl.
+     */
+    void CompleteClose() noexcept;
+
     bool m_senderOpen{false};
     UniqueMessageSender m_messageSender{};
     std::shared_ptr<_detail::LinkImpl> m_link;

--- a/sdk/core/azure-core-amqp/test/ut/management_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/management_tests.cpp
@@ -298,6 +298,48 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
 #endif
   }
 
+  // A close that fails must leave the management client closed. Before the correction, the client
+  // kept its open flag, and the destructor of the client stopped the process.
+  // See https://github.com/Azure/azure-sdk-for-cpp/issues/7323.
+  TEST_F(TestManagement, ManagementCloseWithCancelledContext)
+  {
+#if !defined(USE_NATIVE_BROKER)
+    MessageTests::MockServiceEndpointOptions managementEndpointOptions;
+    managementEndpointOptions.EnableTrace = true;
+    auto endpoint = std::make_shared<ManagementServiceEndpoint>(managementEndpointOptions);
+    m_mockServer.AddServiceEndpoint(endpoint);
+
+    auto connection{CreateAmqpConnection()};
+    auto session{CreateAmqpSession(connection)};
+
+    {
+      ManagementClientOptions options;
+      options.EnableTrace = 1;
+      ManagementClient management(session.CreateManagementClient("Test", options));
+
+      StartServerListening();
+
+      auto openResult = management.Open();
+      EXPECT_EQ(openResult, ManagementOpenStatus::Ok);
+
+      Azure::Core::Context cancelledContext;
+      cancelledContext.Cancel();
+
+      // The close closes the message sender first. That close waits for the detach on the
+      // cancelled context, so it throws, and the client gives that first exception to the caller.
+      // The client must still go to the closed state, which the destructor below tests.
+      EXPECT_THROW(management.Close(cancelledContext), Azure::Core::OperationCancelledException);
+
+      // The management client is destroyed here. The destructor must not stop the process.
+    }
+
+    StopServerListening();
+    EndAmqpSession(session);
+    CloseAmqpConnection(connection);
+#else
+#endif
+  }
+
   TEST_F(TestManagement, ManagementOpenCloseAuthenticated)
   {
 #if !defined(USE_NATIVE_BROKER)

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -354,6 +354,198 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     EXPECT_NO_THROW(CloseAmqpConnection(connection));
   }
 
+  // A close that fails must leave the message receiver closed. Before the correction, the receiver
+  // kept its open flag, and the destructor of the receiver stopped the process.
+  // See https://github.com/Azure/azure-sdk-for-cpp/issues/7323.
+  TEST_F(TestMessageSendReceive, ReceiverCloseWithCancelledContext)
+  {
+    auto connection{
+        CreateAmqpConnection(testing::UnitTest::GetInstance()->current_test_info()->name(), true)};
+    auto session{CreateAmqpSession(connection, {})};
+
+#if !defined(USE_NATIVE_BROKER)
+    // The mock server must attach the link. Without a service endpoint, the peer never sends the
+    // attach, the receiver stays below the Open state, and the close returns without a look at the
+    // context.
+    class ReceiverLinkEndpoint : public MessageTests::MockServiceEndpoint {
+    public:
+      ReceiverLinkEndpoint(
+          std::string const& name,
+          MessageTests::MockServiceEndpointOptions const& options)
+          : MockServiceEndpoint(name, options)
+      {
+      }
+      virtual ~ReceiverLinkEndpoint() = default;
+
+    private:
+      void MessageReceived(
+          std::string const& linkName,
+          std::shared_ptr<Azure::Core::Amqp::Models::AmqpMessage> const& message) override
+      {
+        GTEST_LOG_(INFO) << "Message received on link " << linkName << ": " << *message;
+      }
+    };
+
+    MessageTests::MockServiceEndpointOptions mockServiceEndpointOptions{};
+    mockServiceEndpointOptions.EnableTrace = true;
+    auto receiverEndpoint
+        = std::make_shared<ReceiverLinkEndpoint>("MyTarget", mockServiceEndpointOptions);
+    m_mockServer.AddServiceEndpoint(receiverEndpoint);
+#endif
+
+    StartServerListening();
+    {
+#if ENABLE_UAMQP
+      class ReceiverEvents : public MessageReceiverEvents {
+      public:
+        Azure::Core::Amqp::Common::_internal::AsyncOperationQueue<MessageReceiverState>
+            StateChangeQueue;
+
+      private:
+        void OnMessageReceiverStateChanged(
+            MessageReceiver const& receiver,
+            MessageReceiverState newState,
+            MessageReceiverState oldState) override
+        {
+          GTEST_LOG_(INFO) << "Message receiver state changed: " << oldState << " -> " << newState;
+          (void)receiver;
+          (void)oldState;
+          StateChangeQueue.CompleteOperation(newState);
+        }
+
+        Models::AmqpValue OnMessageReceived(
+            MessageReceiver const&,
+            std::shared_ptr<Models::AmqpMessage> const&) override
+        {
+          return Models::AmqpValue();
+        }
+
+        void OnMessageReceiverDisconnected(
+            MessageReceiver const&,
+            Models::_internal::AmqpError const& error) override
+        {
+          GTEST_LOG_(INFO) << "Message receiver disconnected: " << error;
+        }
+      };
+      ReceiverEvents receiverEvents;
+#endif
+
+      MessageReceiverOptions options;
+      options.Name = "Test Receiver";
+      // The mock server builds its message sender from this target, so the target needs an
+      // address.
+      options.MessageTarget = "MyReceiverTarget";
+      MessageReceiver receiver(session.CreateMessageReceiver(
+          "MyTarget",
+          options
+#if ENABLE_UAMQP
+          ,
+          &receiverEvents
+#endif
+          ));
+
+      EXPECT_NO_THROW(receiver.Open());
+
+#if ENABLE_UAMQP
+      // Wait until the receiver reaches the Open state. The close waits on the context only when
+      // the receiver is in the Open state or in the Closing state.
+      Azure::Core::Context waitContext{Azure::DateTime::clock::now() + std::chrono::seconds(30)};
+      MessageReceiverState currentState{MessageReceiverState::Idle};
+      while (currentState != MessageReceiverState::Open)
+      {
+        auto stateChange = receiverEvents.StateChangeQueue.WaitForResult(waitContext);
+        ASSERT_TRUE(stateChange) << "The message receiver did not reach the Open state.";
+        currentState = std::get<0>(*stateChange);
+      }
+#endif
+
+      Azure::Core::Context cancelledContext;
+      cancelledContext.Cancel();
+
+#if ENABLE_UAMQP
+      // The uAMQP close waits for the detach on the context. The cancelled context makes that wait
+      // fail, so the close throws. The receiver must still go to the closed state, which the
+      // destructor below tests.
+      EXPECT_THROW(receiver.Close(cancelledContext), Azure::Core::OperationCancelledException);
+#else
+      // The Rust transport does not wait on the context during the close, so the close succeeds.
+      EXPECT_NO_THROW(receiver.Close(cancelledContext));
+#endif
+
+      // The message receiver is destroyed here. The destructor must not stop the process.
+    }
+
+    StopServerListening();
+    EndAmqpSession(session);
+    CloseAmqpConnection(connection);
+  }
+
+  // A close that fails must leave the message sender closed. Before the correction, the sender kept
+  // its open flag, and the destructor of the sender stopped the process. The sender also kept the
+  // async operation on the connection, and the destructor of the connection stopped the process.
+  // See https://github.com/Azure/azure-sdk-for-cpp/issues/7323.
+  TEST_F(TestMessageSendReceive, SenderCloseWithCancelledContext)
+  {
+    auto connection{
+        CreateAmqpConnection(testing::UnitTest::GetInstance()->current_test_info()->name(), true)};
+    auto session{CreateAmqpSession(connection, {})};
+
+#if !defined(USE_NATIVE_BROKER)
+    class SenderLinkEndpoint : public MessageTests::MockServiceEndpoint {
+    public:
+      SenderLinkEndpoint(
+          std::string const& name,
+          MessageTests::MockServiceEndpointOptions const& options)
+          : MockServiceEndpoint(name, options)
+      {
+      }
+      virtual ~SenderLinkEndpoint() = default;
+
+    private:
+      void MessageReceived(
+          std::string const& linkName,
+          std::shared_ptr<Azure::Core::Amqp::Models::AmqpMessage> const& message) override
+      {
+        GTEST_LOG_(INFO) << "Message received on link " << linkName << ": " << *message;
+      }
+    };
+
+    MessageTests::MockServiceEndpointOptions mockServiceEndpointOptions{};
+    mockServiceEndpointOptions.EnableTrace = true;
+    auto senderEndpoint
+        = std::make_shared<SenderLinkEndpoint>("MyTarget", mockServiceEndpointOptions);
+    m_mockServer.AddServiceEndpoint(senderEndpoint);
+#endif
+
+    StartServerListening();
+    {
+      MessageSenderOptions options;
+      options.MessageSource = "MySource";
+
+      MessageSender sender(session.CreateMessageSender("MyTarget", options));
+      EXPECT_FALSE(sender.Open());
+
+      Azure::Core::Context cancelledContext;
+      cancelledContext.Cancel();
+
+#if ENABLE_UAMQP
+      // The uAMQP close waits for the detach on the context. The cancelled context makes that wait
+      // fail, so the close throws. The sender must still go to the closed state, which the
+      // destructor below tests.
+      EXPECT_THROW(sender.Close(cancelledContext), Azure::Core::OperationCancelledException);
+#else
+      // The Rust transport does not wait on the context during the close, so the close succeeds.
+      EXPECT_NO_THROW(sender.Close(cancelledContext));
+#endif
+
+      // The message sender is destroyed here. The destructor must not stop the process.
+    }
+
+    StopServerListening();
+    EndAmqpSession(session);
+    CloseAmqpConnection(connection);
+  }
+
 #if ENABLE_UAMQP
 #if !defined(USE_NATIVE_BROKER)
   TEST_F(TestMessageSendReceive, TestLocalhostVsTls)


### PR DESCRIPTION
## Summary

`ManagementClientImpl::Close`, `MessageSenderImpl::Close`, and `MessageReceiverImpl::Close` clear the open flag only on the last line. A close that throws skips that line and leaves the object open. The destructor then calls `AzureNoReturnPath`, which stops the process in a Debug build and in a Release build. The caller cannot catch this.

Fixes #7323.

## Motivation

`MessageSenderImpl::Close` waits on its close queue with the context of the caller. A cancelled context, or a peer that sends no detach, makes `WaitForResult` return nothing. The close then throws `OperationCancelledException`. An Event Hubs caller that puts a deadline on a properties call therefore stops the process.

The uAMQP sender and receiver also run their teardown after that wait, so a throw skips it. The teardown calls `EnableAsyncOperation(false)`. Without that call the poll count stays raised, and `~ConnectionImpl` aborts with "Connection is being destroyed while polling". A fix that only clears the flag moves the abort. `ManagementClientImpl::Close` skips its receiver close when the sender close throws, and the open receiver aborts in its destructor.

Pull request #7308 rebases on this change. Issue #7327 records the one open item in this area.

## Changes

- `MessageSenderImpl` and `MessageReceiverImpl` (uAMQP) move the teardown into a private `CompleteClose` method. `Close` calls it on the normal path and in a catch block that rethrows. `CompleteClose` releases the link, calls `EnableAsyncOperation(false)`, and clears the open flag.
- `ManagementClientImpl::Close` (uAMQP) runs both closes, keeps the first exception, clears its own flag, and rethrows.
- `ManagementClientImpl::Close` and `MessageSenderImpl::Close` (Rust) clear the flag before the detach call. This matches the Rust `MessageReceiverImpl::Close`, which already did this.
- No close gets its own deadline. A ten second deadline stopped the Event Hubs concurrency test on each run. That test passes in 63 seconds when the close keeps the context of the caller.
- The changelog gets an entry under `### Bugs Fixed` for 1.0.0-beta.13.

## Test plan

Three tests open an object, close it with a context that is already cancelled, and then destroy it.

- `TestMessageSendReceive.SenderCloseWithCancelledContext` and `TestMessageSendReceive.ReceiverCloseWithCancelledContext` in `sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp`. Both register a mock service endpoint. Both assert `EXPECT_THROW(..., Azure::Core::OperationCancelledException)` on uAMQP and `EXPECT_NO_THROW` on Rust.
- The receiver test also waits for the Open state through a `MessageReceiverEvents` handler. `MessageReceiverImpl::Open` returns before the link attaches, so an immediate close leaves `shouldWaitForClose` false and never reads the context.
- `TestManagement.ManagementCloseWithCancelledContext` in `sdk/core/azure-core-amqp/test/ut/management_tests.cpp` asserts the same exception. Its body sits behind `#if !defined(USE_NATIVE_BROKER)`, so it is empty on a Rust build.

All three sit inside the `#if !defined(AZ_PLATFORM_MAC)` block that holds the tests around them.

The pipeline builds the Rust stack alone, because `sdk/core/azure-core-amqp/CMakeLists.txt` forces `USE_RUST_AMQP` on unless `DISABLE_RUST_IN_BUILD` is set. A cancelled context cannot make a Rust detach fail. `amqpmessagesender_detach_and_release` in `rust_wrapper/src/amqp/message_sender.rs` uses the call context only for the runtime handle and the error slot, then calls `block_on(sender.inner.detach())`.

## Validation

A Linux container ran the tests on the branch, then ran them again with the production code of `origin/main` restored.

| Test | With the change | With the production code of `main` |
| --- | --- | --- |
| `TestMessageSendReceive.SenderCloseWithCancelledContext` | exit 0, `[ OK ] ... (510 ms)` | exit 134, `AzureNoReturnPath (msg="MessageSenderImpl is being destroyed while open.")` at `message_sender.cpp:125` |
| `TestMessageSendReceive.ReceiverCloseWithCancelledContext` | exit 0, `[ OK ] ... (516 ms)` | exit 134, `AzureNoReturnPath (msg="MessageReceiverImpl is being destroyed while open.")` at `message_receiver.cpp:257` |
| `TestManagement.ManagementCloseWithCancelledContext` | exit 0, `[ OK ] ... (720 ms)` | exit 134, `management.cpp:37: ~ManagementClientImpl(): Assertion ((void)("Management being destroyed while open."), (!m_isOpen)) failed` |

- Each abort site above comes from a `gdb` backtrace of the aborting run, so the frame and the message text are exact.
- The full uAMQP suite passes with the change: `[ PASSED ] 167 tests`, exit 0. With the production code of `main` it reaches 120 tests, then aborts at `TestManagement.ManagementCloseWithCancelledContext` with exit 134.
- The build: `ubuntu:22.04`, GCC 11.4.0, CMake 4.3.4 from the Kitware release (vcpkg needs `string(JSON ... STRING_ENCODE)` and Ubuntu 22.04 ships CMake 3.22), and vcpkg at the `builtin-baseline` of `vcpkg.json`. Then `cmake -S . -B build-uamqp -G Ninja -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DDISABLE_RUST_IN_BUILD=ON` and `cmake --build build-uamqp --target azure-core-amqp-tests`. The build needs no `WARNINGS_AS_ERRORS=OFF`.
- The container is `linux/arm64` and the pipeline uses `x86_64`. The defect sits in C++ control flow and not in code generation, but this measurement does not cover `x86_64`.
- The pipeline covers the Rust stack, which this measurement did not build.
