### PR TITLE
Add CFSClean2 to network isolation policy

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -91,7 +91,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive, CFSClean
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'cpp - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:


### PR DESCRIPTION
## cpp - eventhubs - ci
Step "dump package properties" hits this:

- www.powershellgallery.com
- vcpkg.storage.devpackages.microsoft.io
- shavamanifestazurecdnprod1.azureedge.net (occasionally)

https://dev.azure.com/azure-sdk/public/_build/results?buildId=6711392&view=logs&j=a7bbfb1e-9b1d-5480-b954-b42b4949e5ba&t=0ff50e5f-d0eb-5177-ba7c-701380498833&l=23