### PR TITLE
Fix WinHttpRequest destructor hang when the request context is never bound

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugs Fixed
 
+- [[#7353]](https://github.com/Azure/azure-sdk-for-cpp/pull/7353) Fixed a hang in the WinHTTP transport where `WinHttpRequest`'s destructor could block forever when the request was destroyed before `WinHttpSendRequest` associated the request context with the handle, causing `WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING` to be discarded.
 - [[#7200]](https://github.com/Azure/azure-sdk-for-cpp/pull/7200) Fix global-buffer-overflow and undefined shift in `Base64Decode()`. (A community contribution, courtesy of _[groeneai](https://github.com/groeneai)_)
 
 ### Other Changes

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -1432,6 +1432,30 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // Set the callback function to be called whenever the state of the request handle changes.
     m_httpAction = std::make_unique<_detail::WinHttpAction>(this);
 
+    // Associate the action with the request handle before the status callback is registered.
+    //
+    // WinHttpSendRequest() also passes this value as its context parameter, but it is not reached
+    // if the request is destroyed first - for example when an exception is thrown while preparing
+    // the request. In that case WinHttpAction::StatusCallback() is invoked with dwContext == 0 and
+    // discards every notification, including the WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING that
+    // ~WinHttpRequest() blocks on, so the destructor would wait forever.
+    //
+    // Binding the context here guarantees HANDLE_CLOSING is always delivered, so the destructor's
+    // close barrier - which exists to keep WinHTTP worker threads from dereferencing a freed
+    // WinHttpAction - always completes.
+    //
+    // NB: DO NOT CHANGE THE TYPE OF THE CONTEXT VALUE WITHOUT UPDATING
+    // WinHttpAction::StatusCallback.
+    DWORD_PTR contextValue = reinterpret_cast<DWORD_PTR>(m_httpAction.get());
+    if (!WinHttpSetOption(
+            m_requestHandle.get(),
+            WINHTTP_OPTION_CONTEXT_VALUE,
+            &contextValue,
+            sizeof(contextValue)))
+    {
+      GetErrorAndThrow("Error while setting the request context value.");
+    }
+
     if (!m_httpAction->RegisterWinHttpStatusCallback(m_requestHandle))
     {
       GetErrorAndThrow("Error while setting up the status callback.");

--- a/sdk/core/azure-core/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core/test/ut/CMakeLists.txt
@@ -97,6 +97,7 @@ add_executable (
     transport_policy_options.cpp
     url_test.cpp
     uuid_test.cpp
+    win_http_transport_test.cpp
 )
 
 target_compile_definitions(azure-core-test PRIVATE _azure_BUILDING_TESTS)

--- a/sdk/core/azure-core/test/ut/win_http_transport_test.cpp
+++ b/sdk/core/azure-core/test/ut/win_http_transport_test.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <azure/core/platform.hpp>
+
+#if defined(AZ_PLATFORM_WINDOWS) && defined(BUILD_TRANSPORT_WINHTTP_ADAPTER)
+
+#include "azure/core/context.hpp"
+#include "azure/core/http/http.hpp"
+#include "azure/core/http/win_http_transport.hpp"
+#include "azure/core/io/body_stream.hpp"
+#include "azure/core/url.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <stdexcept>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+namespace Azure { namespace Core { namespace Test {
+
+  namespace {
+
+    // How long to wait for the transport call to return before declaring the thread stuck. The
+    // call either succeeds or throws within milliseconds, so any wait beyond a few seconds means
+    // the destructor is blocked.
+    constexpr auto TransportCallTimeout = std::chrono::seconds(30);
+
+    // The URL is never contacted: WinHttpOpen(), WinHttpConnect() and WinHttpOpenRequest() only
+    // allocate handles, and the request fails during setup before anything is sent on the wire.
+    constexpr const char* TestUrl = "https://localhost/";
+
+    // A body stream whose Length() throws.
+    //
+    // WinHttpRequest::SendRequest() calls request.GetBodyStream()->Length() before it calls
+    // WinHttpSendRequest(), so throwing from Length() aborts the request after the WinHttpRequest
+    // has been constructed (its status callback is registered) but before WinHttpSendRequest()
+    // associates the request context with the handle.
+    class ThrowingLengthBodyStream final : public Azure::Core::IO::BodyStream {
+    public:
+      int64_t Length() const override
+      {
+        throw std::runtime_error("Injected failure from BodyStream::Length");
+      }
+
+    private:
+      size_t OnRead(uint8_t*, size_t, Azure::Core::Context const&) override { return 0; }
+    };
+
+    void SendRequestThatFailsDuringSetup()
+    {
+      Azure::Core::Http::WinHttpTransport transport;
+      ThrowingLengthBodyStream bodyStream;
+      Azure::Core::Http::Request request(
+          Azure::Core::Http::HttpMethod::Put, Azure::Core::Url(TestUrl), &bodyStream);
+
+      Azure::Core::Context context;
+      static_cast<void>(transport.Send(request, context));
+    }
+
+  } // namespace
+
+  // A request that fails during setup, before WinHttpSendRequest() associates the request context
+  // with the handle, must not block the calling thread.
+  //
+  // ~WinHttpRequest() closes the request handle and waits for
+  // WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING so that no WinHTTP worker thread can dereference the
+  // WinHttpAction after it has been freed. WinHttpAction::StatusCallback() drops every
+  // notification that arrives with dwContext == 0, and the context is bound to the handle only by
+  // WinHttpSendRequest(). Without the context being bound in the constructor, the destructor waits
+  // for a notification that is discarded, on a default-constructed Context that is never
+  // cancelled, and the thread is lost for the lifetime of the process.
+  //
+  // The work runs on a detached thread on purpose: when the bug is present the thread cannot be
+  // joined, so the test must still be able to report the failure. On Windows, process exit
+  // terminates the leaked thread.
+  TEST(WinHttpTransport, RequestThatFailsDuringSetupDoesNotHang)
+  {
+    auto callCompleted = std::make_shared<std::promise<void>>();
+    std::future<void> callCompletedFuture = callCompleted->get_future();
+
+    std::thread([callCompleted]() {
+      try
+      {
+        SendRequestThatFailsDuringSetup();
+      }
+      catch (...)
+      {
+        // Expected: the injected Length() failure propagates out of Send(). All this test cares
+        // about is that the call returns rather than blocking forever.
+      }
+
+      callCompleted->set_value();
+    }).detach();
+
+    ASSERT_EQ(std::future_status::ready, callCompletedFuture.wait_for(TransportCallTimeout))
+        << "WinHttpTransport::Send did not return within "
+        << std::chrono::duration_cast<std::chrono::seconds>(TransportCallTimeout).count()
+        << "s. ~WinHttpRequest is blocked waiting for WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING, "
+           "which is discarded because the request context was never associated with the request "
+           "handle.";
+  }
+
+}}} // namespace Azure::Core::Test
+
+#endif // AZ_PLATFORM_WINDOWS && BUILD_TRANSPORT_WINHTTP_ADAPTER


### PR DESCRIPTION
Fixes #7352

## Problem

`WinHttpRequest::~WinHttpRequest()` closes the request handle and then waits for
`WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING` before returning. That barrier is deliberate and
necessary: WinHTTP is used in async mode (`WINHTTP_FLAG_ASYNC`), the callback context is a raw
pointer to the `WinHttpAction` owned by the request, and the callback also dereferences
`m_httpRequest`. Returning before `HANDLE_CLOSING` would let a WinHTTP worker thread touch freed
memory.

However, `WinHttpAction::StatusCallback()` discards every notification that arrives with
`dwContext == 0`, and the context is bound to the handle **only** by `WinHttpSendRequest()` — while
the status callback is registered much earlier, at the end of the constructor. Any request
destroyed in between (for example when an exception is thrown while preparing headers or querying
the body stream length) therefore closes its handle, receives `HANDLE_CLOSING` with no context, has
it dropped, and blocks in `WaitForAction` forever. The wait uses a default-constructed
`Azure::Core::Context`, so `ThrowIfCancelled()` never fires and the poll loop spins indefinitely —
the thread is lost for the lifetime of the process.

`CompleteActionWithError()` intentionally does not signal while waiting for `HANDLE_CLOSING`, so
the `REQUEST_ERROR` / `ERROR_WINHTTP_OPERATION_CANCELLED` notification that WinHTTP raises when
closing a handle with a pending operation does not release the waiter either.

This is the hang that remains in the window #6637 addressed for the FailFast case; that PR's own
comment already observes that "the `initiateAction` call is a call to `WinHttpSendRequest` which
establishes the SendContext".

## Fix

Bind the context to the request handle in the constructor with
`WinHttpSetOption(WINHTTP_OPTION_CONTEXT_VALUE, ...)`, immediately before registering the status
callback. `HANDLE_CLOSING` is then always delivered with a valid context, so the destructor's
barrier always completes. `WinHttpSendRequest()` continues to pass the same value, which is
idempotent.

The barrier itself is unchanged — the fix makes it satisfiable rather than removing it.

### Alternatives considered

- **Track whether the context was bound and skip the wait when it was not.** Safe for the same
  reason the bug exists (with no context every callback is already dropped, so there is nothing to
  synchronize against), but smaller in scope and leaves `HANDLE_CLOSING` unobservable.
- **Give the destructor's wait a deadline.** Rejected: abandoning the wait permits a WinHTTP worker
  thread to invoke the callback after `WinHttpAction`/`WinHttpRequest` are destroyed, converting a
  hang into a use-after-free.
- **Signal the event from `CompleteActionWithError()` during close.** Rejected for the same reason:
  it would release the waiter before `HANDLE_CLOSING`, which is precisely what the barrier prevents.

## Test

`sdk/core/azure-core/test/ut/win_http_transport_test.cpp` adds
`WinHttpTransport.RequestThatFailsDuringSetupDoesNotHang`.

`SendRequest()` calls `request.GetBodyStream()->Length()` before `WinHttpSendRequest()`, and
`BodyStream::Length()` is not `noexcept`, so a body stream that throws from `Length()` enters the
window deterministically. The test needs no network: `WinHttpOpen()`, `WinHttpConnect()` and
`WinHttpOpenRequest()` only allocate handles, and the request fails before anything is sent.

The work runs on a detached thread guarded by a 30 s future wait, so a regression fails the test
instead of hanging the CI run (a blocked destructor cannot be joined).

Verified against the vendored 1.16.3 sources in a downstream consumer: an equivalent test hangs
and fails on the 30 s timeout without the product change, and passes in 0.76 s with it. A leak
checker also reported the abandoned `WinHttpRequest` from
`WinHttpTransportImpl::CreateRequestHandle()` before the fix, and no leaks after.

The full CI matrix is green on this PR, including the `Win2022_Win32Api_debug_tests_winhttp_x64`
and `x86` legs that build and run the new test.

## Pull Request Checklist

- [x] [C++ Guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html)
- [ ] Doxygen docs — n/a, no public API change
- [x] Unit tests
- [x] No unwanted commits/changes
- [x] Descriptive title/description
  - [x] PR is single purpose
  - [x] Related issue listed
- [x] Comments in source
- [x] No typos
- [x] Update changelog
- [ ] Not work-in-progress — opened as a draft for maintainer feedback on the approach
- [x] External references or docs updated
- [x] Self review of PR done
- [x] Any breaking changes? — none; behavior only changes in the case that previously hung

---

<sub>Authored with GitHub Copilot CLI — session ID `6afdad25-6ece-4e65-991c-aa8d88d138fa`</sub>

