### PR TITLE
Prevent a race conditioned crash in WinHTTP transport when SetEvent could get invoked on an already closed handle

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs Fixed
 
 - [[#7200]](https://github.com/Azure/azure-sdk-for-cpp/pull/7200) Fix global-buffer-overflow and undefined shift in `Base64Decode()`. (A community contribution, courtesy of _[groeneai](https://github.com/groeneai)_)
+- Fixed a race conditioned crash in WinHTTP transport when `SetEvent` could get invoked on an already closed handle.
 
 ### Other Changes
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Bugs Fixed
 
 - [[#7200]](https://github.com/Azure/azure-sdk-for-cpp/pull/7200) Fix global-buffer-overflow and undefined shift in `Base64Decode()`. (A community contribution, courtesy of _[groeneai](https://github.com/groeneai)_)
-- Fixed a race conditioned crash in WinHTTP transport when `SetEvent` could get invoked on an already closed handle.
+- Fixed a crash in the WinHTTP transport caused by a race condition where `SetEvent` could be invoked on an already closed handle.
 
 ### Other Changes
 

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -111,7 +111,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     ~WinHttpAction()
     {
-      std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+      std::unique_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
       if (!m_actionCompleteReset)
       {
         m_actionCompleteReset = true;

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -171,6 +171,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
    * @brief A WinHttpRequest object encapsulates an HTTP operation.
    */
   class WinHttpRequest final {
+    std::shared_timed_mutex m_requestHandleClosingMutex;
+    std::atomic<bool> m_requestHandleClosing{false};
     std::shared_timed_mutex m_requestHandleMutex;
     std::atomic<bool> m_requestHandleClosed{false};
     Azure::Core::_internal::UniqueHandle<HINTERNET> m_requestHandle;
@@ -201,6 +203,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
         std::chrono::milliseconds connectionTimeout);
 
     ~WinHttpRequest();
+    void MarkRequestHandleForClosing();
+    bool IsRequestHandleMarkedForClosing();
     void CloseRequestHandle(bool lock);
     void UnregisterCallback();
     void Upload(Azure::Core::Http::Request& request, Azure::Core::Context const& context);

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -109,17 +109,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       }
     }
 
-    ~WinHttpAction()
-    {
-      std::unique_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
-      if (!m_actionCompleteReset)
-      {
-        m_actionCompleteReset = true;
-        m_actionCompleteEvent.reset();
-      }
-
-      m_httpRequest->UnregisterCallback();
-    }
+    ~WinHttpAction();
 
     /**
      * Register the WinHTTP Status callback used by the action.

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -63,13 +63,13 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     WinHttpRequest* const m_httpRequest{};
     wil::unique_event m_actionCompleteEvent;
     // Mutex protecting all mutable members of the class.
-    std::mutex m_scopeExitMutex;
+    std::mutex m_actionCompleteResetMutex;
     std::mutex m_actionCompleteMutex;
     DWORD m_expectedStatus{};
     DWORD m_stowedError{};
     DWORD_PTR m_stowedErrorInformation{};
     DWORD m_bytesAvailable{};
-    std::atomic<bool> m_scopeExit{false};
+    std::atomic<bool> m_actionCompleteReset{false};
 
     /*
      * Callback from WinHTTP called after the TLS certificates are received when the caller sets
@@ -105,6 +105,16 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       if (!m_actionCompleteEvent)
       {
         throw std::runtime_error("Error creating Action Complete Event.");
+      }
+    }
+
+    ~WinHttpAction()
+    {
+      std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+      if (!m_actionCompleteReset)
+      {
+        m_actionCompleteReset = true;
+        m_actionCompleteEvent.reset();
       }
     }
 

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -22,6 +22,7 @@
 
 #include <windows.h>
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <mutex>
@@ -62,11 +63,13 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     WinHttpRequest* const m_httpRequest{};
     wil::unique_event m_actionCompleteEvent;
     // Mutex protecting all mutable members of the class.
+    std::mutex m_scopeExitMutex;
     std::mutex m_actionCompleteMutex;
     DWORD m_expectedStatus{};
     DWORD m_stowedError{};
     DWORD_PTR m_stowedErrorInformation{};
     DWORD m_bytesAvailable{};
+    std::atomic<bool> m_scopeExit{false};
 
     /*
      * Callback from WinHTTP called after the TLS certificates are received when the caller sets

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -26,6 +26,7 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 
 #if defined(_MSC_VER)
 #pragma warning(push)
@@ -63,7 +64,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     WinHttpRequest* const m_httpRequest{};
     wil::unique_event m_actionCompleteEvent;
     // Mutex protecting all mutable members of the class.
-    std::mutex m_actionCompleteResetMutex;
+    std::shared_timed_mutex m_actionCompleteResetMutex;
     std::mutex m_actionCompleteMutex;
     DWORD m_expectedStatus{};
     DWORD m_stowedError{};

--- a/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_request.hpp
@@ -117,6 +117,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
         m_actionCompleteReset = true;
         m_actionCompleteEvent.reset();
       }
+
+      m_httpRequest->UnregisterCallback();
     }
 
     /**
@@ -179,7 +181,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
    * @brief A WinHttpRequest object encapsulates an HTTP operation.
    */
   class WinHttpRequest final {
-    bool m_requestHandleClosed{false};
+    std::shared_timed_mutex m_requestHandleMutex;
+    std::atomic<bool> m_requestHandleClosed{false};
     Azure::Core::_internal::UniqueHandle<HINTERNET> m_requestHandle;
     std::unique_ptr<WinHttpAction> m_httpAction;
     std::vector<std::string> m_expectedTlsRootCertificates;
@@ -208,7 +211,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
         std::chrono::milliseconds connectionTimeout);
 
     ~WinHttpRequest();
-    void MarkRequestHandleClosed() { m_requestHandleClosed = true; };
+    void CloseRequestHandle(bool lock);
+    void UnregisterCallback();
     void Upload(Azure::Core::Http::Request& request, Azure::Core::Context const& context);
     void SendRequest(Azure::Core::Http::Request& request, Azure::Core::Context const& context);
     void ReceiveResponse(Azure::Core::Context const& context);

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -1528,10 +1528,12 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
   void WinHttpRequest::CloseRequestHandle(bool lock)
   {
-    std::unique_lock<std::shared_timed_mutex> requestHandleLock;
+    std::unique_lock<std::shared_timed_mutex> requestHandleLock(
+        m_requestHandleMutex, std::defer_lock);
+
     if (lock)
     {
-      requestHandleLock.lock(m_requestHandleMutex);
+      requestHandleLock.lock();
     }
 
     if (!m_requestHandleClosed)

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -607,8 +607,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     }
     else
     {
-      Log::Stream(Logger::Level::Verbose)
-          << "WinHttpAction::CompleteAction(): not invoking SetEvent_scope_exit() twice.";
+      Log::Stream(Logger::Level::Verbose) << "WinHttpAction::CompleteAction(): "
+                                             "not invoking SetEvent_scope_exit() twice.";
     }
   }
   void WinHttpAction::CompleteActionWithData(DWORD bytesAvailable)
@@ -625,8 +625,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     }
     else
     {
-      Log::Stream(Logger::Level::Verbose)
-          << "WinHttpAction::CompleteActionWithData(): not invoking SetEvent_scope_exit() twice.";
+      Log::Stream(Logger::Level::Verbose) << "WinHttpAction::CompleteActionWithData(): "
+                                             "not invoking SetEvent_scope_exit() twice.";
     }
 
     std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
@@ -648,8 +648,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       }
       else
       {
-        Log::Stream(Logger::Level::Verbose)
-            << "WinHttpAction::CompleteActionWithError(): not invoking SetEvent_scope_exit() twice.";
+        Log::Stream(Logger::Level::Verbose) << "WinHttpAction::CompleteActionWithError(): "
+                                               "not invoking SetEvent_scope_exit() twice.";
       }
 
       std::unique_lock<std::mutex> lock(m_actionCompleteMutex);

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -598,14 +598,27 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
   void WinHttpAction::CompleteAction()
   {
-    auto scope_exit{m_actionCompleteEvent.SetEvent_scope_exit()};
+    wil::event_set_scope_exit scope_exit;
+    std::unique_lock<std::mutex> lock(m_scopeExitMutex);
+    if (!m_scopeExit)
+    {
+      m_scopeExit = true;
+      scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
+    }
   }
   void WinHttpAction::CompleteActionWithData(DWORD bytesAvailable)
   {
     // Note that the order of scope_exit and lock is important - this ensures that scope_exit is
     // destroyed *after* lock is destroyed, ensuring that the event is not set to the signalled
     // state before the lock is released.
-    auto scope_exit{m_actionCompleteEvent.SetEvent_scope_exit()};
+    wil::event_set_scope_exit scope_exit;
+    std::unique_lock<std::mutex> lock(m_scopeExitMutex);
+    if (!m_scopeExit)
+    {
+      m_scopeExit = true;
+      scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
+    }
+
     std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
     m_bytesAvailable = bytesAvailable;
   }
@@ -616,7 +629,14 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       // Note that the order of scope_exit and lock is important - this ensures that scope_exit
       // is destroyed *after* lock is destroyed, ensuring that the event is not set to the
       // signalled state before the lock is released.
-      auto scope_exit{m_actionCompleteEvent.SetEvent_scope_exit()};
+      wil::event_set_scope_exit scope_exit;
+      std::unique_lock<std::mutex> lock(m_scopeExitMutex);
+      if (!m_scopeExit)
+      {
+        m_scopeExit = true;
+        scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
+      }
+
       std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
       m_stowedErrorInformation = stowedErrorInformation;
       m_stowedError = stowedError;

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -622,8 +622,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
   void WinHttpAction::CompleteAction()
   {
-    wil::event_set_scope_exit scope_exit;
     std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    wil::event_set_scope_exit scope_exit;
     if (!m_actionCompleteReset)
     {
       scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -524,6 +524,18 @@ namespace Azure { namespace Core { namespace Http {
 
 namespace Azure { namespace Core { namespace Http { namespace _detail {
 
+  WinHttpAction::~WinHttpAction()
+  {
+    std::unique_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    if (!m_actionCompleteReset)
+    {
+      m_actionCompleteReset = true;
+      m_actionCompleteEvent.reset();
+    }
+
+    m_httpRequest->UnregisterCallback();
+  }
+
   bool WinHttpAction::RegisterWinHttpStatusCallback(
       Azure::Core::_internal::UniqueHandle<HINTERNET> const& internetHandle)
   {

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -1309,7 +1309,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
   void WinHttpRequest::EnableWebSocketsSupport()
   {
-    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 6387) // warning C6387: _Param_(3) could be '0'.
@@ -1494,7 +1494,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
    */
   WinHttpRequest::~WinHttpRequest()
   {
-    std::unique_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+    std::unique_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!m_requestHandleClosed)
     {
       Log::Write(
@@ -1516,7 +1516,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
   void WinHttpRequest::CloseRequestHandle(bool lock)
   {
-    std::unique_lock<std::shred_timed_mutex> requestHandleLock;
+    std::unique_lock<std::shared_timed_mutex> requestHandleLock;
     if (lock)
     {
       requestHandleLock.lock(m_requestHandleMutex);
@@ -1537,7 +1537,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
   void WinHttpRequest::UnregisterCallback()
   {
-    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!m_requestHandleClosed)
     {
       WinHttpSetStatusCallback(
@@ -1588,7 +1588,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
       DWORD dwBytesWritten = 0;
 
-      std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+      std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
       if (!m_httpAction->WaitForAction(
               [&]() { // Write data to the server.
                 if (!WinHttpWriteData(
@@ -1635,7 +1635,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       Log::Stream(Logger::Level::Verbose)
           << "Client certificate needed, providing before request.." << std::endl;
 
-      std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+      std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
       if (!WinHttpSetOption(
               m_requestHandle.get(),
               WINHTTP_OPTION_CLIENT_CERT_CONTEXT,
@@ -1648,7 +1648,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     try
     {
-      std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+      std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
       if (!m_httpAction->WaitForAction(
               [&]() {
                 {
@@ -1717,7 +1717,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // Wait to receive the response to the HTTP request initiated by WinHttpSendRequest.
     // When WinHttpReceiveResponse completes successfully, the status code and response headers
     // have been received.
-    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!m_httpAction->WaitForAction(
             [this]() {
               if (!WinHttpReceiveResponse(m_requestHandle.get(), NULL))
@@ -1756,7 +1756,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // Get the content length as a number.
     if (requestMethod != HttpMethod::Head && responseStatusCode != HttpStatusCode::NoContent)
     {
-      std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+      std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
       if (!WinHttpQueryHeaders(
               m_requestHandle.get(),
               WINHTTP_QUERY_CONTENT_LENGTH | WINHTTP_QUERY_FLAG_NUMBER,
@@ -1785,7 +1785,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // First, use WinHttpQueryHeaders to obtain the size of the buffer.
     // The call is expected to fail since no destination buffer is provided.
     DWORD sizeOfHeaders = 0;
-    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (WinHttpQueryHeaders(
             m_requestHandle.get(),
             WINHTTP_QUERY_RAW_HEADERS,
@@ -1811,7 +1811,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     // Now, use WinHttpQueryHeaders to retrieve all the headers.
     // Each header is terminated by "\0". An additional "\0" terminates the list of headers.
-    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!WinHttpQueryHeaders(
             m_requestHandle.get(),
             WINHTTP_QUERY_RAW_HEADERS,
@@ -1948,7 +1948,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       Azure::Core::Context const& context)
   {
     DWORD numberOfBytesRead = 0;
-    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!m_httpAction->WaitForAction(
             [&]() {
               if (!WinHttpReadData(

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -1660,69 +1660,66 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       }
     }
 
-    try
-    {
-      std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
-      if (!m_httpAction->WaitForAction(
-              [&]() {
+    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
+    if (!m_httpAction->WaitForAction(
+            [&]() {
+              {
+                // Send a request.
+                // NB: DO NOT CHANGE THE TYPE OF THE CONTEXT PARAMETER WITHOUT UPDATING THE
+                // HttpAction::StatusCallback method.
+                if (!WinHttpSendRequest(
+                        m_requestHandle.get(),
+                        requestHeaders.size() == 0 ? WINHTTP_NO_ADDITIONAL_HEADERS
+                                                   : encodedHeaders.c_str(),
+                        encodedHeadersLength,
+                        WINHTTP_NO_REQUEST_DATA,
+                        0,
+                        streamLength > 0 ? static_cast<DWORD>(streamLength) : 0,
+                        reinterpret_cast<DWORD_PTR>(
+                            m_httpAction.get()))) // Context for WinHTTP status callbacks for
+                                                  // this request.
                 {
-                  // Send a request.
-                  // NB: DO NOT CHANGE THE TYPE OF THE CONTEXT PARAMETER WITHOUT UPDATING THE
-                  // HttpAction::StatusCallback method.
-                  if (!WinHttpSendRequest(
-                          m_requestHandle.get(),
-                          requestHeaders.size() == 0 ? WINHTTP_NO_ADDITIONAL_HEADERS
-                                                     : encodedHeaders.c_str(),
-                          encodedHeadersLength,
-                          WINHTTP_NO_REQUEST_DATA,
-                          0,
-                          streamLength > 0 ? static_cast<DWORD>(streamLength) : 0,
-                          reinterpret_cast<DWORD_PTR>(
-                              m_httpAction.get()))) // Context for WinHTTP status callbacks for
-                                                    // this request.
-                  {
-                    // Errors include:
-                    // ERROR_WINHTTP_CANNOT_CONNECT
-                    // ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED
-                    // ERROR_WINHTTP_CONNECTION_ERROR
-                    // ERROR_WINHTTP_INCORRECT_HANDLE_STATE
-                    // ERROR_WINHTTP_INCORRECT_HANDLE_TYPE
-                    // ERROR_WINHTTP_INTERNAL_ERROR
-                    // ERROR_WINHTTP_INVALID_URL
-                    // ERROR_WINHTTP_LOGIN_FAILURE
-                    // ERROR_WINHTTP_NAME_NOT_RESOLVED
-                    // ERROR_WINHTTP_OPERATION_CANCELLED
-                    // ERROR_WINHTTP_RESPONSE_DRAIN_OVERFLOW
-                    // ERROR_WINHTTP_SECURE_FAILURE
-                    // ERROR_WINHTTP_SHUTDOWN
-                    // ERROR_WINHTTP_TIMEOUT
-                    // ERROR_WINHTTP_UNRECOGNIZED_SCHEME
-                    // ERROR_NOT_ENOUGH_MEMORY
-                    // ERROR_INVALID_PARAMETER
-                    // ERROR_WINHTTP_RESEND_REQUEST
-                    GetErrorAndThrow("Error while sending a request.");
-                  }
+                  // Errors include:
+                  // ERROR_WINHTTP_CANNOT_CONNECT
+                  // ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED
+                  // ERROR_WINHTTP_CONNECTION_ERROR
+                  // ERROR_WINHTTP_INCORRECT_HANDLE_STATE
+                  // ERROR_WINHTTP_INCORRECT_HANDLE_TYPE
+                  // ERROR_WINHTTP_INTERNAL_ERROR
+                  // ERROR_WINHTTP_INVALID_URL
+                  // ERROR_WINHTTP_LOGIN_FAILURE
+                  // ERROR_WINHTTP_NAME_NOT_RESOLVED
+                  // ERROR_WINHTTP_OPERATION_CANCELLED
+                  // ERROR_WINHTTP_RESPONSE_DRAIN_OVERFLOW
+                  // ERROR_WINHTTP_SECURE_FAILURE
+                  // ERROR_WINHTTP_SHUTDOWN
+                  // ERROR_WINHTTP_TIMEOUT
+                  // ERROR_WINHTTP_UNRECOGNIZED_SCHEME
+                  // ERROR_NOT_ENOUGH_MEMORY
+                  // ERROR_INVALID_PARAMETER
+                  // ERROR_WINHTTP_RESEND_REQUEST
+                  GetErrorAndThrow("Error while sending a request.");
                 }
-              },
-              WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE,
-              context))
-      {
-        GetErrorAndThrow(
-            "Error while waiting for a send to complete.", m_httpAction->GetStowedError());
-      }
+              }
+            },
+            WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE,
+            context))
+    {
+      GetErrorAndThrow(
+          "Error while waiting for a send to complete.", m_httpAction->GetStowedError());
+    }
 
-      // Chunked transfer encoding is not supported and the content length needs to be known up
-      // front.
-      if (streamLength == -1)
-      {
-        throw Azure::Core::Http::TransportException(
-            "When uploading data, the body stream must have a known length.");
-      }
+    // Chunked transfer encoding is not supported and the content length needs to be known up
+    // front.
+    if (streamLength == -1)
+    {
+      throw Azure::Core::Http::TransportException(
+          "When uploading data, the body stream must have a known length.");
+    }
 
-      if (streamLength > 0)
-      {
-        Upload(request, context);
-      }
+    if (streamLength > 0)
+    {
+      Upload(request, context);
     }
   }
 

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -599,7 +599,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
   void WinHttpAction::CompleteAction()
   {
     wil::event_set_scope_exit scope_exit;
-    std::unique_lock<std::mutex> lock(m_scopeExitMutex);
+    std::unique_lock<std::mutex> scopeExitLock(m_scopeExitMutex);
     if (!m_scopeExit)
     {
       m_scopeExit = true;
@@ -617,7 +617,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // destroyed *after* lock is destroyed, ensuring that the event is not set to the signalled
     // state before the lock is released.
     wil::event_set_scope_exit scope_exit;
-    std::unique_lock<std::mutex> lock(m_scopeExitMutex);
+    std::unique_lock<std::mutex> scopeExitLock(m_scopeExitMutex);
     if (!m_scopeExit)
     {
       m_scopeExit = true;
@@ -640,7 +640,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       // is destroyed *after* lock is destroyed, ensuring that the event is not set to the
       // signalled state before the lock is released.
       wil::event_set_scope_exit scope_exit;
-      std::unique_lock<std::mutex> lock(m_scopeExitMutex);
+      std::unique_lock<std::mutex> scopeExitLock(m_scopeExitMutex);
       if (!m_scopeExit)
       {
         m_scopeExit = true;

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -1504,7 +1504,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       // Close the outstanding request handle, waiting until the HANDLE_CLOSING status is
       // received.
       if (!m_httpAction->WaitForAction(
-              [this]() { CloseRequestHandle(false) },
+              [this]() { CloseRequestHandle(false); },
               WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING,
               Azure::Core::Context{}))
       {

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -605,6 +605,11 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       m_scopeExit = true;
       scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
     }
+    else
+    {
+      Log::Stream(Logger::Level::Verbose)
+          << "WinHttpAction::CompleteAction(): not invoking SetEvent_scope_exit() twice.";
+    }
   }
   void WinHttpAction::CompleteActionWithData(DWORD bytesAvailable)
   {
@@ -617,6 +622,11 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     {
       m_scopeExit = true;
       scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
+    }
+    else
+    {
+      Log::Stream(Logger::Level::Verbose)
+          << "WinHttpAction::CompleteActionWithData(): not invoking SetEvent_scope_exit() twice.";
     }
 
     std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
@@ -635,6 +645,11 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       {
         m_scopeExit = true;
         scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
+      }
+      else
+      {
+        Log::Stream(Logger::Level::Verbose)
+            << "WinHttpAction::CompleteActionWithError(): not invoking SetEvent_scope_exit() twice.";
       }
 
       std::unique_lock<std::mutex> lock(m_actionCompleteMutex);

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -554,7 +554,19 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     // By definition, there cannot be any actions outstanding at this point because we have not
     // yet called initiateAction. So it's safe to reset our state here.
-    ResetEvent(m_actionCompleteEvent.get());
+    std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    if (!m_actionCompleteReset)
+    {
+      ResetEvent(m_actionCompleteEvent.get());
+    }
+    else
+    {
+      Log::Stream(Logger::Level::Verbose) << "WinHttpAction::WaitForAction(): "
+                                             "not invoking ResetEvent() on a closed event.";
+
+      return false;
+    }
+
     m_expectedStatus = expectedCallbackStatus;
     m_stowedError = 0;
     m_stowedErrorInformation = 0;
@@ -599,16 +611,15 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
   void WinHttpAction::CompleteAction()
   {
     wil::event_set_scope_exit scope_exit;
-    std::unique_lock<std::mutex> scopeExitLock(m_scopeExitMutex);
-    if (!m_scopeExit)
+    std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    if (!m_actionCompleteReset)
     {
-      m_scopeExit = true;
       scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
     }
     else
     {
       Log::Stream(Logger::Level::Verbose) << "WinHttpAction::CompleteAction(): "
-                                             "not invoking SetEvent_scope_exit() twice.";
+                                             "not invoking SetEvent_scope_exit() on a closed event.";
     }
   }
   void WinHttpAction::CompleteActionWithData(DWORD bytesAvailable)
@@ -617,16 +628,17 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // destroyed *after* lock is destroyed, ensuring that the event is not set to the signalled
     // state before the lock is released.
     wil::event_set_scope_exit scope_exit;
-    std::unique_lock<std::mutex> scopeExitLock(m_scopeExitMutex);
-    if (!m_scopeExit)
+    std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    if (!m_actionCompleteReset)
     {
-      m_scopeExit = true;
       scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
     }
     else
     {
       Log::Stream(Logger::Level::Verbose) << "WinHttpAction::CompleteActionWithData(): "
-                                             "not invoking SetEvent_scope_exit() twice.";
+                                             "not invoking SetEvent_scope_exit() on a closed event.";
+
+      return;
     }
 
     std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
@@ -640,16 +652,17 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       // is destroyed *after* lock is destroyed, ensuring that the event is not set to the
       // signalled state before the lock is released.
       wil::event_set_scope_exit scope_exit;
-      std::unique_lock<std::mutex> scopeExitLock(m_scopeExitMutex);
-      if (!m_scopeExit)
+      std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+      if (!m_actionCompleteReset)
       {
-        m_scopeExit = true;
         scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
       }
       else
       {
         Log::Stream(Logger::Level::Verbose) << "WinHttpAction::CompleteActionWithError(): "
-                                               "not invoking SetEvent_scope_exit() twice.";
+                                               "not invoking SetEvent_scope_exit() on a closed event.";
+
+        return;
       }
 
       std::unique_lock<std::mutex> lock(m_actionCompleteMutex);

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -1822,7 +1822,6 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     // Now, use WinHttpQueryHeaders to retrieve all the headers.
     // Each header is terminated by "\0". An additional "\0" terminates the list of headers.
-    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!WinHttpQueryHeaders(
             m_requestHandle.get(),
             WINHTTP_QUERY_RAW_HEADERS,

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -554,7 +554,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     // By definition, there cannot be any actions outstanding at this point because we have not
     // yet called initiateAction. So it's safe to reset our state here.
-    std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    std::shared_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
     if (!m_actionCompleteReset)
     {
       ResetEvent(m_actionCompleteEvent.get());
@@ -611,7 +611,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
   void WinHttpAction::CompleteAction()
   {
     wil::event_set_scope_exit scope_exit;
-    std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
     if (!m_actionCompleteReset)
     {
       scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
@@ -629,7 +629,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // destroyed *after* lock is destroyed, ensuring that the event is not set to the signalled
     // state before the lock is released.
     wil::event_set_scope_exit scope_exit;
-    std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    std::shared_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
     if (!m_actionCompleteReset)
     {
       scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
@@ -654,7 +654,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       // is destroyed *after* lock is destroyed, ensuring that the event is not set to the
       // signalled state before the lock is released.
       wil::event_set_scope_exit scope_exit;
-      std::unique_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+      std::shared_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
       if (!m_actionCompleteReset)
       {
         scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -618,8 +618,9 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     }
     else
     {
-      Log::Stream(Logger::Level::Verbose) << "WinHttpAction::CompleteAction(): "
-                                             "not invoking SetEvent_scope_exit() on a closed event.";
+      Log::Stream(Logger::Level::Verbose)
+          << "WinHttpAction::CompleteAction(): "
+             "not invoking SetEvent_scope_exit() on a closed event.";
     }
   }
   void WinHttpAction::CompleteActionWithData(DWORD bytesAvailable)
@@ -635,8 +636,9 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     }
     else
     {
-      Log::Stream(Logger::Level::Verbose) << "WinHttpAction::CompleteActionWithData(): "
-                                             "not invoking SetEvent_scope_exit() on a closed event.";
+      Log::Stream(Logger::Level::Verbose)
+          << "WinHttpAction::CompleteActionWithData(): "
+             "not invoking SetEvent_scope_exit() on a closed event.";
 
       return;
     }
@@ -659,8 +661,9 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       }
       else
       {
-        Log::Stream(Logger::Level::Verbose) << "WinHttpAction::CompleteActionWithError(): "
-                                               "not invoking SetEvent_scope_exit() on a closed event.";
+        Log::Stream(Logger::Level::Verbose)
+            << "WinHttpAction::CompleteActionWithError(): "
+               "not invoking SetEvent_scope_exit() on a closed event.";
 
         return;
       }

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -554,7 +554,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     // By definition, there cannot be any actions outstanding at this point because we have not
     // yet called initiateAction. So it's safe to reset our state here.
-    std::shared_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
     if (!m_actionCompleteReset)
     {
       ResetEvent(m_actionCompleteEvent.get());
@@ -629,7 +629,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // destroyed *after* lock is destroyed, ensuring that the event is not set to the signalled
     // state before the lock is released.
     wil::event_set_scope_exit scope_exit;
-    std::shared_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+    std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
     if (!m_actionCompleteReset)
     {
       scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
@@ -654,7 +654,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       // is destroyed *after* lock is destroyed, ensuring that the event is not set to the
       // signalled state before the lock is released.
       wil::event_set_scope_exit scope_exit;
-      std::shared_lock<std::mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+      std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
       if (!m_actionCompleteReset)
       {
         scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -522,151 +522,109 @@ namespace Azure { namespace Core { namespace Http {
 
 }}} // namespace Azure::Core::Http
 
-namespace Azure { namespace Core { namespace Http { namespace _detail {
+namespace Azure { namespace Core { namespace Http {
+  namespace _detail {
 
-  WinHttpAction::~WinHttpAction()
-  {
-    std::unique_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
-    if (!m_actionCompleteReset)
+    WinHttpAction::~WinHttpAction()
     {
-      m_actionCompleteReset = true;
-      m_actionCompleteEvent.reset();
-    }
-
-    m_httpRequest->UnregisterCallback();
-  }
-
-  bool WinHttpAction::RegisterWinHttpStatusCallback(
-      Azure::Core::_internal::UniqueHandle<HINTERNET> const& internetHandle)
-  {
-    return (
-        WinHttpSetStatusCallback(
-            internetHandle.get(),
-            &WinHttpAction::StatusCallback,
-            WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS,
-            0)
-        != WINHTTP_INVALID_STATUS_CALLBACK);
-  }
-
-  /**
-   * Wait for an action to complete.
-   *
-   */
-  bool WinHttpAction::WaitForAction(
-      std::function<void()> initiateAction,
-      DWORD expectedCallbackStatus,
-      Azure::Core::Context const& context,
-      Azure::DateTime::duration const& pollDuration)
-  {
-    //
-    // Note that we cannot check for cancellation before calling `initiateAction` because it's
-    // possible that the `initiateAction` call is a call to `WinHttpSendRequest` which establishes
-    // the SendContext.
-    //
-
-    // By definition, there cannot be any actions outstanding at this point because we have not
-    // yet called initiateAction. So it's safe to reset our state here.
-    std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
-    if (!m_actionCompleteReset)
-    {
-      ResetEvent(m_actionCompleteEvent.get());
-    }
-    else
-    {
-      Log::Stream(Logger::Level::Verbose) << "WinHttpAction::WaitForAction(): "
-                                             "not invoking ResetEvent() on a closed event.";
-
-      return false;
-    }
-
-    m_expectedStatus = expectedCallbackStatus;
-    m_stowedError = 0;
-    m_stowedErrorInformation = 0;
-    m_bytesAvailable = 0;
-
-    // Call the provided callback to start the WinHTTP action.
-    initiateAction();
-
-    DWORD waitResult;
-    do
-    {
-      waitResult = WaitForSingleObject(
-          m_actionCompleteEvent.get(),
-          static_cast<DWORD>(
-              std::chrono::duration_cast<std::chrono::milliseconds>(pollDuration).count()));
-      if (waitResult == WAIT_TIMEOUT)
+      std::unique_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+      if (!m_actionCompleteReset)
       {
-        // If the request was cancelled while we were waiting, throw an exception.
-        if (context.IsCancelled())
-        {
-          Log::Stream(Logger::Level::Error)
-              << "Request was cancelled while waiting for action to complete." << std::endl;
-        }
-        context.ThrowIfCancelled();
+        m_actionCompleteReset = true;
+        m_actionCompleteEvent.reset();
       }
-      else if (waitResult != WAIT_OBJECT_0)
+
+      m_httpRequest->UnregisterCallback();
+    }
+
+    bool WinHttpAction::RegisterWinHttpStatusCallback(
+        Azure::Core::_internal::UniqueHandle<HINTERNET> const& internetHandle)
+    {
+      return (
+          WinHttpSetStatusCallback(
+              internetHandle.get(),
+              &WinHttpAction::StatusCallback,
+              WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS,
+              0)
+          != WINHTTP_INVALID_STATUS_CALLBACK);
+    }
+
+    /**
+     * Wait for an action to complete.
+     *
+     */
+    bool WinHttpAction::WaitForAction(
+        std::function<void()> initiateAction,
+        DWORD expectedCallbackStatus,
+        Azure::Core::Context const& context,
+        Azure::DateTime::duration const& pollDuration)
+    {
+      //
+      // Note that we cannot check for cancellation before calling `initiateAction` because it's
+      // possible that the `initiateAction` call is a call to `WinHttpSendRequest` which establishes
+      // the SendContext.
+      //
+
+      // By definition, there cannot be any actions outstanding at this point because we have not
+      // yet called initiateAction. So it's safe to reset our state here.
+      std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+      if (!m_actionCompleteReset)
       {
-        Log::Stream(Logger::Level::Error)
-            << "WaitForSingleObject failed with error code " << GetLastError() << std::endl;
+        ResetEvent(m_actionCompleteEvent.get());
+      }
+      else
+      {
+        Log::Stream(Logger::Level::Verbose) << "WinHttpAction::WaitForAction(): "
+                                               "not invoking ResetEvent() on a closed event.";
+
         return false;
       }
-    } while (waitResult != WAIT_OBJECT_0);
-    if (m_stowedError != NO_ERROR)
-    {
-      Log::Stream(Logger::Level::Error)
-          << "Action completed with error: " << GetErrorMessage(m_stowedError);
-      return false;
-    }
-    return true;
-  }
 
-  void WinHttpAction::CompleteAction()
-  {
-    std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
-    wil::event_set_scope_exit scope_exit;
-    if (!m_actionCompleteReset)
-    {
-      scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
-    }
-    else
-    {
-      Log::Stream(Logger::Level::Verbose)
-          << "WinHttpAction::CompleteAction(): "
-             "not invoking SetEvent_scope_exit() on a closed event.";
-    }
-  }
-  void WinHttpAction::CompleteActionWithData(DWORD bytesAvailable)
-  {
-    // Note that the order of scope_exit and lock is important - this ensures that scope_exit is
-    // destroyed *after* lock is destroyed, ensuring that the event is not set to the signalled
-    // state before the lock is released.
-    wil::event_set_scope_exit scope_exit;
-    std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
-    if (!m_actionCompleteReset)
-    {
-      scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
-    }
-    else
-    {
-      Log::Stream(Logger::Level::Verbose)
-          << "WinHttpAction::CompleteActionWithData(): "
-             "not invoking SetEvent_scope_exit() on a closed event.";
+      m_expectedStatus = expectedCallbackStatus;
+      m_stowedError = 0;
+      m_stowedErrorInformation = 0;
+      m_bytesAvailable = 0;
 
-      return;
+      // Call the provided callback to start the WinHTTP action.
+      initiateAction();
+
+      DWORD waitResult;
+      do
+      {
+        waitResult = WaitForSingleObject(
+            m_actionCompleteEvent.get(),
+            static_cast<DWORD>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(pollDuration).count()));
+        if (waitResult == WAIT_TIMEOUT)
+        {
+          // If the request was cancelled while we were waiting, throw an exception.
+          if (context.IsCancelled())
+          {
+            Log::Stream(Logger::Level::Error)
+                << "Request was cancelled while waiting for action to complete." << std::endl;
+          }
+          context.ThrowIfCancelled();
+        }
+        else if (waitResult != WAIT_OBJECT_0)
+        {
+          Log::Stream(Logger::Level::Error)
+              << "WaitForSingleObject failed with error code " << GetLastError() << std::endl;
+          return false;
+        }
+      } while (waitResult != WAIT_OBJECT_0);
+      if (m_stowedError != NO_ERROR)
+      {
+        Log::Stream(Logger::Level::Error)
+            << "Action completed with error: " << GetErrorMessage(m_stowedError);
+        return false;
+      }
+      return true;
     }
 
-    std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
-    m_bytesAvailable = bytesAvailable;
-  }
-  void WinHttpAction::CompleteActionWithError(DWORD_PTR stowedErrorInformation, DWORD stowedError)
-  {
-    if (m_expectedStatus != WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING)
+    void WinHttpAction::CompleteAction()
     {
-      // Note that the order of scope_exit and lock is important - this ensures that scope_exit
-      // is destroyed *after* lock is destroyed, ensuring that the event is not set to the
-      // signalled state before the lock is released.
-      wil::event_set_scope_exit scope_exit;
       std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+      wil::event_set_scope_exit scope_exit;
       if (!m_actionCompleteReset)
       {
         scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
@@ -674,287 +632,335 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       else
       {
         Log::Stream(Logger::Level::Verbose)
-            << "WinHttpAction::CompleteActionWithError(): "
+            << "WinHttpAction::CompleteAction(): "
+               "not invoking SetEvent_scope_exit() on a closed event.";
+      }
+    }
+    void WinHttpAction::CompleteActionWithData(DWORD bytesAvailable)
+    {
+      // Note that the order of scope_exit and lock is important - this ensures that scope_exit is
+      // destroyed *after* lock is destroyed, ensuring that the event is not set to the signalled
+      // state before the lock is released.
+      std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(m_actionCompleteResetMutex);
+      wil::event_set_scope_exit scope_exit;
+      if (!m_actionCompleteReset)
+      {
+        scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
+      }
+      else
+      {
+        Log::Stream(Logger::Level::Verbose)
+            << "WinHttpAction::CompleteActionWithData(): "
                "not invoking SetEvent_scope_exit() on a closed event.";
 
         return;
       }
 
       std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
-      m_stowedErrorInformation = stowedErrorInformation;
-      m_stowedError = stowedError;
+      m_bytesAvailable = bytesAvailable;
     }
-    else
+    void WinHttpAction::CompleteActionWithError(DWORD_PTR stowedErrorInformation, DWORD stowedError)
     {
-      Log::Write(
-          Logger::Level::Verbose, "Received error while closing: " + std::to_string(stowedError));
-    }
-  }
-
-  DWORD WinHttpAction::GetStowedError()
-  {
-    std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
-    return m_stowedError;
-  }
-  DWORD_PTR WinHttpAction::GetStowedErrorInformation()
-  {
-    std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
-    return m_stowedErrorInformation;
-  }
-  DWORD WinHttpAction::GetBytesAvailable()
-  {
-    std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
-    return m_bytesAvailable;
-  }
-
-  /**
-   * Called by WinHTTP when sending a request to the server. This callback allows us to inspect
-   * the TLS certificate before sending it to the server.
-   */
-  void WinHttpAction::StatusCallback(
-      HINTERNET hInternet,
-      DWORD_PTR dwContext,
-      DWORD internetStatus,
-      LPVOID statusInformation,
-      DWORD statusInformationLength)
-  {
-    // If we're called before our context has been set (on Open and Close callbacks), ignore the
-    // status callback.
-    if (dwContext == 0)
-    {
-      return;
-    }
-    WinHttpAction* httpAction = reinterpret_cast<WinHttpAction*>(dwContext);
-    try
-    {
-      httpAction->OnHttpStatusOperation(
-          hInternet, internetStatus, statusInformation, statusInformationLength);
-    }
-    catch (Azure::Core::RequestFailedException const& rfe)
-    {
-      // If an exception is thrown in the handler, log the error and terminate the connection.
-      Log::Write(
-          Logger::Level::Error,
-          "Request Failed Exception Thrown: " + std::string(rfe.what()) + rfe.Message);
-      httpAction->m_httpRequest->CloseRequestHandle(true);
-    }
-    catch (std::exception const& ex)
-    {
-      // If an exception is thrown in the handler, log the error and terminate the connection.
-      Log::Write(Logger::Level::Error, "Exception Thrown: " + std::string(ex.what()));
-    }
-  }
-  namespace {
-    std::string WinHttpAsyncResultToString(DWORD_PTR result)
-    {
-      switch (result)
+      if (m_expectedStatus != WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING)
       {
-        case API_RECEIVE_RESPONSE:
-          return "API_RECEIVE_RESPONSE";
-        case API_QUERY_DATA_AVAILABLE:
-          return "API_QUERY_DATA_AVAILABLE";
-        case API_READ_DATA:
-          return "API_READ_DATA";
-        case API_WRITE_DATA:
-          return "API_WRITE_DATA";
-        case API_SEND_REQUEST:
-          return "API_SEND_REQUEST";
-        case API_GET_PROXY_FOR_URL:
-          return "API_GET_PROXY_FOR_URL";
-        default:
-          return "Unknown (" + std::to_string(result) + ")";
-      }
-    }
-  } // namespace
-  /**
-   * @brief HTTP Callback to enable private certificate checks.
-   *
-   * This method is called by WinHTTP when a certificate is received. This method is called
-   * multiple times based on the state of the TLS connection.
-   *
-   * Special consideration for the WINHTTP_CALLBACK_STATUS_SENDING_REQUEST - this callback is
-   * called during the TLS connection - if a TLS root certificate is configured, we verify that
-   * the certificate chain sent from the server contains the certificate the HTTP client was
-   * configured with. If it is, we accept the connection, if it is not, we abort the connection,
-   * closing the incoming request handle.
-   */
-  void WinHttpAction::OnHttpStatusOperation(
-      HINTERNET hInternet,
-      DWORD internetStatus,
-      LPVOID statusInformation,
-      DWORD statusInformationLength)
-  {
-    Log::Write(
-        Logger::Level::Informational,
-        "Status operation: " + std::to_string(internetStatus) + "("
-            + InternetStatusToString(internetStatus) + ")");
-    if (internetStatus == WINHTTP_CALLBACK_STATUS_SECURE_FAILURE)
-    {
-      DWORD securityFlags = *reinterpret_cast<DWORD*>(statusInformation);
-      Log::Stream(Logger::Level::Error)
-          << "Security failure.  :(" << std::hex << securityFlags << ") ("
-          << InternetStatusInformationToString(securityFlags) << ")";
-    }
-    else if (internetStatus == WINHTTP_CALLBACK_STATUS_REQUEST_ERROR)
-    {
-      WINHTTP_ASYNC_RESULT* asyncResult = static_cast<WINHTTP_ASYNC_RESULT*>(statusInformation);
-      Log::Write(
-          Logger::Level::Error,
-          "Request error: " + GetErrorMessage(asyncResult->dwError)
-              + " Failing API: " + WinHttpAsyncResultToString(asyncResult->dwResult));
-      CompleteActionWithError(asyncResult->dwResult, asyncResult->dwError);
-    }
-    else if (internetStatus == WINHTTP_CALLBACK_STATUS_SENDING_REQUEST)
-    {
-      // We will only set the Status callback if a root certificate has been set. There is no
-      // action which needs to be completed for this notification.
-      m_httpRequest->HandleExpectedTlsRootCertificates(hInternet);
-    }
-    else if (internetStatus == m_expectedStatus)
-    {
-      switch (internetStatus)
-      {
-        case WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE:
-          // A WinHttpSendRequest API call has completed, complete the current action.
-          CompleteAction();
-          break;
-        case WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE:
-          // A WinHttpWriteData call has completed, complete the current action.
-          CompleteAction();
-          break;
-        case WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE:
-          // Headers for an HTTP response are available, complete the current action.
-          CompleteAction();
-          break;
-        case WINHTTP_CALLBACK_STATUS_READ_COMPLETE:
-          // A WinHttpReadData call has completed. Complete the current action, including the
-          // amount of data read.
-          CompleteActionWithData(statusInformationLength);
-          break;
-        case WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING:
-          // An HINTERNET handle is closing, complete the outstanding close request.
-          Log::Write(
-              Logger::Level::Verbose, "Closing handle; completing outstanding Close request");
-          CompleteAction();
-          break;
-        default:
-          Log::Write(
-              Logger::Level::Error,
-              "Received expected status " + InternetStatusToString(internetStatus)
-                  + " but it was not handled.");
-          break;
-      }
-    }
-  }
-
-  void WinHttpRequest::HandleExpectedTlsRootCertificates(HINTERNET hInternet)
-  {
-    if (!m_expectedTlsRootCertificates.empty())
-    {
-      // Ask WinHTTP for the server certificate - this won't be valid outside a status callback.
-      wil::unique_cert_context serverCertificate;
-      {
-        DWORD bufferLength = sizeof(PCCERT_CONTEXT);
-        if (!WinHttpQueryOption(
-                hInternet,
-                WINHTTP_OPTION_SERVER_CERT_CONTEXT,
-                reinterpret_cast<void*>(serverCertificate.addressof()),
-                &bufferLength))
+        // Note that the order of scope_exit and lock is important - this ensures that scope_exit
+        // is destroyed *after* lock is destroyed, ensuring that the event is not set to the
+        // signalled state before the lock is released.
+        std::shared_lock<std::shared_timed_mutex> actionCompleteResetLock(
+            m_actionCompleteResetMutex);
+        wil::event_set_scope_exit scope_exit;
+        if (!m_actionCompleteReset)
         {
-          GetErrorAndThrow("Could not retrieve TLS server certificate.");
+          scope_exit = m_actionCompleteEvent.SetEvent_scope_exit();
         }
-      }
+        else
+        {
+          Log::Stream(Logger::Level::Verbose)
+              << "WinHttpAction::CompleteActionWithError(): "
+                 "not invoking SetEvent_scope_exit() on a closed event.";
 
-      if (!VerifyCertificatesInChain(m_expectedTlsRootCertificates, serverCertificate.get()))
+          return;
+        }
+
+        std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
+        m_stowedErrorInformation = stowedErrorInformation;
+        m_stowedError = stowedError;
+      }
+      else
       {
         Log::Write(
-            Logger::Level::Error, "Server certificate is not trusted.  Aborting HTTP request");
-
-        // To signal to caller that the request is to be terminated, the callback closes the
-        // handle. This ensures that no message is sent to the server.
-        WinHttpCloseHandle(hInternet);
-
-        // To avoid a double free of this handle record that we've
-        // already closed the handle.
-        m_requestHandleClosed = true;
-
-        // And we're done processing the request, return because there's nothing
-        // else to do.
-        return;
+            Logger::Level::Verbose, "Received error while closing: " + std::to_string(stowedError));
       }
     }
-  }
 
-  Azure::Core::_internal::UniqueHandle<HINTERNET> WinHttpTransportImpl::CreateSessionHandle()
-  {
-    // Use WinHttpOpen to obtain a session handle.
-    // The dwFlags is set to 0 - all WinHTTP functions are performed synchronously.
-    Azure::Core::_internal::UniqueHandle<HINTERNET> sessionHandle(WinHttpOpen(
-        NULL, // Do not use a fallback user-agent string, and only rely on the header within the
-              // request itself.
-        // If the customer asks for it, enable use of the system default HTTP proxy.
-        (m_options.EnableSystemDefaultProxy ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY
-                                            : WINHTTP_ACCESS_TYPE_NO_PROXY),
-        WINHTTP_NO_PROXY_NAME,
-        WINHTTP_NO_PROXY_BYPASS,
-        WINHTTP_FLAG_ASYNC)); // All requests on this session are performed asynchronously.
-
-    if (!sessionHandle)
+    DWORD WinHttpAction::GetStowedError()
     {
-      // Errors include:
-      // ERROR_WINHTTP_INTERNAL_ERROR
-      // ERROR_NOT_ENOUGH_MEMORY
-      GetErrorAndThrow("Error while getting a session handle.");
+      std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
+      return m_stowedError;
+    }
+    DWORD_PTR WinHttpAction::GetStowedErrorInformation()
+    {
+      std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
+      return m_stowedErrorInformation;
+    }
+    DWORD WinHttpAction::GetBytesAvailable()
+    {
+      std::unique_lock<std::mutex> lock(m_actionCompleteMutex);
+      return m_bytesAvailable;
     }
 
-    // These options are only available starting from Windows 10 Version 2004, starting
-    // 06/09/2020. These are primarily round trip time (RTT) performance optimizations, and
-    // hence if they don't get set successfully, we shouldn't fail the request and continue as
-    // if the options don't exist. Therefore, we just ignore the error and move on.
+    /**
+     * Called by WinHTTP when sending a request to the server. This callback allows us to inspect
+     * the TLS certificate before sending it to the server.
+     */
+    void WinHttpAction::StatusCallback(
+        HINTERNET hInternet,
+        DWORD_PTR dwContext,
+        DWORD internetStatus,
+        LPVOID statusInformation,
+        DWORD statusInformationLength)
+    {
+      // If we're called before our context has been set (on Open and Close callbacks), ignore the
+      // status callback.
+      if (dwContext == 0)
+      {
+        return;
+      }
+      WinHttpAction* httpAction = reinterpret_cast<WinHttpAction*>(dwContext);
+      try
+      {
+        httpAction->OnHttpStatusOperation(
+            hInternet, internetStatus, statusInformation, statusInformationLength);
+      }
+      catch (Azure::Core::RequestFailedException const& rfe)
+      {
+        // If an exception is thrown in the handler, log the error and terminate the connection.
+        Log::Write(
+            Logger::Level::Error,
+            "Request Failed Exception Thrown: " + std::string(rfe.what()) + rfe.Message);
 
-    // TCP_FAST_OPEN has a bug when the DNS resolution fails which can result
-    // in a leak.  Until that issue is fixed we've disable this option.
+        httpAction->m_httpRequest->MarkRequestHandleForClosing();
+      }
+      catch (std::exception const& ex)
+      {
+        // If an exception is thrown in the handler, log the error and terminate the connection.
+        Log::Write(Logger::Level::Error, "Exception Thrown: " + std::string(ex.what()));
+      }
+    }
+    namespace {
+      std::string WinHttpAsyncResultToString(DWORD_PTR result)
+      {
+        switch (result)
+        {
+          case API_RECEIVE_RESPONSE:
+            return "API_RECEIVE_RESPONSE";
+          case API_QUERY_DATA_AVAILABLE:
+            return "API_QUERY_DATA_AVAILABLE";
+          case API_READ_DATA:
+            return "API_READ_DATA";
+          case API_WRITE_DATA:
+            return "API_WRITE_DATA";
+          case API_SEND_REQUEST:
+            return "API_SEND_REQUEST";
+          case API_GET_PROXY_FOR_URL:
+            return "API_GET_PROXY_FOR_URL";
+          default:
+            return "Unknown (" + std::to_string(result) + ")";
+        }
+      }
+    } // namespace
+    /**
+     * @brief HTTP Callback to enable private certificate checks.
+     *
+     * This method is called by WinHTTP when a certificate is received. This method is called
+     * multiple times based on the state of the TLS connection.
+     *
+     * Special consideration for the WINHTTP_CALLBACK_STATUS_SENDING_REQUEST - this callback is
+     * called during the TLS connection - if a TLS root certificate is configured, we verify that
+     * the certificate chain sent from the server contains the certificate the HTTP client was
+     * configured with. If it is, we accept the connection, if it is not, we abort the connection,
+     * closing the incoming request handle.
+     */
+    void WinHttpAction::OnHttpStatusOperation(
+        HINTERNET hInternet,
+        DWORD internetStatus,
+        LPVOID statusInformation,
+        DWORD statusInformationLength)
+    {
+      Log::Write(
+          Logger::Level::Informational,
+          "Status operation: " + std::to_string(internetStatus) + "("
+              + InternetStatusToString(internetStatus) + ")");
+      if (internetStatus == WINHTTP_CALLBACK_STATUS_SECURE_FAILURE)
+      {
+        DWORD securityFlags = *reinterpret_cast<DWORD*>(statusInformation);
+        Log::Stream(Logger::Level::Error)
+            << "Security failure.  :(" << std::hex << securityFlags << ") ("
+            << InternetStatusInformationToString(securityFlags) << ")";
+      }
+      else if (internetStatus == WINHTTP_CALLBACK_STATUS_REQUEST_ERROR)
+      {
+        WINHTTP_ASYNC_RESULT* asyncResult = static_cast<WINHTTP_ASYNC_RESULT*>(statusInformation);
+        Log::Write(
+            Logger::Level::Error,
+            "Request error: " + GetErrorMessage(asyncResult->dwError)
+                + " Failing API: " + WinHttpAsyncResultToString(asyncResult->dwResult));
+        CompleteActionWithError(asyncResult->dwResult, asyncResult->dwError);
+      }
+      else if (internetStatus == WINHTTP_CALLBACK_STATUS_SENDING_REQUEST)
+      {
+        // We will only set the Status callback if a root certificate has been set. There is no
+        // action which needs to be completed for this notification.
+        m_httpRequest->HandleExpectedTlsRootCertificates(hInternet);
+      }
+      else if (internetStatus == m_expectedStatus)
+      {
+        switch (internetStatus)
+        {
+          case WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE:
+            // A WinHttpSendRequest API call has completed, complete the current action.
+            CompleteAction();
+            break;
+          case WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE:
+            // A WinHttpWriteData call has completed, complete the current action.
+            CompleteAction();
+            break;
+          case WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE:
+            // Headers for an HTTP response are available, complete the current action.
+            CompleteAction();
+            break;
+          case WINHTTP_CALLBACK_STATUS_READ_COMPLETE:
+            // A WinHttpReadData call has completed. Complete the current action, including the
+            // amount of data read.
+            CompleteActionWithData(statusInformationLength);
+            break;
+          case WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING:
+            // An HINTERNET handle is closing, complete the outstanding close request.
+            Log::Write(
+                Logger::Level::Verbose, "Closing handle; completing outstanding Close request");
+            CompleteAction();
+            break;
+          default:
+            Log::Write(
+                Logger::Level::Error,
+                "Received expected status " + InternetStatusToString(internetStatus)
+                    + " but it was not handled.");
+            break;
+        }
+      }
+    }
+
+    void WinHttpRequest::HandleExpectedTlsRootCertificates(HINTERNET hInternet)
+    {
+      if (!m_expectedTlsRootCertificates.empty())
+      {
+        // Ask WinHTTP for the server certificate - this won't be valid outside a status callback.
+        wil::unique_cert_context serverCertificate;
+        {
+          DWORD bufferLength = sizeof(PCCERT_CONTEXT);
+          if (!WinHttpQueryOption(
+                  hInternet,
+                  WINHTTP_OPTION_SERVER_CERT_CONTEXT,
+                  reinterpret_cast<void*>(serverCertificate.addressof()),
+                  &bufferLength))
+          {
+            GetErrorAndThrow("Could not retrieve TLS server certificate.");
+          }
+        }
+
+        if (!VerifyCertificatesInChain(m_expectedTlsRootCertificates, serverCertificate.get()))
+        {
+          Log::Write(
+              Logger::Level::Error, "Server certificate is not trusted.  Aborting HTTP request");
+
+          // To signal to caller that the request is to be terminated, the callback closes the
+          // handle. This ensures that no message is sent to the server.
+          WinHttpCloseHandle(hInternet);
+
+          // To avoid a double free of this handle record that we've
+          // already closed the handle.
+          m_requestHandleClosed = true;
+
+          // And we're done processing the request, return because there's nothing
+          // else to do.
+          return;
+        }
+      }
+    }
+
+    Azure::Core::_internal::UniqueHandle<HINTERNET> WinHttpTransportImpl::CreateSessionHandle()
+    {
+      // Use WinHttpOpen to obtain a session handle.
+      // The dwFlags is set to 0 - all WinHTTP functions are performed synchronously.
+      Azure::Core::_internal::UniqueHandle<HINTERNET> sessionHandle(WinHttpOpen(
+          NULL, // Do not use a fallback user-agent string, and only rely on the header within the
+                // request itself.
+          // If the customer asks for it, enable use of the system default HTTP proxy.
+          (m_options.EnableSystemDefaultProxy ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY
+                                              : WINHTTP_ACCESS_TYPE_NO_PROXY),
+          WINHTTP_NO_PROXY_NAME,
+          WINHTTP_NO_PROXY_BYPASS,
+          WINHTTP_FLAG_ASYNC)); // All requests on this session are performed asynchronously.
+
+      if (!sessionHandle)
+      {
+        // Errors include:
+        // ERROR_WINHTTP_INTERNAL_ERROR
+        // ERROR_NOT_ENOUGH_MEMORY
+        GetErrorAndThrow("Error while getting a session handle.");
+      }
+
+      // These options are only available starting from Windows 10 Version 2004, starting
+      // 06/09/2020. These are primarily round trip time (RTT) performance optimizations, and
+      // hence if they don't get set successfully, we shouldn't fail the request and continue as
+      // if the options don't exist. Therefore, we just ignore the error and move on.
+
+      // TCP_FAST_OPEN has a bug when the DNS resolution fails which can result
+      // in a leak.  Until that issue is fixed we've disable this option.
 
 #if defined(WINHTTP_OPTION_TCP_FAST_OPEN) && FALSE
-    BOOL tcp_fast_open = TRUE;
-    WinHttpSetOption(
-        sessionHandle.get(), WINHTTP_OPTION_TCP_FAST_OPEN, &tcp_fast_open, sizeof(tcp_fast_open));
+      BOOL tcp_fast_open = TRUE;
+      WinHttpSetOption(
+          sessionHandle.get(), WINHTTP_OPTION_TCP_FAST_OPEN, &tcp_fast_open, sizeof(tcp_fast_open));
 #endif
 
 #ifdef WINHTTP_OPTION_TLS_FALSE_START
-    BOOL tls_false_start = TRUE;
-    WinHttpSetOption(
-        sessionHandle.get(),
-        WINHTTP_OPTION_TLS_FALSE_START,
-        &tls_false_start,
-        sizeof(tls_false_start));
+      BOOL tls_false_start = TRUE;
+      WinHttpSetOption(
+          sessionHandle.get(),
+          WINHTTP_OPTION_TLS_FALSE_START,
+          &tls_false_start,
+          sizeof(tls_false_start));
 #endif
 
-    // Enforce TLS version 1.2 or 1.3 (if available).
-    auto tlsOption = WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2;
+      // Enforce TLS version 1.2 or 1.3 (if available).
+      auto tlsOption = WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2;
 #if defined(WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3)
-    tlsOption |= WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3;
+      tlsOption |= WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3;
 #endif
-    if (!WinHttpSetOption(
-            sessionHandle.get(), WINHTTP_OPTION_SECURE_PROTOCOLS, &tlsOption, sizeof(tlsOption)))
-    {
-#if defined(WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3)
-      // If TLS 1.3 is not available, try to set TLS 1.2 only.
-      tlsOption = WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2;
       if (!WinHttpSetOption(
               sessionHandle.get(), WINHTTP_OPTION_SECURE_PROTOCOLS, &tlsOption, sizeof(tlsOption)))
       {
-#endif
-        GetErrorAndThrow("Error while enforcing TLS version for connection request.");
 #if defined(WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3)
-      }
+        // If TLS 1.3 is not available, try to set TLS 1.2 only.
+        tlsOption = WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2;
+        if (!WinHttpSetOption(
+                sessionHandle.get(),
+                WINHTTP_OPTION_SECURE_PROTOCOLS,
+                &tlsOption,
+                sizeof(tlsOption)))
+        {
 #endif
+          GetErrorAndThrow("Error while enforcing TLS version for connection request.");
+#if defined(WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3)
+        }
+#endif
+      }
+
+      return sessionHandle;
     }
 
-    return sessionHandle;
-  }
-
-  namespace {
+    namespace {
 #if 0
     /******************** Begin Potential Throwaway Code *******/
     // These functions are captured because they may be required when further iterations on the mTLS
@@ -1212,542 +1218,577 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     /******************** End Potential Throwaway Code *******/
 #endif
 
-    WinHttpTransportOptions WinHttpTransportOptionsFromTransportOptions(
+      WinHttpTransportOptions WinHttpTransportOptionsFromTransportOptions(
+          Azure::Core::Http::Policies::TransportOptions const& transportOptions)
+      {
+        WinHttpTransportOptions httpOptions;
+        if (transportOptions.HttpProxy.HasValue())
+        {
+          // WinHTTP proxy strings are semicolon separated elements, each of which
+          // has the following format:
+          //  ([<scheme>=][<scheme>"://"]<server>[":"<port>])
+          std::string proxyString;
+          proxyString = "http=" + transportOptions.HttpProxy.Value();
+          proxyString += ";";
+          proxyString += "https=" + transportOptions.HttpProxy.Value();
+          httpOptions.ProxyInformation = proxyString;
+        }
+        httpOptions.ProxyUserName = transportOptions.ProxyUserName;
+        httpOptions.ProxyPassword = transportOptions.ProxyPassword;
+        // Note that WinHTTP accepts a set of root certificates, even though transportOptions only
+        // specifies a single one.
+        if (!transportOptions.ExpectedTlsRootCertificate.empty())
+        {
+          httpOptions.ExpectedTlsRootCertificates.push_back(
+              transportOptions.ExpectedTlsRootCertificate);
+        }
+        if (transportOptions.EnableCertificateRevocationListCheck)
+        {
+          httpOptions.EnableCertificateRevocationListCheck = true;
+        }
+        // If you specify an expected TLS root certificate, you also need to enable ignoring
+        // unknown CAs.
+        if (!transportOptions.ExpectedTlsRootCertificate.empty())
+        {
+          httpOptions.IgnoreUnknownCertificateAuthority = true;
+        }
+
+        if (transportOptions.DisableTlsCertificateValidation)
+        {
+          httpOptions.IgnoreUnknownCertificateAuthority = true;
+          httpOptions.IgnoreInvalidCertificateCommonName = true;
+        }
+
+        return httpOptions;
+      }
+    } // namespace
+
+    WinHttpTransportImpl::WinHttpTransportImpl(
+        WinHttpTransport const* parent,
+        WinHttpTransportOptions const& options)
+        : m_parent{parent}, m_options(options), m_sessionHandle(CreateSessionHandle())
+    {
+      if (options.TlsClientCertificate)
+      {
+        // Preserve the input client certificate for later use.
+        m_tlsClientCertificate.reset(CertDuplicateCertificateContext(options.TlsClientCertificate));
+        if (!m_tlsClientCertificate)
+        {
+          GetErrorAndThrow("Error while duplicating client certificate context.");
+        }
+        // Erase the TLS client certificate in the m_options member because it cannot be relied upon
+        // from this point on.
+        m_options.TlsClientCertificate = nullptr;
+      }
+    }
+
+    WinHttpTransportImpl::WinHttpTransportImpl(
+        WinHttpTransport const* parent,
         Azure::Core::Http::Policies::TransportOptions const& transportOptions)
+        : WinHttpTransportImpl(
+              parent,
+              WinHttpTransportOptionsFromTransportOptions(transportOptions))
     {
-      WinHttpTransportOptions httpOptions;
-      if (transportOptions.HttpProxy.HasValue())
-      {
-        // WinHTTP proxy strings are semicolon separated elements, each of which
-        // has the following format:
-        //  ([<scheme>=][<scheme>"://"]<server>[":"<port>])
-        std::string proxyString;
-        proxyString = "http=" + transportOptions.HttpProxy.Value();
-        proxyString += ";";
-        proxyString += "https=" + transportOptions.HttpProxy.Value();
-        httpOptions.ProxyInformation = proxyString;
-      }
-      httpOptions.ProxyUserName = transportOptions.ProxyUserName;
-      httpOptions.ProxyPassword = transportOptions.ProxyPassword;
-      // Note that WinHTTP accepts a set of root certificates, even though transportOptions only
-      // specifies a single one.
-      if (!transportOptions.ExpectedTlsRootCertificate.empty())
-      {
-        httpOptions.ExpectedTlsRootCertificates.push_back(
-            transportOptions.ExpectedTlsRootCertificate);
-      }
-      if (transportOptions.EnableCertificateRevocationListCheck)
-      {
-        httpOptions.EnableCertificateRevocationListCheck = true;
-      }
-      // If you specify an expected TLS root certificate, you also need to enable ignoring
-      // unknown CAs.
-      if (!transportOptions.ExpectedTlsRootCertificate.empty())
-      {
-        httpOptions.IgnoreUnknownCertificateAuthority = true;
-      }
-
-      if (transportOptions.DisableTlsCertificateValidation)
-      {
-        httpOptions.IgnoreUnknownCertificateAuthority = true;
-        httpOptions.IgnoreInvalidCertificateCommonName = true;
-      }
-
-      return httpOptions;
     }
-  } // namespace
 
-  WinHttpTransportImpl::WinHttpTransportImpl(
-      WinHttpTransport const* parent,
-      WinHttpTransportOptions const& options)
-      : m_parent{parent}, m_options(options), m_sessionHandle(CreateSessionHandle())
-  {
-    if (options.TlsClientCertificate)
+    WinHttpTransportImpl::~WinHttpTransportImpl() = default;
+
+    Azure::Core::_internal::UniqueHandle<HINTERNET> WinHttpTransportImpl::CreateConnectionHandle(
+        Azure::Core::Url const& url,
+        Azure::Core::Context const& context)
     {
-      // Preserve the input client certificate for later use.
-      m_tlsClientCertificate.reset(CertDuplicateCertificateContext(options.TlsClientCertificate));
-      if (!m_tlsClientCertificate)
+      // If port is 0, i.e. INTERNET_DEFAULT_PORT, it uses port 80 for HTTP and port 443 for
+      // HTTPS.
+      uint16_t port = url.GetPort();
+
+      // Before doing any work, check to make sure that the context hasn't already been cancelled.
+      context.ThrowIfCancelled();
+
+      // Specify an HTTP server.
+      // This function always operates synchronously.
+      Azure::Core::_internal::UniqueHandle<HINTERNET> rv(WinHttpConnect(
+          m_sessionHandle.get(),
+          StringToWideString(url.GetHost()).c_str(),
+          port == 0 ? INTERNET_DEFAULT_PORT : port,
+          0));
+
+      if (!rv)
       {
-        GetErrorAndThrow("Error while duplicating client certificate context.");
+        // Errors include:
+        // ERROR_WINHTTP_INCORRECT_HANDLE_TYPE
+        // ERROR_WINHTTP_INTERNAL_ERROR
+        // ERROR_WINHTTP_INVALID_URL
+        // ERROR_WINHTTP_OPERATION_CANCELLED
+        // ERROR_WINHTTP_UNRECOGNIZED_SCHEME
+        // ERROR_WINHTTP_SHUTDOWN
+        // ERROR_NOT_ENOUGH_MEMORY
+        GetErrorAndThrow("Error while getting a connection handle.");
       }
-      // Erase the TLS client certificate in the m_options member because it cannot be relied upon
-      // from this point on.
-      m_options.TlsClientCertificate = nullptr;
+      return rv;
     }
-  }
 
-  WinHttpTransportImpl::WinHttpTransportImpl(
-      WinHttpTransport const* parent,
-      Azure::Core::Http::Policies::TransportOptions const& transportOptions)
-      : WinHttpTransportImpl(parent, WinHttpTransportOptionsFromTransportOptions(transportOptions))
-  {
-  }
-
-  WinHttpTransportImpl::~WinHttpTransportImpl() = default;
-
-  Azure::Core::_internal::UniqueHandle<HINTERNET> WinHttpTransportImpl::CreateConnectionHandle(
-      Azure::Core::Url const& url,
-      Azure::Core::Context const& context)
-  {
-    // If port is 0, i.e. INTERNET_DEFAULT_PORT, it uses port 80 for HTTP and port 443 for
-    // HTTPS.
-    uint16_t port = url.GetPort();
-
-    // Before doing any work, check to make sure that the context hasn't already been cancelled.
-    context.ThrowIfCancelled();
-
-    // Specify an HTTP server.
-    // This function always operates synchronously.
-    Azure::Core::_internal::UniqueHandle<HINTERNET> rv(WinHttpConnect(
-        m_sessionHandle.get(),
-        StringToWideString(url.GetHost()).c_str(),
-        port == 0 ? INTERNET_DEFAULT_PORT : port,
-        0));
-
-    if (!rv)
+    void WinHttpRequest::EnableWebSocketsSupport()
     {
-      // Errors include:
-      // ERROR_WINHTTP_INCORRECT_HANDLE_TYPE
-      // ERROR_WINHTTP_INTERNAL_ERROR
-      // ERROR_WINHTTP_INVALID_URL
-      // ERROR_WINHTTP_OPERATION_CANCELLED
-      // ERROR_WINHTTP_UNRECOGNIZED_SCHEME
-      // ERROR_WINHTTP_SHUTDOWN
-      // ERROR_NOT_ENOUGH_MEMORY
-      GetErrorAndThrow("Error while getting a connection handle.");
-    }
-    return rv;
-  }
-
-  void WinHttpRequest::EnableWebSocketsSupport()
-  {
-    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
+      std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 6387) // warning C6387: _Param_(3) could be '0'.
 #endif
-    if (!WinHttpSetOption(m_requestHandle.get(), WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET, nullptr, 0))
+      if (!WinHttpSetOption(
+              m_requestHandle.get(), WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET, nullptr, 0))
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
-    {
-      GetErrorAndThrow("Error while Enabling WebSocket upgrade.");
-    }
-  }
-
-  /** @brief Construct a new WinHttpRequest object.
-   *
-   * @param connectionHandle The connection handle to use for the request.
-   * @param url The URL to request.
-   * @param method The HTTP method to use for the request.
-   * @param tlsClientCertificate The client certificate to use for the request.
-   * @param options The transport options to use for the request.
-   * @param connectionTimeout Connection timeout in milliseconds.
-   *
-   * @remark Note that we *cannot* use the TlsClientCertificate field in the options passed into
-   * this function because the creator of the associated WinHttpTransport object may have freed the
-   * memory backing that object after constructing the WinHttpTransport object. Therefore, we must
-   * use the tlsClientCertificate saved in the WinHttpTransport object instead.
-   *
-   */
-  WinHttpRequest::WinHttpRequest(
-      Azure::Core::_internal::UniqueHandle<HINTERNET> const& connectionHandle,
-      Azure::Core::Url const& url,
-      Azure::Core::Http::HttpMethod const& method,
-      PCCERT_CONTEXT tlsClientCertificate,
-      WinHttpTransportOptions const& options,
-      std::chrono::milliseconds connectionTimeout)
-      : m_expectedTlsRootCertificates(options.ExpectedTlsRootCertificates),
-        m_tlsClientCertificate(CertDuplicateCertificateContext(tlsClientCertificate))
-  {
-    const std::string& path = url.GetRelativeUrl();
-    HttpMethod requestMethod = method;
-    bool const requestSecureHttp(
-        !Azure::Core::_internal::StringExtensions::LocaleInvariantCaseInsensitiveEqual(
-            url.GetScheme(), HttpScheme)
-        && !Azure::Core::_internal::StringExtensions::LocaleInvariantCaseInsensitiveEqual(
-            url.GetScheme(), WebSocketScheme));
-
-    // Create an HTTP request handle.
-    m_requestHandle.reset(WinHttpOpenRequest(
-        connectionHandle.get(),
-        HttpMethodToWideString(requestMethod).c_str(),
-        path.empty() ? NULL : StringToWideString(path).c_str(), // Name of the target resource
-                                                                // of the specified HTTP verb
-        NULL, // Use HTTP/1.1
-        WINHTTP_NO_REFERER,
-        WINHTTP_DEFAULT_ACCEPT_TYPES, // No media types are accepted by the client
-        requestSecureHttp ? WINHTTP_FLAG_SECURE
-                          : 0)); // Uses secure transaction semantics (SSL/TLS)
-    if (!m_requestHandle)
-    {
-      // Errors include:
-      // ERROR_WINHTTP_INCORRECT_HANDLE_TYPE
-      // ERROR_WINHTTP_INTERNAL_ERROR
-      // ERROR_WINHTTP_INVALID_URL
-      // ERROR_WINHTTP_OPERATION_CANCELLED
-      // ERROR_WINHTTP_UNRECOGNIZED_SCHEME
-      // ERROR_NOT_ENOUGH_MEMORY
-      GetErrorAndThrow("Error while getting a request handle.");
-    }
-
-    if (requestSecureHttp)
-    {
-      if (!m_tlsClientCertificate)
       {
-        // If the service requests TLS client certificates, we want to let the WinHTTP APIs know
-        // that it's ok to initiate the request without a client certificate.
-        //
-        // Note: If/When TLS client certificate support is added to the pipeline, this line may
-        // need to be revisited.
+        GetErrorAndThrow("Error while Enabling WebSocket upgrade.");
+      }
+    }
+
+    /** @brief Construct a new WinHttpRequest object.
+     *
+     * @param connectionHandle The connection handle to use for the request.
+     * @param url The URL to request.
+     * @param method The HTTP method to use for the request.
+     * @param tlsClientCertificate The client certificate to use for the request.
+     * @param options The transport options to use for the request.
+     * @param connectionTimeout Connection timeout in milliseconds.
+     *
+     * @remark Note that we *cannot* use the TlsClientCertificate field in the options passed into
+     * this function because the creator of the associated WinHttpTransport object may have freed
+     * the memory backing that object after constructing the WinHttpTransport object. Therefore, we
+     * must use the tlsClientCertificate saved in the WinHttpTransport object instead.
+     *
+     */
+    WinHttpRequest::WinHttpRequest(
+        Azure::Core::_internal::UniqueHandle<HINTERNET> const& connectionHandle,
+        Azure::Core::Url const& url,
+        Azure::Core::Http::HttpMethod const& method,
+        PCCERT_CONTEXT tlsClientCertificate,
+        WinHttpTransportOptions const& options,
+        std::chrono::milliseconds connectionTimeout)
+        : m_expectedTlsRootCertificates(options.ExpectedTlsRootCertificates),
+          m_tlsClientCertificate(CertDuplicateCertificateContext(tlsClientCertificate))
+    {
+      const std::string& path = url.GetRelativeUrl();
+      HttpMethod requestMethod = method;
+      bool const requestSecureHttp(
+          !Azure::Core::_internal::StringExtensions::LocaleInvariantCaseInsensitiveEqual(
+              url.GetScheme(), HttpScheme)
+          && !Azure::Core::_internal::StringExtensions::LocaleInvariantCaseInsensitiveEqual(
+              url.GetScheme(), WebSocketScheme));
+
+      // Create an HTTP request handle.
+      m_requestHandle.reset(WinHttpOpenRequest(
+          connectionHandle.get(),
+          HttpMethodToWideString(requestMethod).c_str(),
+          path.empty() ? NULL : StringToWideString(path).c_str(), // Name of the target resource
+                                                                  // of the specified HTTP verb
+          NULL, // Use HTTP/1.1
+          WINHTTP_NO_REFERER,
+          WINHTTP_DEFAULT_ACCEPT_TYPES, // No media types are accepted by the client
+          requestSecureHttp ? WINHTTP_FLAG_SECURE
+                            : 0)); // Uses secure transaction semantics (SSL/TLS)
+      if (!m_requestHandle)
+      {
+        // Errors include:
+        // ERROR_WINHTTP_INCORRECT_HANDLE_TYPE
+        // ERROR_WINHTTP_INTERNAL_ERROR
+        // ERROR_WINHTTP_INVALID_URL
+        // ERROR_WINHTTP_OPERATION_CANCELLED
+        // ERROR_WINHTTP_UNRECOGNIZED_SCHEME
+        // ERROR_NOT_ENOUGH_MEMORY
+        GetErrorAndThrow("Error while getting a request handle.");
+      }
+
+      if (requestSecureHttp)
+      {
+        if (!m_tlsClientCertificate)
+        {
+          // If the service requests TLS client certificates, we want to let the WinHTTP APIs know
+          // that it's ok to initiate the request without a client certificate.
+          //
+          // Note: If/When TLS client certificate support is added to the pipeline, this line may
+          // need to be revisited.
+          if (!WinHttpSetOption(
+                  m_requestHandle.get(),
+                  WINHTTP_OPTION_CLIENT_CERT_CONTEXT,
+                  WINHTTP_NO_CLIENT_CERT_CONTEXT,
+                  0))
+          {
+            GetErrorAndThrow("Error while setting client cert context to ignore.");
+          }
+        }
+      }
+
+      if (connectionTimeout.count() > 0
+          && connectionTimeout.count() < std::numeric_limits<ULONG>::max())
+      {
+        auto timeoutMillisecondsULong = static_cast<ULONG>(connectionTimeout.count());
         if (!WinHttpSetOption(
                 m_requestHandle.get(),
-                WINHTTP_OPTION_CLIENT_CERT_CONTEXT,
-                WINHTTP_NO_CLIENT_CERT_CONTEXT,
+                WINHTTP_OPTION_CONNECT_TIMEOUT,
+                &timeoutMillisecondsULong,
+                sizeof(timeoutMillisecondsULong)))
+        {
+          GetErrorAndThrow("Error while setting connection timeout.");
+        }
+      }
+
+      if (!options.ProxyInformation.empty())
+      {
+        WINHTTP_PROXY_INFO proxyInfo{};
+        std::wstring proxyWide{StringToWideString(options.ProxyInformation)};
+        proxyInfo.dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
+        proxyInfo.lpszProxy = const_cast<LPWSTR>(proxyWide.c_str());
+        proxyInfo.lpszProxyBypass = WINHTTP_NO_PROXY_BYPASS;
+        if (!WinHttpSetOption(
+                m_requestHandle.get(), WINHTTP_OPTION_PROXY, &proxyInfo, sizeof(proxyInfo)))
+        {
+          GetErrorAndThrow("Error while setting Proxy information.");
+        }
+      }
+      if (options.ProxyUserName.HasValue() || options.ProxyPassword.HasValue())
+      {
+        if (!WinHttpSetCredentials(
+                m_requestHandle.get(),
+                WINHTTP_AUTH_TARGET_PROXY,
+                WINHTTP_AUTH_SCHEME_BASIC,
+                StringToWideString(options.ProxyUserName.Value()).c_str(),
+                StringToWideString(options.ProxyPassword.Value()).c_str(),
                 0))
         {
-          GetErrorAndThrow("Error while setting client cert context to ignore.");
+          GetErrorAndThrow("Error while setting Proxy credentials.");
+        }
+      }
+
+      if (options.IgnoreUnknownCertificateAuthority || !options.ExpectedTlsRootCertificates.empty())
+      {
+        auto option = SECURITY_FLAG_IGNORE_UNKNOWN_CA;
+        if (!WinHttpSetOption(
+                m_requestHandle.get(), WINHTTP_OPTION_SECURITY_FLAGS, &option, sizeof(option)))
+        {
+          GetErrorAndThrow("Error while setting ignore unknown server certificate.");
+        }
+      }
+
+      if (options.IgnoreInvalidCertificateCommonName)
+      {
+        auto option = SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
+        if (!WinHttpSetOption(
+                m_requestHandle.get(), WINHTTP_OPTION_SECURITY_FLAGS, &option, sizeof(option)))
+        {
+          GetErrorAndThrow("Error while setting ignore invalid certificate common name.");
+        }
+      }
+
+      if (options.EnableCertificateRevocationListCheck)
+      {
+        DWORD value = WINHTTP_ENABLE_SSL_REVOCATION;
+        if (!WinHttpSetOption(
+                m_requestHandle.get(), WINHTTP_OPTION_ENABLE_FEATURE, &value, sizeof(value)))
+        {
+          GetErrorAndThrow("Error while enabling CRL validation.");
+        }
+      }
+
+      DWORD disableRedirects = WINHTTP_DISABLE_REDIRECTS;
+      if (!WinHttpSetOption(
+              m_requestHandle.get(),
+              WINHTTP_OPTION_DISABLE_FEATURE,
+              &disableRedirects,
+              sizeof(disableRedirects)))
+      {
+        GetErrorAndThrow("Error while disabling redirects.");
+      }
+
+      // Set the callback function to be called whenever the state of the request handle changes.
+      m_httpAction = std::make_unique<_detail::WinHttpAction>(this);
+
+      if (!m_httpAction->RegisterWinHttpStatusCallback(m_requestHandle))
+      {
+        GetErrorAndThrow("Error while setting up the status callback.");
+      }
+    }
+
+    /*
+     * Destructor for WinHTTP request. Closes the request handle.
+     */
+    WinHttpRequest::~WinHttpRequest()
+    {
+      std::unique_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
+      if (!m_requestHandleClosed)
+      {
+        Log::Write(
+            Logger::Level::Informational,
+            "WinHttpRequest::~WinHttpRequest. Closing handle synchronously.");
+
+        // Close the outstanding request handle, waiting until the HANDLE_CLOSING status is
+        // received.
+        if (!m_httpAction->WaitForAction(
+                [this]() { CloseRequestHandle(false); },
+                WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING,
+                Azure::Core::Context{}))
+        {
+          Log::Write(Logger::Level::Error, "Error while closing the request handle.");
+        }
+        Log::Write(Logger::Level::Informational, "WinHttpRequest::~WinHttpRequest. Handle closed.");
+      }
+    }
+
+    void WinHttpRequest::CloseRequestHandle(bool lock)
+    {
+      std::unique_lock<std::shared_timed_mutex> requestHandleLock(
+          m_requestHandleMutex, std::defer_lock);
+
+      if (lock)
+      {
+        requestHandleLock.lock();
+      }
+
+      if (!m_requestHandleClosed)
+      {
+        m_requestHandleClosed = true;
+        auto requestHandle = m_requestHandle.release();
+        if (!WinHttpCloseHandle(requestHandle))
+        {
+          Log::Write(
+              Logger::Level::Error,
+              "Error closing WinHTTP handle: " + GetErrorMessage(GetLastError()));
         }
       }
     }
 
-    if (connectionTimeout.count() > 0
-        && connectionTimeout.count() < std::numeric_limits<ULONG>::max())
+    void WinHttpRequest::MarkRequestHandleForClosing()
     {
-      auto timeoutMillisecondsULong = static_cast<ULONG>(connectionTimeout.count());
-      if (!WinHttpSetOption(
-              m_requestHandle.get(),
-              WINHTTP_OPTION_CONNECT_TIMEOUT,
-              &timeoutMillisecondsULong,
-              sizeof(timeoutMillisecondsULong)))
+      std::unique_lock<std::shared_timed_mutex> requestHandleClosingLock(
+          m_requestHandleClosingMutex);
+
+      m_requestHandleClosing = true;
+    }
+
+    bool WinHttpRequest::IsRequestHandleMarkedForClosing()
+    {
+      std::shared_lock<std::shared_timed_mutex> requestHandleClosingLock(
+          m_requestHandleClosingMutex);
+
+      return m_requestHandleClosing;
+    }
+
+    void WinHttpRequest::UnregisterCallback()
+    {
+      std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
+      if (!m_requestHandleClosed)
       {
-        GetErrorAndThrow("Error while setting connection timeout.");
+        WinHttpSetStatusCallback(
+            m_requestHandle.get(), nullptr, WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS, 0);
       }
     }
 
-    if (!options.ProxyInformation.empty())
+    std::unique_ptr<WinHttpRequest> WinHttpTransportImpl::CreateRequestHandle(
+        Azure::Core::_internal::UniqueHandle<HINTERNET> const& connectionHandle,
+        Azure::Core::Url const& url,
+        Azure::Core::Http::HttpMethod const& method,
+        std::chrono::milliseconds connectionTimeout)
     {
-      WINHTTP_PROXY_INFO proxyInfo{};
-      std::wstring proxyWide{StringToWideString(options.ProxyInformation)};
-      proxyInfo.dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
-      proxyInfo.lpszProxy = const_cast<LPWSTR>(proxyWide.c_str());
-      proxyInfo.lpszProxyBypass = WINHTTP_NO_PROXY_BYPASS;
-      if (!WinHttpSetOption(
-              m_requestHandle.get(), WINHTTP_OPTION_PROXY, &proxyInfo, sizeof(proxyInfo)))
+      auto request{std::make_unique<WinHttpRequest>(
+          connectionHandle,
+          url,
+          method,
+          m_tlsClientCertificate.get(),
+          m_options,
+          connectionTimeout)};
+      // If we are supporting WebSockets, then let WinHTTP know that it should
+      // prepare to upgrade the HttpRequest to a WebSocket.
+      if (HasWebSocketSupport())
       {
-        GetErrorAndThrow("Error while setting Proxy information.");
+        request->EnableWebSocketsSupport();
+      }
+      return request;
+    }
+
+    // For PUT/POST requests, send additional data using WinHttpWriteData.
+    void WinHttpRequest::Upload(
+        Azure::Core::Http::Request& request,
+        Azure::Core::Context const& context)
+    {
+      auto streamBody = request.GetBodyStream();
+      int64_t streamLength = streamBody->Length();
+
+      // Consider using `MaximumUploadChunkSize` here, after some perf measurements
+      size_t uploadChunkSize = DefaultUploadChunkSize;
+      if (streamLength < MaximumUploadChunkSize)
+      {
+        uploadChunkSize = static_cast<size_t>(streamLength);
+      }
+      auto unique_buffer = std::make_unique<uint8_t[]>(uploadChunkSize);
+
+      while (true)
+      {
+        size_t rawRequestLen = streamBody->Read(unique_buffer.get(), uploadChunkSize, context);
+        if (rawRequestLen == 0)
+        {
+          break;
+        }
+
+        DWORD dwBytesWritten = 0;
+
+        std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
+        if (!m_httpAction->WaitForAction(
+                [&]() { // Write data to the server.
+                  if (!WinHttpWriteData(
+                          m_requestHandle.get(),
+                          unique_buffer.get(),
+                          static_cast<DWORD>(rawRequestLen),
+                          &dwBytesWritten))
+                  {
+                    GetErrorAndThrow("Error while uploading/sending data.");
+                  }
+                },
+                WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE,
+                context))
+
+        {
+          GetErrorAndThrow(
+              "Error sending HTTP request asynchronously", m_httpAction->GetStowedError());
+        }
       }
     }
-    if (options.ProxyUserName.HasValue() || options.ProxyPassword.HasValue())
+
+    void WinHttpRequest::SendRequest(
+        Azure::Core::Http::Request& request,
+        Azure::Core::Context const& context)
     {
-      if (!WinHttpSetCredentials(
-              m_requestHandle.get(),
-              WINHTTP_AUTH_TARGET_PROXY,
-              WINHTTP_AUTH_SCHEME_BASIC,
-              StringToWideString(options.ProxyUserName.Value()).c_str(),
-              StringToWideString(options.ProxyPassword.Value()).c_str(),
-              0))
+      std::wstring encodedHeaders;
+      int encodedHeadersLength = 0;
+
+      auto requestHeaders = request.GetHeaders();
+      if (requestHeaders.size() != 0)
       {
-        GetErrorAndThrow("Error while setting Proxy credentials.");
+        // The encodedHeaders will be null-terminated and the length is calculated.
+        encodedHeadersLength = -1;
+        std::string requestHeaderString = GetHeadersAsString(request);
+        requestHeaderString.append("\0");
+
+        encodedHeaders = StringToWideString(requestHeaderString);
+      }
+
+      int64_t streamLength = request.GetBodyStream()->Length();
+
+      if (m_tlsClientCertificate)
+      {
+        Log::Stream(Logger::Level::Verbose)
+            << "Client certificate needed, providing before request.." << std::endl;
+
+        std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
+        if (!WinHttpSetOption(
+                m_requestHandle.get(),
+                WINHTTP_OPTION_CLIENT_CERT_CONTEXT,
+                reinterpret_cast<void*>(const_cast<PCERT_CONTEXT>(m_tlsClientCertificate.get())),
+                sizeof(CERT_CONTEXT)))
+        {
+          GetErrorAndThrow("Error setting client certificate.");
+        }
+      }
+
+      try
+      {
+        std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
+        if (!m_httpAction->WaitForAction(
+                [&]() {
+                  {
+                    // Send a request.
+                    // NB: DO NOT CHANGE THE TYPE OF THE CONTEXT PARAMETER WITHOUT UPDATING THE
+                    // HttpAction::StatusCallback method.
+                    if (!WinHttpSendRequest(
+                            m_requestHandle.get(),
+                            requestHeaders.size() == 0 ? WINHTTP_NO_ADDITIONAL_HEADERS
+                                                       : encodedHeaders.c_str(),
+                            encodedHeadersLength,
+                            WINHTTP_NO_REQUEST_DATA,
+                            0,
+                            streamLength > 0 ? static_cast<DWORD>(streamLength) : 0,
+                            reinterpret_cast<DWORD_PTR>(
+                                m_httpAction.get()))) // Context for WinHTTP status callbacks for
+                                                      // this request.
+                    {
+                      // Errors include:
+                      // ERROR_WINHTTP_CANNOT_CONNECT
+                      // ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED
+                      // ERROR_WINHTTP_CONNECTION_ERROR
+                      // ERROR_WINHTTP_INCORRECT_HANDLE_STATE
+                      // ERROR_WINHTTP_INCORRECT_HANDLE_TYPE
+                      // ERROR_WINHTTP_INTERNAL_ERROR
+                      // ERROR_WINHTTP_INVALID_URL
+                      // ERROR_WINHTTP_LOGIN_FAILURE
+                      // ERROR_WINHTTP_NAME_NOT_RESOLVED
+                      // ERROR_WINHTTP_OPERATION_CANCELLED
+                      // ERROR_WINHTTP_RESPONSE_DRAIN_OVERFLOW
+                      // ERROR_WINHTTP_SECURE_FAILURE
+                      // ERROR_WINHTTP_SHUTDOWN
+                      // ERROR_WINHTTP_TIMEOUT
+                      // ERROR_WINHTTP_UNRECOGNIZED_SCHEME
+                      // ERROR_NOT_ENOUGH_MEMORY
+                      // ERROR_INVALID_PARAMETER
+                      // ERROR_WINHTTP_RESEND_REQUEST
+                      GetErrorAndThrow("Error while sending a request.");
+                    }
+                  }
+                },
+                WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE,
+                context))
+        {
+          GetErrorAndThrow(
+              "Error while waiting for a send to complete.", m_httpAction->GetStowedError());
+        }
+
+        // Chunked transfer encoding is not supported and the content length needs to be known up
+        // front.
+        if (streamLength == -1)
+        {
+          throw Azure::Core::Http::TransportException(
+              "When uploading data, the body stream must have a known length.");
+        }
+
+        if (streamLength > 0)
+        {
+          Upload(request, context);
+        }
+      }
+      catch (TransportException const&)
+      {
+        if (IsRequestHandleMarkedForClosing())
+        {
+          CloseRequestHandle(true);
+        }
       }
     }
 
-    if (options.IgnoreUnknownCertificateAuthority || !options.ExpectedTlsRootCertificates.empty())
+    void WinHttpRequest::ReceiveResponse(Azure::Core::Context const& context)
     {
-      auto option = SECURITY_FLAG_IGNORE_UNKNOWN_CA;
-      if (!WinHttpSetOption(
-              m_requestHandle.get(), WINHTTP_OPTION_SECURITY_FLAGS, &option, sizeof(option)))
-      {
-        GetErrorAndThrow("Error while setting ignore unknown server certificate.");
-      }
-    }
-
-    if (options.IgnoreInvalidCertificateCommonName)
-    {
-      auto option = SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
-      if (!WinHttpSetOption(
-              m_requestHandle.get(), WINHTTP_OPTION_SECURITY_FLAGS, &option, sizeof(option)))
-      {
-        GetErrorAndThrow("Error while setting ignore invalid certificate common name.");
-      }
-    }
-
-    if (options.EnableCertificateRevocationListCheck)
-    {
-      DWORD value = WINHTTP_ENABLE_SSL_REVOCATION;
-      if (!WinHttpSetOption(
-              m_requestHandle.get(), WINHTTP_OPTION_ENABLE_FEATURE, &value, sizeof(value)))
-      {
-        GetErrorAndThrow("Error while enabling CRL validation.");
-      }
-    }
-
-    DWORD disableRedirects = WINHTTP_DISABLE_REDIRECTS;
-    if (!WinHttpSetOption(
-            m_requestHandle.get(),
-            WINHTTP_OPTION_DISABLE_FEATURE,
-            &disableRedirects,
-            sizeof(disableRedirects)))
-    {
-      GetErrorAndThrow("Error while disabling redirects.");
-    }
-
-    // Set the callback function to be called whenever the state of the request handle changes.
-    m_httpAction = std::make_unique<_detail::WinHttpAction>(this);
-
-    if (!m_httpAction->RegisterWinHttpStatusCallback(m_requestHandle))
-    {
-      GetErrorAndThrow("Error while setting up the status callback.");
-    }
-  }
-
-  /*
-   * Destructor for WinHTTP request. Closes the request handle.
-   */
-  WinHttpRequest::~WinHttpRequest()
-  {
-    std::unique_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
-    if (!m_requestHandleClosed)
-    {
-      Log::Write(
-          Logger::Level::Informational,
-          "WinHttpRequest::~WinHttpRequest. Closing handle synchronously.");
-
-      // Close the outstanding request handle, waiting until the HANDLE_CLOSING status is
-      // received.
-      if (!m_httpAction->WaitForAction(
-              [this]() { CloseRequestHandle(false); },
-              WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING,
-              Azure::Core::Context{}))
-      {
-        Log::Write(Logger::Level::Error, "Error while closing the request handle.");
-      }
-      Log::Write(Logger::Level::Informational, "WinHttpRequest::~WinHttpRequest. Handle closed.");
-    }
-  }
-
-  void WinHttpRequest::CloseRequestHandle(bool lock)
-  {
-    std::unique_lock<std::shared_timed_mutex> requestHandleLock(
-        m_requestHandleMutex, std::defer_lock);
-
-    if (lock)
-    {
-      requestHandleLock.lock();
-    }
-
-    if (!m_requestHandleClosed)
-    {
-      m_requestHandleClosed = true;
-      auto requestHandle = m_requestHandle.release();
-      if (!WinHttpCloseHandle(requestHandle))
-      {
-        Log::Write(
-            Logger::Level::Error,
-            "Error closing WinHTTP handle: " + GetErrorMessage(GetLastError()));
-      }
-    }
-  }
-
-  void WinHttpRequest::UnregisterCallback()
-  {
-    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
-    if (!m_requestHandleClosed)
-    {
-      WinHttpSetStatusCallback(
-          m_requestHandle.get(), nullptr, WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS, 0);
-    }
-  }
-
-  std::unique_ptr<WinHttpRequest> WinHttpTransportImpl::CreateRequestHandle(
-      Azure::Core::_internal::UniqueHandle<HINTERNET> const& connectionHandle,
-      Azure::Core::Url const& url,
-      Azure::Core::Http::HttpMethod const& method,
-      std::chrono::milliseconds connectionTimeout)
-  {
-    auto request{std::make_unique<WinHttpRequest>(
-        connectionHandle, url, method, m_tlsClientCertificate.get(), m_options, connectionTimeout)};
-    // If we are supporting WebSockets, then let WinHTTP know that it should
-    // prepare to upgrade the HttpRequest to a WebSocket.
-    if (HasWebSocketSupport())
-    {
-      request->EnableWebSocketsSupport();
-    }
-    return request;
-  }
-
-  // For PUT/POST requests, send additional data using WinHttpWriteData.
-  void WinHttpRequest::Upload(
-      Azure::Core::Http::Request& request,
-      Azure::Core::Context const& context)
-  {
-    auto streamBody = request.GetBodyStream();
-    int64_t streamLength = streamBody->Length();
-
-    // Consider using `MaximumUploadChunkSize` here, after some perf measurements
-    size_t uploadChunkSize = DefaultUploadChunkSize;
-    if (streamLength < MaximumUploadChunkSize)
-    {
-      uploadChunkSize = static_cast<size_t>(streamLength);
-    }
-    auto unique_buffer = std::make_unique<uint8_t[]>(uploadChunkSize);
-
-    while (true)
-    {
-      size_t rawRequestLen = streamBody->Read(unique_buffer.get(), uploadChunkSize, context);
-      if (rawRequestLen == 0)
-      {
-        break;
-      }
-
-      DWORD dwBytesWritten = 0;
-
+      // Wait to receive the response to the HTTP request initiated by WinHttpSendRequest.
+      // When WinHttpReceiveResponse completes successfully, the status code and response headers
+      // have been received.
       std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
       if (!m_httpAction->WaitForAction(
-              [&]() { // Write data to the server.
-                if (!WinHttpWriteData(
-                        m_requestHandle.get(),
-                        unique_buffer.get(),
-                        static_cast<DWORD>(rawRequestLen),
-                        &dwBytesWritten))
-                {
-                  GetErrorAndThrow("Error while uploading/sending data.");
-                }
-              },
-              WINHTTP_CALLBACK_STATUS_WRITE_COMPLETE,
-              context))
-
-      {
-        GetErrorAndThrow(
-            "Error sending HTTP request asynchronously", m_httpAction->GetStowedError());
-      }
-    }
-  }
-
-  void WinHttpRequest::SendRequest(
-      Azure::Core::Http::Request& request,
-      Azure::Core::Context const& context)
-  {
-    std::wstring encodedHeaders;
-    int encodedHeadersLength = 0;
-
-    auto requestHeaders = request.GetHeaders();
-    if (requestHeaders.size() != 0)
-    {
-      // The encodedHeaders will be null-terminated and the length is calculated.
-      encodedHeadersLength = -1;
-      std::string requestHeaderString = GetHeadersAsString(request);
-      requestHeaderString.append("\0");
-
-      encodedHeaders = StringToWideString(requestHeaderString);
-    }
-
-    int64_t streamLength = request.GetBodyStream()->Length();
-
-    if (m_tlsClientCertificate)
-    {
-      Log::Stream(Logger::Level::Verbose)
-          << "Client certificate needed, providing before request.." << std::endl;
-
-      std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
-      if (!WinHttpSetOption(
-              m_requestHandle.get(),
-              WINHTTP_OPTION_CLIENT_CERT_CONTEXT,
-              reinterpret_cast<void*>(const_cast<PCERT_CONTEXT>(m_tlsClientCertificate.get())),
-              sizeof(CERT_CONTEXT)))
-      {
-        GetErrorAndThrow("Error setting client certificate.");
-      }
-    }
-
-    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
-    if (!m_httpAction->WaitForAction(
-            [&]() {
-              {
-                // Send a request.
-                // NB: DO NOT CHANGE THE TYPE OF THE CONTEXT PARAMETER WITHOUT UPDATING THE
-                // HttpAction::StatusCallback method.
-                if (!WinHttpSendRequest(
-                        m_requestHandle.get(),
-                        requestHeaders.size() == 0 ? WINHTTP_NO_ADDITIONAL_HEADERS
-                                                   : encodedHeaders.c_str(),
-                        encodedHeadersLength,
-                        WINHTTP_NO_REQUEST_DATA,
-                        0,
-                        streamLength > 0 ? static_cast<DWORD>(streamLength) : 0,
-                        reinterpret_cast<DWORD_PTR>(
-                            m_httpAction.get()))) // Context for WinHTTP status callbacks for
-                                                  // this request.
+              [this]() {
+                if (!WinHttpReceiveResponse(m_requestHandle.get(), NULL))
                 {
                   // Errors include:
                   // ERROR_WINHTTP_CANNOT_CONNECT
+                  // ERROR_WINHTTP_CHUNKED_ENCODING_HEADER_SIZE_OVERFLOW
                   // ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED
-                  // ERROR_WINHTTP_CONNECTION_ERROR
-                  // ERROR_WINHTTP_INCORRECT_HANDLE_STATE
-                  // ERROR_WINHTTP_INCORRECT_HANDLE_TYPE
-                  // ERROR_WINHTTP_INTERNAL_ERROR
-                  // ERROR_WINHTTP_INVALID_URL
-                  // ERROR_WINHTTP_LOGIN_FAILURE
-                  // ERROR_WINHTTP_NAME_NOT_RESOLVED
-                  // ERROR_WINHTTP_OPERATION_CANCELLED
-                  // ERROR_WINHTTP_RESPONSE_DRAIN_OVERFLOW
-                  // ERROR_WINHTTP_SECURE_FAILURE
-                  // ERROR_WINHTTP_SHUTDOWN
+                  // ...
                   // ERROR_WINHTTP_TIMEOUT
                   // ERROR_WINHTTP_UNRECOGNIZED_SCHEME
                   // ERROR_NOT_ENOUGH_MEMORY
-                  // ERROR_INVALID_PARAMETER
-                  // ERROR_WINHTTP_RESEND_REQUEST
-                  GetErrorAndThrow("Error while sending a request.");
+                  GetErrorAndThrow("Error while receiving a response.");
                 }
-              }
-            },
-            WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE,
-            context))
-    {
-      GetErrorAndThrow(
-          "Error while waiting for a send to complete.", m_httpAction->GetStowedError());
-    }
-
-    // Chunked transfer encoding is not supported and the content length needs to be known up
-    // front.
-    if (streamLength == -1)
-    {
-      throw Azure::Core::Http::TransportException(
-          "When uploading data, the body stream must have a known length.");
-    }
-
-    if (streamLength > 0)
-    {
-      Upload(request, context);
-    }
-  }
-
-  void WinHttpRequest::ReceiveResponse(Azure::Core::Context const& context)
-  {
-    // Wait to receive the response to the HTTP request initiated by WinHttpSendRequest.
-    // When WinHttpReceiveResponse completes successfully, the status code and response headers
-    // have been received.
-    std::shared_lock<std::shared_timed_mutex> requestHandleLock(m_requestHandleMutex);
-    if (!m_httpAction->WaitForAction(
-            [this]() {
-              if (!WinHttpReceiveResponse(m_requestHandle.get(), NULL))
-              {
-                // Errors include:
-                // ERROR_WINHTTP_CANNOT_CONNECT
-                // ERROR_WINHTTP_CHUNKED_ENCODING_HEADER_SIZE_OVERFLOW
-                // ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED
-                // ...
-                // ERROR_WINHTTP_TIMEOUT
-                // ERROR_WINHTTP_UNRECOGNIZED_SCHEME
-                // ERROR_NOT_ENOUGH_MEMORY
-                GetErrorAndThrow("Error while receiving a response.");
-              }
-            },
-            WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE,
-            context))
-    {
-      GetErrorAndThrow("Error while receiving a response.", m_httpAction->GetStowedError());
+              },
+              WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE,
+              context))
+      {
+        GetErrorAndThrow("Error while receiving a response.", m_httpAction->GetStowedError());
+      }
     }
   }
 
@@ -2022,4 +2063,5 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     }
     return numberOfBytesRead;
   }
-}}}} // namespace Azure::Core::Http::_detail
+}}}
+} // namespace Azure::Core::Http::_detail

--- a/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
+++ b/sdk/core/azure-core/src/http/winhttp/win_http_transport.cpp
@@ -724,8 +724,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       Log::Write(
           Logger::Level::Error,
           "Request Failed Exception Thrown: " + std::string(rfe.what()) + rfe.Message);
-      WinHttpCloseHandle(hInternet);
-      httpAction->m_httpRequest->MarkRequestHandleClosed();
+      httpAction->m_httpRequest->CloseRequestHandle(true);
     }
     catch (std::exception const& ex)
     {
@@ -1310,6 +1309,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
   void WinHttpRequest::EnableWebSocketsSupport()
   {
+    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 6387) // warning C6387: _Param_(3) could be '0'.
@@ -1494,6 +1494,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
    */
   WinHttpRequest::~WinHttpRequest()
   {
+    std::unique_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!m_requestHandleClosed)
     {
       Log::Write(
@@ -1503,22 +1504,44 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       // Close the outstanding request handle, waiting until the HANDLE_CLOSING status is
       // received.
       if (!m_httpAction->WaitForAction(
-              [this]() {
-                auto requestHandle = m_requestHandle.release();
-                if (!WinHttpCloseHandle(requestHandle))
-                {
-                  Log::Write(
-                      Logger::Level::Error,
-                      "Error closing WinHTTP handle: " + GetErrorMessage(GetLastError()));
-                }
-              },
-
+              [this]() { CloseRequestHandle(false) },
               WINHTTP_CALLBACK_STATUS_HANDLE_CLOSING,
               Azure::Core::Context{}))
       {
         Log::Write(Logger::Level::Error, "Error while closing the request handle.");
       }
       Log::Write(Logger::Level::Informational, "WinHttpRequest::~WinHttpRequest. Handle closed.");
+    }
+  }
+
+  void WinHttpRequest::CloseRequestHandle(bool lock)
+  {
+    std::unique_lock<std::shred_timed_mutex> requestHandleLock;
+    if (lock)
+    {
+      requestHandleLock.lock(m_requestHandleMutex);
+    }
+
+    if (!m_requestHandleClosed)
+    {
+      m_requestHandleClosed = true;
+      auto requestHandle = m_requestHandle.release();
+      if (!WinHttpCloseHandle(requestHandle))
+      {
+        Log::Write(
+            Logger::Level::Error,
+            "Error closing WinHTTP handle: " + GetErrorMessage(GetLastError()));
+      }
+    }
+  }
+
+  void WinHttpRequest::UnregisterCallback()
+  {
+    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
+    if (!m_requestHandleClosed)
+    {
+      WinHttpSetStatusCallback(
+          m_requestHandle.get(), nullptr, WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS, 0);
     }
   }
 
@@ -1565,6 +1588,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
       DWORD dwBytesWritten = 0;
 
+      std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
       if (!m_httpAction->WaitForAction(
               [&]() { // Write data to the server.
                 if (!WinHttpWriteData(
@@ -1610,6 +1634,8 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     {
       Log::Stream(Logger::Level::Verbose)
           << "Client certificate needed, providing before request.." << std::endl;
+
+      std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
       if (!WinHttpSetOption(
               m_requestHandle.get(),
               WINHTTP_OPTION_CLIENT_CERT_CONTEXT,
@@ -1622,6 +1648,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     try
     {
+      std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
       if (!m_httpAction->WaitForAction(
               [&]() {
                 {
@@ -1683,17 +1710,6 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
         Upload(request, context);
       }
     }
-    catch (TransportException const&)
-    {
-      // If there was a TLS validation error, then we will have closed the request handle
-      // during the TLS validation callback. So if an exception was thrown, if we force closed
-      // the request handle, clear the handle in the requestHandle to prevent a double free.
-      if (m_requestHandleClosed)
-      {
-        m_requestHandle.release();
-      }
-      throw;
-    }
   }
 
   void WinHttpRequest::ReceiveResponse(Azure::Core::Context const& context)
@@ -1701,6 +1717,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // Wait to receive the response to the HTTP request initiated by WinHttpSendRequest.
     // When WinHttpReceiveResponse completes successfully, the status code and response headers
     // have been received.
+    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!m_httpAction->WaitForAction(
             [this]() {
               if (!WinHttpReceiveResponse(m_requestHandle.get(), NULL))
@@ -1739,6 +1756,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // Get the content length as a number.
     if (requestMethod != HttpMethod::Head && responseStatusCode != HttpStatusCode::NoContent)
     {
+      std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
       if (!WinHttpQueryHeaders(
               m_requestHandle.get(),
               WINHTTP_QUERY_CONTENT_LENGTH | WINHTTP_QUERY_FLAG_NUMBER,
@@ -1767,6 +1785,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
     // First, use WinHttpQueryHeaders to obtain the size of the buffer.
     // The call is expected to fail since no destination buffer is provided.
     DWORD sizeOfHeaders = 0;
+    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (WinHttpQueryHeaders(
             m_requestHandle.get(),
             WINHTTP_QUERY_RAW_HEADERS,
@@ -1792,6 +1811,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
 
     // Now, use WinHttpQueryHeaders to retrieve all the headers.
     // Each header is terminated by "\0". An additional "\0" terminates the list of headers.
+    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!WinHttpQueryHeaders(
             m_requestHandle.get(),
             WINHTTP_QUERY_RAW_HEADERS,
@@ -1928,6 +1948,7 @@ namespace Azure { namespace Core { namespace Http { namespace _detail {
       Azure::Core::Context const& context)
   {
     DWORD numberOfBytesRead = 0;
+    std::shared_lock<std::shred_timed_mutex> requestHandleLock(m_requestHandleMutex);
     if (!m_httpAction->WaitForAction(
             [&]() {
               if (!WinHttpReadData(


### PR DESCRIPTION
It is possible that there is more lightweight way of fixing it with more assumptions. But I don't think we can go wrong with a mutex. Given that to get the crash you need some concurrency (and `SetEvent_scope_exit()` does not seem to have guards against that) and some right timing to trigger it, this should prevent calling `SetEvent_scope_exit()` on an already closed handle. If this is right, there should be no downside, other than a little extra code.

We introduce mutexes and atomics to prevent handles from being closed or reset, no matter the contracts and expected order of execution. We use shared locks to read, so things should still work fast and not wait on the mutex in most common cases (and I assume if we would close the handle while it is still being used, then we could be in a bigger trouble, so now all the code would do is to do a little wait in this cases, while previously we would get into an undefined behavior territory). And when everything works according to assumptions - we know it did in the past, given that the crash is rare, then the performance should be comparable in the write case. But even if we wait on a mutex while it is being written, the operation it performs to close a handle should be relatively fast.
