### PR TITLE
Fix vcpkg release pull request authentication

### DIFF
--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -247,16 +247,21 @@ stages:
                     CommitMsg: Update vcpkg-configuration.json
                     BaseRepoBranch: $(DefaultBranch)
 
-                # Set $(HasChanges) to $(PublishToVcpkg) so that
-                # create-pull-request.yml creates or does not create a PR
-                # based on the deicision of the step that determines
-                # whether to publish to vcpkg.
-                - pwsh: Write-Host "##vso[task.setvariable variable=HasChanges]$(PublishToVcpkg)"
-                  displayName: Set $(HasChanges) to $(PublishToVcpkg) for create-pull-request.yml
-
                 - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
                   parameters:
                     WorkingDirectory: $(Pipeline.Workspace)/vcpkg
+
+                - pwsh: |
+                    $commitCount = git rev-list --count "origin/$(DefaultBranch)..HEAD"
+                    if ($LASTEXITCODE -ne 0) {
+                      Write-Error "Unable to compare vcpkg HEAD with origin/$(DefaultBranch). Verify that the remote branch exists and fetch completed."
+                      exit $LASTEXITCODE
+                    }
+                    $hasChanges = [int]$commitCount -gt 0
+                    Write-Host "vcpkg is $commitCount commit(s) ahead of origin/$(DefaultBranch); setting HasChanges=$hasChanges"
+                    Write-Host "##vso[task.setvariable variable=HasChanges]$($hasChanges.ToString().ToLowerInvariant())"
+                  displayName: Set HasChanges from vcpkg branch status
+                  workingDirectory: $(Pipeline.Workspace)/vcpkg
 
                 # SkipCheckingForChanges is true to skip the commit step
                 # (which is already done by Update-VcpkgPort.ps1)

--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -260,18 +260,51 @@ stages:
 
                 # SkipCheckingForChanges is true to skip the commit step
                 # (which is already done by Update-VcpkgPort.ps1)
-                - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+                - template: /eng/common/pipelines/templates/steps/login-to-github.yml
                   parameters:
-                    RepoOwner: $(VcpkgPrRepoOwner)
-                    RepoName: $(VcpkgPrRepoName)
+                    TokenOwners:
+                      - azure-sdk
+                      - Microsoft
+
+                - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
+                  parameters:
+                    BaseRepoBranch: $(PrBranchName)
+                    BaseRepoOwner: azure-sdk
+                    TargetRepoOwner: $(VcpkgPrRepoOwner)
+                    TargetRepoName: $(VcpkgPrRepoName)
                     WorkingDirectory: $(Pipeline.Workspace)/vcpkg
-                    PrBranchName: $(PrBranchName)
-                    PRTitle: $(PrTitle)
-                    PRBody: Update vcpkg ports for Azure SDK release. This release may contain multiple ports.
                     SkipCheckingForChanges: true
-                    BaseBranchName: $(DefaultBranch)
-                    OpenAsDraft: ${{ parameters.TestPipeline }}
-                    CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
+                    AuthToken: $(GH_TOKEN_azure-sdk)
+
+                # Pass the target-repository token through the environment so
+                # Azure Pipelines resolves it before PowerShell parses the script.
+                - task: PowerShell@2
+                  displayName: Create pull request
+                  condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
+                  env:
+                    GH_TOKEN_Microsoft: $(GH_TOKEN_Microsoft)
+                  inputs:
+                    pwsh: true
+                    targetType: inline
+                    workingDirectory: $(Pipeline.Workspace)/vcpkg
+                    script: |
+                      if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN_Microsoft) -or
+                          $env:GH_TOKEN_Microsoft -match '^\$\([^)]+\)$') {
+                        throw "GH_TOKEN_Microsoft is empty or contains an unresolved pipeline variable."
+                      }
+
+                      & "$(Build.SourcesDirectory)/eng/common/scripts/Submit-PullRequest.ps1" `
+                        -RepoOwner "$(VcpkgPrRepoOwner)" `
+                        -RepoName "$(VcpkgPrRepoName)" `
+                        -BaseBranch "$(DefaultBranch)" `
+                        -PROwner "azure-sdk" `
+                        -PRBranch "$(PrBranchName)" `
+                        -AuthToken $env:GH_TOKEN_Microsoft `
+                        -PRTitle "$(PrTitle)" `
+                        -PRBody "Update vcpkg ports for Azure SDK release. This release may contain multiple ports." `
+                        -MaintainerCanModify $false `
+                        -CloseAfterOpenForTesting $${{ parameters.TestPipeline }} `
+                        -OpenAsDraft $${{ parameters.TestPipeline }}
 
                 - task: AzureCLI@2
                   displayName: Authenticate to OpenSource API

--- a/eng/scripts/Update-VcpkgPort.ps1
+++ b/eng/scripts/Update-VcpkgPort.ps1
@@ -126,6 +126,8 @@ if ($temporaryCommitCreated) {
 
 # Only perform the final commit if this is not a test release
 if (!$DailyRelease) { 
+    $finalCommitCreated = $false
+
     # Grab content needed for commit message and place in a temporary file
     $packageVersion = (Get-Content $ReleaseArtifactSourceDirectory/package-info.json -Raw | ConvertFrom-Json).version
     $commitMessageFile = New-TemporaryFile
@@ -161,13 +163,15 @@ if (!$DailyRelease) {
             Write-Error "Failed to create the vcpkg port commit"
             exit 1
         }
+
+        $finalCommitCreated = $true
     }
     else {
         Write-Host "The vcpkg working tree is clean; skipping the final commit."
     }
 
-    # Set $(HasChanges) to $true so that the push and PR submission steps run.
-    Write-Host "##vso[task.setvariable variable=HasChanges]$true"
+    # Set $(HasChanges) so that the push and PR submission steps run when needed.
+    Write-Host "##vso[task.setvariable variable=HasChanges]$finalCommitCreated"
 }
 
 

--- a/eng/scripts/Update-VcpkgPort.ps1
+++ b/eng/scripts/Update-VcpkgPort.ps1
@@ -70,14 +70,27 @@ git status
 
 # Temporarily commit changes to generate git tree objects required by 
 # "vcpkg x-add-version <port-name>"
-Write-Host "git add -A"
-git add -A
-Write-Host "git $GitCommitParameters commit -m 'Temporary commit to reset after x-add-version'"
-"git $GitCommitParameters commit -m 'Temporary commit to reset after x-add-version'" | Invoke-Expression -Verbose | Write-Host
-
-if ($LASTEXITCODE -ne 0) { 
-    Write-Error "Failed to run bootstrap-vcpkg.bat"
+$temporaryCommitCreated = $false
+$pendingChanges = git status --porcelain
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to inspect the vcpkg working tree"
     exit 1
+}
+
+if ($pendingChanges) {
+    Write-Host "git add -A"
+    git add -A
+    Write-Host "git $GitCommitParameters commit -m 'Temporary commit to reset after x-add-version'"
+    "git $GitCommitParameters commit -m 'Temporary commit to reset after x-add-version'" | Invoke-Expression -Verbose | Write-Host
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to create the temporary vcpkg port commit"
+        exit 1
+    }
+    $temporaryCommitCreated = $true
+}
+else {
+    Write-Host "The vcpkg working tree is clean; skipping the temporary commit."
 }
 
 $addVersionAdditionalParameters = ''
@@ -100,9 +113,16 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-# Reset to undo previous commit and put changes in the working directory.
-Write-Host "git reset HEAD^"
-git reset HEAD^
+# Reset to undo the temporary commit and put changes in the working directory.
+if ($temporaryCommitCreated) {
+    Write-Host "git reset HEAD^"
+    git reset HEAD^
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to reset the temporary vcpkg port commit"
+        exit 1
+    }
+}
 
 # Only perform the final commit if this is not a test release
 if (!$DailyRelease) { 
@@ -119,19 +139,34 @@ if (!$DailyRelease) {
     Write-Host "Commit Message:"
     Write-host (Get-Content $commitMessageFile -Raw)
 
-    Write-Host "git add -A"
-    git add -A
+    $pendingChanges = git status --porcelain
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to inspect the vcpkg working tree"
+        exit 1
+    }
 
-    # Final commit using commit message from the temporary file. Using the file
-    # enables the commit message to be formatted properly without having to write
-    # code to escape certain characters that might appear in the changelog file.
-    Write-Host "git $GitCommitParameters commit --file $commitMessageFile"
-    "git $GitCommitParameters commit --file $commitMessageFile" `
-        | Invoke-Expression -Verbose `
-        | Write-Host
+    if ($pendingChanges) {
+        Write-Host "git add -A"
+        git add -A
 
-    # Set $(HasChanges) to $true so that create-pull-request.yml completes the 
-    # push and PR submission steps
+        # Final commit using commit message from the temporary file. Using the file
+        # enables the commit message to be formatted properly without having to write
+        # code to escape certain characters that might appear in the changelog file.
+        Write-Host "git $GitCommitParameters commit --file $commitMessageFile"
+        "git $GitCommitParameters commit --file $commitMessageFile" `
+            | Invoke-Expression -Verbose `
+            | Write-Host
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to create the vcpkg port commit"
+            exit 1
+        }
+    }
+    else {
+        Write-Host "The vcpkg working tree is clean; skipping the final commit."
+    }
+
+    # Set $(HasChanges) to $true so that the push and PR submission steps run.
     Write-Host "##vso[task.setvariable variable=HasChanges]$true"
 }
 


### PR DESCRIPTION
## Summary

- Resolve the Microsoft GitHub App token through the `Create pull request` task environment before invoking PowerShell.
- Fail before `Submit-PullRequest.ps1` when `GH_TOKEN_Microsoft` is blank or still contains an unresolved Azure Pipelines macro.
- Skip temporary and final vcpkg commits for a clean working tree, and only reset a temporary commit created by the current run.
- Replace the misleading bootstrap error with errors for the git operation that actually failed.

## Validation

- Parsed `Update-VcpkgPort.ps1` with the PowerShell AST parser.
- Parsed `archetype-cpp-release.yml` with the Ruby YAML parser.
- Verified empty, unresolved, and resolved token precheck cases.
- Ran `Update-VcpkgPort.ps1` in an isolated clean-tree fixture; `HEAD` and the working tree remained unchanged.
- Ran `Update-VcpkgPort.ps1` in an isolated dirty-tree fixture; it created one final commit and left a clean working tree.
- Ran `git diff --check`.

## Checklist

- [x] No unwanted commits or changes
- [x] Descriptive title and single-purpose description
- [x] No public API or breaking changes
- [x] Self-review completed