### PR TITLE
Fix uAMQP sender close failures

### DIFF
--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bugs Fixed
 
+- uAMQP now tears down unsettled sends without leaving late dispositions with freed callback state. Sender Open cleanup no longer deadlocks with link polling. Sender Open, sender Close, and receiver Close report caller cancellation separately from synthetic timeout. [[#7350]](https://github.com/Azure/azure-sdk-for-cpp/issues/7350)
 - A close that fails now leaves the object closed. `ManagementClient`, `MessageSender`, and `MessageReceiver` kept the open flag when the close threw, and the destructor then stopped the process. [[#7323]](https://github.com/Azure/azure-sdk-for-cpp/issues/7323)
 - The connection no longer returns a cached CBS token that is at or near its expiry. It authenticates the audience again instead. [[#7254]](https://github.com/Azure/azure-sdk-for-cpp/issues/7254)
 - The connection now replaces each cached CBS token before that token expires, so a client that runs for longer than one token lifetime keeps working. This refresh applies to the uAMQP transport. Without this refresh, a send that gets the `amqp:unauthorized-access` condition stops at the first attempt, because the Event Hubs producer treats that condition as not transient. [[#7254]](https://github.com/Azure/azure-sdk-for-cpp/issues/7254)

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_receiver.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_receiver.cpp
@@ -522,10 +522,29 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
           Context const closeContext{
               _detail::ContextWithOperationDeadline(context, std::chrono::system_clock::now())};
           auto closeResult = m_closeQueue.WaitForResult(closeContext);
+          Models::_internal::AmqpError rv;
           if (!closeResult)
           {
-            throw Azure::Core::OperationCancelledException(
-                "MessageReceiver close operation was cancelled.");
+            if (context.IsCancelled())
+            {
+              throw Azure::Core::OperationCancelledException(
+                  "MessageReceiver close operation was cancelled.");
+            }
+
+            rv
+                = {Models::_internal::AmqpErrorCondition::TimeoutError,
+                   "Message receiver close operation timed out.",
+                   {}};
+          }
+          else
+          {
+            rv = std::move(std::get<0>(*closeResult));
+          }
+          if (rv)
+          {
+            throw std::runtime_error(
+                "Message receiver close operation failed: " + rv.Condition.ToString()
+                + " description: " + rv.Description);
           }
         }
       }

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
@@ -373,18 +373,27 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         }
         m_session->GetConnection()->EnableAsyncOperation(false);
         // Clean up from changes made earlier in the open, since the open was not successful.
-        auto lock{m_session->GetConnection()->Lock()};
-        m_link->UnsubscribeFromDetachEvent();
-
         Common::_detail::GlobalStateHolder::GlobalStateInstance()->RemovePollable(
             m_link); // This will ensure that the link is cleaned up on the next poll()
-        messagesender_close(m_messageSender.get());
-        m_link.reset();
-        m_messageSender.reset();
+        {
+          auto lock{m_session->GetConnection()->Lock()};
+          m_link->UnsubscribeFromDetachEvent();
+
+          messagesender_close(m_messageSender.get());
+          m_link.reset();
+          m_messageSender.reset();
+        }
         if (!result)
         {
-          throw Azure::Core::OperationCancelledException(
-              "Message sender open operation cancelled.");
+          if (context.IsCancelled())
+          {
+            throw Azure::Core::OperationCancelledException(
+                "Message sender open operation cancelled.");
+          }
+          rv
+              = {Models::_internal::AmqpErrorCondition::TimeoutError,
+                 "Message sender open operation timed out.",
+                 {}};
         }
         else
         {
@@ -451,20 +460,29 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
           Context const closeContext{
               _detail::ContextWithOperationDeadline(context, std::chrono::system_clock::now())};
           auto result = m_closeQueue.WaitForResult(closeContext);
+          Models::_internal::AmqpError rv;
           if (!result)
           {
-            throw Azure::Core::OperationCancelledException(
-                "Message sender close operation cancelled.");
-          }
-          if (std::get<0>(*result))
-          {
-            auto rv = std::move(std::get<0>(*result));
-            if (rv)
+            if (context.IsCancelled())
             {
-              throw std::runtime_error(
-                  "Message sender close operation failed: " + rv.Condition.ToString()
-                  + " description: " + rv.Description);
+              throw Azure::Core::OperationCancelledException(
+                  "Message sender close operation cancelled.");
             }
+
+            rv
+                = {Models::_internal::AmqpErrorCondition::TimeoutError,
+                   "Message sender close operation timed out.",
+                   {}};
+          }
+          else
+          {
+            rv = std::move(std::get<0>(*result));
+          }
+          if (rv)
+          {
+            throw std::runtime_error(
+                "Message sender close operation failed: " + rv.Condition.ToString()
+                + " description: " + rv.Description);
           }
         }
       }

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/vendor/azure-uamqp-c/inc/azure_uamqp_c/link.h
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/vendor/azure-uamqp-c/inc/azure_uamqp_c/link.h
@@ -76,6 +76,7 @@ MOCKABLE_FUNCTION(, int, link_send_disposition, LINK_HANDLE, link, delivery_numb
 MOCKABLE_FUNCTION(, int, link_attach, LINK_HANDLE, link, ON_TRANSFER_RECEIVED, on_transfer_received, ON_LINK_STATE_CHANGED, on_link_state_changed, ON_LINK_FLOW_ON, on_link_flow_on, void*, callback_context);
 MOCKABLE_FUNCTION(, int, link_detach, LINK_HANDLE, link, bool, close, const char*, error_condition, const char*, error_description, AMQP_VALUE, info);
 MOCKABLE_FUNCTION(, ASYNC_OPERATION_HANDLE, link_transfer_async, LINK_HANDLE, handle, message_format, message_format, PAYLOAD*, payloads, size_t, payload_count, ON_DELIVERY_SETTLED, on_delivery_settled, void*, callback_context, LINK_TRANSFER_RESULT*, link_transfer_result,tickcounter_ms_t, timeout);
+MOCKABLE_FUNCTION(, int, link_transfer_async_cancel, LINK_HANDLE, link, ASYNC_OPERATION_HANDLE, link_transfer_operation);
 MOCKABLE_FUNCTION(, void, link_dowork, LINK_HANDLE, link);
 MOCKABLE_FUNCTION(, int, link_reset_link_credit, LINK_HANDLE, link, uint32_t, link_credit, bool, drain);
 

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/vendor/azure-uamqp-c/src/link.c
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/vendor/azure-uamqp-c/src/link.c
@@ -1489,6 +1489,59 @@ static bool remove_pending_delivery_condition_function(const void* item, const v
     return result;
 }
 
+int link_transfer_async_cancel(LINK_HANDLE link, ASYNC_OPERATION_HANDLE link_transfer_operation)
+{
+    int result;
+
+    if ((link == NULL) || (link_transfer_operation == NULL))
+    {
+        LogError("Invalid arguments: link = %p, link_transfer_operation = %p", link, link_transfer_operation);
+        result = MU_FAILURE;
+    }
+    else if (link->pending_deliveries == NULL)
+    {
+        LogError("Link has no pending deliveries");
+        result = MU_FAILURE;
+    }
+    else
+    {
+        LIST_ITEM_HANDLE pending_delivery = singlylinkedlist_get_head_item(link->pending_deliveries);
+
+        result = MU_FAILURE;
+        while (pending_delivery != NULL)
+        {
+            if ((ASYNC_OPERATION_HANDLE)singlylinkedlist_item_get_value(pending_delivery) == link_transfer_operation)
+            {
+                DELIVERY_INSTANCE* delivery_instance
+                    = GET_ASYNC_OPERATION_CONTEXT(DELIVERY_INSTANCE, link_transfer_operation);
+                if ((delivery_instance == NULL) || (delivery_instance->link != link))
+                {
+                    LogError("Pending delivery does not belong to link");
+                }
+                else if (singlylinkedlist_remove(link->pending_deliveries, pending_delivery) != 0)
+                {
+                    LogError("Cannot remove pending delivery");
+                }
+                else
+                {
+                    async_operation_destroy(link_transfer_operation);
+                    result = 0;
+                }
+                break;
+            }
+
+            pending_delivery = singlylinkedlist_get_next_item(pending_delivery);
+        }
+
+        if (pending_delivery == NULL)
+        {
+            LogError("Pending delivery was not found");
+        }
+    }
+
+    return result;
+}
+
 static void link_transfer_cancel_handler(ASYNC_OPERATION_HANDLE link_transfer_operation)
 {
     DELIVERY_INSTANCE* pending_delivery = GET_ASYNC_OPERATION_CONTEXT(DELIVERY_INSTANCE, link_transfer_operation);

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/vendor/azure-uamqp-c/src/message_sender.c
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/vendor/azure-uamqp-c/src/message_sender.c
@@ -857,16 +857,36 @@ static void indicate_all_messages_as_error(MESSAGE_SENDER_INSTANCE* message_send
     for (i = 0; i < message_sender->message_count; i++)
     {
         MESSAGE_WITH_CALLBACK* message_with_callback = GET_ASYNC_OPERATION_CONTEXT(MESSAGE_WITH_CALLBACK, message_sender->messages[i]);
-        if (message_with_callback->on_message_send_complete != NULL)
+        bool can_destroy_message = true;
+
+        if (message_with_callback->transfer_async_operation != NULL)
         {
-            message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_ERROR, NULL);
+            if (link_transfer_async_cancel(message_sender->link, message_with_callback->transfer_async_operation) != 0)
+            {
+                LogError("Cannot cancel pending message transfer");
+                // Retain the callback state because the delivery still owns a pointer to it.
+                message_with_callback->on_message_send_complete = NULL;
+                can_destroy_message = false;
+            }
+            else
+            {
+                message_with_callback->transfer_async_operation = NULL;
+            }
         }
 
-        if (message_with_callback->message != NULL)
+        if (can_destroy_message)
         {
-            message_destroy(message_with_callback->message);
+            if (message_with_callback->on_message_send_complete != NULL)
+            {
+                message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_ERROR, NULL);
+            }
+
+            if (message_with_callback->message != NULL)
+            {
+                message_destroy(message_with_callback->message);
+            }
+            async_operation_destroy(message_sender->messages[i]);
         }
-        async_operation_destroy(message_sender->messages[i]);
     }
 
     if (message_sender->messages != NULL)

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -27,8 +27,12 @@
 #include <azure/core/platform.hpp>
 #include <azure/core/url.hpp>
 
+#include <chrono>
+#include <exception>
 #include <functional>
+#include <future>
 #include <random>
+#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -841,6 +845,127 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       std::this_thread::sleep_for(std::chrono::seconds(6));
 
       sender.Close();
+    }
+    StopServerListening();
+
+    EndAmqpSession(session);
+    CloseAmqpConnection(connection);
+  }
+#endif // !defined(USE_NATIVE_BROKER)
+
+#if !defined(USE_NATIVE_BROKER)
+  TEST_F(TestMessageSendReceive, SenderCloseWhileUnsettledSendIgnoresLateDisposition)
+  {
+    class DelayedSenderLinkEndpoint final : public MessageTests::MockServiceEndpoint {
+    public:
+      DelayedSenderLinkEndpoint(
+          std::string const& name,
+          MessageTests::MockServiceEndpointOptions const& options)
+          : MockServiceEndpoint(name, options),
+            m_transferReceived{m_transferReceivedPromise.get_future()},
+            m_settlementReleased{m_settlementReleasedPromise.get_future()}
+      {
+      }
+
+      std::future_status WaitForTransfer(std::chrono::milliseconds timeout)
+      {
+        return m_transferReceived.wait_for(timeout);
+      }
+
+      void ReleaseSettlement() { m_settlementReleasedPromise.set_value(); }
+
+      Azure::Core::Amqp::Models::AmqpValue OnMessageReceived(
+          Azure::Core::Amqp::_internal::MessageReceiver const& receiver,
+          std::shared_ptr<Azure::Core::Amqp::Models::AmqpMessage> const& message) override
+      {
+        m_transferReceivedPromise.set_value();
+        m_settlementReleased.wait();
+        return MockServiceEndpoint::OnMessageReceived(receiver, message);
+      }
+
+    private:
+      void MessageReceived(
+          std::string const&,
+          std::shared_ptr<Azure::Core::Amqp::Models::AmqpMessage> const&) override
+      {
+      }
+
+      std::promise<void> m_transferReceivedPromise;
+      std::future<void> m_transferReceived;
+      std::promise<void> m_settlementReleasedPromise;
+      std::future<void> m_settlementReleased;
+    };
+
+    MessageTests::MockServiceEndpointOptions mockServiceEndpointOptions{};
+    mockServiceEndpointOptions.EnableTrace = true;
+    auto senderEndpoint = std::make_shared<DelayedSenderLinkEndpoint>(
+        "localhost/ingress", mockServiceEndpointOptions);
+    m_mockServer.AddServiceEndpoint(senderEndpoint);
+
+    auto connection{CreateAmqpConnection()};
+    auto session{CreateAmqpSession(connection)};
+
+    StartServerListening();
+
+    {
+      MessageSenderOptions options;
+      options.Name = "sender-link";
+      options.MessageSource = "ingress";
+      options.SettleMode = SenderSettleMode::Unsettled;
+      options.MaxMessageSize = 65536;
+      MessageSender sender(session.CreateMessageSender("localhost/ingress", options));
+      EXPECT_FALSE(sender.Open());
+
+      Azure::Core::Amqp::Models::AmqpMessage message;
+      message.SetBody(Azure::Core::Amqp::Models::AmqpValue{"Hello"});
+
+      std::promise<void> sendFinishedPromise;
+      auto sendFinished = sendFinishedPromise.get_future();
+      std::exception_ptr sendException;
+      std::thread sendWorker([&]() {
+        try
+        {
+          (void)sender.Send(message);
+        }
+        catch (...)
+        {
+          sendException = std::current_exception();
+        }
+        sendFinishedPromise.set_value();
+      });
+
+      EXPECT_EQ(
+          senderEndpoint->WaitForTransfer(std::chrono::seconds(5)), std::future_status::ready);
+
+      std::promise<void> closeStartedPromise;
+      auto closeStarted = closeStartedPromise.get_future();
+      std::promise<void> closeFinishedPromise;
+      auto closeFinished = closeFinishedPromise.get_future();
+      std::exception_ptr closeException;
+      std::thread closeWorker([&]() {
+        closeStartedPromise.set_value();
+        try
+        {
+          sender.Close(
+              Azure::Core::Context{Azure::DateTime::clock::now() + std::chrono::seconds(5)});
+        }
+        catch (...)
+        {
+          closeException = std::current_exception();
+        }
+        closeFinishedPromise.set_value();
+      });
+
+      EXPECT_EQ(closeStarted.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+      EXPECT_EQ(sendFinished.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+      senderEndpoint->ReleaseSettlement();
+
+      EXPECT_EQ(closeFinished.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+      sendWorker.join();
+      closeWorker.join();
+      EXPECT_EQ(sendException, nullptr);
+      EXPECT_EQ(closeException, nullptr);
     }
     StopServerListening();
 

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -959,9 +959,9 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
 
       EXPECT_EQ(closeStarted.wait_for(std::chrono::seconds(5)), std::future_status::ready);
 
+      EXPECT_EQ(sendFinished.wait_for(std::chrono::seconds(5)), std::future_status::ready);
       senderEndpoint->ReleaseSettlement();
 
-      EXPECT_EQ(sendFinished.wait_for(std::chrono::seconds(5)), std::future_status::ready);
       EXPECT_EQ(closeFinished.wait_for(std::chrono::seconds(5)), std::future_status::ready);
       sendWorker.join();
       closeWorker.join();

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -853,6 +853,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
   }
 #endif // !defined(USE_NATIVE_BROKER)
 
+#if ENABLE_UAMQP
 #if !defined(USE_NATIVE_BROKER)
   TEST_F(TestMessageSendReceive, SenderCloseWhileUnsettledSendIgnoresLateDisposition)
   {
@@ -957,10 +958,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       });
 
       EXPECT_EQ(closeStarted.wait_for(std::chrono::seconds(5)), std::future_status::ready);
-      EXPECT_EQ(sendFinished.wait_for(std::chrono::seconds(5)), std::future_status::ready);
 
       senderEndpoint->ReleaseSettlement();
 
+      EXPECT_EQ(sendFinished.wait_for(std::chrono::seconds(5)), std::future_status::ready);
       EXPECT_EQ(closeFinished.wait_for(std::chrono::seconds(5)), std::future_status::ready);
       sendWorker.join();
       closeWorker.join();
@@ -973,6 +974,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     CloseAmqpConnection(connection);
   }
 #endif // !defined(USE_NATIVE_BROKER)
+#endif // ENABLE_UAMQP
 
   TEST_F(TestMessageSendReceive, AuthenticatedSender)
   {


### PR DESCRIPTION
## Summary

Fixes #7350.

## Motivation

uAMQP could free an unsettled send callback before a delayed broker disposition used it. Sender Open cleanup could also wait for polling while it held the connection lock.

## Changes

- Remove a pending native transfer before freeing its outer send state during close.
- Move sender Open polling removal before the connection lock.
- Report synthetic sender and receiver deadlines as retryable AMQP timeouts, while caller cancellation stays final.

## Test plan

- Ran the socket-mock-broker regression under AddressSanitizer. The unchanged source reports a heap-use-after-free in `message_sender.c:113`; this branch passes.
- Ran 216 `azure-core-amqp` tests and 9 uAMQP-only tests under AddressSanitizer.
- Ran `RetriesAllowlistedEventHubsConditions` and `DoesNotRetryOperationCancelledException`.