### PR TITLE
Fix Event Hubs partition key live test timeout

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
@@ -313,9 +313,10 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
       partitionOptions.StartPosition.SequenceNumber = sequenceNumberBeforeSend[partitionId];
       auto receiver = consumer->CreatePartitionClient(partitionId, partitionOptions);
 
-      // ReceiveEvents returns as soon as the receiver queue is empty, so one call can return fewer
-      // events than the batch holds. Read until this partition holds the whole batch, or until the
-      // partition stays quiet, or until the time runs out.
+      // ReceiveEvents waits for the first event and then returns when the receiver queue is empty,
+      // so pass the deadline to stop a read on a partition that holds none of this batch. Read
+      // until this partition holds the whole batch, or until the partition stays quiet, or until
+      // the time runs out.
       std::vector<std::shared_ptr<const Azure::Messaging::EventHubs::Models::ReceivedEventData>>
           eventsOnPartition;
       auto const deadline = std::chrono::system_clock::now() + std::chrono::seconds(60);
@@ -323,7 +324,16 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace Test {
       while (eventsOnPartition.size() < eventCount && quietReads < 6
              && std::chrono::system_clock::now() < deadline)
       {
-        auto batchOfEvents = receiver.ReceiveEvents(eventCount);
+        std::vector<std::shared_ptr<const Azure::Messaging::EventHubs::Models::ReceivedEventData>>
+            batchOfEvents;
+        try
+        {
+          batchOfEvents = receiver.ReceiveEvents(eventCount, Azure::Core::Context{deadline});
+        }
+        catch (Azure::Core::OperationCancelledException const&)
+        {
+          break;
+        }
         if (batchOfEvents.empty())
         {
           quietReads++;


### PR DESCRIPTION
## Summary

Fixes the Event Hubs partition key live test timeout.

## Motivation

`PartitionClient::ReceiveEvents` waits for the first event when a partition has no queued events. The live test read every partition without passing its existing deadline, so the first empty partition blocked until the 1,200-second CTest timeout.

## Changes

- The live test passes a 60-second per-partition deadline to `ReceiveEvents`.
- The live test treats a deadline cancellation as the end of events for the partition.
- The corrected test comment describes the long-poll behavior.

## Test plan

- The macOS ARM64 build completed the `azure-messaging-eventhubs-test` target with the Rust AMQP backend.
- The Event Hubs playback suite passed each of 107 tests or skipped it as live-only.
- `CTest` registers the affected live test with a 1,200-second guard. The Azure live pipeline will exercise the service path.
