### PR TITLE
Finalize Event Hubs beta changelogs for release

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/CHANGELOG.md
@@ -1,24 +1,10 @@
 # Release History
 
-## 1.0.0-beta.4 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.4 (2026-08-18)
 
 ### Other Changes
 
-## 1.0.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- No public changes in this release.
 
 ## 1.0.0-beta.2 (2026-05-15)
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.14 (Unreleased)
+## 1.0.0-beta.14 (2026-08-18)
 
 ### Features Added
 
@@ -8,8 +8,6 @@
 - [[#7295]](https://github.com/Azure/azure-sdk-for-cpp/issues/7295) Connection-string authentication now works on the Rust AMQP backend. `ProducerClient` and `ConsumerClient` no longer throw when the caller passes a connection string.
 - [[#7254]](https://github.com/Azure/azure-sdk-for-cpp/issues/7254) `ProducerClient::Send` now builds a new sender on each retry attempt. A failed attempt discards the sender, the session, and the connection for that partition, so the next attempt builds all three again and authenticates with a current token. A send that a link detach ended previously failed for the life of the client.
 - [[#7254]](https://github.com/Azure/azure-sdk-for-cpp/issues/7254) `PartitionClient::ReceiveEvents` now attaches a new receiver after a link fault, and it starts after the last event that it gave the caller. So the caller sees no duplicate event and no lost event. A permanent condition, for example `amqp:link:stolen`, still reaches the caller at once. A call that already holds events gives them back and recovers on the next call.
-
-### Breaking Changes
 
 ### Bugs Fixed
 


### PR DESCRIPTION
## Summary

- Finalize the Event Hubs 1.0.0-beta.14 changelog for the 2026-08-18 release.
- Finalize the checkpoint-store 1.0.0-beta.4 changelog and remove the empty, unpublished beta.3 placeholder.
- Remove empty changelog sections rejected by the release gate.

## Validation

- Ran Verify-ChangeLog.ps1 with ForRelease enabled for both packages.
- Both verifications passed.
- Ran git diff --check.

## Checklist

- [x] No unwanted commits or changes
- [x] Descriptive title and single-purpose description
- [x] Changelogs updated
- [x] No breaking changes
- [x] Self-review completed