### PR TITLE
Azure Core AMQP 1.0.0-beta.13 release

### DIFF
--- a/sdk/core/azure-core-amqp/CHANGELOG.md
+++ b/sdk/core/azure-core-amqp/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Release History
 
-## 1.0.0-beta.13 (Unreleased)
+## 1.0.0-beta.13 (2026-09-03)
 
 ### Features Added
 
 - The Rust AMQP backend now generates SAS tokens from a shared access key. It sends CBS put-token requests with the `servicebus.windows.net:sastoken` token type.
 - Added support for the AMQP Decimal types (AmqpDecimal128, AmqpDecimal64, and AmqpDecimal32).
-
-### Breaking Changes
 
 ### Bugs Fixed
 
@@ -47,8 +45,6 @@
 - The uAMQP management client now names the management node and the open status in the lines that it writes when an open fails, and it keeps the text of the exception that ended the open. The message sender open failure moved from the Error level to the Warning level, because that call reports the failure to its caller.
 - A claims based security open that fails now carries the reason that the layer below reported. `CbsOpenResult::Error` covers every transport, TLS and link failure, so a reader holding only the result could not separate a refused socket from a rejected attach. The management client wrote that reason to the log and then dropped it, because `ManagementClientImpl::Open` reports a failure as a status and the exception that named the cause was destroyed in the handler. The reason now travels with the status and reaches both the warning and the `CbsOpenFailedException` message, so a caller that logs the exception and has no log listener can still tell what failed. It names which of the two links failed, because the sender and the receiver fail for different causes. The reason is empty when the layer below gave none, and the sentence then reads exactly as it did before. It never holds the token.
 - The claims based security object now keeps the AMQP error that the service sent. `ClaimsBasedSecurityImpl::OnError` receives the condition, the description, and the info map, which is the richest statement the service makes about a refused claim, and it only wrote them to the log. They are now added to the reason that the open failure carries. The capture takes a lock of its own, because that callback runs on the polling thread while the management client holds its open lock.
-
-### Other Changes
 
 ## 1.0.0-beta.12 (2026-05-14)
 

--- a/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
@@ -12,6 +12,7 @@
 #include "azure/core/amqp/internal/network/socket_listener.hpp"
 #include "azure/core/amqp/internal/network/socket_transport.hpp"
 #include "azure/core/amqp/internal/session.hpp"
+#include "azure/core/amqp/rtti.hpp"
 #include "azure/core/internal/environment.hpp"
 #include "azure/core/url.hpp"
 #include "mock_amqp_server.hpp"
@@ -515,9 +516,14 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
     catch (std::runtime_error const& e)
     {
       EXPECT_EQ(text, std::string{e.what()});
+#if defined(AZ_CORE_AMQP_RTTI)
       auto const* typed = dynamic_cast<CbsOpenFailedException const*>(&e);
       ASSERT_NE(nullptr, typed);
       EXPECT_EQ(CbsOpenResult::Error, typed->Result);
+#else
+      EXPECT_EQ(
+          CbsOpenResult::Error, static_cast<CbsOpenFailedException const&>(e).Result);
+#endif
     }
 
     // Every failure value survives the throw, so a caller can branch on it.

--- a/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
+++ b/sdk/core/azure-core-amqp/test/ut/connection_tests.cpp
@@ -521,8 +521,7 @@ namespace Azure { namespace Core { namespace Amqp { namespace Tests {
       ASSERT_NE(nullptr, typed);
       EXPECT_EQ(CbsOpenResult::Error, typed->Result);
 #else
-      EXPECT_EQ(
-          CbsOpenResult::Error, static_cast<CbsOpenFailedException const&>(e).Result);
+      EXPECT_EQ(CbsOpenResult::Error, static_cast<CbsOpenFailedException const&>(e).Result);
 #endif
     }
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/vcpkg.json
+++ b/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/vcpkg.json
@@ -23,7 +23,7 @@
     {
       "name": "azure-core-amqp-cpp",
       "default-features": false,
-      "version>=": "1.0.0-beta.12"
+      "version>=": "1.0.0-beta.13"
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
## Summary

Prepare `azure-core-amqp` 1.0.0-beta.13 for release.

## Motivation

Event Hubs 1.0.0-beta.15 uses AMQP APIs added after beta.12. Publishing beta.13 unblocks [microsoft/vcpkg#53761](https://github.com/microsoft/vcpkg/pull/53761).

## Changes

- Set the AMQP release date to 2026-09-03 and remove empty changelog sections.
- Require `azure-core-amqp-cpp` 1.0.0-beta.13 from the Event Hubs vcpkg manifest.
- Guard the typed exception assertion so builds without RTTI compile.

## Validation

- Ran `eng/common/scripts/Prepare-Release.ps1` for `azure-core-amqp` 1.0.0-beta.13.
- Ran the release changelog and manifest checks.
- Confirmed the original CI failure was MSVC warning C4541 under `/GR-`.

Release work item: [16234](https://dev.azure.com/azure-sdk/Release/_workitems/edit/16234/)