### PR TITLE
Update variables passed to create-pull-request.yml

### DIFF
--- a/eng/pipelines/templates/stages/archetype-cpp-release.yml
+++ b/eng/pipelines/templates/stages/archetype-cpp-release.yml
@@ -262,8 +262,8 @@ stages:
                 # (which is already done by Update-VcpkgPort.ps1)
                 - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                   parameters:
-                    RepoOwner: $(VcpkgPrRepoOwner)
-                    RepoName: $(VcpkgPrRepoName)
+                    RepoOwner: ${{ variables.VcpkgPrRepoOwner }}
+                    RepoName: ${{ variables.VcpkgPrRepoName }}
                     WorkingDirectory: $(Pipeline.Workspace)/vcpkg
                     PrBranchName: $(PrBranchName)
                     PRTitle: $(PrTitle)


### PR DESCRIPTION
This pull request makes a small update to the `archetype-cpp-release.yml` pipeline template. The change updates how the `RepoOwner` and `RepoName` parameters are referenced, switching from standard pipeline variables to template expressions for improved parameter handling.

- Changed `RepoOwner` and `RepoName` parameter references in the `create-pull-request.yml` template step to use template expressions (`${{ variables.VcpkgPrRepoOwner }}` and `${{ variables.VcpkgPrRepoName }}`) instead of pipeline variables (`$(VcpkgPrRepoOwner)` and `$(VcpkgPrRepoName)`).