### PR TITLE
[DO NOT MERGE] Test azure-c-shared-utility socket retry fix in Event Hubs

### DIFF
--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -7,6 +7,20 @@ set(AZ_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 macro(az_vcpkg_integrate)
   message("Vcpkg integrate step.")
 
+  # Prefer repository-owned dependency pins over the builtin vcpkg registry. This overlay
+  # temporarily carries azure-c-shared-utility PR #683 and its prerequisite PR #684 until an
+  # upstream release is available.
+  set(_azure_sdk_vcpkg_overlay_ports "${AZ_ROOT_DIR}/vcpkg-overlays")
+  if(EXISTS "${_azure_sdk_vcpkg_overlay_ports}/azure-c-shared-utility/portfile.cmake")
+    list(FIND VCPKG_OVERLAY_PORTS "${_azure_sdk_vcpkg_overlay_ports}" _azure_sdk_vcpkg_overlay_index)
+    if(_azure_sdk_vcpkg_overlay_index EQUAL -1)
+      list(INSERT VCPKG_OVERLAY_PORTS 0 "${_azure_sdk_vcpkg_overlay_ports}")
+    endif()
+    message(STATUS "Using Azure SDK vcpkg overlay ports from ${_azure_sdk_vcpkg_overlay_ports}")
+  endif()
+  unset(_azure_sdk_vcpkg_overlay_index)
+  unset(_azure_sdk_vcpkg_overlay_ports)
+
   # AUTO CMAKE_TOOLCHAIN_FILE:
   #   User can call `cmake -DCMAKE_TOOLCHAIN_FILE="path_to_the_toolchain"` as the most specific scenario.
   #   As the last alternative (default case), Azure SDK will automatically clone VCPKG folder and set toolchain from there.

--- a/vcpkg-overlays/azure-c-shared-utility/portfile.cmake
+++ b/vcpkg-overlays/azure-c-shared-utility/portfile.cmake
@@ -1,0 +1,36 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+# Backport the merged socket retry fix while azure-c-shared-utility master carries
+# unreleased dependency revisions that are not in the SDK's vcpkg baseline.
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Azure/azure-c-shared-utility
+    REF 772a4f8bc338140b4a0f404cf9c344283c5c937f
+    SHA512 cd81698e58ad14b17ca87ce2ff80fd48f5bf4b6dded9d311f9ce0822b90f0f874d99210a019e00aa9a2e1c48914a4c2934f4d935638af68d2f88c5bdb26669dd
+    HEAD_REF master
+    PATCHES
+        socket-retry-backport.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dskip_samples=ON
+        -Duse_installed_dependencies=ON
+        -Duse_default_uuid=ON
+        -Dbuild_as_dynamic=OFF
+    MAYBE_UNUSED_VARIABLES
+        build_as_dynamic
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME azure_c_shared_utility CONFIG_PATH lib/cmake/azure_c_shared_utility)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(COPY "${SOURCE_PATH}/configs/azure_iot_build_rules.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+vcpkg_copy_pdbs()

--- a/vcpkg-overlays/azure-c-shared-utility/socket-retry-backport.patch
+++ b/vcpkg-overlays/azure-c-shared-utility/socket-retry-backport.patch
@@ -1,0 +1,1006 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8522095..8248b58 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -552,8 +552,7 @@ if(${use_http})
+             set(CURL_FIND_REQUIRED 1)
+             find_package_handle_standard_args(CURL DEFAULT_MSG CURL_LIBRARIES)
+ 
+-            include_directories(${CURL_INCLUDE_DIRS})
+-            set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} ${CURL_LIBRARIES})
++            set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} CURL::libcurl)
+         endif(NOT use_builtin_httpapi)
+     endif()
+ endif(${use_http})
+@@ -592,7 +591,7 @@ if(${use_bearssl})
+ endif()
+ 
+ if(${use_openssl})
+-    set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} ${OPENSSL_LIBRARIES})
++    set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} OpenSSL::SSL)
+     if (WIN32)
+         set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} crypt32 ws2_32 secur32)
+     endif()
+@@ -728,7 +727,7 @@ install (TARGETS ${targets} EXPORT aziotsharedutilTargets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
+ )
+-install (FILES ${source_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azure_c_shared_utility)
++install (FILES ${source_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot/azure_c_shared_utility)
+ install (FILES ${micromock_h_files_full_path} ${INSTALL_H_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)
+ 
+ 
+@@ -742,7 +741,7 @@ write_basic_package_version_file(
+ 
+ configure_file("configs/${PROJECT_NAME}Config.cmake"
+     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
+-    COPYONLY
++    @ONLY
+ )
+ 
+ install(EXPORT aziotsharedutilTargets
+@@ -754,7 +753,7 @@ install(EXPORT aziotsharedutilTargets
+ 
+ install(
+ FILES
+-    "configs/${PROJECT_NAME}Config.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
+     "configs/${PROJECT_NAME}Functions.cmake"
+     "configs/azure_iot_build_rules.cmake"
+     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+diff --git a/adapters/socketio_berkeley.c b/adapters/socketio_berkeley.c
+index 983e899..c07e3c8 100755
+--- a/adapters/socketio_berkeley.c
++++ b/adapters/socketio_berkeley.c
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include <signal.h>
++#include <stdbool.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+ #include <stdio.h>
+@@ -29,6 +30,7 @@
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <sys/select.h>
++#include <sys/time.h>
+ #ifdef TIZENRT
+ #include <net/lwip/tcp.h>
+ #else
+@@ -218,6 +220,51 @@ static void indicate_error(SOCKET_IO_INSTANCE* socket_io_instance)
+     }
+ }
+ 
++static void socketio_cleanup(SOCKET_IO_INSTANCE* socket_io_instance)
++{
++    if (socket_io_instance->socket != INVALID_SOCKET)
++    {
++        (void)close(socket_io_instance->socket);
++    }
++
++    socket_io_instance->socket = INVALID_SOCKET;
++    socket_io_instance->io_state = IO_STATE_CLOSED;
++
++    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
++        socket_io_instance->dns_resolver != NULL)
++    {
++        dns_resolver_destroy(socket_io_instance->dns_resolver);
++        socket_io_instance->dns_resolver = NULL;
++    }
++}
++
++static void indicate_open_failure(SOCKET_IO_INSTANCE* socket_io_instance)
++{
++    socketio_cleanup(socket_io_instance);
++    if (socket_io_instance->on_io_error != NULL)
++    {
++        socket_io_instance->on_io_error(socket_io_instance->on_io_error_context);
++    }
++}
++
++static int refresh_dns_resolver(SOCKET_IO_INSTANCE* socket_io_instance)
++{
++    int result = 0;
++
++    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
++        socket_io_instance->dns_resolver == NULL)
++    {
++        socket_io_instance->dns_resolver = dns_resolver_create(socket_io_instance->hostname, socket_io_instance->port, NULL);
++        if (socket_io_instance->dns_resolver == NULL)
++        {
++            LogError("Failure: unable to create DNS resolver.");
++            result = MU_FAILURE;
++        }
++    }
++
++    return result;
++}
++
+ static int add_pending_io(SOCKET_IO_INSTANCE* socket_io_instance, const unsigned char* buffer, size_t size, ON_SEND_COMPLETE on_send_complete, void* callback_context)
+ {
+     int result;
+@@ -271,10 +318,20 @@ static int lookup_address(SOCKET_IO_INSTANCE* socket_io_instance)
+ 
+     if (socket_io_instance->address_type == ADDRESS_TYPE_IP)
+     {
+-        if (!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
++        if (socket_io_instance->dns_resolver == NULL)
++        {
++            LogError("DNS resolver is NULL.");
++            result = MU_FAILURE;
++        }
++        else if (!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
+         {
+             socket_io_instance->io_state = IO_STATE_OPENING;
+         }
++        else if (dns_resolver_get_addrInfo(socket_io_instance->dns_resolver) == NULL)
++        {
++            LogError("DNS resolution failed. Hostname:%s", socket_io_instance->hostname);
++            result = MU_FAILURE;
++        }
+         else
+         {
+             socket_io_instance->io_state = IO_STATE_OPEN;
+@@ -317,16 +374,20 @@ static void destroy_network_interface_descriptions(NETWORK_INTERFACE_DESCRIPTION
+     }
+ }
+ 
+-static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struct ifreq *ifr, NETWORK_INTERFACE_DESCRIPTION* previous_nid)
++// ifr_hwaddr and ifr_addr are members of the same union, so the hardware address
++// and the IP address must be read from separate struct ifreq instances.
++static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struct ifreq *ifr_hw, struct ifreq *ifr_ip, NETWORK_INTERFACE_DESCRIPTION* previous_nid)
+ {
+     NETWORK_INTERFACE_DESCRIPTION* result;
+     size_t malloc_size;
+ 
+-    if ((result = (NETWORK_INTERFACE_DESCRIPTION*)malloc(sizeof(NETWORK_INTERFACE_DESCRIPTION))) == NULL)
++    // calloc so that every pointer member is NULL and destroy_network_interface_descriptions
++    // stays safe if the description is only partially constructed.
++    if ((result = (NETWORK_INTERFACE_DESCRIPTION*)calloc(1, sizeof(NETWORK_INTERFACE_DESCRIPTION))) == NULL)
+     {
+         LogError("Failed allocating NETWORK_INTERFACE_DESCRIPTION");
+     }
+-    else if ((malloc_size = safe_multiply_size_t(safe_add_size_t(strlen(ifr->ifr_name), 1), sizeof(char))) == SIZE_MAX)
++    else if ((malloc_size = safe_multiply_size_t(safe_add_size_t(strlen(ifr_hw->ifr_name), 1), sizeof(char))) == SIZE_MAX)
+     {
+         LogError("invalid malloc size");
+         destroy_network_interface_descriptions(result);
+@@ -340,10 +401,10 @@ static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struc
+     }
+     else
+     {
+-        strcpy(result->name, ifr->ifr_name);
++        strcpy(result->name, ifr_hw->ifr_name);
+ 
+         char* ip_address;
+-        unsigned char* mac = (unsigned char*)ifr->ifr_hwaddr.sa_data;
++        unsigned char* mac = (unsigned char*)ifr_hw->ifr_hwaddr.sa_data;
+         size_t malloc_size = safe_multiply_size_t(sizeof(char), MAC_ADDRESS_STRING_LENGTH);
+ 
+         if (malloc_size == SIZE_MAX ||
+@@ -359,7 +420,7 @@ static NETWORK_INTERFACE_DESCRIPTION* create_network_interface_description(struc
+             destroy_network_interface_descriptions(result);
+             result = NULL;
+         }
+-        else if ((ip_address = inet_ntoa(((struct sockaddr_in*)&ifr->ifr_addr)->sin_addr)) == NULL)
++        else if ((ip_address = inet_ntoa(((struct sockaddr_in*)&ifr_ip->ifr_addr)->sin_addr)) == NULL)
+         {
+             LogError("failed setting the ip address (inet_ntoa failed)");
+             destroy_network_interface_descriptions(result);
+@@ -396,7 +457,8 @@ static int get_network_interface_descriptions(int socket, NETWORK_INTERFACE_DESC
+ {
+     int result;
+ 
+-    struct ifreq ifr;
++    struct ifreq ifr_hw;
++    struct ifreq ifr_ip;
+     struct ifconf ifc;
+     char buf[IFREQ_BUFFER_SIZE];
+ 
+@@ -420,27 +482,28 @@ static int get_network_interface_descriptions(int socket, NETWORK_INTERFACE_DESC
+ 
+         for (; it != end; ++it)
+         {
+-            strcpy(ifr.ifr_name, it->ifr_name);
++            strcpy(ifr_hw.ifr_name, it->ifr_name);
++            strcpy(ifr_ip.ifr_name, it->ifr_name);
+ 
+-            if (ioctl(socket, SIOCGIFFLAGS, &ifr) != 0)
++            if (ioctl(socket, SIOCGIFFLAGS, &ifr_ip) != 0)
+             {
+                 LogError("ioctl failed querying socket (SIOCGIFFLAGS, errno=%d)", errno);
+                 result = MU_FAILURE;
+                 break;
+             }
+-            else if (ioctl(socket, SIOCGIFHWADDR, &ifr) != 0)
++            else if (ioctl(socket, SIOCGIFHWADDR, &ifr_hw) != 0)
+             {
+                 LogError("ioctl failed querying socket (SIOCGIFHWADDR, errno=%d)", errno);
+                 result = MU_FAILURE;
+                 break;
+             }
+-            else if (ioctl(socket, SIOCGIFADDR, &ifr) != 0)
++            else if (ioctl(socket, SIOCGIFADDR, &ifr_ip) != 0)
+             {
+                 LogError("ioctl failed querying socket (SIOCGIFADDR, errno=%d)", errno);
+                 result = MU_FAILURE;
+                 break;
+             }
+-            else if ((new_nid = create_network_interface_description(&ifr, new_nid)) == NULL)
++            else if ((new_nid = create_network_interface_description(&ifr_hw, &ifr_ip, new_nid)) == NULL)
+             {
+                 LogError("Failed creating network interface description");
+                 result = MU_FAILURE;
+@@ -616,21 +679,8 @@ static int initiate_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
+             {
+                 // Async connect will return -1.
+                 result = 0;
+-                if (socket_io_instance->on_io_open_complete != NULL)
+-                {
+-                    socket_io_instance->on_io_open_complete(socket_io_instance->on_io_open_complete_context, IO_OPEN_OK /*: IO_OPEN_ERROR*/);
+-                }
+             }
+         }
+-
+-        if (result != 0)
+-        {
+-            if (socket_io_instance->socket >= SOCKET_SUCCESS)
+-            {
+-                close(socket_io_instance->socket);
+-            }
+-            socket_io_instance->socket = INVALID_SOCKET;
+-        }
+     }
+ 
+     return result;
+@@ -653,6 +703,38 @@ static int lookup_address_and_initiate_socket_connection(SOCKET_IO_INSTANCE* soc
+     return result;
+ }
+ 
++// Computes the time left until deadline. Returns false, leaving remaining
++// zeroed, once the deadline has passed.
++static bool get_time_remaining(const struct timeval* deadline, struct timeval* remaining)
++{
++    bool result;
++    struct timeval now;
++
++    (void)gettimeofday(&now, NULL);
++
++    remaining->tv_sec = deadline->tv_sec - now.tv_sec;
++    remaining->tv_usec = deadline->tv_usec - now.tv_usec;
++
++    if (remaining->tv_usec < 0)
++    {
++        remaining->tv_usec += 1000000;
++        remaining->tv_sec--;
++    }
++
++    if (remaining->tv_sec < 0 || (remaining->tv_sec == 0 && remaining->tv_usec == 0))
++    {
++        remaining->tv_sec = 0;
++        remaining->tv_usec = 0;
++        result = false;
++    }
++    else
++    {
++        result = true;
++    }
++
++    return result;
++}
++
+ static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
+ {
+     int result;
+@@ -663,55 +745,69 @@ static int wait_for_socket_connection(SOCKET_IO_INSTANCE* socket_io_instance)
+     fd_set fdset;
+     struct timeval tv;
+ 
+-    FD_ZERO(&fdset);
+-    FD_SET(socket_io_instance->socket, &fdset);
+-    tv.tv_sec = CONNECT_TIMEOUT;
+-    tv.tv_usec = 0;
+-
+-    do
+-    {
+-        retval = select(socket_io_instance->socket + 1, NULL, &fdset, NULL, &tv);
+-
+-        if (retval < 0)
+-        {
+-            select_errno = errno;
+-        }
+-    } while (retval < 0 && select_errno == EINTR);
+-
+-    if (retval != 1)
++    // FD_SET indexes the descriptor set by descriptor value, so a descriptor at
++    // or above FD_SETSIZE writes past the end of the set.
++    if (socket_io_instance->socket >= FD_SETSIZE)
+     {
+-        LogError("Failure: select failure.");
++        LogError("Failure: socket %d is not below FD_SETSIZE.", socket_io_instance->socket);
+         result = MU_FAILURE;
+     }
+     else
+     {
+-        int so_error = 0;
+-        socklen_t len = sizeof(so_error);
+-        err = getsockopt(socket_io_instance->socket, SOL_SOCKET, SO_ERROR, &so_error, &len);
+-        if (err != 0)
++        struct timeval deadline;
++
++        (void)gettimeofday(&deadline, NULL);
++        deadline.tv_sec += CONNECT_TIMEOUT;
++
++        // select() may report EINTR before the connection is decided. Retrying
++        // against a fixed deadline bounds the total wait: platforms that leave
++        // the timeout untouched would otherwise restart it on every signal.
++        do
+         {
+-            LogError("Failure: getsockopt failure %d.", errno);
+-            result = MU_FAILURE;
+-        }
+-        else if (so_error != 0)
++            if (!get_time_remaining(&deadline, &tv))
++            {
++                // Deadline reached; report it the same way select() reports a timeout.
++                retval = 0;
++                break;
++            }
++
++            FD_ZERO(&fdset);
++            FD_SET(socket_io_instance->socket, &fdset);
++
++            retval = select(socket_io_instance->socket + 1, NULL, &fdset, NULL, &tv);
++
++            if (retval < 0)
++            {
++                select_errno = errno;
++            }
++        } while (retval < 0 && select_errno == EINTR);
++
++        if (retval != 1)
+         {
+-            err = so_error;
+-            LogError("Failure: connect failure %d.", so_error);
++            LogError("Failure: select failure.");
+             result = MU_FAILURE;
+         }
+         else
+         {
+-            result = 0;
+-        }
+-    }
+-
+-    if (result != 0)
+-    {
+-        if (socket_io_instance->socket >= SOCKET_SUCCESS)
+-        {
+-            close(socket_io_instance->socket);
++            int so_error = 0;
++            socklen_t len = sizeof(so_error);
++            err = getsockopt(socket_io_instance->socket, SOL_SOCKET, SO_ERROR, &so_error, &len);
++            if (err != 0)
++            {
++                LogError("Failure: getsockopt failure %d.", errno);
++                result = MU_FAILURE;
++            }
++            else if (so_error != 0)
++            {
++                err = so_error;
++                LogError("Failure: connect failure %d.", so_error);
++                result = MU_FAILURE;
++            }
++            else
++            {
++                result = 0;
++            }
+         }
+-        socket_io_instance->socket = INVALID_SOCKET;
+     }
+ 
+     return result;
+@@ -877,14 +973,21 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
+         }
+         else
+         {
+-            if ((result = lookup_address_and_initiate_socket_connection(socket_io_instance)) != 0)
++            socket_io_instance->on_io_open_complete = NULL;
++            socket_io_instance->on_io_open_complete_context = NULL;
++
++            if ((result = refresh_dns_resolver(socket_io_instance)) != 0)
++            {
++                LogError("refresh_dns_resolver failed");
++            }
++            else if ((result = lookup_address_and_initiate_socket_connection(socket_io_instance)) != 0)
+             {
+                 LogError("lookup_address_and_connect_socket failed");
+             }
+             else if ((socket_io_instance->io_state == IO_STATE_OPEN) && (result = wait_for_socket_connection(socket_io_instance)) != 0)
+             {
+                 LogError("wait_for_socket_connection failed");
+-            } 
++            }
+             else
+             {
+                 socket_io_instance->on_bytes_received = on_bytes_received;
+@@ -896,10 +999,15 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
+                 socket_io_instance->on_io_open_complete = on_io_open_complete;
+                 socket_io_instance->on_io_open_complete_context = on_io_open_complete_context;
+             }
++
++            if (result != 0)
++            {
++                socketio_cleanup(socket_io_instance);
++            }
+         }
+     }
+ 
+-    if (socket_io_instance->io_state != IO_STATE_OPENING)
++    if (socket_io_instance != NULL && socket_io_instance->io_state != IO_STATE_OPENING)
+     {
+         if (on_io_open_complete != NULL)
+         {
+@@ -923,11 +1031,12 @@ int socketio_close(CONCRETE_IO_HANDLE socket_io, ON_IO_CLOSE_COMPLETE on_io_clos
+         SOCKET_IO_INSTANCE* socket_io_instance = (SOCKET_IO_INSTANCE*)socket_io;
+         if ((socket_io_instance->io_state != IO_STATE_CLOSED) && (socket_io_instance->io_state != IO_STATE_CLOSING))
+         {
+-            // Only close if the socket isn't already in the closed or closing state
+-            (void)shutdown(socket_io_instance->socket, SHUT_RDWR);
+-            close(socket_io_instance->socket);
+-            socket_io_instance->socket = INVALID_SOCKET;
+-            socket_io_instance->io_state = IO_STATE_CLOSED;
++            // Only shut down an active socket before cleanup.
++            if (socket_io_instance->socket != INVALID_SOCKET)
++            {
++                (void)shutdown(socket_io_instance->socket, SHUT_RDWR);
++            }
++            socketio_cleanup(socket_io_instance);
+         }
+ 
+         if (on_io_close_complete != NULL)
+@@ -1125,25 +1234,25 @@ void socketio_dowork(CONCRETE_IO_HANDLE socket_io)
+                 if(lookup_address(socket_io_instance) != 0)
+                 {
+                     LogError("Socketio_Failure: lookup address failed");
+-                    indicate_error(socket_io_instance);
++                    indicate_open_failure(socket_io_instance);
+                 }
+-                else
++                else if (socket_io_instance->io_state == IO_STATE_OPEN)
+                 {
+-                    if(socket_io_instance->io_state == IO_STATE_OPEN)
++                    if (initiate_socket_connection(socket_io_instance) != 0)
+                     {
+-                        if (initiate_socket_connection(socket_io_instance) != 0)
+-                        {
+-                            LogError("Socketio_Failure: initiate_socket_connection failed");
+-                            indicate_error(socket_io_instance);
+-                        }
+-                        else if (wait_for_socket_connection(socket_io_instance) != 0)
+-                        {
+-                            LogError("Socketio_Failure: wait_for_socket_connection failed");
+-                            indicate_error(socket_io_instance);
+-                        }
++                        LogError("Socketio_Failure: initiate_socket_connection failed");
++                        indicate_open_failure(socket_io_instance);
++                    }
++                    else if (wait_for_socket_connection(socket_io_instance) != 0)
++                    {
++                        LogError("Socketio_Failure: wait_for_socket_connection failed");
++                        indicate_open_failure(socket_io_instance);
++                    }
++                    else if (socket_io_instance->on_io_open_complete != NULL)
++                    {
++                        socket_io_instance->on_io_open_complete(socket_io_instance->on_io_open_complete_context, IO_OPEN_OK);
+                     }
+                 }
+-
+             }
+         }
+     }
+@@ -1280,4 +1389,3 @@ const IO_INTERFACE_DESCRIPTION* socketio_get_interface_description(void)
+ {
+     return &socket_io_interface_description;
+ }
+-
+diff --git a/adapters/socketio_win32.c b/adapters/socketio_win32.c
+index dc7313f..05980c4 100644
+--- a/adapters/socketio_win32.c
++++ b/adapters/socketio_win32.c
+@@ -109,6 +109,42 @@ static void indicate_error(SOCKET_IO_INSTANCE* socket_io_instance)
+     }
+ }
+ 
++static void socketio_cleanup(SOCKET_IO_INSTANCE* socket_io_instance)
++{
++    if (socket_io_instance->socket != INVALID_SOCKET)
++    {
++        (void)closesocket(socket_io_instance->socket);
++    }
++
++    socket_io_instance->socket = INVALID_SOCKET;
++    socket_io_instance->io_state = IO_STATE_CLOSED;
++
++    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
++        socket_io_instance->dns_resolver != NULL)
++    {
++        dns_resolver_destroy(socket_io_instance->dns_resolver);
++        socket_io_instance->dns_resolver = NULL;
++    }
++}
++
++static int refresh_dns_resolver(SOCKET_IO_INSTANCE* socket_io_instance)
++{
++    int result = 0;
++
++    if (socket_io_instance->address_type == ADDRESS_TYPE_IP && socket_io_instance->hostname != NULL &&
++        socket_io_instance->dns_resolver == NULL)
++    {
++        socket_io_instance->dns_resolver = dns_resolver_create(socket_io_instance->hostname, socket_io_instance->port, NULL);
++        if (socket_io_instance->dns_resolver == NULL)
++        {
++            LogError("Failure: unable to create DNS resolver.");
++            result = MU_FAILURE;
++        }
++    }
++
++    return result;
++}
++
+ static int add_pending_io(SOCKET_IO_INSTANCE* socket_io_instance, const unsigned char* buffer, size_t size, ON_SEND_COMPLETE on_send_complete, void* callback_context)
+ {
+     int result;
+@@ -159,7 +195,12 @@ static int lookup_address(SOCKET_IO_INSTANCE* socket_io_instance)
+     
+     if (socket_io_instance->address_type == ADDRESS_TYPE_IP)
+     {
+-        if (!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
++        if (socket_io_instance->dns_resolver == NULL)
++        {
++            LogError("DNS resolver is NULL.");
++            result = MU_FAILURE;
++        }
++        else if (!dns_resolver_is_lookup_complete(socket_io_instance->dns_resolver))
+         {
+             socket_io_instance->io_state = IO_STATE_OPENING;
+         }
+@@ -405,7 +446,10 @@ void socketio_destroy(CONCRETE_IO_HANDLE socket_io)
+     {
+         SOCKET_IO_INSTANCE* socket_io_instance = (SOCKET_IO_INSTANCE*)socket_io;
+         /* we cannot do much if the close fails, so just ignore the result */
+-        (void)closesocket(socket_io_instance->socket);
++        if (socket_io_instance->socket != INVALID_SOCKET)
++        {
++            (void)closesocket(socket_io_instance->socket);
++        }
+ 
+         /* clear allpending IOs */
+ 
+@@ -458,6 +502,9 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
+         }
+         else
+         {
++            socket_io_instance->on_io_open_complete = NULL;
++            socket_io_instance->on_io_open_complete_context = NULL;
++
+ #ifdef AF_UNIX_ON_WINDOWS
+             int addr_family = socket_io_instance->address_type == ADDRESS_TYPE_IP ? AF_INET : AF_UNIX;
+ #else
+@@ -467,20 +514,24 @@ int socketio_open(CONCRETE_IO_HANDLE socket_io, ON_IO_OPEN_COMPLETE on_io_open_c
+             if (socket_io_instance->socket == INVALID_SOCKET)
+             {
+                 LogError("Failure: socket create failure %d.", WSAGetLastError());
++                socketio_cleanup(socket_io_instance);
++                result = MU_FAILURE;
++            }
++            else if (refresh_dns_resolver(socket_io_instance) != 0)
++            {
++                socketio_cleanup(socket_io_instance);
+                 result = MU_FAILURE;
+             }
+             else if (lookup_address(socket_io_instance) != 0)
+             {
+                 LogError("lookup_address failed");
+-                (void)closesocket(socket_io_instance->socket);
+-                socket_io_instance->socket = INVALID_SOCKET;
++                socketio_cleanup(socket_io_instance);
+                 result = MU_FAILURE;
+             }
+             else if (socket_io_instance->io_state == IO_STATE_OPEN && initiate_socket_connection(socket_io_instance) != 0)
+             {
+                 LogError("initiate_socket_connection failed");
+-                (void)closesocket(socket_io_instance->socket);
+-                socket_io_instance->socket = INVALID_SOCKET;
++                socketio_cleanup(socket_io_instance);
+                 result = MU_FAILURE;
+             }
+             else
+@@ -521,12 +572,9 @@ int socketio_close(CONCRETE_IO_HANDLE socket_io, ON_IO_CLOSE_COMPLETE on_io_clos
+     {
+         SOCKET_IO_INSTANCE* socket_io_instance = (SOCKET_IO_INSTANCE*)socket_io;
+ 
+-        if ((socket_io_instance->io_state != IO_STATE_CLOSING) &&
+-            (socket_io_instance->io_state != IO_STATE_CLOSED))
++        if ((socket_io_instance->io_state != IO_STATE_CLOSED) && (socket_io_instance->io_state != IO_STATE_CLOSING))
+         {
+-            (void)closesocket(socket_io_instance->socket);
+-            socket_io_instance->socket = INVALID_SOCKET;
+-            socket_io_instance->io_state = IO_STATE_CLOSED;
++            socketio_cleanup(socket_io_instance);
+         }
+ 
+         if (on_io_close_complete != NULL)
+@@ -712,16 +760,14 @@ void socketio_dowork(CONCRETE_IO_HANDLE socket_io)
+                 if (lookup_address(socket_io_instance) != 0)
+                 {
+                     LogError("lookup_address failed");
+-                    (void)closesocket(socket_io_instance->socket);
+-                    socket_io_instance->socket = INVALID_SOCKET;
+-                    socket_io_instance->io_state = IO_STATE_CLOSED;
++                    socketio_cleanup(socket_io_instance);
++                    indicate_error(socket_io_instance);
+                 }
+                 else if (socket_io_instance->io_state == IO_STATE_OPEN && initiate_socket_connection(socket_io_instance) != 0)
+                 {
+                     LogError("initialize_socket_connection failed");
+-                    (void)closesocket(socket_io_instance->socket);
+-                    socket_io_instance->socket = INVALID_SOCKET;
+-                    socket_io_instance->io_state = IO_STATE_CLOSED;
++                    socketio_cleanup(socket_io_instance);
++                    indicate_error(socket_io_instance);
+                 }
+             }
+         }
+diff --git a/configs/azure_c_shared_utilityConfig.cmake b/configs/azure_c_shared_utilityConfig.cmake
+index 2d7c733..0e1e4d4 100644
+--- a/configs/azure_c_shared_utilityConfig.cmake
++++ b/configs/azure_c_shared_utilityConfig.cmake
+@@ -1,11 +1,12 @@
+ #Copyright (c) Microsoft. All rights reserved.
+ #Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ 
+-if(UNIX)
+-    if(${use_http})
+-        include(CMakeFindDependencyMacro)
+-        find_dependency(CURL)
+-    endif()
++include(CMakeFindDependencyMacro)
++if("@use_openssl@")
++    find_dependency(OpenSSL)
++endif()
++if(UNIX AND NOT "@use_builtin_httpapi@")
++    find_dependency(CURL)
+ endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/azure_c_shared_utilityTargets.cmake")
+diff --git a/configs/azure_c_shared_utilityFunctions.cmake b/configs/azure_c_shared_utilityFunctions.cmake
+index 9b6e1d1..9c53061 100644
+--- a/configs/azure_c_shared_utilityFunctions.cmake
++++ b/configs/azure_c_shared_utilityFunctions.cmake
+@@ -2,11 +2,11 @@
+ #Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ 
+ function(target_link_libraries_with_arg_prefix arg_prefix whatIsBuilding lib)
+-    if(${arg_prefix} STREQUAL "debug")
++    if(arg_prefix STREQUAL "debug")
+         target_link_libraries(${whatIsBuilding} debug ${lib})
+-    elseif(${arg_prefix} STREQUAL "optimized")
++    elseif(arg_prefix STREQUAL "optimized")
+         target_link_libraries(${whatIsBuilding} optimized ${lib})
+-    elseif(${arg_prefix} STREQUAL "general")
++    elseif(arg_prefix STREQUAL "general")
+         target_link_libraries(${whatIsBuilding} general ${lib})
+     else()
+         target_link_libraries(${whatIsBuilding} ${lib})
+@@ -43,13 +43,13 @@ function(windows_unittests_add_dll whatIsBuilding)
+     set(ARG_PREFIX "none")
+     foreach(f ${ARGN})
+         set(skip_to_next FALSE)
+-        if(${f} STREQUAL "ADDITIONAL_LIBS")
++        if(f STREQUAL "ADDITIONAL_LIBS")
+             SET(PARSING_ADDITIONAL_LIBS ON)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+             set(ARG_PREFIX "none")
+             #also unset all the other states
+             set(skip_to_next TRUE)
+-        elseif(${f} STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
++        elseif(f STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
+             SET(PARSING_ADDITIONAL_LIBS OFF)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
+             set(skip_to_next TRUE)
+@@ -57,7 +57,7 @@ function(windows_unittests_add_dll whatIsBuilding)
+ 
+         if(NOT skip_to_next)
+             if(PARSING_ADDITIONAL_LIBS)
+-                if((${f} STREQUAL "debug") OR (${f} STREQUAL "optimized") OR (${f} STREQUAL "general"))
++                if((f STREQUAL "debug") OR (f STREQUAL "optimized") OR (f STREQUAL "general"))
+                     SET(ARG_PREFIX ${f})
+                 else()
+                     target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_dll ${f})
+@@ -90,13 +90,13 @@ function(windows_unittests_add_exe whatIsBuilding)
+     set(ARG_PREFIX "none")
+     foreach(f ${ARGN})
+         set(skip_to_next FALSE)
+-        if(${f} STREQUAL "ADDITIONAL_LIBS")
++        if(f STREQUAL "ADDITIONAL_LIBS")
+             SET(PARSING_ADDITIONAL_LIBS ON)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+             set(ARG_PREFIX "none")
+             #also unset all the other states
+             set(skip_to_next TRUE)
+-        elseif(${f} STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
++        elseif(f STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
+             SET(PARSING_ADDITIONAL_LIBS OFF)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
+             set(skip_to_next TRUE)
+@@ -104,7 +104,7 @@ function(windows_unittests_add_exe whatIsBuilding)
+ 
+         if(NOT skip_to_next)
+             if(PARSING_ADDITIONAL_LIBS)
+-                if((${f} STREQUAL "debug") OR (${f} STREQUAL "optimized") OR (${f} STREQUAL "general"))
++                if((f STREQUAL "debug") OR (f STREQUAL "optimized") OR (f STREQUAL "general"))
+                     SET(ARG_PREFIX ${f})
+                 else()
+                     target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_exe ${f})
+@@ -150,14 +150,14 @@ function(linux_unittests_add_exe whatIsBuilding)
+     set(ARG_PREFIX "none")
+     foreach(f ${ARGN})
+         set(skip_to_next FALSE)
+-        if(${f} STREQUAL "ADDITIONAL_LIBS")
++        if(f STREQUAL "ADDITIONAL_LIBS")
+             SET(PARSING_ADDITIONAL_LIBS ON)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+             set(ARG_PREFIX "none")
+             set(skip_to_next TRUE)
+             #also unset all the other states
+ 
+-        elseif(${f} STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
++        elseif(f STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
+             SET(PARSING_ADDITIONAL_LIBS OFF)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
+             set(skip_to_next TRUE)
+@@ -165,7 +165,7 @@ function(linux_unittests_add_exe whatIsBuilding)
+ 
+         if(NOT skip_to_next)
+             if(PARSING_ADDITIONAL_LIBS)
+-                if((${f} STREQUAL "debug") OR (${f} STREQUAL "optimized") OR (${f} STREQUAL "general"))
++                if((f STREQUAL "debug") OR (f STREQUAL "optimized") OR (f STREQUAL "general"))
+                     SET(ARG_PREFIX ${f})
+                 else()
+                     target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_exe ${f})
+@@ -184,7 +184,7 @@ function(linux_unittests_add_exe whatIsBuilding)
+ 
+     if(${run_valgrind})
+         find_program(VALGRIND_FOUND NAMES valgrind)
+-        if(${VALGRIND_FOUND} STREQUAL VALGRIND_FOUND-NOTFOUND)
++        if(VALGRIND_FOUND STREQUAL VALGRIND_FOUND-NOTFOUND)
+             message(WARNING "run_valgrind was TRUE, but valgrind was not found - there will be no tests run under valgrind")
+         else()
+             add_test(NAME ${whatIsBuilding}_valgrind COMMAND valgrind                 --num-callers=100 --error-exitcode=1 --leak-check=full --track-origins=yes ${VALGRIND_SUPPRESSIONS_FILE_EXTRA_PARAMETER} $<TARGET_FILE:${whatIsBuilding}_exe>)
+@@ -308,13 +308,13 @@ function(c_windows_unittests_add_dll whatIsBuilding folder)
+     set(ARG_PREFIX "none")
+     foreach(f ${ARGN})
+         set(skip_to_next FALSE)
+-        if(${f} STREQUAL "ADDITIONAL_LIBS")
++        if(f STREQUAL "ADDITIONAL_LIBS")
+             SET(PARSING_ADDITIONAL_LIBS ON)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+             set(ARG_PREFIX "none")
+             #also unset all the other states
+             set(skip_to_next TRUE)
+-        elseif(${f} STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
++        elseif(f STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
+             SET(PARSING_ADDITIONAL_LIBS OFF)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
+             set(skip_to_next TRUE)
+@@ -322,7 +322,7 @@ function(c_windows_unittests_add_dll whatIsBuilding folder)
+ 
+         if(NOT skip_to_next)
+             if(PARSING_ADDITIONAL_LIBS)
+-                if((${f} STREQUAL "debug") OR (${f} STREQUAL "optimized") OR (${f} STREQUAL "general"))
++                if((f STREQUAL "debug") OR (f STREQUAL "optimized") OR (f STREQUAL "general"))
+                     SET(ARG_PREFIX ${f})
+                 else()
+                     target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_dll ${f})
+@@ -370,13 +370,13 @@ function(c_windows_unittests_add_exe whatIsBuilding folder)
+     set(ARG_PREFIX "none")
+     foreach(f ${ARGN})
+         set(skip_to_next FALSE)
+-        if(${f} STREQUAL "ADDITIONAL_LIBS")
++        if(f STREQUAL "ADDITIONAL_LIBS")
+             SET(PARSING_ADDITIONAL_LIBS ON)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+             set(ARG_PREFIX "none")
+             #also unset all the other states
+             set(skip_to_next TRUE)
+-        elseif(${f} STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
++        elseif(f STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
+             SET(PARSING_ADDITIONAL_LIBS OFF)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
+             set(skip_to_next TRUE)
+@@ -384,7 +384,7 @@ function(c_windows_unittests_add_exe whatIsBuilding folder)
+ 
+         if(NOT skip_to_next)
+             if(PARSING_ADDITIONAL_LIBS)
+-                if((${f} STREQUAL "debug") OR (${f} STREQUAL "optimized") OR (${f} STREQUAL "general"))
++                if((f STREQUAL "debug") OR (f STREQUAL "optimized") OR (f STREQUAL "general"))
+                     SET(ARG_PREFIX ${f})
+                 else()
+                     target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_exe ${f})
+@@ -430,13 +430,13 @@ function(c_linux_unittests_add_exe whatIsBuilding folder)
+     set(ARG_PREFIX "none")
+     foreach(f ${ARGN})
+         set(skip_to_next FALSE)
+-        if(${f} STREQUAL "ADDITIONAL_LIBS")
++        if(f STREQUAL "ADDITIONAL_LIBS")
+             SET(PARSING_ADDITIONAL_LIBS ON)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+             set(ARG_PREFIX "none")
+             #also unset all the other states
+             set(skip_to_next TRUE)
+-        elseif(${f} STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
++        elseif(f STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
+             SET(PARSING_ADDITIONAL_LIBS OFF)
+             SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
+             set(skip_to_next TRUE)
+@@ -444,7 +444,7 @@ function(c_linux_unittests_add_exe whatIsBuilding folder)
+ 
+         if(NOT skip_to_next)
+             if(PARSING_ADDITIONAL_LIBS)
+-                if((${f} STREQUAL "debug") OR (${f} STREQUAL "optimized") OR (${f} STREQUAL "general"))
++                if((f STREQUAL "debug") OR (f STREQUAL "optimized") OR (f STREQUAL "general"))
+                     SET(ARG_PREFIX ${f})
+                 else()
+                     target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_exe ${f})
+@@ -463,7 +463,7 @@ function(c_linux_unittests_add_exe whatIsBuilding folder)
+ 
+     if(${run_valgrind})
+         find_program(VALGRIND_FOUND NAMES valgrind)
+-        if(${VALGRIND_FOUND} STREQUAL VALGRIND_FOUND-NOTFOUND)
++        if(VALGRIND_FOUND STREQUAL VALGRIND_FOUND-NOTFOUND)
+             message(WARNING "run_valgrind was TRUE, but valgrind was not found - there will be no tests run under valgrind")
+         else()
+             add_test(NAME ${whatIsBuilding}_valgrind COMMAND valgrind                 --gen-suppressions=all --num-callers=100 --error-exitcode=1 --leak-check=full --track-origins=yes ${VALGRIND_SUPPRESSIONS_FILE_EXTRA_PARAMETER} $<TARGET_FILE:${whatIsBuilding}_exe>)
+@@ -549,29 +549,29 @@ function(compile_c_test_artifacts_as whatIsBuilding compileAsWhat)
+             (("${whatIsBuilding}" MATCHES ".*int.*") AND ${run_int_tests})
+         )
+             if (${use_cppunittest})
+-                if(${compileAsWhat} STREQUAL "C99")
++                if(compileAsWhat STREQUAL "C99")
+                     compileTargetAsC99(${whatIsBuilding}_dll)
+                     compileTargetAsC99(${whatIsBuilding}_testsonly_lib)
+                 endif()
+-                if(${compileAsWhat} STREQUAL "C11")
++                if(compileAsWhat STREQUAL "C11")
+                     compileTargetAsC11(${whatIsBuilding}_dll)
+                     compileTargetAsC11(${whatIsBuilding}_testsonly_lib)
+                 endif()
+             endif()
+-            if(${compileAsWhat} STREQUAL "C99")
++            if(compileAsWhat STREQUAL "C99")
+                 compileTargetAsC99(${whatIsBuilding}_exe)
+             endif()
+-            if(${compileAsWhat} STREQUAL "C11")
++            if(compileAsWhat STREQUAL "C11")
+                 compileTargetAsC11(${whatIsBuilding}_exe)
+             endif()
+         else()
+             if(
+                 (("${whatIsBuilding}" MATCHES ".*e2e.*") AND ${nuget_e2e_tests})
+             )
+-                if(${compileAsWhat} STREQUAL "C99")
++                if(compileAsWhat STREQUAL "C99")
+                     compileTargetAsC99(${whatIsBuilding}_exe)
+                 endif()
+-                if(${compileAsWhat} STREQUAL "C11")
++                if(compileAsWhat STREQUAL "C11")
+                     compileTargetAsC11(${whatIsBuilding}_exe)
+                 endif()
+             else()
+@@ -584,10 +584,10 @@ function(compile_c_test_artifacts_as whatIsBuilding compileAsWhat)
+             (("${whatIsBuilding}" MATCHES ".*e2e.*") AND ${run_e2e_tests}) OR
+             (("${whatIsBuilding}" MATCHES ".*int.*") AND ${run_int_tests})
+         )
+-            if(${compileAsWhat} STREQUAL "C99")
++            if(compileAsWhat STREQUAL "C99")
+                 compileTargetAsC99(${whatIsBuilding}_exe)
+             endif()
+-            if(${compileAsWhat} STREQUAL "C11")
++            if(compileAsWhat STREQUAL "C11")
+                 compileTargetAsC11(${whatIsBuilding}_exe)
+             endif()
+         endif()
+@@ -681,15 +681,15 @@ function(set_platform_files c_shared_dir)
+             set(CONDITION_C_FILE ${c_shared_dir}/adapters/condition_win32.c PARENT_SCOPE)
+         endif()
+         
+-        if(${use_etw} STREQUAL "OFF")
++        if(use_etw STREQUAL "OFF")
+             set(XLOGGING_C_FILE ${c_shared_dir}/src/xlogging.c PARENT_SCOPE)
+             set(LOGGING_C_FILE ${c_shared_dir}/src/consolelogger.c PARENT_SCOPE)
+             set(LOGGING_H_FILE ${c_shared_dir}/inc/azure_c_shared_utility/consolelogger.h PARENT_SCOPE)
+-        elseif(${use_etw} STREQUAL "TRACELOGGING")
++        elseif(use_etw STREQUAL "TRACELOGGING")
+             set(XLOGGING_C_FILE ${c_shared_dir}/src/etwxlogging.c PARENT_SCOPE)
+             set(LOGGING_C_FILE ${c_shared_dir}/src/etwlogger_driver.c PARENT_SCOPE)
+             set(LOGGING_H_FILE ${c_shared_dir}/inc/azure_c_shared_utility/etwlogger_driver.h PARENT_SCOPE)
+-        elseif(${use_etw} STREQUAL "TRACELOGGING_WITH_CONSOLE")
++        elseif(use_etw STREQUAL "TRACELOGGING_WITH_CONSOLE")
+             set(XLOGGING_C_FILE ${c_shared_dir}/src/etwxlogging.c PARENT_SCOPE)
+             set(LOGGING_C_FILE ${c_shared_dir}/src/etwlogger_driver.c ${c_shared_dir}/src/consolelogger.c PARENT_SCOPE)
+             set(LOGGING_H_FILE ${c_shared_dir}/inc/azure_c_shared_utility/etwlogger_driver.h ${c_shared_dir}/inc/azure_c_shared_utility/consolelogger.h PARENT_SCOPE)
+diff --git a/configs/azure_iot_build_rules.cmake b/configs/azure_iot_build_rules.cmake
+index 655b7f0..00c94c7 100644
+--- a/configs/azure_iot_build_rules.cmake
++++ b/configs/azure_iot_build_rules.cmake
+@@ -71,11 +71,9 @@ if(MSVC)
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")
+ elseif(UNIX) #LINUX OR APPLE
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+     if(NOT (IN_OPENWRT OR APPLE))
+         # _XOPEN_SOURCE=500 is required for glibc to expose random and srandom.
+-        set (CMAKE_C_FLAGS "-D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=500 ${CMAKE_C_FLAGS}")
++        set (CMAKE_C_FLAGS "-D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500 ${CMAKE_C_FLAGS}")
+     endif()
+ endif()
+ 
+@@ -208,12 +206,6 @@ endmacro(generate_cppunittest_wrapper)
+ IF((WIN32) AND (NOT(MINGW)))
+     #windows needs this define
+     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+-    # Make warning as error
+-    add_definitions(/WX)
+-ELSE()
+-    # Make warning as error
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+ ENDIF()
+ 
+ 
+diff --git a/src/dns_resolver_sync.c b/src/dns_resolver_sync.c
+index fbd45f5..502d0f9 100644
+--- a/src/dns_resolver_sync.c
++++ b/src/dns_resolver_sync.c
+@@ -162,7 +162,24 @@ bool dns_resolver_is_lookup_complete(DNSRESOLVER_HANDLE dns_in)
+             else
+             {
+                 /* Codes_SRS_dns_resolver_30_033: [ If dns_resolver_is_create_complete has returned true and the lookup process has failed, dns_resolver_get_ipv4 shall return 0. ]*/
+-                LogInfo("Failed DNS lookup for %s: %d", dns->hostname, getAddrResult);
++#ifdef EAI_SYSTEM
++                int saved_errno = errno;
++#endif
++#ifdef _WIN32
++                const char* gai_error = gai_strerrorA(getAddrResult);
++#else
++                const char* gai_error = gai_strerror(getAddrResult);
++#endif
++#ifdef EAI_SYSTEM
++                if (getAddrResult == EAI_SYSTEM)
++                {
++                    LogInfo("Failed DNS lookup for %s: %d (%s), errno=%d", dns->hostname, getAddrResult, gai_error, saved_errno);
++                }
++                else
++#endif
++                {
++                    LogInfo("Failed DNS lookup for %s: %d (%s)", dns->hostname, getAddrResult, gai_error);
++                }
+                 dns->is_failed = true;
+             }
+ 
+@@ -192,9 +209,12 @@ void dns_resolver_destroy(DNSRESOLVER_HANDLE dns_in)
+     else
+     {
+         /* Codes_SRS_dns_resolver_30_051: [ dns_resolver_destroy shall delete all acquired resources and delete the DNSRESOLVER_HANDLE. ]*/
+-        if(dns->is_complete && !dns->is_failed && dns->addrInfo != NULL)
++        // addrInfo is only set when getaddrinfo succeeded, so it must be released even
++        // when the lookup was then marked failed for holding no usable address.
++        if (dns->addrInfo != NULL)
+         {
+             freeaddrinfo(dns->addrInfo);
++            dns->addrInfo = NULL;
+         }
+ 
+         if(dns->hostname != NULL)

--- a/vcpkg-overlays/azure-c-shared-utility/vcpkg.json
+++ b/vcpkg-overlays/azure-c-shared-utility/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "azure-c-shared-utility",
+  "version-date": "2025-03-31",
+  "port-version": 1,
+  "description": "Azure C SDKs common code",
+  "homepage": "https://github.com/Azure/azure-c-shared-utility",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    "azure-macro-utils-c",
+    {
+      "name": "curl",
+      "platform": "!windows"
+    },
+    {
+      "name": "openssl",
+      "platform": "!windows & !osx"
+    },
+    "umock-c",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose

Validates [Azure/azure-c-shared-utility#683](https://github.com/Azure/azure-c-shared-utility/pull/683) in the Event Hubs SDK before the next azure-c-shared-utility release.

## Changes

- Adds a repository-owned vcpkg overlay for `azure-c-shared-utility`.
- Backports PR #683 and its prerequisite, [PR #684](https://github.com/Azure/azure-c-shared-utility/pull/684), onto the source revision used by the current vcpkg port.
- Selects the overlay automatically during Azure SDK CMake configuration.

A direct pin to the PR merge commit is not used because that revision references additional unreleased dependency and submodule revisions that are incompatible with the current Azure SDK vcpkg baseline.

## Testing

- Configured successfully with vcpkg and the vendored uAMQP implementation.
- Built `azure-c-shared-utility` in Debug and Release configurations.
- Built the `azure-messaging-eventhubs-test` target.
- Ran 119 selected Event Hubs tests in playback mode with no failures. Live-only tests were skipped, and the credential-dependent checkpoint test was excluded.

## Notes

**DO NOT MERGE.** This PR exists only to enable validation builds. The overlay should be removed in favor of the released dependency update.