### PR TITLE
fix(core-amqp): avoid uAMQP pollable registry deadlock

### DIFF
--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### Bugs Fixed
 
+- uAMQP pollable registration and removal no longer block each other while a poll is in flight. The
+  polling registry now waits on completion notifications, and sender, receiver, and link setup and
+  teardown do not hold connection locks across registry operations. [[#7370]](https://github.com/Azure/azure-sdk-for-cpp/issues/7370)
 - uAMQP now tears down unsettled sends without leaving late dispositions with freed callback state. Sender Open cleanup no longer deadlocks with link polling. Sender Open, sender Close, and receiver Close report caller cancellation separately from synthetic timeout. [[#7350]](https://github.com/Azure/azure-sdk-for-cpp/issues/7350)
 - A close that fails now leaves the object closed. `ManagementClient`, `MessageSender`, and `MessageReceiver` kept the open flag when the close threw, and the destructor then stopped the process. [[#7323]](https://github.com/Azure/azure-sdk-for-cpp/issues/7323)
 - The connection no longer returns a cached CBS token that is at or near its expiry. It authenticates the audience again instead. [[#7254]](https://github.com/Azure/azure-sdk-for-cpp/issues/7254)

--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -13,7 +13,9 @@
 
 - uAMQP pollable registration and removal no longer block each other while a poll is in flight. The
   polling registry now waits on completion notifications, and sender, receiver, and link setup and
-  teardown do not hold connection locks across registry operations. [[#7370]](https://github.com/Azure/azure-sdk-for-cpp/issues/7370)
+  teardown do not hold connection locks across registry operations. The polling thread now sleeps
+  when no pollable is registered. It spun on one core after a process closed its last connection.
+  [[#7370]](https://github.com/Azure/azure-sdk-for-cpp/issues/7370)
 - uAMQP now tears down unsettled sends without leaving late dispositions with freed callback state. Sender Open cleanup no longer deadlocks with link polling. Sender Open, sender Close, and receiver Close report caller cancellation separately from synthetic timeout. [[#7350]](https://github.com/Azure/azure-sdk-for-cpp/issues/7350)
 - A close that fails now leaves the object closed. `ManagementClient`, `MessageSender`, and `MessageReceiver` kept the open flag when the close threw, and the destructor then stopped the process. [[#7323]](https://github.com/Azure/azure-sdk-for-cpp/issues/7323)
 - The connection no longer returns a cached CBS token that is at or near its expiry. It authenticates the audience again instead. [[#7254]](https://github.com/Azure/azure-sdk-for-cpp/issues/7254)

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/global_state.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/common/global_state.hpp
@@ -6,6 +6,8 @@
 #include <azure/core/azure_assert.hpp>
 
 #include <atomic>
+#include <condition_variable>
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -49,8 +51,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
 #if ENABLE_UAMQP
     std::list<std::shared_ptr<Pollable>> m_pollables;
     std::mutex m_pollablesMutex;
+    std::condition_variable m_pollingCondition;
+    uint64_t m_pollingGeneration{0};
+    uint64_t m_completedGeneration{0};
     std::thread m_pollingThread;
-    std::atomic<bool> m_activelyPolling;
     bool m_stopped{false};
 #elif ENABLE_RUST_AMQP
     RustRuntimeContext m_runtimeContext;

--- a/sdk/core/azure-core-amqp/src/common/global_state.cpp
+++ b/sdk/core/azure-core-amqp/src/common/global_state.cpp
@@ -107,30 +107,34 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
     xlogging_set_log_function(AmqpLogFunction);
 
     m_pollingThread = std::thread([this]() {
-      do
+      while (true)
       {
+        std::list<std::shared_ptr<Pollable>> capturedList;
+        uint64_t pollingGeneration;
         {
-          std::list<std::shared_ptr<Pollable>> capturedList;
+          std::unique_lock<std::mutex> lock{m_pollablesMutex};
+          m_pollingCondition.wait(lock, [this]() { return m_stopped || !m_pollables.empty(); });
+          if (m_stopped)
           {
-            std::unique_lock<std::mutex> lock{m_pollablesMutex};
-            // If there are no pollables, there's no point in doing any work.
-            if (m_pollables.empty())
-            {
-              continue;
-            }
-            capturedList = m_pollables;
-            m_activelyPolling = true;
+            break;
           }
-
-          for (auto const& pollable : capturedList)
-          {
-            pollable->Poll();
-          }
+          capturedList = m_pollables;
+          pollingGeneration = ++m_pollingGeneration;
         }
-        m_activelyPolling = false;
-        //        std::this_thread::yield();
+
+        for (auto const& pollable : capturedList)
+        {
+          pollable->Poll();
+        }
+        capturedList.clear();
+
+        {
+          std::lock_guard<std::mutex> lock{m_pollablesMutex};
+          m_completedGeneration = pollingGeneration;
+        }
+        m_pollingCondition.notify_all();
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      } while (!m_stopped);
+      }
     });
 #endif
   }
@@ -138,7 +142,11 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
   GlobalStateHolder::~GlobalStateHolder()
   {
 #if ENABLE_UAMQP
-    m_stopped = true;
+    {
+      std::lock_guard<std::mutex> lock{m_pollablesMutex};
+      m_stopped = true;
+    }
+    m_pollingCondition.notify_all();
     if (m_pollingThread.joinable())
     {
       m_pollingThread.join();
@@ -156,50 +164,28 @@ namespace Azure { namespace Core { namespace Amqp { namespace Common { namespace
    *
    * @param pollable The pollable object to add.
    *
-   * @note Note that you *cannot* hold any connection or link locks when calling AddPollable. This
-   * is because the the AddPollable function attempts to lock the pollable and the RemovePollable
-   * function blocks until any pollables have completed while holding the pollable lock.
-   *
-   * This can result in a deadlock because the polling thread is also going to acquire the
-   * connection lock resulting in a deadlock.
+   * @note Do not hold a connection or link lock when calling AddPollable or RemovePollable. The
+   * polling thread acquires those locks while it polls an item, and RemovePollable waits for the
+   * active polling generation to complete.
    *
    */
   void GlobalStateHolder::AddPollable(std::shared_ptr<Pollable> pollable)
   {
-    std::lock_guard<std::mutex> lock(m_pollablesMutex);
+    std::lock_guard<std::mutex> lock{m_pollablesMutex};
     if (std::find(m_pollables.begin(), m_pollables.end(), pollable) == m_pollables.end())
     {
       m_pollables.push_back(pollable);
     }
+    m_pollingCondition.notify_one();
   }
 
   void GlobalStateHolder::RemovePollable(std::shared_ptr<Pollable> pollable)
   {
-    // There is a bit of a complicated lock-free dance happening here.
-    // The m_pollables list is accessed by the polling thread, and the list is modified by the user
-    // thread. To ensure integrity of the list, the polling thread takes the lock, copies the
-    // pollable from the list, releases the lock and then iterates over the pollables at the
-    // snapshot.
-    //
-    // Because the pollable is a shared_ptr, the user thread can remove a pollable while the
-    // background thread is polling.
-    //
-    // But we want to make sure that the thread has finished polling (and thus has removed the copy
-    // of the pollables list). For that, we have the m_activelyPolling variable. It is set under the
-    // pollables lock, and cleared after the polling thread has finished polling (outside the lock).
-    //
-    // This means that we can spin on the m_activelyPolling variable *under* the pollables lock safe
-    // in the knowledge that IF the variable is set to true, it means that we acquired the
-    // pollablesMutex during the interval when the captured list is being interated over. And that
-    // the m_activelyPolling variable will only be cleared AFTER the captured list is freed.
-    //
-
-    std::lock_guard<std::mutex> lock(m_pollablesMutex);
+    std::unique_lock<std::mutex> lock{m_pollablesMutex};
     m_pollables.remove(pollable);
-    // Spin until m_activelyPolling is false, this ensures that the polling thread is not using the
-    // capturedList copy of m_pollables.
-    while (m_activelyPolling.load())
-      ;
+    auto const pollingGeneration = m_pollingGeneration;
+    m_pollingCondition.wait(
+        lock, [this, pollingGeneration]() { return m_completedGeneration >= pollingGeneration; });
   }
 #endif
 

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_receiver.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_receiver.cpp
@@ -444,19 +444,15 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       {
         Log::Stream(Logger::Level::Verbose) << "Opening message receiver. Start async";
       }
-
-      // Mark the connection as async so that we can use the async APIs.
-      m_session->GetConnection()->EnableAsyncOperation(true);
     }
+
+    // Mark the connection as async so that we can use the async APIs.
+    m_session->GetConnection()->EnableAsyncOperation(true);
 
     // And add the link to the list of pollable items.
     //
-    // Note that you *cannot* hold any connection or link locks when calling AddPollable. This is
-    // because the the AddPollable function attempts to lock the pollable and the RemovePollable
-    // function blocks until any pollables have completed while holding the pollable lock.
-    //
-    // This can result in a deadlock because the polling thread is also going to acquire the
-    // connection lock resulting in a deadlock.
+    // Do not hold a connection or link lock while registering the link. The polling thread acquires
+    // those locks while it polls an item.
     // If we're not deferring link polling, enable the async operation on the connection.
     if (!m_deferLinkPolling)
     {

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
@@ -345,20 +345,20 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         throw std::runtime_error(
             "Could not open message sender. errno=" + std::to_string(err) + ", \"" + buf + "\".");
       }
-      // Mark the connection as async so that we can use the async APIs.
-      if (m_options.EnableTrace)
-      {
-        Log::Stream(Logger::Level::Verbose) << "Opening message sender. Enable async operation.";
-      }
-      m_session->GetConnection()->EnableAsyncOperation(true);
-      // Enable async on the link as well.
-      Common::_detail::GlobalStateHolder::GlobalStateInstance()->AddPollable(m_link);
-
       registration = m_session->GetConnection()->GetPendingOperations().Register(
           [this](Models::_internal::AmqpError const& error) {
             m_openQueue.CompleteOperation(error);
           });
     }
+    // Mark the connection as async so that we can use the async APIs.
+    if (m_options.EnableTrace)
+    {
+      Log::Stream(Logger::Level::Verbose) << "Opening message sender. Enable async operation.";
+    }
+    m_session->GetConnection()->EnableAsyncOperation(true);
+    // Enable async on the link as well.
+    Common::_detail::GlobalStateHolder::GlobalStateInstance()->AddPollable(m_link);
+
     if (!halfOpen)
     {
       // A caller that gave no deadline must not wait forever for an attach.

--- a/sdk/core/azure-core-amqp/test/ut/CMakeLists.txt
+++ b/sdk/core/azure-core-amqp/test/ut/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(azure-core-amqp-tests
   claim_based_security_tests.cpp
   connection_string_tests.cpp
   connection_tests.cpp
+  global_state_tests.cpp
   management_tests.cpp
   message_sender_receiver.cpp
   message_source_target.cpp

--- a/sdk/core/azure-core-amqp/test/ut/global_state_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/global_state_tests.cpp
@@ -98,30 +98,25 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     globalState->AddPollable(removedPollableTwo);
     blockedPollable->WaitForPollStart();
 
-    auto removeBlocked = std::async(
-        std::launch::async, [globalState, blockedPollable]() {
-          globalState->RemovePollable(blockedPollable);
-        });
+    auto removeBlocked = std::async(std::launch::async, [globalState, blockedPollable]() {
+      globalState->RemovePollable(blockedPollable);
+    });
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    auto removeOne = std::async(
-        std::launch::async, [globalState, removedPollableOne]() {
-          globalState->RemovePollable(removedPollableOne);
-        });
-    auto removeTwo = std::async(
-        std::launch::async, [globalState, removedPollableTwo]() {
-          globalState->RemovePollable(removedPollableTwo);
-        });
+    auto removeOne = std::async(std::launch::async, [globalState, removedPollableOne]() {
+      globalState->RemovePollable(removedPollableOne);
+    });
+    auto removeTwo = std::async(std::launch::async, [globalState, removedPollableTwo]() {
+      globalState->RemovePollable(removedPollableTwo);
+    });
 
     auto addedPollableOne = std::make_shared<GatedPollable>(false);
     auto addedPollableTwo = std::make_shared<GatedPollable>(false);
-    auto addOne = std::async(
-        std::launch::async, [globalState, addedPollableOne]() {
-          globalState->AddPollable(addedPollableOne);
-        });
-    auto addTwo = std::async(
-        std::launch::async, [globalState, addedPollableTwo]() {
-          globalState->AddPollable(addedPollableTwo);
-        });
+    auto addOne = std::async(std::launch::async, [globalState, addedPollableOne]() {
+      globalState->AddPollable(addedPollableOne);
+    });
+    auto addTwo = std::async(std::launch::async, [globalState, addedPollableTwo]() {
+      globalState->AddPollable(addedPollableTwo);
+    });
 
     bool const addsCompletedBeforePollRelease
         = addOne.wait_for(std::chrono::milliseconds(200)) == std::future_status::ready
@@ -151,9 +146,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     pollable->WaitForPollStart();
 
     auto remove = std::async(
-        std::launch::async, [globalState, pollable]() {
-          globalState->RemovePollable(pollable);
-        });
+        std::launch::async, [globalState, pollable]() { globalState->RemovePollable(pollable); });
     bool const removeCompletedBeforePollRelease
         = remove.wait_for(std::chrono::milliseconds(200)) == std::future_status::ready;
 
@@ -165,9 +158,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
 
     globalState->AddPollable(pollable);
     bool const pollRanAfterAdd = WaitUntil(
-        [pollable, pollCountAfterRemove]() {
-          return pollable->PollCount() > pollCountAfterRemove;
-        },
+        [pollable, pollCountAfterRemove]() { return pollable->PollCount() > pollCountAfterRemove; },
         std::chrono::milliseconds(500));
     globalState->RemovePollable(pollable);
     globalState->AssertIdle();

--- a/sdk/core/azure-core-amqp/test/ut/global_state_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/global_state_tests.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+
+#if ENABLE_UAMQP
+
+#include "azure/core/amqp/internal/common/global_state.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+namespace Azure { namespace Core { namespace Amqp { namespace Tests {
+  namespace {
+    using GlobalStateHolder = Common::_detail::GlobalStateHolder;
+    using Pollable = Common::_detail::Pollable;
+
+    class Latch final {
+    public:
+      void Signal()
+      {
+        {
+          std::lock_guard<std::mutex> lock(m_mutex);
+          m_signaled = true;
+        }
+        m_condition.notify_all();
+      }
+
+      void Wait()
+      {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_condition.wait(lock, [this]() { return m_signaled; });
+      }
+
+    private:
+      std::condition_variable m_condition;
+      std::mutex m_mutex;
+      bool m_signaled{false};
+    };
+
+    class GatedPollable final : public Pollable {
+    public:
+      explicit GatedPollable(bool blockPoll) : m_blockPoll{blockPoll} {}
+
+      void Poll() override
+      {
+        bool expected = false;
+        if (m_pollStarted.compare_exchange_strong(expected, true))
+        {
+          m_started.Signal();
+        }
+        if (m_blockPoll)
+        {
+          m_release.Wait();
+        }
+        m_pollCount++;
+      }
+
+      void WaitForPollStart() { m_started.Wait(); }
+      void Release() { m_release.Signal(); }
+      int PollCount() const { return m_pollCount.load(); }
+
+    private:
+      bool m_blockPoll;
+      std::atomic<bool> m_pollStarted{false};
+      std::atomic<int> m_pollCount{0};
+      Latch m_started;
+      Latch m_release;
+    };
+
+    template <class Predicate>
+    bool WaitUntil(Predicate predicate, std::chrono::milliseconds timeout)
+    {
+      auto const deadline = std::chrono::steady_clock::now() + timeout;
+      while (!predicate() && std::chrono::steady_clock::now() < deadline)
+      {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+      return predicate();
+    }
+  } // namespace
+
+  TEST(GlobalStateHolderTest, ConcurrentRegistryOperationsWhilePollBlocked)
+  {
+    auto const globalState = GlobalStateHolder::GlobalStateInstance();
+    globalState->AssertIdle();
+
+    auto blockedPollable = std::make_shared<GatedPollable>(true);
+    auto removedPollableOne = std::make_shared<GatedPollable>(false);
+    auto removedPollableTwo = std::make_shared<GatedPollable>(false);
+    globalState->AddPollable(blockedPollable);
+    globalState->AddPollable(removedPollableOne);
+    globalState->AddPollable(removedPollableTwo);
+    blockedPollable->WaitForPollStart();
+
+    auto removeBlocked = std::async(
+        std::launch::async, [globalState, blockedPollable]() {
+          globalState->RemovePollable(blockedPollable);
+        });
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    auto removeOne = std::async(
+        std::launch::async, [globalState, removedPollableOne]() {
+          globalState->RemovePollable(removedPollableOne);
+        });
+    auto removeTwo = std::async(
+        std::launch::async, [globalState, removedPollableTwo]() {
+          globalState->RemovePollable(removedPollableTwo);
+        });
+
+    auto addedPollableOne = std::make_shared<GatedPollable>(false);
+    auto addedPollableTwo = std::make_shared<GatedPollable>(false);
+    auto addOne = std::async(
+        std::launch::async, [globalState, addedPollableOne]() {
+          globalState->AddPollable(addedPollableOne);
+        });
+    auto addTwo = std::async(
+        std::launch::async, [globalState, addedPollableTwo]() {
+          globalState->AddPollable(addedPollableTwo);
+        });
+
+    bool const addsCompletedBeforePollRelease
+        = addOne.wait_for(std::chrono::milliseconds(200)) == std::future_status::ready
+        && addTwo.wait_for(std::chrono::milliseconds(200)) == std::future_status::ready;
+
+    blockedPollable->Release();
+    removeOne.get();
+    removeTwo.get();
+    removeBlocked.get();
+    addOne.get();
+    addTwo.get();
+
+    globalState->RemovePollable(addedPollableOne);
+    globalState->RemovePollable(addedPollableTwo);
+    globalState->AssertIdle();
+
+    EXPECT_TRUE(addsCompletedBeforePollRelease);
+  }
+
+  TEST(GlobalStateHolderTest, RemovedPollableIsACompletionBarrier)
+  {
+    auto const globalState = GlobalStateHolder::GlobalStateInstance();
+    globalState->AssertIdle();
+
+    auto pollable = std::make_shared<GatedPollable>(true);
+    globalState->AddPollable(pollable);
+    pollable->WaitForPollStart();
+
+    auto remove = std::async(
+        std::launch::async, [globalState, pollable]() {
+          globalState->RemovePollable(pollable);
+        });
+    bool const removeCompletedBeforePollRelease
+        = remove.wait_for(std::chrono::milliseconds(200)) == std::future_status::ready;
+
+    pollable->Release();
+    remove.get();
+    auto const pollCountAfterRemove = pollable->PollCount();
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    bool const noPollAfterRemove = pollable->PollCount() == pollCountAfterRemove;
+
+    globalState->AddPollable(pollable);
+    bool const pollRanAfterAdd = WaitUntil(
+        [pollable, pollCountAfterRemove]() {
+          return pollable->PollCount() > pollCountAfterRemove;
+        },
+        std::chrono::milliseconds(500));
+    globalState->RemovePollable(pollable);
+    globalState->AssertIdle();
+
+    EXPECT_FALSE(removeCompletedBeforePollRelease);
+    EXPECT_TRUE(noPollAfterRemove);
+    EXPECT_TRUE(pollRanAfterAdd);
+  }
+}}}} // namespace Azure::Core::Amqp::Tests
+
+#endif // ENABLE_UAMQP


### PR DESCRIPTION
## Summary

GlobalStateHolder::RemovePollable can deadlock when CBS refresh or sender cleanup waits for a poll in progress.

## Motivation

RemovePollable held m_pollablesMutex while waiting for an in-flight Poll completion. This blocks unrelated registry operations and can deadlock uAMQP connection or link cleanup paths. Event Hubs CreateBatch cleanup and CBS management refresh share affected lock-order risks.

## Changes

- Makes RemovePollable release the registry mutex while waiting for in-flight polling and preserve completion barriers for earlier snapshots.
- Moves sender and receiver open async registry activation outside connection locks.
- Audits CBS management refresh and Event Hubs CreateBatch failed-open cleanup lock scopes.
- Adds repeated concurrent core registry tests and a changelog entry for issue #7370.
- Leaves Rust AMQP unchanged.

## Test plan

Affected uAMQP and Event Hubs build passed. Core AMQP suite passed 210 of 210. Playback runner passed 224 tests with 14 live-only skips. Concurrency tests passed 100 repetitions on the first validation pass, 50 on the second, and 20 in the root rerun. clang-format, CSpell, git diff check, commit boundary check, and Rust diff audit passed. Direct CBS and CreateBatch integration tests were not added because unchanged source aborts in an existing TransportImpl handle assertion before their assertions; core concurrency tests and static lock-scope audit cover these paths. The exact live Event Hubs runner was not run because EVENTHUBS_HOST is absent.

Closes #7370