### PR TITLE
fix(eventhubs): stop discovering a dead link from an exception

### DIFF
--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -11,6 +11,15 @@
 
 ### Bugs Fixed
 
+- `MessageSender` now stores the negotiated maximum message size when its link attaches, and
+  `GetMaxMessageSize` returns that stored value instead of reading the link. The value is fixed when
+  the peer's ATTACH arrives and cannot change for the life of a link, but the read failed once the
+  link was no longer attached, so callers were discovering a dead link from an exception thrown by a
+  getter. The value is read again on each attach, so an entity whose maximum was reconfigured
+  between links stays correct. `MessageSender::IsLinkDetached` reports the same fact without
+  throwing, and a close no longer waits for a DETACH from a peer that has already detached. The
+  teardown still runs on every path. This change applies to the uAMQP transport.
+  [[#7389]](https://github.com/Azure/azure-sdk-for-cpp/issues/7389)
 - uAMQP pollable registration and removal no longer block each other while a poll is in flight. The
   polling registry now waits on completion notifications, and sender, receiver, and link setup and
   teardown do not hold connection locks across registry operations. The polling thread now sleeps

--- a/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/message_sender.hpp
+++ b/sdk/core/azure-core-amqp/inc/azure/core/amqp/internal/message_sender.hpp
@@ -171,6 +171,15 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
     std::uint64_t GetMaxMessageSize() const;
 
 #if ENABLE_UAMQP
+    /** @brief Reports whether the peer has taken the link away.
+     *
+     * Never throws, so a caller holding a cached sender can test it instead of discovering the
+     * loss from a call that fails.
+     *
+     * @return true if the peer has detached the link.
+     */
+    bool IsLinkDetached() const noexcept;
+
     /** @brief Send a message synchronously to the target of the message sender.
      *
      * @param message The message to send.

--- a/sdk/core/azure-core-amqp/src/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/amqp/message_sender.cpp
@@ -75,6 +75,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _internal {
 
   std::uint64_t MessageSender::GetMaxMessageSize() const { return m_impl->GetMaxMessageSize(); }
 #if ENABLE_UAMQP
+  bool MessageSender::IsLinkDetached() const noexcept { return m_impl->IsLinkDetached(); }
   std::string MessageSender::GetLinkName() const { return m_impl->GetLinkName(); }
 #endif
   MessageSender::~MessageSender() noexcept {}

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
@@ -298,8 +298,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
       {
         sender->OnLinkAttached();
       }
-      else if (
-          oldState == MESSAGE_SENDER_STATE_OPEN || oldState == MESSAGE_SENDER_STATE_CLOSING)
+      else if (oldState == MESSAGE_SENDER_STATE_OPEN || oldState == MESSAGE_SENDER_STATE_CLOSING)
       {
         // The link was usable and is not any longer. A connection or session failure takes it down
         // through on_session_state_changed, which never raises the detach event, so this is the
@@ -482,9 +481,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
             m_link); // This will ensure that the link is cleaned up on the next poll()
         // A peer that has already detached the link will never answer with a DETACH of its own,
         // so waiting for one can only burn the deadline. The teardown below still runs.
-        bool shouldWaitForClose
-            = (m_currentState == _internal::MessageSenderState::Closing
-               || m_currentState == _internal::MessageSenderState::Open)
+        bool shouldWaitForClose = (m_currentState == _internal::MessageSenderState::Closing
+                                   || m_currentState == _internal::MessageSenderState::Open)
             && !m_linkDetached.load(std::memory_order_acquire);
 
         {

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
@@ -194,19 +194,57 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
   std::uint64_t MessageSenderImpl::GetMaxMessageSize() const
   {
+    // The peer fixes this value in its ATTACH and never changes it, so a stored copy stays correct.
+    // Reading the link instead fails once the peer is gone, which made a getter the way callers
+    // discovered a dead link.
+    if (m_maxMessageSizeCached.load(std::memory_order_acquire))
+    {
+      return m_maxMessageSize.load(std::memory_order_relaxed);
+    }
+
     if (!m_senderOpen)
     {
       throw std::runtime_error("Message sender is not open.");
     }
+    return CaptureMaxMessageSize();
+  }
+
+  std::uint64_t MessageSenderImpl::CaptureMaxMessageSize() const
+  {
     // Get the max message size from the link (which is the max frame size for the link
     // endpoint) and the peer (which is the max frame size for the other end of the connection).
     //
     auto linkSize{m_link->GetMaxMessageSize()};
     auto peerSize{m_link->GetPeerMaxMessageSize()};
 
-    // Return the smaller of the two values
-    return (std::min)(linkSize, peerSize);
+    // Store the smaller of the two values
+    auto const maxMessageSize{(std::min)(linkSize, peerSize)};
+    m_maxMessageSize.store(maxMessageSize, std::memory_order_relaxed);
+    m_maxMessageSizeCached.store(true, std::memory_order_release);
+    return maxMessageSize;
   }
+
+  void MessageSenderImpl::OnLinkAttached() noexcept
+  {
+    m_linkDetached.store(false, std::memory_order_release);
+
+    // uAMQP calls this from its polling thread, so an exception must not unwind into C code.
+    // Failing here is not fatal: the getter still reads the link on demand.
+    try
+    {
+      if (m_link)
+      {
+        CaptureMaxMessageSize();
+      }
+    }
+    catch (std::exception const& ex)
+    {
+      Log::Stream(Logger::Level::Warning)
+          << "Could not read the maximum message size when the link attached: " << ex.what()
+          << " It will be read on demand instead.";
+    }
+  }
+
   _internal::MessageSenderState MessageSenderStateFromLowLevel(MESSAGE_SENDER_STATE lowLevel)
   {
     switch (lowLevel)
@@ -251,6 +289,22 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         Log::Stream(Logger::Level::Verbose)
             << "Message sender state changed from " << oldState << " to " << newState << ".";
       }
+
+      // Capture the size while the link is attached, before anything observes the new state. Every
+      // transition into Open, not just the first, so a reconfigured entity stays correct.
+      if (newState == MESSAGE_SENDER_STATE_OPEN)
+      {
+        sender->OnLinkAttached();
+      }
+      else if (
+          oldState == MESSAGE_SENDER_STATE_OPEN || oldState == MESSAGE_SENDER_STATE_CLOSING)
+      {
+        // The link was usable and is not any longer. A connection or session failure takes it down
+        // through on_session_state_changed, which never raises the detach event, so this is the
+        // only notification for that path. A DETACH performative also ends up here.
+        sender->m_linkDetached.store(true, std::memory_order_release);
+      }
+
       if (sender->m_events)
       {
         sender->m_events->OnMessageSenderStateChanged(
@@ -424,8 +478,12 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         }
         Common::_detail::GlobalStateHolder::GlobalStateInstance()->RemovePollable(
             m_link); // This will ensure that the link is cleaned up on the next poll()
-        bool shouldWaitForClose = m_currentState == _internal::MessageSenderState::Closing
-            || m_currentState == _internal::MessageSenderState::Open;
+        // A peer that has already detached the link will never answer with a DETACH of its own,
+        // so waiting for one can only burn the deadline. The teardown below still runs.
+        bool shouldWaitForClose
+            = (m_currentState == _internal::MessageSenderState::Closing
+               || m_currentState == _internal::MessageSenderState::Open)
+            && !m_linkDetached.load(std::memory_order_acquire);
 
         {
           if (m_options.EnableTrace)
@@ -523,6 +581,10 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
   void MessageSenderImpl::OnLinkDetached(Models::_internal::AmqpError const& error)
   {
+    // Record this first. The peer has taken the link away, so callers need a test for that rather
+    // than an exception thrown by an unrelated getter.
+    m_linkDetached.store(true, std::memory_order_release);
+
     // Log before the open test. A detach that arrives while the sender is still
     // opening leaves m_senderOpen false, and the open then fails with a generic
     // error that does not name the condition. The $cbs sender takes that path

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/message_sender.cpp
@@ -194,18 +194,20 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
   std::uint64_t MessageSenderImpl::GetMaxMessageSize() const
   {
+    // A closed sender has nothing to report, and that contract predates the stored value.
+    if (!m_senderOpen)
+    {
+      throw std::runtime_error("Message sender is not open.");
+    }
+
     // The peer fixes this value in its ATTACH and never changes it, so a stored copy stays correct.
     // Reading the link instead fails once the peer is gone, which made a getter the way callers
-    // discovered a dead link.
+    // discovered a dead link. A peer detach leaves the sender open, so this path still serves it.
     if (m_maxMessageSizeCached.load(std::memory_order_acquire))
     {
       return m_maxMessageSize.load(std::memory_order_relaxed);
     }
 
-    if (!m_senderOpen)
-    {
-      throw std::runtime_error("Message sender is not open.");
-    }
     return CaptureMaxMessageSize();
   }
 

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/message_sender_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/message_sender_impl.hpp
@@ -9,6 +9,7 @@
 
 #include <azure_uamqp_c/message_sender.h>
 
+#include <atomic>
 #include <cstdint>
 #include <map>
 
@@ -61,6 +62,16 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
 
     std::uint64_t GetMaxMessageSize() const;
 
+    /** @brief Reports whether the peer has taken the link away.
+     *
+     * Never throws, so a caller can test a cached sender rather than discovering a dead link from
+     * a call that fails.
+     */
+    bool IsLinkDetached() const noexcept
+    {
+      return m_linkDetached.load(std::memory_order_acquire);
+    }
+
     std::string GetLinkName() const;
 
   private:
@@ -76,6 +87,19 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
         Azure::Core::Amqp::_internal::MessageSender::MessageSendCompleteCallback onSendComplete,
         Context const& context);
     void OnLinkDetached(Models::_internal::AmqpError const& error);
+
+    /** @brief Read the negotiated maximum message size from the link and store it.
+     *
+     * The caller must know the link is attached. Returns the value it stored.
+     */
+    std::uint64_t CaptureMaxMessageSize() const;
+
+    /** @brief Record that the link reached the attached state.
+     *
+     * Runs on the uAMQP polling thread, so it swallows any failure rather than letting an
+     * exception unwind into C code.
+     */
+    void OnLinkAttached() noexcept;
 
     /** @brief Release the link and the async operation on the connection, then mark the sender as
      * closed.
@@ -97,6 +121,16 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
     };
 
     bool m_senderOpen{false};
+
+    // The negotiated maximum message size, captured each time the link attaches. Mutable so the
+    // const getter can fill it on demand.
+    mutable std::atomic<bool> m_maxMessageSizeCached{false};
+    mutable std::atomic<std::uint64_t> m_maxMessageSize{0};
+
+    // Set when the peer takes the link away, cleared when a link attaches. Presence in a cache is
+    // not liveness, so callers need a test that does not throw.
+    std::atomic<bool> m_linkDetached{false};
+
     UniqueMessageSender m_messageSender{};
     std::shared_ptr<_detail::LinkImpl> m_link;
     _internal::MessageSenderEvents* m_events;

--- a/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/message_sender_impl.hpp
+++ b/sdk/core/azure-core-amqp/src/impl/uamqp/amqp/private/message_sender_impl.hpp
@@ -67,10 +67,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace _detail {
      * Never throws, so a caller can test a cached sender rather than discovering a dead link from
      * a call that fails.
      */
-    bool IsLinkDetached() const noexcept
-    {
-      return m_linkDetached.load(std::memory_order_acquire);
-    }
+    bool IsLinkDetached() const noexcept { return m_linkDetached.load(std::memory_order_acquire); }
 
     std::string GetLinkName() const;
 

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -1064,8 +1064,8 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
   }
 
   // CreateBatch reads the negotiated maximum message size on every call. That read used to go to
-  // the link, so it threw once the peer was gone. The value is fixed when the peer's ATTACH arrives,
-  // so a stored copy stays correct after the link goes.
+  // the link, so it threw once the peer was gone. The value is fixed when the peer's ATTACH
+  // arrives, so a stored copy stays correct after the link goes.
   TEST_F(TestMessageSendReceive, SenderKeepsTheMaxMessageSizeAfterThePeerGoesAway)
   {
     MessageTests::MockServiceEndpointOptions mockServiceEndpointOptions{};

--- a/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/message_sender_receiver.cpp
@@ -976,6 +976,148 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
 #endif // !defined(USE_NATIVE_BROKER)
 #endif // ENABLE_UAMQP
 
+#if ENABLE_UAMQP
+#if !defined(USE_NATIVE_BROKER)
+  namespace {
+    // A service endpoint that accepts a sender link and ignores what arrives on it.
+    class QuietSenderLinkEndpoint final : public MessageTests::MockServiceEndpoint {
+    public:
+      QuietSenderLinkEndpoint(
+          std::string const& name,
+          MessageTests::MockServiceEndpointOptions const& options)
+          : MockServiceEndpoint(name, options)
+      {
+      }
+
+      virtual ~QuietSenderLinkEndpoint() = default;
+
+    private:
+      void MessageReceived(
+          std::string const&,
+          std::shared_ptr<Azure::Core::Amqp::Models::AmqpMessage> const&) override
+      {
+      }
+    };
+
+    bool WaitForLinkDetached(MessageSender const& sender, std::chrono::seconds timeout)
+    {
+      auto const deadline = std::chrono::system_clock::now() + timeout;
+      while (!sender.IsLinkDetached() && std::chrono::system_clock::now() < deadline)
+      {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      }
+      return sender.IsLinkDetached();
+    }
+  } // namespace
+
+  // A sender whose peer has gone away must say so, rather than leaving a caller to discover it from
+  // a call that throws. The connection is closed while the link is still up, because uAMQP reaches
+  // the link that way through on_session_state_changed and never raises the link detach event.
+  TEST_F(TestMessageSendReceive, SenderReportsTheLinkGoneWhenTheConnectionClosesWithoutADetach)
+  {
+    MessageTests::MockServiceEndpointOptions mockServiceEndpointOptions{};
+    m_mockServer.AddServiceEndpoint(
+        std::make_shared<QuietSenderLinkEndpoint>("localhost/ingress", mockServiceEndpointOptions));
+
+    auto connection{CreateAmqpConnection({})};
+    auto session{CreateAmqpSession(connection)};
+
+    StartServerListening();
+
+    {
+      MessageSenderOptions options;
+      options.SettleMode = SenderSettleMode::Settled;
+      options.MaxMessageSize = 65536;
+      options.MessageSource = "ingress";
+      options.Name = "sender-link";
+      MessageSender sender(session.CreateMessageSender("localhost/ingress", options));
+      EXPECT_FALSE(sender.Open());
+
+      // An attached link is not detached.
+      EXPECT_FALSE(sender.IsLinkDetached());
+
+      // Take the connection away, leaving the link attached. No DETACH is sent.
+      m_mockServer.CloseConnectionsWithoutDetachingLinks();
+
+      EXPECT_TRUE(WaitForLinkDetached(sender, std::chrono::seconds(30)))
+          << "The sender never observed the connection going away, so a caller holding it has no "
+             "way to tell that it is unusable, and the first call that touches the link is what "
+             "reports the failure.";
+
+      // A sender whose peer is gone must still close. The network close can report a failure, but
+      // the teardown has to run, because the destructor stops the process on a sender that is
+      // still open.
+      try
+      {
+        sender.Close();
+      }
+      catch (std::exception const& ex)
+      {
+        GTEST_LOG_(INFO) << "Close of a detached sender reported: " << ex.what();
+      }
+      // The sender is destroyed here. Reaching the end of the test is the assertion.
+    }
+
+    StopServerListening();
+    EXPECT_NO_THROW(EndAmqpSession(session));
+    EXPECT_NO_THROW(CloseAmqpConnection(connection));
+  }
+
+  // CreateBatch reads the negotiated maximum message size on every call. That read used to go to
+  // the link, so it threw once the peer was gone. The value is fixed when the peer's ATTACH arrives,
+  // so a stored copy stays correct after the link goes.
+  TEST_F(TestMessageSendReceive, SenderKeepsTheMaxMessageSizeAfterThePeerGoesAway)
+  {
+    MessageTests::MockServiceEndpointOptions mockServiceEndpointOptions{};
+    m_mockServer.AddServiceEndpoint(
+        std::make_shared<QuietSenderLinkEndpoint>("localhost/ingress", mockServiceEndpointOptions));
+
+    auto connection{CreateAmqpConnection({})};
+    auto session{CreateAmqpSession(connection)};
+
+    StartServerListening();
+
+    {
+      MessageSenderOptions options;
+      options.SettleMode = SenderSettleMode::Settled;
+      options.MaxMessageSize = 65536;
+      options.MessageSource = "ingress";
+      options.Name = "sender-link";
+      MessageSender sender(session.CreateMessageSender("localhost/ingress", options));
+      EXPECT_FALSE(sender.Open());
+
+      std::uint64_t sizeWhileAttached{};
+      ASSERT_NO_THROW(sizeWhileAttached = sender.GetMaxMessageSize());
+
+      // Take the connection away, leaving the link attached, which is the shape seen in production.
+      m_mockServer.CloseConnectionsWithoutDetachingLinks();
+
+      ASSERT_TRUE(WaitForLinkDetached(sender, std::chrono::seconds(30)))
+          << "The peer never went away, so this test would not prove anything.";
+      // Without the stored value this read reaches the link, finds it is no longer attached, and
+      // throws "Could not get peer max message size."
+      std::uint64_t sizeAfterThePeerLeft{};
+      EXPECT_NO_THROW(sizeAfterThePeerLeft = sender.GetMaxMessageSize())
+          << "Reading the maximum message size must not depend on a live link.";
+      EXPECT_EQ(sizeWhileAttached, sizeAfterThePeerLeft);
+
+      try
+      {
+        sender.Close();
+      }
+      catch (std::exception const& ex)
+      {
+        GTEST_LOG_(INFO) << "Close of a detached sender reported: " << ex.what();
+      }
+    }
+
+    StopServerListening();
+    EXPECT_NO_THROW(EndAmqpSession(session));
+    EXPECT_NO_THROW(CloseAmqpConnection(connection));
+  }
+#endif // !defined(USE_NATIVE_BROKER)
+#endif // ENABLE_UAMQP
+
   TEST_F(TestMessageSendReceive, AuthenticatedSender)
   {
 #if !defined(USE_NATIVE_BROKER)

--- a/sdk/core/azure-core-amqp/test/ut/mock_amqp_server.hpp
+++ b/sdk/core/azure-core-amqp/test/ut/mock_amqp_server.hpp
@@ -656,6 +656,28 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
         m_listening = false;
       }
 
+      // Closes the connections without closing the links on them first, which is the shape of a
+      // service side idle close: the links go away with the connection rather than through a
+      // DETACH. StopListening cannot be used for this, because it closes every service endpoint
+      // first and that sends a real DETACH.
+      void CloseConnectionsWithoutDetachingLinks()
+      {
+        GTEST_LOG_(INFO) << "Closing connections without detaching their links";
+        for (const auto& connection : m_connections)
+        {
+          try
+          {
+            connection->Close({});
+          }
+          catch (std::exception const& ex)
+          {
+            GTEST_LOG_(INFO) << "Close of a mock connection reported: " << ex.what();
+          }
+        }
+        // Dropped here so the teardown in StopListening does not close them a second time.
+        m_connections.clear();
+      }
+
       void ForceCbsError(bool forceError)
       {
         for (const auto& serviceEndpoint : m_serviceEndpoints)

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release History
 
+## 1.0.0-beta.15 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- [[#7389]](https://github.com/Azure/azure-sdk-for-cpp/issues/7389) `ProducerClient` now tests a cached sender for liveness before it uses one. Holding a sender in the map is not the same as holding a usable one: a link that the service detached during an idle period stayed cached, and the read of the maximum message size in `CreateBatch` was the first call to touch it, so that read threw and the exception was how the client learned the link had died. The producer now discards a detached stack before use, and the size read no longer depends on a live link. A rebuild after an idle close costs the same connection, TLS and claims based security handshake as before; what this removes is the exception and its warnings on that path. This change applies to the uAMQP transport.
+- [[#7389]](https://github.com/Azure/azure-sdk-for-cpp/issues/7389) The claims based security retry in `ProducerClient::CreateBatch` now waits a short random interval before its one further attempt, instead of making it in the same instant. Every producer in a process that failed together went back into whatever caused the first failure together. The wait is a uniform value between zero and 100 milliseconds, drawn from a generator seeded for each thread. It is deliberately not the configured `RetryDelay` and not a backoff step: the purpose is to spread producers that failed at the same moment, not to wait for a condition to clear, so it does not add the best part of a second to a path that is already rebuilding a connection, and it does not depend on `RetryOptions`. The bound stays one retry, and only a claims based security open that reported `CbsOpenResult::Error` is retried; `Cancelled` and `Invalid` still reach the caller on the first attempt.
+
+### Other Changes
+
 ## 1.0.0-beta.14 (2026-08-18)
 
 ### Features Added

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
@@ -261,9 +261,7 @@ namespace Azure { namespace Messaging { namespace EventHubs {
 
     // Discards the cached stack when the peer has taken its link away. Presence in the sender map
     // is not liveness.
-    void DiscardDetachedSender(
-        std::string const& partitionId,
-        Azure::Core::Context const& context);
+    void DiscardDetachedSender(std::string const& partitionId, Azure::Core::Context const& context);
 
     // Calls EnsureSender, and discards a failed attach unless the context is cancelled.
     void EnsureSenderOrInvalidate(

--- a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
@@ -259,6 +259,12 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     // Ensure that a message sender for the specified partition has been created.
     void EnsureSender(std::string const& partitionId, Azure::Core::Context const& context);
 
+    // Discards the cached stack when the peer has taken its link away. Presence in the sender map
+    // is not liveness.
+    void DiscardDetachedSender(
+        std::string const& partitionId,
+        Azure::Core::Context const& context);
+
     // Calls EnsureSender, and discards a failed attach unless the context is cancelled.
     void EnsureSenderOrInvalidate(
         std::string const& partitionId,

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/private/retry_operation.hpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/private/retry_operation.hpp
@@ -62,6 +62,12 @@ namespace Azure { namespace Messaging { namespace EventHubs { namespace _detail 
         std::chrono::milliseconds& retryAfter,
         double jitterFactor = -1);
 
+    // Honours a retry delay while staying responsive to cancellation. Shared so a caller with its
+    // own recovery loop waits the same way `Execute` does.
+    static void WaitForRetryDelay(
+        std::chrono::milliseconds retryAfter,
+        Azure::Core::Context const& context);
+
     explicit RetryOperation(Azure::Core::Http::Policies::RetryOptions const& retryOptions)
         : m_retryOptions(retryOptions)
     {

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
@@ -16,7 +16,10 @@
 #include <azure/core/internal/diagnostics/log.hpp>
 
 #include <algorithm>
+#include <chrono>
+#include <cstdint>
 #include <memory>
+#include <random>
 #include <stdexcept>
 #include <vector>
 
@@ -24,7 +27,21 @@ using namespace Azure::Core::Diagnostics::_internal;
 using namespace Azure::Core::Diagnostics;
 namespace {
 const std::string DefaultAuthScope = "https://eventhubs.azure.net/.default";
+
+// Spreads producers that failed together. Not a backoff, so the window is small and starts at
+// zero, and a producer that failed on its own pays almost nothing.
+constexpr std::chrono::milliseconds CbsRetryJitterWindow{100};
+
+std::chrono::milliseconds NextCbsRetryJitter()
+{
+  // Seeded per thread, and not from std::rand: on the Microsoft CRT every thread starts that
+  // generator from the same seed, so all producers would draw the same value and retry together.
+  static thread_local std::mt19937 engine{std::random_device{}()};
+  std::uniform_int_distribution<std::chrono::milliseconds::rep> distribution{
+      0, CbsRetryJitterWindow.count()};
+  return std::chrono::milliseconds{distribution(engine)};
 }
+} // namespace
 
 namespace Azure { namespace Messaging { namespace EventHubs {
 
@@ -111,10 +128,8 @@ namespace Azure { namespace Messaging { namespace EventHubs {
     EventDataBatchOptions optionsToUse{options};
     if (!options.MaxBytes.HasValue())
     {
-      // EnsureSender only checks whether the map holds a sender; a link the service
-      // detached during an idle period stays cached. Reading the peer max message size
-      // is the first call that touches that dead link, and a live test that waited past
-      // the 30 minute idle detach failed exactly here. Rebuild once and read again.
+      // The sender stores the size when its link attaches, so this read no longer touches the link.
+      // The recovery below stays for a sender that never attached and so has nothing stored.
       auto readMaxMessageSize = [&](std::uint64_t& observedGeneration) -> std::uint64_t {
         auto& guard = GetPartitionGuard(options.PartitionId);
         std::shared_lock<std::shared_timed_mutex> stackLock(guard.stackLock);
@@ -343,10 +358,46 @@ namespace Azure { namespace Messaging { namespace EventHubs {
       GetPartitionGuard(partitionId).generation.fetch_add(1);
     }
   }
+  void ProducerClient::DiscardDetachedSender(
+      std::string const& partitionId,
+      Azure::Core::Context const& context)
+  {
+#if ENABLE_UAMQP
+    // Read the generation before taking m_sendersLock. InvalidateSender takes the partition guard
+    // first and the sender map second, so acquiring them the other way round here would invert
+    // that order.
+    auto const observedGeneration = GetPartitionGuard(partitionId).generation.load();
+
+    {
+      std::unique_lock<std::mutex> lock(m_sendersLock);
+      auto sender = m_senders.find(partitionId);
+      if (sender == m_senders.end() || !sender->second.IsLinkDetached())
+      {
+        return;
+      }
+    }
+
+    Log::Stream(Logger::Level::Informational)
+        << "The peer detached the link for partition '"
+        << (partitionId.empty() ? std::string("<gateway>") : partitionId)
+        << "'. Discard the cached stack before using it." << std::endl;
+    InvalidateSender(partitionId, observedGeneration, context);
+#else
+    // The Rust backend reports a detached link through its own send path, so there is nothing
+    // to test here.
+    (void)partitionId;
+    (void)context;
+#endif
+  }
+
   void ProducerClient::EnsureSenderOrInvalidate(
       std::string const& partitionId,
       Azure::Core::Context const& context)
   {
+    // Holding a sender in the map is not the same as holding a usable one. Test for that here, so
+    // the next call to the sender is not what discovers it.
+    DiscardDetachedSender(partitionId, context);
+
     // A capture after the throw could remove a stack another thread rebuilt.
     auto const observedGeneration = GetPartitionGuard(partitionId).generation.load();
     try
@@ -378,6 +429,9 @@ namespace Azure { namespace Messaging { namespace EventHubs {
   // cannot separate a transient failure from a permanent one; do not make this a loop.
   // `EnsureSenderOrInvalidate` invalidates before it rethrows, so the retry builds a new
   // connection rather than reusing a socket a failed open may have left non-closed.
+  //
+  // The retry waits a short random interval first, so producers that failed together do not go
+  // back into the same failure on the same instant.
   void ProducerClient::EstablishSenderWithRetry(
       std::string const& partitionId,
       Azure::Core::Context const& context)
@@ -396,11 +450,14 @@ namespace Azure { namespace Messaging { namespace EventHubs {
         throw;
       }
 
+      auto const retryAfter = NextCbsRetryJitter();
       Log::Stream(Logger::Level::Warning)
           << "Could not establish the message sender for partition '"
           << (partitionId.empty() ? std::string("<gateway>") : partitionId)
-          << "'. Building the stack again for one final attempt: " << cbsFailure.what()
-          << std::endl;
+          << "'. Building the stack again for one final attempt in " << retryAfter.count()
+          << " ms: " << cbsFailure.what() << std::endl;
+
+      _detail::RetryOperation::WaitForRetryDelay(retryAfter, context);
       EnsureSenderOrInvalidate(partitionId, context);
     }
   }

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
@@ -13,8 +13,11 @@
 
 namespace {
 constexpr std::chrono::milliseconds CancellationCheckInterval{100};
+} // namespace
 
-void WaitForRetryDelay(std::chrono::milliseconds retryAfter, Azure::Core::Context const& context)
+void Azure::Messaging::EventHubs::_detail::RetryOperation::WaitForRetryDelay(
+    std::chrono::milliseconds retryAfter,
+    Azure::Core::Context const& context)
 {
   auto const deadline = std::chrono::steady_clock::now() + retryAfter;
   while (true)
@@ -30,7 +33,6 @@ void WaitForRetryDelay(std::chrono::milliseconds retryAfter, Azure::Core::Contex
     std::this_thread::sleep_until((std::min)(deadline, now + CancellationCheckInterval));
   }
 }
-} // namespace
 
 bool Azure::Messaging::EventHubs::_detail::RetryOperation::Execute(
     std::function<bool()> operation,


### PR DESCRIPTION
Fixes #7389

## The problem

`ProducerClient` caches one sender per partition, and `EnsureSender` only checked whether the map
held one. A link the service took away during an idle period stayed cached, so the maximum message
size read in `CreateBatch` was the first call to touch it, and that read threw. The exception was
how the client learned the link had died.

Measured over a 22.6 hour run at 450 pods x 200 producers, 13,709,613 log lines:

| Signal | Count |
|---|---|
| `The service closed the connection` | 2,020,181 |
| `Could not get peer max message size` | 2,002,191 |
| Ratio | **99.1%** |

## What changed

**1. The size is stored at attach.** `MessageSenderImpl` captures the negotiated maximum message
size when its link reaches `Open` and `GetMaxMessageSize` returns the stored value. `link.c` assigns
`peer_max_message_size` only in the ATTACH-received handler and never changes it, so a stored copy
stays correct for that link. It is captured again on every attach, not once, so an entity whose
maximum was reconfigured between links stays correct.

**2. Liveness is a test, not an exception.** `MessageSender::IsLinkDetached` reports the loss without
throwing, and `ProducerClient::DiscardDetachedSender` discards a detached stack before use.

The flag is set from the **sender state transition**, not from the link detach event. That detail
is the whole fix. `on_link_detach_received` is invoked only from the DETACH performative handler
(`link.c:657`); a connection or session failure reaches the link through `on_session_state_changed`
(`link.c:692-701`), which calls `set_link_state` directly and never raises that event. In the same
22.6 hour run, with `detach` present in the harness trace filter so the line was eligible for
capture, `Message sender link detached` appeared **zero** times. A fix that hooked only
`OnLinkDetached` would have changed nothing in production.

`Close` also no longer waits for a DETACH from a peer that has already gone. It still runs the
teardown on every path, because `~MessageSenderImpl` calls `AzureNoReturnPath` on a sender that is
still open.

**3. The CBS retry waits.** `EstablishSenderWithRetry` previously made its one further attempt in
the same instant, so every producer in a process that failed together went back into the same
failure at once. It now waits a uniform interval between 0 and 100 ms first.

The bound is unchanged at one retry, and only `CbsOpenResult::Error` is retried; `Cancelled` and
`Invalid` still reach the caller on the first attempt. The wait is deliberately not `RetryDelay` and
not a backoff step: this is decorrelation rather than waiting for a condition to clear, so a window
that starts at zero spreads the retries without adding the best part of a second to a path that is
already rebuilding a connection, and it does not depend on `RetryOptions`.

The generator is `thread_local` and seeded from `std::random_device`. On the Microsoft CRT the state
behind `std::rand` is per-thread but every thread starts from the same seed unless that thread calls
`std::srand`, so every producer would otherwise have drawn the same value and retried in lockstep.

## Testing

Two regression tests in `message_sender_receiver.cpp`, both closing the connection while the link is
still attached, using a new `AmqpServerMock::CloseConnectionsWithoutDetachingLinks`. The ordinary
mock teardown closes each service endpoint first, which sends a real DETACH, so it exercises the one
shape that never occurs against the live service.

Each was checked in both directions:

- Bypassing the stored size makes `SenderKeepsTheMaxMessageSizeAfterThePeerGoesAway` fail with
  `Could not get peer max message size.`, the same text behind the 2,002,191 production lines.
- Removing the sender state transition makes
  `SenderReportsTheLinkGoneWhenTheConnectionClosesWithoutADetach` fail: it waits the full timeout and
  then aborts in the destructor, because the sender never learned it was unusable.

Suites, x64 Debug, uAMQP:

- `azure-core-amqp-tests`: 232 tests, 230 pass. The two failures, `TestCbs.CbsOpenNoListener` and
  `TestMessageSendReceive.SenderCloseWhileUnsettledSendIgnoresLateDisposition`, fail identically on
  an unmodified tree.
- `azure-messaging-eventhubs-test`: 72 of 72 offline tests pass. The rest need live resources.

`GetMaxMessageSize` still throws for a sender the caller closed. The open flag is tested ahead of
the stored value, so that contract is unchanged; a peer detach leaves the sender open until
teardown, which is why the stored value still serves the case it was added for.

## Known gaps

- **The Event Hubs half of this change has no test, and no existing test covers it.** Commenting out
  the `DiscardDetachedSender` call entirely leaves every suite green: 72 of 72 offline Event Hubs
  tests pass and `azure-core-amqp-tests` still reports 230 of 232. `SendSurvivesAnIdleDetach_LIVEONLY_`
  asserts only that the second send succeeds, which was already true through the old exception
  recovery, so it cannot tell the two paths apart.

  There is nowhere to hang a unit test today: the Event Hubs test project has no mock AMQP server,
  its `CMakeLists.txt` includes only `../../src`, every producer and reattach test is `_LIVEONLY_`,
  and `MessageSender` has no virtual interface to substitute. Closing this properly means making
  `mock_amqp_server.hpp` available to the Event Hubs tests and driving a `ProducerClient` at it over
  a localhost connection string.

  This path is instead being validated by a scale run, where it executes on the order of two million
  times against the live service under real concurrency. A broken discard does not fail silently
  there: the cached size keeps `CreateBatch` from throwing, so the failure moves to `Send`, and the
  run distinguishes the two outcomes directly.

  | Signal | Working | Broken |
  |---|---|---|
  | `The peer detached the link ... Discard the cached stack` | present, at the rate of the idle closes | absent |
  | Send path retries | flat | rises to match the idle closes |

  That covers behaviour but not regression: a scale run cannot gate CI. If the maintainers want the
  mock-based test before this merges, it can be added on top with the behaviour already proven.

- The lock ordering in `DiscardDetachedSender`, which reads the generation before taking
  `m_sendersLock` so it does not invert the order `InvalidateSender` uses, is reasoned rather than
  tested. The scale run exercises it under 200 threads per process, which a unit test would not do
  reliably.
- The 100 ms window is a judgement call. It spreads the producers inside one process; spreading
  across machines stays the caller's job.

## Deliberately not included

- Eager release at the moment the connection closes. .NET drops its cached link from the close
  callback and frees the socket during the idle window. Doing that here means dispatching from the
  uAMQP polling thread, and phase 1 of `InvalidateSender` takes the partition guard exclusively, so
  a send in flight would stall AMQP I/O. Invalidation stays lazy, at first use after the close.
- Seeding the shared jitter generators. `retry_operation.cpp` and `azure-core`'s `retry_policy.cpp`
  both draw from `std::rand` with no per-thread seed and have the same lockstep problem. Fixing the
  `azure-core` one touches every service library, so both belong in their own change.
- Any reduction in reconnects. The connection is genuinely gone, so the TCP, TLS and CBS handshake
  after an idle close cost exactly what they did before. This removes the exception and its
  warnings, not the rebuild.
